### PR TITLE
Define global identity binding contract

### DIFF
--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,0 +1,3 @@
+export * from './names.js';
+export * from './service.js';
+export * from './types.js';

--- a/src/domain/names.ts
+++ b/src/domain/names.ts
@@ -1,0 +1,43 @@
+import type { BindingResult } from './types.js';
+
+export interface ValidatedName {
+  readonly name: string;
+  readonly canonicalName: string;
+}
+
+const paneTargetPatterns = [/^%\d+$/, /^\d+\.\d+$/, /^[^\s:]+:\d+\.\d+$/];
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint < 0x20 || codePoint === 0x7f;
+  });
+}
+
+export function normalizeName(name: string): string {
+  return name.trim().normalize('NFKC').toLowerCase();
+}
+
+export function validateName(name: string): BindingResult<ValidatedName> {
+  const trimmed = name.trim();
+  const canonicalName = normalizeName(name);
+  if (!trimmed || hasControlCharacter(trimmed)) {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_NAME',
+        message: 'Identity name must not be empty or contain control characters.',
+      },
+    };
+  }
+  if (paneTargetPatterns.some((pattern) => pattern.test(canonicalName))) {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_NAME',
+        message: 'Identity name must not look like a pane target.',
+      },
+    };
+  }
+  return { ok: true, value: { name: trimmed, canonicalName } };
+}

--- a/src/domain/service.test.ts
+++ b/src/domain/service.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { bindGlobalName, normalizeName, unbindGlobalPane, validateName } from './service.js';
+import type { ActiveRegistration, BindingErrorCode } from './types.js';
+
+const active = (name: string, paneId: string): ActiveRegistration => ({
+  name,
+  canonicalName: normalizeName(name),
+  paneId,
+});
+
+describe('global name validation', () => {
+  it('normalizes deterministically and rejects invalid/pane-shaped names', () => {
+    expect(normalizeName(' Ａlice ')).toBe('alice');
+    for (const name of [
+      '',
+      '  ',
+      'a\u0000b',
+      '%14',
+      '10.3',
+      'session:2.1',
+      '％１４',
+      '１０.３',
+      'session：２.１',
+    ]) {
+      expect(validateName(name).ok).toBe(false);
+    }
+  });
+});
+
+describe('global registration transitions', () => {
+  it('binds new names and does not mutate input', () => {
+    const input: readonly ActiveRegistration[] = [active('Alice', '%1')];
+    const result = bindGlobalName(input, 'Bob', '%2');
+    expect(result).toMatchObject({ ok: true, value: [...input, active('Bob', '%2')] });
+    expect(input).toEqual([active('Alice', '%1')]);
+  });
+
+  it('is idempotent for same canonical name and pane', () => {
+    const input = [active('Alice', '%1')];
+    const result = bindGlobalName(input, ' alice ', '%1');
+    expect(result).toEqual({ ok: true, value: input });
+  });
+
+  it.each([
+    ['PANE_ALREADY_BOUND', [active('Alice', '%1')], 'Bob', '%1'],
+    ['NAME_ALREADY_ACTIVE', [active('Alice', '%1')], ' alice ', '%2'],
+  ] as readonly [BindingErrorCode, readonly ActiveRegistration[], string, string][])(
+    'reports %s without changing state',
+    (
+      code: BindingErrorCode,
+      input: readonly ActiveRegistration[],
+      name: string,
+      paneId: string
+    ) => {
+      expect(bindGlobalName(input, name, paneId)).toMatchObject({ ok: false, error: { code } });
+      expect(input).toEqual([active('Alice', '%1')]);
+    }
+  );
+
+  it('rejects invalid bind names without changing state', () => {
+    const input = [active('Alice', '%1')];
+    expect(bindGlobalName(input, '%14', '%2')).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_NAME' },
+    });
+    expect(input).toHaveLength(1);
+  });
+
+  it('unbinds only the selected pane and preserves other registrations', () => {
+    const input = [active('Alice', '%1'), active('Bob', '%2')];
+    expect(unbindGlobalPane(input, '%1')).toEqual({ ok: true, value: [active('Bob', '%2')] });
+    expect(input).toHaveLength(2);
+  });
+
+  it('reports missing pane without changing state', () => {
+    const input = [active('Alice', '%1')];
+    expect(unbindGlobalPane(input, '%9')).toMatchObject({
+      ok: false,
+      error: { code: 'UNBOUND_PANE' },
+    });
+    expect(input).toHaveLength(1);
+  });
+});

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -1,0 +1,48 @@
+import { normalizeName, validateName } from './names.js';
+import type { ActiveRegistration, BindingResult } from './types.js';
+
+export function bindGlobalName(
+  registrations: readonly ActiveRegistration[],
+  name: string,
+  paneId: string
+): BindingResult<readonly ActiveRegistration[]> {
+  const valid = validateName(name);
+  if (!valid.ok) return valid;
+  const samePane = registrations.find((entry) => entry.paneId === paneId);
+  if (samePane) {
+    if (samePane.canonicalName === valid.value.canonicalName)
+      return { ok: true, value: registrations };
+    return {
+      ok: false,
+      error: { code: 'PANE_ALREADY_BOUND', message: 'Pane is already bound to another name.' },
+    };
+  }
+  if (registrations.some((entry) => entry.canonicalName === valid.value.canonicalName)) {
+    return {
+      ok: false,
+      error: { code: 'NAME_ALREADY_ACTIVE', message: 'Name is already active on another pane.' },
+    };
+  }
+  return {
+    ok: true,
+    value: [
+      ...registrations,
+      { name: valid.value.name, canonicalName: valid.value.canonicalName, paneId },
+    ],
+  };
+}
+
+export function unbindGlobalPane(
+  registrations: readonly ActiveRegistration[],
+  paneId: string
+): BindingResult<readonly ActiveRegistration[]> {
+  if (!registrations.some((entry) => entry.paneId === paneId)) {
+    return {
+      ok: false,
+      error: { code: 'UNBOUND_PANE', message: 'Pane has no active global name.' },
+    };
+  }
+  return { ok: true, value: registrations.filter((entry) => entry.paneId !== paneId) };
+}
+
+export { normalizeName, validateName };

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,0 +1,20 @@
+export interface ActiveRegistration {
+  readonly name: string;
+  readonly canonicalName: string;
+  readonly paneId: string;
+}
+
+export type BindingErrorCode =
+  | 'INVALID_NAME'
+  | 'PANE_ALREADY_BOUND'
+  | 'NAME_ALREADY_ACTIVE'
+  | 'UNBOUND_PANE';
+
+export interface BindingError {
+  readonly code: BindingErrorCode;
+  readonly message: string;
+}
+
+export type BindingResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: BindingError };


### PR DESCRIPTION
## Summary

- define deterministic global-name normalization and validation
- model the minimal active registration as a global name bound to a resolved tmux pane ID
- add pure, immutable bind and unbind transitions with distinct conflict outcomes
- cover idempotency, validation, conflicts, and state preservation with tests

## Scope

This PR is the first bounded implementation slice of TMT-2. It only introduces pure TypeScript helpers for the existing CLI and active tmux state.

Explicitly out of scope:

- daemon, background process, or IPC
- SQLite, JSON identity storage, or durable persistence
- identity or runtime UUIDs
- authorization framework
- CLI parsing and output
- tmux metadata reads and writes
- team, alias, memory, profile, role, or management behavior
- talk, check, or list migration

## Verification

- pnpm test:run — 19 test files and 309 tests passed
- statement coverage: 92.08%
- branch coverage: 85.42%
- pnpm check — typecheck and formatting passed; lint reported 5 pre-existing warnings and 0 errors

## Linear

- TMT-2: https://linear.app/tigerpig-dev/issue/TMT-2/define-global-identity-and-runtime-binding-domain-contract
- Specification: https://linear.app/tigerpig-dev/document/tmt-5-spec-global-identity-and-runtime-binding-80b4a7da9a48