### PR TITLE
ci: add required pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-quality:
+    name: Code quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.2
+      - name: Activate pinned pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run code quality checks
+        run: pnpm check
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.2
+      - name: Activate pinned pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run unit tests and coverage checks
+        run: pnpm test:run
+
+  docker-e2e:
+    name: Docker E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.2
+      - name: Activate pinned pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run Docker end-to-end tests
+        run: pnpm test:e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,14 @@ The primary agent must review the findings before any edits begin, record which 
 
 If delegation is unavailable, document that limitation and perform the same read-only audit locally before editing. Delegation never expands the user's authorization.
 
+## Repository content language
+
+All repository content must be written in English, including code, tests,
+comments, documentation, configuration, workflows, repository skills, commit
+messages, and pull request metadata. Non-language symbols and technically
+required fixture data are allowed when necessary; explain any such exception
+in English.
+
 ## Code organization
 
 - Keep production behavior, test infrastructure, fixtures, and scenario assertions in clearly separated modules.


### PR DESCRIPTION
## Summary

- add three independent pull-request checks for code quality, unit coverage, and Docker E2E
- use standard ubuntu-latest runners with read-only permissions and bounded job timeouts
- cancel superseded runs for the same pull request
- document the repository-wide English-only content rule in AGENTS.md

## Check contract

- Code quality runs pnpm check, including TypeScript, Oxlint, and Prettier
- Unit tests runs pnpm test:run, including the 90% statement and 85% branch thresholds
- Docker E2E runs pnpm test:e2e against the real CLI and isolated real tmux with deterministic mock agents

## Scope

This stacked PR targets the TMT-6 branch so the workflow itself can be verified before PR #36 is merged. It adds no product behavior, daemon, persistence, deployment, artifact upload, secrets, cache, or larger runner.

## Local verification

- pnpm check
- pnpm test:run — 301 tests passed; 91.98% statements and 85.27% branches
- pnpm test:e2e — 6 scenarios passed
- pinned Node 22.23.2 Corepack activation produced pnpm 10.33.0
- workflow YAML parse and git diff checks passed

Linear: TMT-8