### PR TITLE
test: establish Docker-backed tmux E2E foundation

### DIFF
--- a/.agents/skills/tmt-e2e/SKILL.md
+++ b/.agents/skills/tmt-e2e/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: tmt-e2e
+description: Add, change, diagnose, or run this repository's Docker-isolated end-to-end tests for tmt and tmux.
+---
+
+# TMT end-to-end testing
+
+Use this skill for the repository's Docker E2E test foundation. Keep E2E tests separate from unit tests and unit-test coverage: Docker provides isolation, while Vitest is the scenario runner and assertion layer.
+
+## Required test boundary
+
+- Exercise the real `tmt`/`tmux-team` CLI and a real tmux server.
+- Run deterministic mock agents inside tmux panes; never invoke a real AI agent, model, credential, or network service.
+- Never touch the host user's tmux server, host credentials, or unrelated processes. The container must be network-isolated.
+- Reuse the existing E2E harness and its cleanup hooks. Every scenario must leave its temporary tmux server, socket, panes, and files cleaned up, including on assertion failure.
+- For lifecycle or cleanup changes, run the Docker suite twice to catch leaked state and non-idempotent teardown.
+
+## Test quality gate
+
+Do not optimize for a passing suite or a larger test count. Every scenario must name the concrete regression risk or invariant it covers, and a reviewer should be able to explain what realistic defect would make it fail.
+
+- Cover distinct boundaries and failure modes instead of repeating equivalent happy paths.
+- Exercise the subject under test rather than recreating its logic in the harness. Mock agents are allowed because they are deterministic peers; `tmt` and tmux themselves stay real.
+- Assert causal output and durable state. Terminal-echoed input is not proof that a mock agent processed a request; wait for agent-produced output and corroborate it with the structured event log or metadata.
+- Include negative paths for exit-code propagation, invalid operations, timeouts, partial startup, and thrown scenario errors when those risks are relevant.
+- Use bounded polling for observable state changes. Do not use fixed sleeps to hide races or make a flaky scenario appear stable.
+- Verify state preservation after failed operations and verify cleanup with observable absence, not only by calling a cleanup function.
+- Prefer stable JSON fields, exit codes, pane IDs, metadata, and essential output over incidental formatting.
+- Keep foundation tests focused on infrastructure invariants. Add feature semantics only through the issue that defines that feature's state matrix.
+- Treat a test that can pass without the intended action occurring as a test bug. Fix false positives before expanding coverage.
+
+## Maintained implementation
+
+Read the relevant files before changing behavior:
+
+- [`test/e2e/`](../../../test/e2e/): Vitest configuration, scenarios, harness, and mock-agent behavior.
+- [`scripts/run-e2e.mjs`](../../../scripts/run-e2e.mjs): Docker build/run wrapper and exit-code handling.
+
+Keep orchestration in the wrapper and scenario assertions in Vitest. Do not duplicate harness or mock-agent implementation in this skill.
+
+## Scope guard
+
+This foundation covers CLI/tmux integration scenarios only. Do not expand it into daemon behavior, persistence, team workflows, aliases, or memory unless a separate, explicit requirement adds those areas.
+
+## Verification
+
+Prefer the repository's documented E2E command through [`scripts/run-e2e.mjs`](../../../scripts/run-e2e.mjs). Confirm failures propagate as non-zero exit codes, and inspect cleanup behavior when tests fail—not only when they pass.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.agents
+node_modules
+coverage
+dist
+.DS_Store
+*.log
+.env
+.env.*
+!.env.example
+*.key
+*.pem
+tmux-team.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-quality:
+    name: Code quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.2
+      - name: Activate pinned pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run code quality checks
+        run: pnpm check
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.2
+      - name: Activate pinned pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run unit tests and coverage checks
+        run: pnpm test:run
+
+  docker-e2e:
+    name: Docker E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.2
+      - name: Activate pinned pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run Docker end-to-end tests
+        run: pnpm test:e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Repository Working Agreement
+
+## Pattern audit before changes
+
+Before editing code, tests, documentation, configuration, or repository skills, the primary agent must delegate a read-only repository pattern audit to a `gpt-5.6-luna` agent with high reasoning effort.
+
+The audit must inspect the relevant architecture, helpers, fixtures, scripts, naming conventions, tests, documentation, and skills. It must identify reusable patterns, duplicated behavior, and conflicts with established conventions. The delegated agent must not edit files, mutate external systems, or broaden the requested scope during this audit.
+
+The primary agent must review the findings before any edits begin, record which findings are accepted or rejected and why, and reuse or extend established abstractions where practical. If the audit finds unnecessary duplication or an inconsistent implementation within scope, correct it before continuing. When this rule is introduced after work has started, pause new edits, run the audit, and apply the same review.
+
+If delegation is unavailable, document that limitation and perform the same read-only audit locally before editing. Delegation never expands the user's authorization.
+
+## Code organization
+
+- Keep production behavior, test infrastructure, fixtures, and scenario assertions in clearly separated modules.
+- Prefer small, purpose-specific interfaces and existing dependency-injection boundaries over new global state or parallel abstractions.
+- Put shared behavior in one named helper only after more than one caller needs it; keep scenario-specific behavior close to the scenario.
+- Use names that describe observable behavior and stable domain concepts rather than implementation accidents.
+- Keep changes bounded to the tracked issue. Record adjacent improvements as follow-up work instead of silently expanding scope.
+
+## Verification quality
+
+- Verify observable behavior and durable state, not only exit codes, log echoes, snapshots, or test counts.
+- Include representative success, failure, cleanup, and lifecycle cases for the changed behavior.
+- Prefer deterministic readiness signals and bounded polling over fixed sleeps.
+- Treat false positives, leaked processes, leaked tmux servers, and non-isolated state as test failures.
+- Run the repository checks relevant to every changed layer and report the exact commands and results.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,14 @@ The primary agent must review the findings before any edits begin, record which 
 
 If delegation is unavailable, document that limitation and perform the same read-only audit locally before editing. Delegation never expands the user's authorization.
 
+## Repository content language
+
+All repository content must be written in English, including code, tests,
+comments, documentation, configuration, workflows, repository skills, commit
+messages, and pull request metadata. Non-language symbols and technically
+required fixture data are allowed when necessary; explain any such exception
+in English.
+
 ## Code organization
 
 - Keep production behavior, test infrastructure, fixtures, and scenario assertions in clearly separated modules.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,13 +6,13 @@
 - Install dependencies:
 
 ```bash
-npm install
+pnpm install
 ```
 
 - Run the CLI locally:
 
 ```bash
-npm run dev -- --help
+pnpm dev -- --help
 ```
 
 ## Running Tests
@@ -20,13 +20,13 @@ npm run dev -- --help
 - Watch mode:
 
 ```bash
-npm test
+pnpm test:watch
 ```
 
 - Single run:
 
 ```bash
-npm run test:run
+pnpm test:run
 ```
 
 - Docker-backed end-to-end smoke tests:
@@ -49,7 +49,7 @@ its temporary state.
 - Full checks:
 
 ```bash
-npm run check
+pnpm check
 ```
 
 ## Testing Strategy

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,6 +29,23 @@ npm test
 npm run test:run
 ```
 
+- Docker-backed end-to-end smoke tests:
+
+```bash
+pnpm test:e2e
+```
+
+The E2E command requires Docker, builds the pinned Node, pnpm, and tmux versions
+in `test/e2e/Dockerfile` from the current checkout, runs Vitest inside it with
+`--network none`, and removes the tagged image afterward. Each test starts its
+own tmux server on a private socket and
+launches the deterministic mock agent from `test/e2e/mock-agent.mjs`; no real
+agent, credentials, or host tmux session is used. The tests invoke
+`bin/tmux-team` as a subprocess and exercise CLI process propagation, tmux
+transport, pane movement, and fixture cleanup. Failures include the
+container/Vitest output, and each fixture kills its private server and removes
+its temporary state.
+
 - Full checks:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -15,11 +15,14 @@
     "test:e2e": "node scripts/run-e2e.mjs",
     "test:run": "vitest run --coverage && node scripts/check-coverage.mjs --threshold 90 --branches 85",
     "lint": "oxlint src/",
+    "e2e:typecheck": "tsc --project tsconfig.e2e.json --noEmit",
+    "e2e:lint": "oxlint test/e2e/ scripts/run-e2e.mjs",
+    "e2e:format:check": "prettier --check test/e2e/ scripts/run-e2e.mjs tsconfig.e2e.json DEVELOPMENT.md AGENTS.md .agents/skills/tmt-e2e/SKILL.md",
     "lint:fix": "oxlint src/ --fix",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
     "type:check": "tsc --noEmit",
-    "check": "pnpm type:check && pnpm lint && pnpm format:check"
+    "check": "pnpm type:check && pnpm e2e:typecheck && pnpm lint && pnpm e2e:lint && pnpm format:check && pnpm e2e:format:check"
   },
   "keywords": [
     "tmux",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "tmt": "./bin/tmux-team",
     "test": "pnpm test:run",
     "test:watch": "vitest",
+    "test:e2e": "node scripts/run-e2e.mjs",
     "test:run": "vitest run --coverage && node scripts/check-coverage.mjs --threshold 90 --branches 85",
     "lint": "oxlint src/",
     "lint:fix": "oxlint src/ --fix",

--- a/scripts/run-e2e.mjs
+++ b/scripts/run-e2e.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const image = `tmux-team-e2e:${process.pid}-${Date.now().toString(36)}`;
+const dockerfile = path.join(repoRoot, 'test', 'e2e', 'Dockerfile');
+let activeChild;
+let interrupted = false;
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: repoRoot, stdio: 'inherit', ...options });
+    activeChild = child;
+    let settled = false;
+    child.once('error', (error) => {
+      if (settled) return;
+      settled = true;
+      if (activeChild === child) activeChild = undefined;
+      reject(error);
+    });
+    child.once('close', (code) => {
+      if (settled) return;
+      settled = true;
+      if (activeChild === child) activeChild = undefined;
+      resolve(code ?? 1);
+    });
+  });
+}
+
+function forwardSignal(signal) {
+  interrupted = true;
+  activeChild?.kill(signal);
+}
+
+process.once('SIGINT', () => forwardSignal('SIGINT'));
+process.once('SIGTERM', () => forwardSignal('SIGTERM'));
+
+async function removeImage() {
+  try {
+    await run('docker', ['image', 'rm', '--force', image], { stdio: 'ignore' });
+  } catch {
+    // Preserve the primary build/test failure when cleanup cannot run.
+  }
+}
+
+async function main() {
+  try {
+    const buildStatus = await run('docker', [
+      'build',
+      '--tag',
+      image,
+      '--file',
+      dockerfile,
+      repoRoot,
+    ]);
+    if (buildStatus !== 0) return interrupted ? 130 : buildStatus;
+    if (interrupted) return 130;
+    const testStatus = await run('docker', ['run', '--rm', '--init', '--network', 'none', image]);
+    return interrupted ? 130 : testStatus;
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      console.error('E2E setup failed: Docker is required but was not found on PATH.');
+    } else {
+      console.error(`E2E setup failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    return 1;
+  } finally {
+    await removeImage();
+  }
+}
+
+main().then((code) => {
+  process.exitCode = code;
+});

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
+
+ARG TMUX_VERSION=3.3a-3
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y "tmux=${TMUX_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install --global pnpm@10.33.0
+
+WORKDIR /workspace
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+
+CMD ["pnpm", "exec", "vitest", "run", "--config", "test/e2e/vitest.config.ts"]

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -16,10 +16,11 @@ export interface CliResult<T = unknown> {
 }
 
 export interface MockEvent {
-  event: string;
+  event: 'ready' | 'request' | 'response' | 'silent' | 'malformed' | 'stopped';
   message?: string;
   nonce?: string;
   mode?: string;
+  pid?: number;
 }
 
 function shellQuote(value: string): string {
@@ -38,6 +39,8 @@ export class E2EFixture {
   readonly wrapperDir = path.join(this.root, 'bin');
   readonly tmuxPath: string;
   pane = '';
+  panePid = 0;
+  serverPid = 0;
   socketPath = '';
   private started = false;
   private serverStarted = false;
@@ -59,7 +62,9 @@ export class E2EFixture {
     }
   }
 
-  start(options: { mode?: 'respond' | 'silent' | 'malformed'; delayMs?: number } = {}): void {
+  async start(
+    options: { mode?: 'respond' | 'silent' | 'malformed'; delayMs?: number } = {}
+  ): Promise<void> {
     try {
       fs.mkdirSync(this.workspace, { recursive: true });
       fs.mkdirSync(this.globalDir, { recursive: true });
@@ -97,13 +102,24 @@ export class E2EFixture {
       ]);
       this.serverStarted = true;
       this.socketPath = this.tmux(['display-message', '-p', '#{socket_path}']).trim();
+      this.serverPid = Number(this.tmux(['display-message', '-p', '#{pid}']).trim());
       this.pane = this.tmux(['display-message', '-p', '-t', 'e2e:0.0', '#{pane_id}']).trim();
+      this.panePid = Number(
+        this.tmux(['display-message', '-p', '-t', this.pane, '#{pane_pid}']).trim()
+      );
       if (!this.socketPath || !this.pane) {
         throw new Error('E2E fixture could not determine its socket path and mock-agent pane ID.');
       }
+      if (!Number.isInteger(this.panePid) || this.panePid <= 0) {
+        throw new Error('E2E fixture could not determine its mock-agent pane process ID.');
+      }
+      if (!Number.isInteger(this.serverPid) || this.serverPid <= 0) {
+        throw new Error('E2E fixture could not determine its private tmux server process ID.');
+      }
+      await this.waitForEvent((event) => event.event === 'ready');
       this.started = true;
     } catch (error) {
-      this.stop();
+      await this.stop();
       throw new Error(
         `E2E fixture failed to start its private tmux server: ${error instanceof Error ? error.message : String(error)}`,
         { cause: error }
@@ -113,7 +129,7 @@ export class E2EFixture {
 
   runCli<T = Record<string, unknown>>(args: string[]): Promise<CliResult<T>> {
     if (!this.started) throw new Error('E2E fixture must be started before invoking the CLI.');
-    const child = spawn(binPath, ['--json', ...args], {
+    const child = spawn(binPath, args, {
       cwd: this.workspace,
       env: { ...this.env, TMUX_PANE: this.pane },
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -144,12 +160,26 @@ export class E2EFixture {
     });
   }
 
+  runJsonCli<T = Record<string, unknown>>(args: string[]): Promise<CliResult<T>> {
+    return this.runCli<T>(['--json', ...args]);
+  }
+
   tmux(args: string[]): string {
     return execFileSync(path.join(this.wrapperDir, 'tmux'), args, {
       env: this.env,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+  }
+
+  paneTarget(pane = this.pane): string {
+    return this.tmux([
+      'display-message',
+      '-p',
+      '-t',
+      pane,
+      '#{session_name}:#{window_index}.#{pane_index}',
+    ]).trim();
   }
 
   events(): MockEvent[] {
@@ -162,7 +192,22 @@ export class E2EFixture {
       .map((line) => JSON.parse(line) as MockEvent);
   }
 
-  stop(): void {
+  async waitForEvent(
+    predicate: (event: MockEvent) => boolean,
+    timeoutMs = 2_000
+  ): Promise<MockEvent> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const event = this.events().find(predicate);
+      if (event) return event;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error(
+      `Timed out waiting for mock-agent event. Events: ${JSON.stringify(this.events())}`
+    );
+  }
+
+  async stop(): Promise<void> {
     if (this.serverStarted) {
       try {
         this.tmux(['kill-server']);
@@ -172,6 +217,7 @@ export class E2EFixture {
     }
     this.serverStarted = false;
     this.started = false;
+    await this.waitForProcessExit();
     fs.rmSync(this.root, { recursive: true, force: true });
     fs.rmSync(this.socketRoot, { recursive: true, force: true });
   }
@@ -179,12 +225,40 @@ export class E2EFixture {
   serverIsRunning(): boolean {
     if (!this.socketPath) return false;
     try {
-      execFileSync(this.tmuxPath, ['-S', this.socketPath, 'has-session', '-t', 'e2e'], {
+      execFileSync(this.tmuxPath, ['-S', this.socketPath, 'list-sessions'], {
         stdio: 'ignore',
       });
       return true;
     } catch {
+      return this.serverProcessIsRunning();
+    }
+  }
+
+  serverProcessIsRunning(): boolean {
+    if (!Number.isInteger(this.serverPid) || this.serverPid <= 0) return false;
+    try {
+      process.kill(this.serverPid, 0);
+      return true;
+    } catch {
       return false;
+    }
+  }
+
+  mockProcessIsRunning(): boolean {
+    if (!Number.isInteger(this.panePid) || this.panePid <= 0) return false;
+    try {
+      process.kill(this.panePid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async waitForProcessExit(timeoutMs = 2_000): Promise<void> {
+    if (!this.panePid) return;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline && this.mockProcessIsRunning()) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
     }
   }
 
@@ -221,10 +295,10 @@ export async function withE2EFixture<T>(
   options: { mode?: 'respond' | 'silent' | 'malformed'; delayMs?: number } = {}
 ): Promise<T> {
   const fixture = new E2EFixture();
-  fixture.start(options);
   try {
+    await fixture.start(options);
     return await callback(fixture);
   } finally {
-    fixture.stop();
+    await fixture.stop();
   }
 }

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -1,0 +1,230 @@
+import { execFileSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const binPath = path.join(repoRoot, 'bin', 'tmux-team');
+const mockAgentPath = path.join(repoRoot, 'test', 'e2e', 'mock-agent.mjs');
+
+export interface CliResult<T = unknown> {
+  code: number;
+  stdout: string;
+  stderr: string;
+  json?: T;
+}
+
+export interface MockEvent {
+  event: string;
+  message?: string;
+  nonce?: string;
+  mode?: string;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+export class E2EFixture {
+  readonly root = fs.mkdtempSync(path.join(os.tmpdir(), 'tmux-team-e2e-'));
+  readonly socketRoot = fs.mkdtempSync(
+    path.join(process.platform === 'darwin' ? '/private/tmp' : os.tmpdir(), 'te2e-')
+  );
+  readonly workspace = path.join(this.root, 'workspace');
+  readonly globalDir = path.join(this.root, 'global');
+  readonly logPath = path.join(this.root, 'mock-agent.jsonl');
+  readonly socket = `tmt-e2e-${process.pid}-${Math.random().toString(16).slice(2)}`;
+  readonly wrapperDir = path.join(this.root, 'bin');
+  readonly tmuxPath: string;
+  pane = '';
+  socketPath = '';
+  private started = false;
+  private serverStarted = false;
+  private env: NodeJS.ProcessEnv = {};
+
+  constructor() {
+    try {
+      this.tmuxPath = execFileSync('/bin/sh', ['-lc', 'command -v tmux'], {
+        encoding: 'utf8',
+      }).trim();
+      if (!this.tmuxPath) throw new Error('tmux was not found on PATH.');
+    } catch (error) {
+      fs.rmSync(this.root, { recursive: true, force: true });
+      fs.rmSync(this.socketRoot, { recursive: true, force: true });
+      throw new Error(
+        `E2E fixture requires tmux: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      );
+    }
+  }
+
+  start(options: { mode?: 'respond' | 'silent' | 'malformed'; delayMs?: number } = {}): void {
+    try {
+      fs.mkdirSync(this.workspace, { recursive: true });
+      fs.mkdirSync(this.globalDir, { recursive: true });
+      fs.mkdirSync(this.wrapperDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(this.wrapperDir, 'tmux'),
+        `#!/bin/sh\nexec ${shellQuote(this.tmuxPath)} -L "$TMT_E2E_SOCKET" "$@"\n`
+      );
+      fs.chmodSync(path.join(this.wrapperDir, 'tmux'), 0o755);
+
+      this.env = {
+        ...process.env,
+        PATH: `${this.wrapperDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        TMT_E2E_SOCKET: this.socket,
+        TMUX_TMPDIR: this.socketRoot,
+        TMUX_TEAM_HOME: this.globalDir,
+        TMT_MOCK_MODE: options.mode ?? 'respond',
+        TMT_MOCK_DELAY_MS: String(options.delayMs ?? 0),
+        TMT_MOCK_LOG: this.logPath,
+      };
+      delete this.env.TMUX;
+      delete this.env.TMUX_PANE;
+
+      this.tmux(['-V']);
+      this.tmux([
+        'new-session',
+        '-d',
+        '-s',
+        'e2e',
+        '-x',
+        '160',
+        '-y',
+        '50',
+        `${shellQuote(process.execPath)} ${shellQuote(mockAgentPath)}`,
+      ]);
+      this.serverStarted = true;
+      this.socketPath = this.tmux(['display-message', '-p', '#{socket_path}']).trim();
+      this.pane = this.tmux(['display-message', '-p', '-t', 'e2e:0.0', '#{pane_id}']).trim();
+      if (!this.socketPath || !this.pane) {
+        throw new Error('E2E fixture could not determine its socket path and mock-agent pane ID.');
+      }
+      this.started = true;
+    } catch (error) {
+      this.stop();
+      throw new Error(
+        `E2E fixture failed to start its private tmux server: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      );
+    }
+  }
+
+  runCli<T = Record<string, unknown>>(args: string[]): Promise<CliResult<T>> {
+    if (!this.started) throw new Error('E2E fixture must be started before invoking the CLI.');
+    const child = spawn(binPath, ['--json', ...args], {
+      cwd: this.workspace,
+      env: { ...this.env, TMUX_PANE: this.pane },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
+    child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
+    return new Promise<CliResult<T>>((resolve) => {
+      let settled = false;
+      child.once('error', (error) => {
+        if (settled) return;
+        settled = true;
+        stderr += `${error.message}\n`;
+        resolve({ code: 1, stdout, stderr });
+      });
+      child.on('close', (code) => {
+        if (settled) return;
+        settled = true;
+        let json: T | undefined;
+        try {
+          json = JSON.parse(stdout) as T;
+        } catch {
+          // The caller receives stdout/stderr for a useful assertion failure.
+        }
+        resolve({ code: code ?? 1, stdout, stderr, json });
+      });
+    });
+  }
+
+  tmux(args: string[]): string {
+    return execFileSync(path.join(this.wrapperDir, 'tmux'), args, {
+      env: this.env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  }
+
+  events(): MockEvent[] {
+    if (!fs.existsSync(this.logPath)) return [];
+    return fs
+      .readFileSync(this.logPath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as MockEvent);
+  }
+
+  stop(): void {
+    if (this.serverStarted) {
+      try {
+        this.tmux(['kill-server']);
+      } catch {
+        // The server may already have exited; cleanup remains best effort.
+      }
+    }
+    this.serverStarted = false;
+    this.started = false;
+    fs.rmSync(this.root, { recursive: true, force: true });
+    fs.rmSync(this.socketRoot, { recursive: true, force: true });
+  }
+
+  serverIsRunning(): boolean {
+    if (!this.socketPath) return false;
+    try {
+      execFileSync(this.tmuxPath, ['-S', this.socketPath, 'has-session', '-t', 'e2e'], {
+        stdio: 'ignore',
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  sendMockInput(lines: string[]): void {
+    for (const line of lines) {
+      execFileSync(
+        path.join(this.wrapperDir, 'tmux'),
+        ['send-keys', '-t', this.pane, '--', line, 'Enter'],
+        {
+          env: this.env,
+          stdio: 'ignore',
+        }
+      );
+    }
+  }
+
+  capture(lines = 100): string {
+    return this.tmux(['capture-pane', '-p', '-t', this.pane, '-S', `-${lines}`]);
+  }
+
+  async waitForCapture(predicate: (output: string) => boolean): Promise<string> {
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const output = this.capture();
+      if (predicate(output)) return output;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`Timed out waiting for mock-agent pane output.\n${this.capture()}`);
+  }
+}
+
+export async function withE2EFixture<T>(
+  callback: (fixture: E2EFixture) => Promise<T> | T,
+  options: { mode?: 'respond' | 'silent' | 'malformed'; delayMs?: number } = {}
+): Promise<T> {
+  const fixture = new E2EFixture();
+  fixture.start(options);
+  try {
+    return await callback(fixture);
+  } finally {
+    fixture.stop();
+  }
+}

--- a/test/e2e/mock-agent.mjs
+++ b/test/e2e/mock-agent.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import readline from 'node:readline';
+
+const mode = process.env.TMT_MOCK_MODE ?? 'respond';
+const delayMs = Number(process.env.TMT_MOCK_DELAY_MS ?? 0);
+const logPath = process.env.TMT_MOCK_LOG;
+
+function appendEvent(event) {
+  if (!logPath) return;
+  fs.appendFileSync(logPath, `${JSON.stringify(event)}\n`);
+}
+
+function respond(message, nonce) {
+  const output = `mock-agent response: ${message || '(empty)'}\nRESPONSE-END-${nonce}\n`;
+  process.stdout.write(output);
+}
+
+const input = readline.createInterface({ input: process.stdin, terminal: false });
+let messageLines = [];
+
+input.on('line', (line) => {
+  const instruction = line.match(
+    /^When done, output exactly: RESPONSE-END-xxxx \(where xxxx = ([A-Za-z0-9]+)\)$/
+  );
+  if (!instruction) {
+    if (line.length > 0) messageLines.push(line);
+    return;
+  }
+
+  const nonce = instruction[1];
+  const message = messageLines.join('\n').trim();
+  messageLines = [];
+  appendEvent({ event: 'request', message, nonce, mode });
+
+  if (mode === 'silent') return;
+  const send = () => respond(message, nonce);
+  if (mode === 'malformed') {
+    setTimeout(() => process.stdout.write(`mock-agent malformed response: ${message}\n`), delayMs);
+    return;
+  }
+  setTimeout(send, delayMs);
+});
+
+input.on('close', () => appendEvent({ event: 'stopped' }));

--- a/test/e2e/mock-agent.mjs
+++ b/test/e2e/mock-agent.mjs
@@ -14,11 +14,13 @@ function appendEvent(event) {
 
 function respond(message, nonce) {
   const output = `mock-agent response: ${message || '(empty)'}\nRESPONSE-END-${nonce}\n`;
-  process.stdout.write(output);
+  process.stdout.write(output, () => appendEvent({ event: 'response', message, nonce, mode }));
 }
 
 const input = readline.createInterface({ input: process.stdin, terminal: false });
 let messageLines = [];
+
+appendEvent({ event: 'ready', mode, pid: process.pid });
 
 input.on('line', (line) => {
   const instruction = line.match(
@@ -34,10 +36,19 @@ input.on('line', (line) => {
   messageLines = [];
   appendEvent({ event: 'request', message, nonce, mode });
 
-  if (mode === 'silent') return;
+  if (mode === 'silent') {
+    appendEvent({ event: 'silent', message, nonce, mode });
+    return;
+  }
   const send = () => respond(message, nonce);
   if (mode === 'malformed') {
-    setTimeout(() => process.stdout.write(`mock-agent malformed response: ${message}\n`), delayMs);
+    setTimeout(
+      () =>
+        process.stdout.write(`mock-agent malformed response: ${message}\n`, () =>
+          appendEvent({ event: 'malformed', message, nonce, mode })
+        ),
+      delayMs
+    );
     return;
   }
   setTimeout(send, delayMs);

--- a/test/e2e/smoke.e2e.test.ts
+++ b/test/e2e/smoke.e2e.test.ts
@@ -35,24 +35,85 @@ describe.sequential('Docker/Vitest tmux foundation smoke scenarios', () => {
           capture.includes('mock-agent response: hello from the foundation') &&
           capture.includes(`RESPONSE-END-${nonce}`)
       );
+      await fixture.waitForEvent((event) => event.event === 'response' && event.nonce === nonce);
 
-      expect(fixture.events()).toEqual([
-        { event: 'request', message: 'hello from the foundation', nonce, mode: 'respond' },
-      ]);
+      const events = fixture.events();
+      expect(events[0]).toEqual({
+        event: 'ready',
+        mode: 'respond',
+        pid: fixture.panePid,
+      });
+      expect(events).toContainEqual({
+        event: 'request',
+        message: 'hello from the foundation',
+        nonce,
+        mode: 'respond',
+      });
+      expect(events).toContainEqual({
+        event: 'response',
+        message: 'hello from the foundation',
+        nonce,
+        mode: 'respond',
+      });
       expect(output).toContain('mock-agent response: hello from the foundation');
     });
+  });
+
+  it('records a silent mock-agent lifecycle without fabricating a response', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const nonce = 'silent123';
+        fixture.sendMockInput([
+          'silent request',
+          '',
+          `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`,
+        ]);
+        await fixture.waitForEvent((event) => event.event === 'silent' && event.nonce === nonce);
+
+        const events = fixture.events();
+        expect(events.map((event) => event.event)).toEqual(['ready', 'request', 'silent']);
+        expect(fixture.capture()).not.toContain('mock-agent response: silent request');
+      },
+      { mode: 'silent' }
+    );
+  });
+
+  it('records malformed output separately from a valid response', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const nonce = 'malformed123';
+        fixture.sendMockInput([
+          'malformed request',
+          '',
+          `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`,
+        ]);
+        const output = await fixture.waitForCapture((capture) =>
+          capture.includes('mock-agent malformed response: malformed request')
+        );
+        await fixture.waitForEvent((event) => event.event === 'malformed' && event.nonce === nonce);
+
+        const events = fixture.events();
+        expect(events.map((event) => event.event)).toEqual(['ready', 'request', 'malformed']);
+        expect(output).not.toContain(`RESPONSE-END-${nonce}`);
+      },
+      { mode: 'malformed' }
+    );
   });
 
   it('keeps the canonical pane ID across a real tmux move', async () => {
     await withE2EFixture((fixture) => {
       const originalPane = fixture.pane;
+      const originalTarget = fixture.paneTarget(originalPane);
       const targetPane = fixture
         .tmux(['new-window', '-d', '-P', '-F', '#{pane_id}', '-t', 'e2e', '-n', 'sink', 'sleep 30'])
         .trim();
+      const targetWindow = fixture.paneTarget(targetPane);
       fixture.tmux(['move-pane', '-s', originalPane, '-t', targetPane]);
 
       expect(fixture.pane).toBe(originalPane);
-      expect(fixture.tmux(['list-panes', '-a']).trim()).toContain(originalPane);
+      expect(fixture.paneTarget(originalPane)).not.toBe(originalTarget);
+      expect(fixture.paneTarget(originalPane)).toContain(targetWindow.split('.')[0]);
+      expect(fixture.tmux(['list-panes', '-a', '-F', '#{pane_id}']).trim()).toContain(originalPane);
     });
   });
 
@@ -67,6 +128,7 @@ describe.sequential('Docker/Vitest tmux foundation smoke scenarios', () => {
 
     expect(failedFixture).toBeDefined();
     expect(failedFixture?.serverIsRunning()).toBe(false);
+    expect(failedFixture?.mockProcessIsRunning()).toBe(false);
     expect(fs.existsSync(failedFixture?.socketPath ?? '')).toBe(false);
     expect(fs.existsSync(failedFixture?.root ?? '')).toBe(false);
     expect(fs.existsSync(failedFixture?.socketRoot ?? '')).toBe(false);
@@ -79,5 +141,6 @@ describe.sequential('Docker/Vitest tmux foundation smoke scenarios', () => {
       expect(fixture.root).not.toBe(failedFixture?.root);
     });
     expect(secondFixture?.serverIsRunning()).toBe(false);
+    expect(secondFixture?.mockProcessIsRunning()).toBe(false);
   });
 });

--- a/test/e2e/smoke.e2e.test.ts
+++ b/test/e2e/smoke.e2e.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { E2EFixture, withE2EFixture } from './harness.js';
+
+describe.sequential('Docker/Vitest tmux foundation smoke scenarios', () => {
+  it('propagates real CLI stdout, stderr, and exit codes', async () => {
+    await withE2EFixture(async (fixture) => {
+      const version = await fixture.runCli(['--version']);
+      expect(version.code).toBe(0);
+      expect(version.stdout.trim()).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+
+      const help = await fixture.runCli(['--help']);
+      expect(help.code).toBe(0);
+      expect(help.stdout.toLowerCase()).toContain('tmux-team');
+
+      const invalid = await fixture.runCli(['definitely-not-a-command']);
+      expect(invalid.code).not.toBe(0);
+      expect(invalid.stderr.toLowerCase()).toContain('unknown command');
+    });
+  });
+
+  it('transports deterministic mock-agent input/output through real tmux', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect(fixture.serverIsRunning()).toBe(true);
+      expect(fixture.tmux(['list-panes', '-a']).trim()).toContain(fixture.pane);
+
+      const nonce = 'foundation123';
+      fixture.sendMockInput([
+        'hello from the foundation',
+        '',
+        `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`,
+      ]);
+      const output = await fixture.waitForCapture(
+        (capture) =>
+          capture.includes('mock-agent response: hello from the foundation') &&
+          capture.includes(`RESPONSE-END-${nonce}`)
+      );
+
+      expect(fixture.events()).toEqual([
+        { event: 'request', message: 'hello from the foundation', nonce, mode: 'respond' },
+      ]);
+      expect(output).toContain('mock-agent response: hello from the foundation');
+    });
+  });
+
+  it('keeps the canonical pane ID across a real tmux move', async () => {
+    await withE2EFixture((fixture) => {
+      const originalPane = fixture.pane;
+      const targetPane = fixture
+        .tmux(['new-window', '-d', '-P', '-F', '#{pane_id}', '-t', 'e2e', '-n', 'sink', 'sleep 30'])
+        .trim();
+      fixture.tmux(['move-pane', '-s', originalPane, '-t', targetPane]);
+
+      expect(fixture.pane).toBe(originalPane);
+      expect(fixture.tmux(['list-panes', '-a']).trim()).toContain(originalPane);
+    });
+  });
+
+  it('cleans the private server and files after a thrown scenario error', async () => {
+    let failedFixture: E2EFixture | undefined;
+    await expect(
+      withE2EFixture((fixture) => {
+        failedFixture = fixture;
+        throw new Error('simulated scenario failure');
+      })
+    ).rejects.toThrow('simulated scenario failure');
+
+    expect(failedFixture).toBeDefined();
+    expect(failedFixture?.serverIsRunning()).toBe(false);
+    expect(fs.existsSync(failedFixture?.socketPath ?? '')).toBe(false);
+    expect(fs.existsSync(failedFixture?.root ?? '')).toBe(false);
+    expect(fs.existsSync(failedFixture?.socketRoot ?? '')).toBe(false);
+
+    let secondFixture: E2EFixture | undefined;
+    await withE2EFixture((fixture) => {
+      secondFixture = fixture;
+      expect(fixture.serverIsRunning()).toBe(true);
+      expect(fixture.socket).not.toBe(failedFixture?.socket);
+      expect(fixture.root).not.toBe(failedFixture?.root);
+    });
+    expect(secondFixture?.serverIsRunning()).toBe(false);
+  });
+});

--- a/test/e2e/vitest.config.ts
+++ b/test/e2e/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/e2e/**/*.e2e.test.ts'],
+    exclude: ['node_modules', 'dist'],
+    fileParallelism: false,
+    testTimeout: 15_000,
+    hookTimeout: 5_000,
+    maxConcurrency: 1,
+    sequence: { concurrent: false, shuffle: false },
+    reporters: ['default'],
+    coverage: { enabled: false },
+  },
+});

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["test/e2e/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['test/e2e/**', 'node_modules', 'dist'],
     testTimeout: 1000,
     coverage: {
       all: true,


### PR DESCRIPTION
## Summary

- add a Docker-backed Vitest E2E harness using the real TMT CLI and an isolated real tmux server
- use a deterministic mock agent with explicit ready, request, response, silent, and malformed lifecycle events
- verify canonical pane IDs survive tmux moves and assert server, process, socket, container, and image cleanup
- add a repository-local E2E skill and an AGENTS.md pattern-audit working agreement
- include E2E type, lint, and formatting validation in the standard check command

## Scope

This PR establishes test infrastructure only. It does not add v5 identity semantics, daemon behavior, persistence, or real-agent integration. Feature lifecycle scenarios remain tracked separately in TMT-7.

## Verification

- pnpm check
- pnpm test:run — 301 tests passed; 91.98% statements and 85.27% branches
- pnpm test:e2e — 6 scenarios passed twice consecutively
- post-run audit confirmed no E2E Docker images, containers, or temporary tmux socket roots remained

Linear: TMT-6