### PR TITLE
TMT-3: Add global pane identity commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,32 +20,36 @@ once-daily cached update check, while local drift checks work without network.
 
 **Alias:** `tmt` (shorthand for `tmux-team`)
 
-## What's new in 4.3
+## What's new in 5.0
 
-- `tmt name <name>` labels a pane in its border using tmux highlight colors.
+- `tmt name <global-name>` assigns a global identity to the current pane.
+- `tmt this <global-name>` remains a supported, exact alias for `tmt name`.
+- `tmt add <pane-target> <global-name>` assigns an identity to an explicit pane
+  after resolving the target to tmux's stable `%pane_id`.
+- `tmt whoami` and `tmt unbind` inspect and remove the current pane's identity.
 - Multiline messages now preserve real line breaks when delivered.
 - Skills can be installed and refreshed with `tmt install` and `tmt upgrade`.
 
 ## Quick Start
 
 ```bash
-# 1. Go to working folder and register agents (run inside each agent's pane)
-tmt this claude      # registers current pane as "claude"
-tmt this codex       # registers current pane as "codex"
-# Alternatively, register a specific panel to the session
-tmt add gemini 10.1  # register a panel 10.1 as "gemini"
+# 1. Assign global identities (run inside each agent's pane)
+tmt name claude      # binds the current pane as "claude"
+tmt this codex       # exact alias for `tmt name codex`
+# Or bind an explicit pane target; it is stored by stable `%pane_id`
+tmt add 10.1 gemini
 
 # 2. Talk to agents
 tmt talk codex "Review this code"    # waits for response by default
 
-# 4. Update or remove an agent
-tmt update codex --pane 2.3
-tmt rm codex
+# 4. Inspect or remove the current pane's identity
+tmt whoami
+tmt unbind
 
 # List panels in the session
 tmt ls 
 
-# Name the current pane (shown at the upper-right of its border)
+# `name` is an identity command; any title update is only a best-effort side effect.
 tmt name backend
 ```
 
@@ -53,11 +57,15 @@ tmt name backend
 
 ### How scopes work
 
-Registrations live in tmux pane metadata, not in a JSON file you have to track.
-By default they are scoped to the current **workspace** — the nearest Git root,
-or the current folder when you are not inside a Git repo. So `tmt this`,
-`tmt add`, `tmt rm`, `tmt update`, `tmt preamble`, and `tmt list` all act on
-the workspace you are currently in.
+Global identities live in tmux pane metadata, not in a JSON file you have to
+track. `tmt name`, `tmt this`, and `tmt add` write the same global identity
+record, independent of the current working folder. `tmt whoami` and `tmt unbind`
+operate on the current pane. The identity name may be an undeclared name; it
+does not need to match a configured agent role. Each pane has at most one
+global identity and each global name identifies at most one pane.
+
+Shared-team and workspace-scoped registrations remain separate from this
+global identity contract.
 
 Reach for `--team <name>` only when you want an explicit shared team that spans
 folders (see [Shared Teams](#shared-teams)).
@@ -69,7 +77,7 @@ workspace you can add an agent whose pane lives in another project:
 
 ```bash
 # In project-a folder, add an agent that's running in project-b
-tmt add codex-reviewer 5.1    # Use the pane ID from the other project
+tmt add 5.1 codex-reviewer    # The target is resolved and stored as `%pane_id`
 ```
 
 Find pane IDs with: `tmux display-message -p "#{pane_id}"`
@@ -84,8 +92,11 @@ visible on both sides, use a [shared team](#shared-teams).
 |---------|-------------|
 | `install [claude\|codex\|gemini\|all]` | Install or repair agent integrations |
 | `upgrade` | Upgrade tmux-team; managed skill links update automatically |
-| `this <name> [remark]` | Register current pane as an agent |
-| `name <name> [pane]` | Set a pane title, shown upper-right in its border |
+| `name <global-name>` | Bind the current pane to a global identity |
+| `this <global-name>` | Exact supported alias for `name` |
+| `add <pane-target> <global-name>` | Bind an explicit pane to a global identity |
+| `whoami` | Show the current pane's global identity, if any |
+| `unbind` | Remove the current pane's global identity |
 | `talk <agent> "msg"` | Send message and wait for response |
 | `talk all "msg"` | Broadcast to all agents |
 | `check <agent> [lines]` | Read agent's pane output |
@@ -104,10 +115,14 @@ visible on both sides, use a [shared team](#shared-teams).
 
 Run `tmt help` for all commands and options.
 
-`tmt name <name> [pane]` sets a visible title on the current pane, or on the
-specified tmux pane target (`%pane_id`, `window.pane`, or `session:window.pane`).
-The title appears in the upper-right of the pane border and inherits tmux's
-active/inactive pane-border highlight colors.
+`tmt name <global-name>` binds the current pane to a global identity.
+`tmt this <global-name>` has exactly the same behavior and is not deprecated.
+Use `tmt add <pane-target> <global-name>` to bind another pane; targets may be
+`%pane_id`, `window.pane`, or `session:window.pane`, and are stored by the
+resolved stable `%pane_id`. `tmt whoami` reports the current binding and
+`tmt unbind` removes only the current pane's binding. A pane title may be
+updated as a best-effort presentation side effect, but titles are not the
+identity API and there is no panel-title command.
 
 ## Message Delivery
 
@@ -172,11 +187,11 @@ tmt team panes        # grouped pane inventory
 tmt team panes --json # { teams, panes } incl. each pane's registrations
 ```
 
-**Add an agent from any pane.** Targets can be `%pane_id`, `window.pane`, or
-`session:window.pane`; tmux-team stores the canonical `%pane_id`.
+**Add an identity from any pane.** Targets can be `%pane_id`, `window.pane`, or
+`session:window.pane`; tmux-team resolves and stores the canonical `%pane_id`.
 
 ```bash
-tmt add codex 1.1 "Code reviewer"
+tmt add 1.1 codex
 ```
 
 **Remove an agent** from the current scope:
@@ -253,7 +268,7 @@ tmt talk all "Starting deploy - heads up" --team myproject
 **Single project** (default) — agents work in the same folder:
 ```bash
 tmt this claude
-tmt add codex 1.1
+tmt add 1.1 codex
 ```
 
 **Shared team** — agents work across folders but collaborate:

--- a/plugins/tmux-team/commands/team.md
+++ b/plugins/tmux-team/commands/team.md
@@ -21,7 +21,11 @@ To broadcast to all agents:
 
 To see available agents:
   tmt list
-  tmt name <name> [pane]
+  tmt name <global-name>
+  tmt this <global-name>
+  tmt add <pane-target> <global-name>
+  tmt whoami
+  tmt unbind
   tmt team ls <team>
 
 ## Examples

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -26,7 +26,11 @@ tmt talk all "message for everyone" --wait
 
 # List configured agents
 tmt list
-tmt name backend
+tmt name backend                 # bind the current pane globally
+tmt this reviewer                # exact alias for `name`
+tmt add %12 backend              # bind an explicit pane by stable pane ID
+tmt whoami
+tmt unbind
 tmt team add project codex %12
 ```
 
@@ -43,8 +47,9 @@ tmux-team talk codex "Review this authentication code" --wait
 
 - Use `--wait` when the user needs a response before continuing; use `check`
   after a timeout or for polling.
-- `tmt name` sets a visible pane title. `team` commands manage registrations
-  shared across folders; ordinary commands use the current workspace.
+- `tmt name` binds a global identity; `tmt this` is its exact supported alias.
+  `tmt whoami` inspects the current binding and `tmt unbind` removes it. `team`
+  commands manage the separate shared-team material documented below.
 - Preserve multiline text. Sending input to another pane is an external action
   and requires user authorization; do not infer permission to send commands.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;

--- a/skills/README.md
+++ b/skills/README.md
@@ -46,7 +46,11 @@ tmt install codex
 tmt install gemini
 ```
 
-After installation, run `tmux-team add <name> <pane>` to register your agents, or use `tmux-team this <name>` inside each agent's tmux pane.
+After installation, use `tmux-team name <global-name>` (or its exact `this`
+alias) inside each agent's tmux pane. To bind another pane, run
+`tmux-team add <pane-target> <global-name>`; targets are resolved to stable
+tmux `%pane_id` values. Use `tmux-team whoami` to inspect the current identity
+and `tmux-team unbind` to remove it.
 
 ## Claude Code
 

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -31,9 +31,19 @@ tmt check gemini 200
 
 # List all configured agents
 tmt list
-tmt name backend
+tmt name backend                 # bind the current pane globally
+tmt this reviewer                # exact alias for `name`
+tmt add %12 backend              # bind an explicit pane by stable pane ID
+tmt whoami
+tmt unbind
 tmt team panes
 ```
+
+Global identities are independent of the current folder. Names may be
+undeclared; they do not need a configured role. `tmt add` resolves `%pane_id`,
+`window.pane`, or `session:window.pane` targets before storing the stable pane
+ID. Pane-title updates are best-effort presentation side effects only; there is
+no panel-title command or daemon.
 
 ## Workflow
 

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -31,9 +31,19 @@ tmt check gemini 200
 
 # List all configured agents
 tmt list
-tmt name backend
+tmt name backend                 # bind the current pane globally
+tmt this reviewer                # exact alias for `name`
+tmt add %12 backend              # bind an explicit pane by stable pane ID
+tmt whoami
+tmt unbind
 tmt team panes
 ```
+
+Global identities are independent of the current folder. Names may be
+undeclared; they do not need a configured role. `tmt add` resolves `%pane_id`,
+`window.pane`, or `session:window.pane` targets before storing the stable pane
+ID. Pane-title updates are best-effort presentation side effects only; there is
+no panel-title command or daemon.
 
 ## Workflow
 

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -11,9 +11,11 @@ Use `tmt` (the short alias for `tmux-team`) when the user asks you to communicat
 
 ```bash
 tmt list
-tmt name <pane-name> [pane]          # label a pane
-tmt this <agent-name> [remark]       # register the current pane
-tmt add <agent-name> <pane> [remark]
+tmt name <global-name>               # bind the current pane globally
+tmt this <global-name>               # exact supported alias for `name`
+tmt add <pane-target> <global-name>  # bind an explicit pane by stable `%pane_id`
+tmt whoami                            # show the current pane identity
+tmt unbind                            # remove the current pane identity
 tmt talk <agent> "message"           # `all` broadcasts
 tmt check <agent> [lines]
 tmt team add <team> <agent> [pane]
@@ -21,6 +23,12 @@ tmt team panes
 tmt install [claude|codex|gemini|all]
 tmt upgrade
 ```
+
+`name`, `this`, and `add` manage one global identity per pane. Names can be
+undeclared identities; they do not need to match a configured role. `add`
+accepts `%pane_id`, `window.pane`, or `session:window.pane` and stores the
+resolved stable `%pane_id`. There is no daemon. A pane title update is only a
+best-effort side effect and is not a separate command or API.
 
 `talk` sends text to another pane and can cause external input there. Only use it when the user has requested that communication or the surrounding task clearly authorizes it; do not infer permission for unrelated changes. Use `--wait` to wait for a response, `--timeout <seconds>` to bound the wait, and `--delay <seconds>` to delay sending.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -40,6 +40,9 @@ function makeStubContext(): Context {
       listTeams: vi.fn(() => ({})),
       listTeamPanes: vi.fn(() => []),
       removeTeam: vi.fn(() => ({ removed: 0, agents: [] })),
+      listGlobalIdentities: vi.fn(() => []),
+      setGlobalIdentity: vi.fn(),
+      clearGlobalIdentity: vi.fn(() => false),
     },
     paths: {
       globalDir: '/g',
@@ -219,7 +222,7 @@ describe('cli', () => {
 
   it('routes this command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'this', 'myagent', 'remark'];
+    process.argv = ['node', 'cli', 'this', 'myagent'];
 
     const ctx = makeStubContext();
     const thisSpy = vi.fn();
@@ -233,13 +236,13 @@ describe('cli', () => {
     await import('./cli.js');
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(thisSpy).toHaveBeenCalledWith(ctx, 'myagent', 'remark');
+    expect(thisSpy).toHaveBeenCalledWith(ctx, 'myagent');
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it('routes name command with an optional pane target', async () => {
+  it('routes name command as a current-pane identity binding', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'name', 'backend', 'main:1.2'];
+    process.argv = ['node', 'cli', 'name', 'backend'];
 
     const ctx = makeStubContext();
     const nameSpy = vi.fn();
@@ -253,7 +256,7 @@ describe('cli', () => {
     await import('./cli.js');
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(nameSpy).toHaveBeenCalledWith(ctx, 'backend', 'main:1.2');
+    expect(nameSpy).toHaveBeenCalledWith(ctx, 'backend');
   });
 
   it('errors when name command has missing or extra arguments', async () => {
@@ -272,7 +275,24 @@ describe('cli', () => {
     await import('./cli.js');
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team name <name> [pane]');
+    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team name <global-name>');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('errors when name command has no name', async () => {
+    vi.resetModules();
+    process.argv = ['node', 'cli', 'name'];
+    const ctx = makeStubContext();
+    const exitSpy = vi.fn();
+    ctx.exit = exitSpy as any;
+    vi.doMock('./context.js', () => ({
+      createContext: () => ctx,
+      ExitCodes: { SUCCESS: 0, ERROR: 1 },
+    }));
+    vi.doMock('./commands/name.js', () => ({ cmdName: vi.fn() }));
+    await import('./cli.js');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team name <global-name>');
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
@@ -292,7 +312,73 @@ describe('cli', () => {
     await import('./cli.js');
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team this <name> [remark]');
+    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team this <global-name>');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('errors when this command has an extra argument', async () => {
+    vi.resetModules();
+    process.argv = ['node', 'cli', 'this', 'backend', 'extra'];
+    const ctx = makeStubContext();
+    const exitSpy = vi.fn();
+    ctx.exit = exitSpy as any;
+    vi.doMock('./context.js', () => ({
+      createContext: () => ctx,
+      ExitCodes: { SUCCESS: 0, ERROR: 1 },
+    }));
+    vi.doMock('./commands/this.js', () => ({ cmdThis: vi.fn() }));
+    await import('./cli.js');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team this <global-name>');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('routes whoami without arguments', async () => {
+    vi.resetModules();
+    process.argv = ['node', 'cli', 'whoami'];
+    const ctx = makeStubContext();
+    const whoamiSpy = vi.fn();
+    vi.doMock('./context.js', () => ({
+      createContext: () => ctx,
+      ExitCodes: { SUCCESS: 0, ERROR: 1 },
+    }));
+    vi.doMock('./commands/whoami.js', () => ({ cmdWhoami: whoamiSpy }));
+    await import('./cli.js');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(whoamiSpy).toHaveBeenCalledWith(ctx);
+  });
+
+  it('routes unbind without arguments', async () => {
+    vi.resetModules();
+    process.argv = ['node', 'cli', 'unbind'];
+    const ctx = makeStubContext();
+    const unbindSpy = vi.fn();
+    vi.doMock('./context.js', () => ({
+      createContext: () => ctx,
+      ExitCodes: { SUCCESS: 0, ERROR: 1 },
+    }));
+    vi.doMock('./commands/unbind.js', () => ({ cmdUnbind: unbindSpy }));
+    await import('./cli.js');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(unbindSpy).toHaveBeenCalledWith(ctx);
+  });
+
+  it.each(['whoami', 'unbind'])('rejects arguments for %s', async (command) => {
+    vi.resetModules();
+    process.argv = ['node', 'cli', command, 'extra'];
+    const ctx = makeStubContext();
+    const exitSpy = vi.fn();
+    ctx.exit = exitSpy as any;
+    vi.doMock('./context.js', () => ({
+      createContext: () => ctx,
+      ExitCodes: { SUCCESS: 0, ERROR: 1 },
+    }));
+    vi.doMock(`./commands/${command}.js`, () => ({
+      [command === 'whoami' ? 'cmdWhoami' : 'cmdUnbind']: vi.fn(),
+    }));
+    await import('./cli.js');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ctx.ui.error).toHaveBeenCalledWith(`Usage: tmux-team ${command}`);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
@@ -370,7 +456,7 @@ describe('cli', () => {
 
   it('routes add command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'add', 'myagent', '1.0', 'remark'];
+    process.argv = ['node', 'cli', 'add', '1.0', 'myagent'];
 
     const ctx = makeStubContext();
     const addSpy = vi.fn();
@@ -383,7 +469,27 @@ describe('cli', () => {
     await import('./cli.js');
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(addSpy).toHaveBeenCalledWith(ctx, 'myagent', '1.0', 'remark');
+    expect(addSpy).toHaveBeenCalledWith(ctx, '1.0', 'myagent');
+  });
+
+  it.each([
+    ['missing', ['node', 'cli', 'add', '1.0']],
+    ['extra', ['node', 'cli', 'add', '1.0', 'backend', 'remark']],
+  ])('rejects add command with %s arguments', async (_case, argv) => {
+    vi.resetModules();
+    process.argv = argv;
+    const ctx = makeStubContext();
+    const exitSpy = vi.fn();
+    ctx.exit = exitSpy as any;
+    vi.doMock('./context.js', () => ({
+      createContext: () => ctx,
+      ExitCodes: { SUCCESS: 0, ERROR: 1 },
+    }));
+    vi.doMock('./commands/add.js', () => ({ cmdAdd: vi.fn() }));
+    await import('./cli.js');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team add <pane-target> <global-name>');
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it('routes config command', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,8 @@ import { cmdMigrate } from './commands/migrate.js';
 import { cmdTeam } from './commands/team.js';
 import { cmdName } from './commands/name.js';
 import { cmdUpgrade } from './commands/upgrade.js';
+import { cmdWhoami } from './commands/whoami.js';
+import { cmdUnbind } from './commands/unbind.js';
 import { runStartupChecks } from './update-check.js';
 
 // ─────────────────────────────────────────────────────────────
@@ -156,7 +158,17 @@ function main(): void {
   const ctx = createContext({ argv, flags });
 
   // Warn if not in tmux for commands that require it
-  const TMUX_REQUIRED_COMMANDS = ['talk', 'send', 'check', 'read', 'this', 'name'];
+  const TMUX_REQUIRED_COMMANDS = [
+    'talk',
+    'send',
+    'check',
+    'read',
+    'this',
+    'name',
+    'add',
+    'whoami',
+    'unbind',
+  ];
   if (!process.env.TMUX && TMUX_REQUIRED_COMMANDS.includes(command)) {
     ctx.ui.warn('Not running inside tmux. Some features may not work.');
   }
@@ -178,11 +190,11 @@ function main(): void {
         break;
 
       case 'add':
-        if (args.length < 2) {
-          ctx.ui.error('Usage: tmux-team add <name> <pane> [remark]');
+        if (args.length !== 2) {
+          ctx.ui.error('Usage: tmux-team add <pane-target> <global-name>');
           ctx.exit(ExitCodes.ERROR);
         }
-        cmdAdd(ctx, args[0], args[1], args[2]);
+        cmdAdd(ctx, args[0], args[1]);
         break;
 
       case 'update':
@@ -225,19 +237,35 @@ function main(): void {
         break;
 
       case 'this':
-        if (args.length < 1) {
-          ctx.ui.error('Usage: tmux-team this <name> [remark]');
+        if (args.length !== 1) {
+          ctx.ui.error('Usage: tmux-team this <global-name>');
           ctx.exit(ExitCodes.ERROR);
         }
-        cmdThis(ctx, args[0], args[1]);
+        cmdThis(ctx, args[0]);
         break;
 
       case 'name':
-        if (args.length < 1 || args.length > 2) {
-          ctx.ui.error('Usage: tmux-team name <name> [pane]');
+        if (args.length !== 1) {
+          ctx.ui.error('Usage: tmux-team name <global-name>');
           ctx.exit(ExitCodes.ERROR);
         }
-        cmdName(ctx, args[0], args[1]);
+        cmdName(ctx, args[0]);
+        break;
+
+      case 'whoami':
+        if (args.length !== 0) {
+          ctx.ui.error('Usage: tmux-team whoami');
+          ctx.exit(ExitCodes.ERROR);
+        }
+        cmdWhoami(ctx);
+        break;
+
+      case 'unbind':
+        if (args.length !== 0) {
+          ctx.ui.error('Usage: tmux-team unbind');
+          ctx.exit(ExitCodes.ERROR);
+        }
+        cmdUnbind(ctx);
         break;
 
       case 'talk':

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -3,38 +3,12 @@
 // ─────────────────────────────────────────────────────────────
 
 import type { Context } from '../types.js';
-import { ExitCodes } from '../exits.js';
-import { getRegistryScope, registrationFromEntry } from '../registry.js';
+import { bindIdentity, failIdentity, resolvePane } from './global-identity.js';
 
-export function cmdAdd(ctx: Context, name: string, pane: string, remark?: string): void {
-  const { ui, config, tmux, flags, exit } = ctx;
-
-  if (config.paneRegistry[name]) {
-    ui.error(`Agent '${name}' already exists. Use 'tmux-team update' to modify.`);
-    exit(ExitCodes.ERROR);
-  }
-
-  const resolvedPane = tmux.resolvePaneTarget(pane);
+export function cmdAdd(ctx: Context, pane: string, name: string): void {
+  const resolvedPane = resolvePane(ctx, pane);
   if (!resolvedPane) {
-    ui.error(`Pane '${pane}' not found. Is tmux running?`);
-    exit(ExitCodes.PANE_NOT_FOUND);
+    failIdentity(ctx, 'PANE_NOT_FOUND', `Pane '${pane}' not found. Is tmux running?`);
   }
-  const paneId = resolvedPane as string;
-
-  const scope = getRegistryScope(ctx);
-  const registration = registrationFromEntry(name, {
-    pane: paneId,
-    ...(remark !== undefined && { remark }),
-  });
-  tmux.setAgentRegistration(paneId, scope, registration);
-
-  if (flags.json) {
-    ui.json({ added: name, pane: paneId, remark, team: flags.team });
-  } else {
-    if (flags.team) {
-      ui.success(`Added agent '${name}' to team "${flags.team}" at pane ${paneId}`);
-    } else {
-      ui.success(`Added agent '${name}' at pane ${paneId}`);
-    }
-  }
+  bindIdentity(ctx, resolvedPane, name);
 }

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -48,6 +48,9 @@ function createMockTmux(): Tmux {
     listTeams: vi.fn(() => ({})),
     listTeamPanes: vi.fn(() => []),
     removeTeam: vi.fn(() => ({ removed: 0, agents: [] })),
+    listGlobalIdentities: vi.fn(() => []),
+    setGlobalIdentity: vi.fn(),
+    clearGlobalIdentity: vi.fn(() => false),
   };
 }
 
@@ -124,38 +127,33 @@ describe('basic commands', () => {
     expect((ctx.ui as any).jsonCalls[0]).toMatchObject({ created: ctx.paths.localConfig });
   });
 
-  it('cmdAdd writes new agent to tmux metadata', () => {
+  it('cmdAdd writes global identity metadata', () => {
     const ctx = createCtx(testDir);
-    cmdAdd(ctx, 'codex', '1.1', 'review');
-    expect(ctx.tmux.setAgentRegistration).toHaveBeenCalledWith(
-      '1.1',
-      expect.objectContaining({ type: 'workspace' }),
-      { name: 'codex', remark: 'review' }
-    );
+    cmdAdd(ctx, '1.1', 'codex');
+    expect(ctx.tmux.setGlobalIdentity).toHaveBeenCalledWith('1.1', 'codex');
   });
 
   it('cmdAdd errors if agent exists', () => {
     const ctx = createCtx(testDir, { config: { paneRegistry: { codex: { pane: '1.1' } } } });
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({ codex: { pane: '1.1' } }, null, 2));
-    expect(() => cmdAdd(ctx, 'codex', '1.1')).toThrow(`exit(${ExitCodes.ERROR})`);
+    (ctx.tmux.listGlobalIdentities as ReturnType<typeof vi.fn>).mockReturnValue([
+      { name: 'codex', canonicalName: 'codex', paneId: '1.1' },
+    ]);
+    expect(() => cmdAdd(ctx, '1.1', 'other')).toThrow(`exit(${ExitCodes.CONFLICT})`);
   });
 
   it('cmdThis registers current pane with given name', () => {
     const ctx = createCtx(testDir);
     (ctx.tmux.getCurrentPaneId as ReturnType<typeof vi.fn>).mockReturnValue('%5');
-    cmdThis(ctx, 'myagent', 'test remark');
-    expect(ctx.tmux.setAgentRegistration).toHaveBeenCalledWith(
-      '%5',
-      expect.objectContaining({ type: 'workspace' }),
-      { name: 'myagent', remark: 'test remark' }
-    );
+    cmdThis(ctx, 'myagent');
+    expect(ctx.tmux.setGlobalIdentity).toHaveBeenCalledWith('%5', 'myagent');
   });
 
   it('cmdThis errors when not in tmux', () => {
     const ctx = createCtx(testDir);
     (ctx.tmux.getCurrentPaneId as ReturnType<typeof vi.fn>).mockReturnValue(null);
-    expect(() => cmdThis(ctx, 'myagent')).toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(ctx.ui.error).toHaveBeenCalledWith('Not running inside tmux.');
+    expect(() => cmdThis(ctx, 'myagent')).toThrow(`exit(${ExitCodes.PANE_NOT_FOUND})`);
+    expect(ctx.ui.error).toHaveBeenCalledWith('Not running inside a resolvable tmux pane.');
   });
 
   it('cmdThis outputs JSON when --json flag set', () => {
@@ -163,7 +161,11 @@ describe('basic commands', () => {
     (ctx.tmux.getCurrentPaneId as ReturnType<typeof vi.fn>).mockReturnValue('%3');
     cmdThis(ctx, 'jsonagent');
     expect((ctx.ui as any).jsonCalls.length).toBe(1);
-    expect((ctx.ui as any).jsonCalls[0]).toMatchObject({ added: 'jsonagent', pane: '%3' });
+    expect((ctx.ui as any).jsonCalls[0]).toMatchObject({
+      bound: true,
+      name: 'jsonagent',
+      pane: '%3',
+    });
   });
 
   it('cmdRemove deletes agent', () => {
@@ -881,11 +883,18 @@ describe('basic commands', () => {
   it('cmdCompletion prints scripts', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     cmdCompletion('bash');
-    expect(logSpy.mock.calls.join('\n')).toContain('complete -F _tmux_team');
+    const bashOutput = logSpy.mock.calls.join('\n');
+    expect(bashOutput).toContain('complete -F _tmux_team');
+    expect(bashOutput).toContain('name this whoami unbind');
 
     logSpy.mockClear();
     cmdCompletion('zsh');
-    expect(logSpy.mock.calls.join('\n')).toContain('#compdef tmux-team');
+    const zshOutput = logSpy.mock.calls.join('\n');
+    expect(zshOutput).toContain('#compdef tmux-team');
+    expect(zshOutput).toContain('name:Bind the current pane identity');
+    expect(zshOutput).toContain('this:Bind the current pane identity');
+    expect(zshOutput).toContain('whoami:Show the current pane identity');
+    expect(zshOutput).toContain('unbind:Remove the current pane identity');
 
     logSpy.mockClear();
     cmdCompletion();
@@ -897,6 +906,11 @@ describe('basic commands', () => {
     cmdHelp({ mode: 'polling', showIntro: true });
     cmdHelp({ mode: 'wait', timeout: 10 });
     cmdLearn();
-    expect(logSpy).toHaveBeenCalled();
+    const output = logSpy.mock.calls.join('\n');
+    expect(output).toContain('add <pane-target> <global-name>');
+    expect(output).toContain('this <global-name>');
+    expect(output).toContain('name <global-name>');
+    expect(output).toContain('whoami');
+    expect(output).toContain('unbind');
   });
 });

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -18,7 +18,10 @@ _tmux-team() {
     'remove:Remove an agent'
     'migrate:Copy legacy tmux-team.json registry into tmux metadata'
     'team:Manage shared teams'
-    'name:Set a visible pane title'
+    'name:Bind the current pane identity'
+    'this:Bind the current pane identity'
+    'whoami:Show the current pane identity'
+    'unbind:Remove the current pane identity'
     'install:Install agent skills'
     'upgrade:Upgrade tmux-team and refresh skills'
     'init:Create empty legacy tmux-team.json'
@@ -70,7 +73,7 @@ const bashCompletion = `_tmux_team() {
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
-  commands="talk check list add update remove migrate team init completion help name install upgrade"
+  commands="talk check list add update remove migrate team init completion help name this whoami unbind install upgrade"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "\${commands}" -- \${cur}) )

--- a/src/commands/config-command.test.ts
+++ b/src/commands/config-command.test.ts
@@ -59,6 +59,9 @@ function createCtx(
     listTeams: vi.fn(() => ({})),
     listTeamPanes: vi.fn(() => []),
     removeTeam: vi.fn(() => ({ removed: 0, agents: [] })),
+    listGlobalIdentities: vi.fn(() => []),
+    setGlobalIdentity: vi.fn(),
+    clearGlobalIdentity: vi.fn(() => false),
   };
   return {
     argv: [],

--- a/src/commands/global-identity.ts
+++ b/src/commands/global-identity.ts
@@ -1,0 +1,75 @@
+import { bindGlobalName, unbindGlobalPane } from '../domain/service.js';
+import type { BindingErrorCode } from '../domain/types.js';
+import type { Context } from '../types.js';
+import { ExitCodes } from '../exits.js';
+
+export function resolveCurrentPane(ctx: Context): string | null {
+  const current = ctx.tmux.getCurrentPaneId();
+  return current ? ctx.tmux.resolvePaneTarget(current) : null;
+}
+
+export function resolvePane(ctx: Context, target: string): string | null {
+  return ctx.tmux.resolvePaneTarget(target);
+}
+
+export function failIdentity(
+  ctx: Context,
+  code: BindingErrorCode | 'PANE_NOT_FOUND',
+  message: string
+): never {
+  if (ctx.flags.json) {
+    ctx.ui.json({ error: { code, message } });
+  } else {
+    ctx.ui.error(message);
+  }
+
+  const exitCode =
+    code === 'PANE_NOT_FOUND'
+      ? ExitCodes.PANE_NOT_FOUND
+      : code === 'PANE_ALREADY_BOUND' || code === 'NAME_ALREADY_ACTIVE'
+        ? ExitCodes.CONFLICT
+        : ExitCodes.ERROR;
+  return ctx.exit(exitCode);
+}
+
+export function bindIdentity(ctx: Context, paneId: string, name: string): void {
+  const registrations = ctx.tmux.listGlobalIdentities();
+  const result = bindGlobalName(registrations, name, paneId);
+  if (!result.ok) failIdentity(ctx, result.error.code, result.error.message);
+
+  const registration = result.value.find((entry) => entry.paneId === paneId);
+  if (!registration) return failIdentity(ctx, 'PANE_NOT_FOUND', `Pane '${paneId}' not found.`);
+
+  if (result.value !== registrations) {
+    ctx.tmux.setGlobalIdentity(paneId, registration.name);
+  }
+
+  try {
+    ctx.tmux.setPaneTitle(paneId, registration.name);
+  } catch {
+    // Identity metadata is authoritative; title synchronization is presentation only.
+  }
+
+  if (ctx.flags.json) {
+    ctx.ui.json({ bound: true, name: registration.name, pane: paneId });
+  } else {
+    ctx.ui.success(`Bound '${registration.name}' to pane ${paneId}`);
+  }
+}
+
+export function unbindIdentity(ctx: Context, paneId: string): void {
+  const registrations = ctx.tmux.listGlobalIdentities();
+  const current = registrations.find((entry) => entry.paneId === paneId);
+  const result = unbindGlobalPane(registrations, paneId);
+  if (!result.ok) failIdentity(ctx, result.error.code, result.error.message);
+
+  if (!ctx.tmux.clearGlobalIdentity(paneId)) {
+    return failIdentity(ctx, 'UNBOUND_PANE', 'Pane has no active global name.');
+  }
+
+  if (ctx.flags.json) {
+    ctx.ui.json({ unbound: true, name: current?.name, pane: paneId });
+  } else {
+    ctx.ui.success(`Unbound pane ${paneId}`);
+  }
+}

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -48,9 +48,11 @@ ${colors.yellow('COMMANDS')}
   ${colors.green('talk')} <target> <message>     Send message to an agent (or "all")
   ${colors.green('check')} <target> [lines]      Capture output from agent's pane
   ${colors.green('list')} [team|pane]             List workspace, team, or pane status
-  ${colors.green('add')} <name> <pane> [remark]  Add a new agent
-  ${colors.green('this')} <name> [remark]       Register current pane as an agent
-  ${colors.green('name')} <name> [pane]         Set a visible pane title
+  ${colors.green('add')} <pane-target> <global-name> Bind an explicit pane identity
+  ${colors.green('this')} <global-name>       Bind the current pane (alias of name)
+  ${colors.green('name')} <global-name>       Bind the current pane identity
+  ${colors.green('whoami')}                   Show the current pane identity
+  ${colors.green('unbind')}                   Remove the current pane identity
   ${colors.green('update')} <name> [options]     Update an agent's config
   ${colors.green('remove')} <name>               Remove an agent
   ${colors.green('migrate')} [--dry-run]          Copy legacy JSON registry to tmux metadata
@@ -92,7 +94,7 @@ ${colors.yellow('EXAMPLES')}${
   tmux-team list --json
   tmux-team list acme-app
   tmux-team list main.1.0
-  tmux-team add codex 10.1 "Code review specialist"
+  tmux-team add 10.1 codex
   tmux-team name backend
   tmt install
   tmt upgrade

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -51,6 +51,9 @@ function createCtx(testDir: string, overrides?: Partial<{ flags: Partial<Flags> 
     listTeams: vi.fn(() => ({})),
     listTeamPanes: vi.fn(() => []),
     removeTeam: vi.fn(() => ({ removed: 0, agents: [] })),
+    listGlobalIdentities: vi.fn(() => []),
+    setGlobalIdentity: vi.fn(),
+    clearGlobalIdentity: vi.fn(() => false),
   };
   return {
     argv: [],

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -211,7 +211,9 @@ function printNextSteps(ctx: Context, installed: InstallResult[]): void {
     console.log(`  ${colors.cyan('/plugin install tmux-team@tmux-team')}`);
   }
   console.log(colors.yellow('Next steps:'));
-  console.log(`  ${colors.cyan('tmt add <name> <pane>')} or ${colors.cyan('tmt this <name>')}`);
+  console.log(
+    `  ${colors.cyan('tmt add <pane-target> <global-name>')} or ${colors.cyan('tmt this <global-name>')}`
+  );
   console.log(`  ${colors.cyan('tmt talk <agent> "message" --wait')}`);
 }
 

--- a/src/commands/name.test.ts
+++ b/src/commands/name.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 import { cmdName } from './name.js';
+import { cmdThis } from './this.js';
+import { cmdAdd } from './add.js';
+import type { ActiveRegistration } from '../domain/types.js';
 import type { Context } from '../types.js';
 
-function context(overrides: Partial<Context['tmux']> = {}, json = false): Context {
+function context(registrations: ActiveRegistration[] = [], json = false): Context {
   const tmux: Context['tmux'] = {
     send: vi.fn(),
     capture: vi.fn(),
     listPanes: vi.fn(() => []),
     getCurrentPaneId: vi.fn(() => '%1'),
-    resolvePaneTarget: vi.fn((target: string) => (target === 'main:1.2' ? '%9' : target)),
+    resolvePaneTarget: vi.fn((target: string) => target),
     setPaneTitle: vi.fn(),
     getAgentRegistry: vi.fn(() => ({ paneRegistry: {}, agents: {} })),
     setAgentRegistration: vi.fn(),
@@ -16,7 +19,9 @@ function context(overrides: Partial<Context['tmux']> = {}, json = false): Contex
     listTeams: vi.fn(() => ({})),
     listTeamPanes: vi.fn(() => []),
     removeTeam: vi.fn(() => ({ removed: 0, agents: [] })),
-    ...overrides,
+    listGlobalIdentities: vi.fn(() => registrations),
+    setGlobalIdentity: vi.fn(),
+    clearGlobalIdentity: vi.fn(() => true),
   };
   return {
     argv: [],
@@ -51,25 +56,167 @@ function context(overrides: Partial<Context['tmux']> = {}, json = false): Contex
   };
 }
 
-describe('cmdName', () => {
-  it('names the current pane by default', () => {
+const active = (name: string, paneId: string): ActiveRegistration => ({
+  name,
+  canonicalName: name.toLowerCase(),
+  paneId,
+});
+
+describe('global identity commands', () => {
+  it('binds the current pane and writes canonical metadata', () => {
     const ctx = context();
-    cmdName(ctx, 'backend');
-    expect(ctx.tmux.resolvePaneTarget).toHaveBeenCalledWith('%1');
-    expect(ctx.tmux.setPaneTitle).toHaveBeenCalledWith('%1', 'backend');
-    expect(ctx.ui.success).toHaveBeenCalled();
+    cmdName(ctx, 'Backend');
+    expect(ctx.tmux.setGlobalIdentity).toHaveBeenCalledWith('%1', 'Backend');
+    expect(ctx.tmux.setPaneTitle).toHaveBeenCalledWith('%1', 'Backend');
+    expect(ctx.ui.success).toHaveBeenCalledWith("Bound 'Backend' to pane %1");
   });
 
-  it('resolves an explicit pane target and supports JSON output', () => {
-    const ctx = context({}, true);
-    cmdName(ctx, 'frontend', 'main:1.2');
-    expect(ctx.tmux.setPaneTitle).toHaveBeenCalledWith('%9', 'frontend');
-    expect(ctx.ui.json).toHaveBeenCalledWith({ named: 'frontend', pane: '%9' });
+  it('uses the exact same implementation for this', () => {
+    const ctx = context();
+    cmdThis(ctx, 'backend');
+    expect(ctx.tmux.setGlobalIdentity).toHaveBeenCalledWith('%1', 'backend');
+    expect(ctx.ui.error).not.toHaveBeenCalled();
   });
 
-  it.each(['', '   ', 'bad\nname', 'bad\u0007name'])('rejects invalid names: %j', (name) => {
+  it('keeps human success output exactly identical between name and this', () => {
+    const nameCtx = context();
+    const thisCtx = context();
+    cmdName(nameCtx, 'backend');
+    cmdThis(thisCtx, 'backend');
+    expect(thisCtx.ui.success).toHaveBeenCalledWith(
+      (nameCtx.ui.success as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    );
+  });
+
+  it('keeps JSON success output exactly identical between name and this', () => {
+    const nameCtx = context([], true);
+    const thisCtx = context([], true);
+    cmdName(nameCtx, 'backend');
+    cmdThis(thisCtx, 'backend');
+    expect(thisCtx.ui.json).toHaveBeenCalledWith(
+      (nameCtx.ui.json as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    );
+  });
+
+  it('keeps semantic failure code, message, and exit identical between name and this', () => {
+    const nameCtx = context([active('Alice', '%2')], true);
+    const thisCtx = context([active('Alice', '%2')], true);
+    let nameError: unknown;
+    let thisError: unknown;
+    try {
+      cmdName(nameCtx, 'alice');
+    } catch (error) {
+      nameError = error;
+    }
+    try {
+      cmdThis(thisCtx, 'alice');
+    } catch (error) {
+      thisError = error;
+    }
+    expect((nameError as Error & { exitCode: number }).exitCode).toBe(5);
+    expect((thisError as Error & { exitCode: number }).exitCode).toBe(5);
+    expect(nameCtx.ui.json).toHaveBeenCalledWith(
+      (thisCtx.ui.json as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    );
+    expect(nameCtx.ui.warn).not.toHaveBeenCalled();
+    expect(thisCtx.ui.warn).not.toHaveBeenCalled();
+  });
+
+  it.each(['10.3', '%14', 'session:2.1'])('binds an explicit target: %s', (target) => {
     const ctx = context();
-    expect(() => cmdName(ctx, name)).toThrow('exit(1)');
+    (ctx.tmux.resolvePaneTarget as ReturnType<typeof vi.fn>).mockReturnValue('%14');
+    cmdAdd(ctx, target, 'server-log');
+    expect(ctx.tmux.setGlobalIdentity).toHaveBeenCalledWith('%14', 'server-log');
+  });
+
+  it('rejects a stale explicit target before any name or metadata work', () => {
+    const ctx = context([], true);
+    (ctx.tmux.resolvePaneTarget as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    expect(() => cmdAdd(ctx, '10.3', 'server-log')).toThrow('exit(3)');
+    expect(ctx.ui.json).toHaveBeenCalledWith({
+      error: { code: 'PANE_NOT_FOUND', message: "Pane '10.3' not found. Is tmux running?" },
+    });
+    expect(ctx.tmux.listGlobalIdentities).not.toHaveBeenCalled();
+    expect(ctx.tmux.setGlobalIdentity).not.toHaveBeenCalled();
     expect(ctx.tmux.setPaneTitle).not.toHaveBeenCalled();
+  });
+
+  it('returns deterministic JSON for binding output', () => {
+    const ctx = context([], true);
+    cmdName(ctx, 'alice');
+    expect(ctx.ui.json).toHaveBeenCalledWith({ bound: true, name: 'alice', pane: '%1' });
+  });
+
+  it.each(['', '  ', 'bad\nname', '%14', '10.3', 'session:2.1'])(
+    'rejects invalid names without writing: %j',
+    (name) => {
+      const ctx = context();
+      expect(() => cmdName(ctx, name)).toThrow('exit(1)');
+      expect(ctx.tmux.setGlobalIdentity).not.toHaveBeenCalled();
+    }
+  );
+
+  it('reports name conflicts without mutation', () => {
+    const ctx = context([active('Alice', '%2')]);
+    expect(() => cmdName(ctx, 'alice')).toThrow('exit(5)');
+    expect(ctx.tmux.setGlobalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('reports NAME_ALREADY_ACTIVE as structured JSON without mutation', () => {
+    const ctx = context([active('Alice', '%2')], true);
+    expect(() => cmdName(ctx, 'alice')).toThrow('exit(5)');
+    expect(ctx.ui.json).toHaveBeenCalledWith({
+      error: { code: 'NAME_ALREADY_ACTIVE', message: 'Name is already active on another pane.' },
+    });
+    expect(ctx.tmux.setGlobalIdentity).not.toHaveBeenCalled();
+    expect(ctx.tmux.setPaneTitle).not.toHaveBeenCalled();
+  });
+
+  it('reports PANE_ALREADY_BOUND as structured JSON without mutation', () => {
+    const ctx = context([active('Alice', '%1')], true);
+    expect(() => cmdName(ctx, 'other')).toThrow('exit(5)');
+    expect(ctx.ui.json).toHaveBeenCalledWith({
+      error: { code: 'PANE_ALREADY_BOUND', message: 'Pane is already bound to another name.' },
+    });
+    expect(ctx.tmux.setGlobalIdentity).not.toHaveBeenCalled();
+    expect(ctx.tmux.setPaneTitle).not.toHaveBeenCalled();
+  });
+
+  it('reports INVALID_NAME as structured JSON without mutation', () => {
+    const ctx = context([], true);
+    expect(() => cmdName(ctx, '%14')).toThrow('exit(1)');
+    expect(ctx.ui.json).toHaveBeenCalledWith({
+      error: { code: 'INVALID_NAME', message: 'Identity name must not look like a pane target.' },
+    });
+    expect(ctx.tmux.setGlobalIdentity).not.toHaveBeenCalled();
+    expect(ctx.tmux.setPaneTitle).not.toHaveBeenCalled();
+  });
+
+  it('trims display names while comparing canonical names case-insensitively', () => {
+    const ctx = context();
+    cmdName(ctx, '  Backend  ');
+    expect(ctx.tmux.setGlobalIdentity).toHaveBeenCalledWith('%1', 'Backend');
+  });
+
+  it('is idempotent for the same canonical name and pane', () => {
+    const ctx = context([active('Alice', '%1')]);
+    cmdName(ctx, ' alice ');
+    expect(ctx.tmux.setGlobalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('treats NFKC-equivalent names as the same active identity', () => {
+    const ctx = context([active('Alice', '%1')]);
+    cmdName(ctx, 'ＡＬＩＣＥ');
+    expect(ctx.tmux.setGlobalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('does not fail a successful bind when title synchronization fails', () => {
+    const ctx = context();
+    (ctx.tmux.setPaneTitle as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('title unavailable');
+    });
+    cmdName(ctx, 'backend');
+    expect(ctx.tmux.setGlobalIdentity).toHaveBeenCalledWith('%1', 'backend');
+    expect(ctx.ui.success).toHaveBeenCalled();
   });
 });

--- a/src/commands/name.ts
+++ b/src/commands/name.ts
@@ -1,38 +1,12 @@
-// name command - set the visible title of a tmux pane
+// name command - bind a global identity to the current tmux pane
 
 import type { Context } from '../types.js';
-import { ExitCodes } from '../exits.js';
+import { failIdentity, bindIdentity, resolveCurrentPane } from './global-identity.js';
 
-export function cmdName(ctx: Context, name: string, target?: string): void {
-  const { ui, tmux, flags, exit } = ctx;
-
-  const hasControlCharacter = [...name].some((character) => {
-    const codePoint = character.codePointAt(0) ?? 0;
-    return codePoint < 32 || codePoint === 127;
-  });
-
-  if (!name || name.trim().length === 0 || hasControlCharacter) {
-    ui.error('Pane name must be non-empty and contain no control characters or newlines.');
-    exit(ExitCodes.ERROR);
-  }
-
-  const requestedTarget = target ?? tmux.getCurrentPaneId();
-  if (!requestedTarget) {
-    ui.error('Not running inside tmux.');
-    return exit(ExitCodes.PANE_NOT_FOUND);
-  }
-
-  const paneId = tmux.resolvePaneTarget(requestedTarget);
+export function cmdName(ctx: Context, name: string): void {
+  const paneId = resolveCurrentPane(ctx);
   if (!paneId) {
-    ui.error(`Pane '${requestedTarget}' not found. Is tmux running?`);
-    return exit(ExitCodes.PANE_NOT_FOUND);
+    failIdentity(ctx, 'PANE_NOT_FOUND', 'Not running inside a resolvable tmux pane.');
   }
-
-  tmux.setPaneTitle(paneId, name);
-
-  if (flags.json) {
-    ui.json({ named: name, pane: paneId });
-  } else {
-    ui.success(`Named pane ${paneId} '${name}'`);
-  }
+  bindIdentity(ctx, paneId, name);
 }

--- a/src/commands/preamble.test.ts
+++ b/src/commands/preamble.test.ts
@@ -78,6 +78,9 @@ function createMockTmux(): Tmux {
     listTeams: vi.fn(() => ({})),
     listTeamPanes: vi.fn(() => []),
     removeTeam: vi.fn(() => ({ removed: 0, agents: [] })),
+    listGlobalIdentities: vi.fn(() => []),
+    setGlobalIdentity: vi.fn(),
+    clearGlobalIdentity: vi.fn(() => false),
   };
 }
 

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -63,6 +63,13 @@ function createMockTmux(): Tmux & {
     removeTeam() {
       return { removed: 0, agents: [] };
     },
+    listGlobalIdentities() {
+      return [];
+    },
+    setGlobalIdentity() {},
+    clearGlobalIdentity() {
+      return false;
+    },
   };
   return mock;
 }

--- a/src/commands/this.ts
+++ b/src/commands/this.ts
@@ -3,18 +3,8 @@
 // ─────────────────────────────────────────────────────────────
 
 import type { Context } from '../types.js';
-import { ExitCodes } from '../exits.js';
-import { cmdAdd } from './add.js';
+import { cmdName } from './name.js';
 
-export function cmdThis(ctx: Context, name: string, remark?: string): void {
-  const { ui, tmux, exit } = ctx;
-
-  const currentPaneId = tmux.getCurrentPaneId();
-  if (!currentPaneId) {
-    ui.error('Not running inside tmux.');
-    return exit(ExitCodes.ERROR);
-  }
-
-  // Reuse existing add logic
-  cmdAdd(ctx, name, currentPaneId, remark);
+export function cmdThis(ctx: Context, name: string): void {
+  cmdName(ctx, name);
 }

--- a/src/commands/unbind.ts
+++ b/src/commands/unbind.ts
@@ -1,0 +1,8 @@
+import type { Context } from '../types.js';
+import { resolveCurrentPane, unbindIdentity, failIdentity } from './global-identity.js';
+
+export function cmdUnbind(ctx: Context): void {
+  const paneId = resolveCurrentPane(ctx);
+  if (!paneId) failIdentity(ctx, 'PANE_NOT_FOUND', 'Not running inside a resolvable tmux pane.');
+  unbindIdentity(ctx, paneId);
+}

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { cmdWhoami } from './whoami.js';
+import { cmdUnbind } from './unbind.js';
+import type { ActiveRegistration } from '../domain/types.js';
+import type { Context } from '../types.js';
+
+function context(registrations: ActiveRegistration[] = [], json = false): Context {
+  const tmux: Context['tmux'] = {
+    send: vi.fn(),
+    capture: vi.fn(),
+    listPanes: vi.fn(() => []),
+    getCurrentPaneId: vi.fn(() => '%1'),
+    resolvePaneTarget: vi.fn((target: string) => target),
+    setPaneTitle: vi.fn(),
+    getAgentRegistry: vi.fn(() => ({ paneRegistry: {}, agents: {} })),
+    setAgentRegistration: vi.fn(),
+    clearAgentRegistration: vi.fn(() => false),
+    listTeams: vi.fn(() => ({})),
+    listTeamPanes: vi.fn(() => []),
+    removeTeam: vi.fn(() => ({ removed: 0, agents: [] })),
+    listGlobalIdentities: vi.fn(() => registrations),
+    setGlobalIdentity: vi.fn(),
+    clearGlobalIdentity: vi.fn(() => true),
+  };
+  return {
+    argv: [],
+    flags: { json, verbose: false },
+    ui: {
+      info: vi.fn(),
+      success: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      table: vi.fn(),
+      json: vi.fn(),
+    },
+    config: {
+      mode: 'polling',
+      preambleMode: 'always',
+      defaults: {
+        timeout: 1,
+        pollInterval: 1,
+        captureLines: 1,
+        maxCaptureLines: 1,
+        preambleEvery: 1,
+        pasteEnterDelayMs: 0,
+      },
+      agents: {},
+      paneRegistry: {},
+    },
+    tmux,
+    paths: { globalDir: '', globalConfig: '', localConfig: '', stateFile: '' },
+    exit: ((code: number) => {
+      throw Object.assign(new Error(`exit(${code})`), { exitCode: code });
+    }) as Context['exit'],
+  };
+}
+
+describe('whoami and unbind', () => {
+  it('reports bound identity as JSON', () => {
+    const ctx = context([{ name: 'alice', canonicalName: 'alice', paneId: '%1' }], true);
+    cmdWhoami(ctx);
+    expect(ctx.ui.json).toHaveBeenCalledWith({ bound: true, name: 'alice', pane: '%1' });
+  });
+
+  it('reports bound identity in concise human output', () => {
+    const ctx = context([{ name: 'alice', canonicalName: 'alice', paneId: '%1' }]);
+    cmdWhoami(ctx);
+    expect(ctx.ui.info).toHaveBeenCalledWith("Bound identity 'alice' on pane %1");
+  });
+
+  it('reports an unbound pane successfully', () => {
+    const ctx = context([], true);
+    cmdWhoami(ctx);
+    expect(ctx.ui.json).toHaveBeenCalledWith({ bound: false, pane: '%1' });
+  });
+
+  it('reports an unbound pane in concise human output', () => {
+    const ctx = context();
+    cmdWhoami(ctx);
+    expect(ctx.ui.info).toHaveBeenCalledWith('Pane %1 is unbound.');
+  });
+
+  it('unbinds only the current pane', () => {
+    const ctx = context([
+      { name: 'alice', canonicalName: 'alice', paneId: '%1' },
+      { name: 'bob', canonicalName: 'bob', paneId: '%2' },
+    ]);
+    cmdUnbind(ctx);
+    expect(ctx.tmux.clearGlobalIdentity).toHaveBeenCalledWith('%1');
+  });
+
+  it('returns exact JSON for successful unbind', () => {
+    const ctx = context([{ name: 'alice', canonicalName: 'alice', paneId: '%1' }], true);
+    cmdUnbind(ctx);
+    expect(ctx.ui.json).toHaveBeenCalledWith({ unbound: true, name: 'alice', pane: '%1' });
+  });
+
+  it('returns UNBOUND_PANE without mutation when repeated', () => {
+    const ctx = context([], true);
+    (ctx.tmux.clearGlobalIdentity as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    expect(() => cmdUnbind(ctx)).toThrow('exit(1)');
+    expect(ctx.ui.json).toHaveBeenCalledWith({
+      error: { code: 'UNBOUND_PANE', message: 'Pane has no active global name.' },
+    });
+  });
+
+  it('returns a pane-not-found error when outside tmux', () => {
+    const ctx = context([], true);
+    (ctx.tmux.getCurrentPaneId as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    expect(() => cmdWhoami(ctx)).toThrow('exit(3)');
+    expect(ctx.ui.json).toHaveBeenCalledWith({
+      error: { code: 'PANE_NOT_FOUND', message: 'Not running inside a resolvable tmux pane.' },
+    });
+  });
+});

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,0 +1,18 @@
+import type { Context } from '../types.js';
+import { failIdentity, resolveCurrentPane } from './global-identity.js';
+
+export function cmdWhoami(ctx: Context): void {
+  const paneId = resolveCurrentPane(ctx);
+  if (!paneId) failIdentity(ctx, 'PANE_NOT_FOUND', 'Not running inside a resolvable tmux pane.');
+
+  const identity = ctx.tmux.listGlobalIdentities().find((entry) => entry.paneId === paneId);
+  if (ctx.flags.json) {
+    ctx.ui.json(
+      identity ? { bound: true, name: identity.name, pane: paneId } : { bound: false, pane: paneId }
+    );
+  } else if (identity) {
+    ctx.ui.info(`Bound identity '${identity.name}' on pane ${paneId}`);
+  } else {
+    ctx.ui.info(`Pane ${paneId} is unbound.`);
+  }
+}

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -50,6 +50,9 @@ describe('createContext', () => {
       listTeams: vi.fn(() => ({})),
       listTeamPanes: vi.fn(() => []),
       removeTeam: vi.fn(() => ({ removed: 0, agents: [] })),
+      listGlobalIdentities: vi.fn(() => []),
+      setGlobalIdentity: vi.fn(),
+      clearGlobalIdentity: vi.fn(() => false),
     };
 
     vi.doMock('./config.js', () => ({
@@ -106,6 +109,9 @@ describe('createContext', () => {
       listTeams: vi.fn(() => ({})),
       listTeamPanes: vi.fn(() => []),
       removeTeam: vi.fn(() => ({ removed: 0, agents: [] })),
+      listGlobalIdentities: vi.fn(() => []),
+      setGlobalIdentity: vi.fn(),
+      clearGlobalIdentity: vi.fn(() => false),
     };
 
     vi.doMock('./config.js', () => ({

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -247,6 +247,81 @@ describe('createTmux', () => {
       ]);
     });
 
+    it('lists global identities independently of workspace metadata', () => {
+      mockedExecSync.mockReturnValue(
+        '%1\tmain:1.0\t/repo-a\tcodex\t{"version":1,"globalIdentity":{"name":"Alice","canonicalName":"alice"}}\n%2\tmain:2.0\t/repo-b\tzsh\t{"version":1}\n'
+      );
+      const tmux = createTmux();
+      expect(tmux.listGlobalIdentities()).toEqual([
+        { name: 'Alice', canonicalName: 'alice', paneId: '%1' },
+      ]);
+    });
+
+    it('ignores malformed global identity metadata', () => {
+      mockedExecSync.mockReturnValue(
+        '%1\tmain:1.0\t/repo\tzsh\t{"version":1,"globalIdentity":{"name":42}}\n'
+      );
+      expect(createTmux().listGlobalIdentities()).toEqual([]);
+    });
+
+    it('writes and clears global identity metadata without touching workspace entries', () => {
+      mockedExecFileSync.mockReturnValueOnce(
+        '{"version":1,"workspaces":{"/repo":{"name":"legacy"}},"teams":{"egp":{"name":"codex"}},"globalIdentity":{"name":"Old","canonicalName":"old"}}'
+      );
+      const tmux = createTmux();
+      tmux.setGlobalIdentity('%9', 'Alice');
+      expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+        'tmux',
+        [
+          'set-option',
+          '-p',
+          '-t',
+          '%9',
+          '@tmux-team.agent',
+          JSON.stringify({
+            version: 1,
+            workspaces: { '/repo': { name: 'legacy' } },
+            teams: { egp: { name: 'codex' } },
+            globalIdentity: { name: 'Alice', canonicalName: 'alice' },
+          }),
+        ],
+        expect.any(Object)
+      );
+
+      mockedExecFileSync.mockReset();
+      mockedExecFileSync.mockReturnValueOnce(
+        '{"version":1,"workspaces":{"/repo":{"name":"legacy"}},"teams":{"egp":{"name":"codex"}},"globalIdentity":{"name":"Alice","canonicalName":"alice"}}'
+      );
+      expect(tmux.clearGlobalIdentity('%9')).toBe(true);
+      expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+        'tmux',
+        [
+          'set-option',
+          '-p',
+          '-t',
+          '%9',
+          '@tmux-team.agent',
+          JSON.stringify({
+            version: 1,
+            workspaces: { '/repo': { name: 'legacy' } },
+            teams: { egp: { name: 'codex' } },
+          }),
+        ],
+        expect.any(Object)
+      );
+
+      mockedExecFileSync.mockReset();
+      mockedExecFileSync.mockReturnValueOnce(
+        '{"version":1,"globalIdentity":{"name":"Alice","canonicalName":"alice"}}'
+      );
+      expect(tmux.clearGlobalIdentity('%9')).toBe(true);
+      expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+        'tmux',
+        ['set-option', '-p', '-u', '-t', '%9', '@tmux-team.agent'],
+        expect.any(Object)
+      );
+    });
+
     it('builds team registries and agent config from metadata', () => {
       mockedExecSync.mockReturnValue(
         '%1\tcodex\t{"version":1,"teams":{"egp":{"name":"codex","preamble":"Be strict","deny":["x"]}}}\n'

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -13,6 +13,7 @@ import type {
   TeamPaneInfo,
   TmuxRegistry,
 } from './types.js';
+import { normalizeName } from './domain/service.js';
 
 const AGENT_METADATA_OPTION = '@tmux-team.agent';
 
@@ -104,6 +105,7 @@ function deleteRegistrationForScope(
 
 function hasRegistrations(metadata: PaneAgentMetadata): boolean {
   return Boolean(
+    metadata.globalIdentity ||
     (metadata.workspaces && Object.keys(metadata.workspaces).length > 0) ||
     (metadata.teams && Object.keys(metadata.teams).length > 0)
   );
@@ -388,6 +390,37 @@ export function createTmux(): Tmux {
         removed += 1;
       }
       return { removed, agents: [...agents].sort() };
+    },
+
+    listGlobalIdentities() {
+      return this.listPanes().flatMap((pane) => {
+        const identity = pane.metadata?.globalIdentity;
+        if (!identity || typeof identity.name !== 'string') return [];
+        return [
+          {
+            name: identity.name,
+            canonicalName:
+              typeof identity.canonicalName === 'string' && identity.canonicalName
+                ? identity.canonicalName
+                : normalizeName(identity.name),
+            paneId: pane.id,
+          },
+        ];
+      });
+    },
+
+    setGlobalIdentity(paneId: string, name: string): void {
+      const metadata = readPaneMetadata(paneId);
+      metadata.globalIdentity = { name, canonicalName: normalizeName(name) };
+      writePaneMetadata(paneId, metadata);
+    },
+
+    clearGlobalIdentity(paneId: string): boolean {
+      const metadata = readPaneMetadata(paneId);
+      if (!metadata.globalIdentity) return false;
+      delete metadata.globalIdentity;
+      writePaneMetadata(paneId, metadata);
+      return true;
     },
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { ActiveRegistration } from './domain/types.js';
+
 // ─────────────────────────────────────────────────────────────
 // Shared TypeScript interfaces for tmux-team
 // ─────────────────────────────────────────────────────────────
@@ -23,6 +25,10 @@ export interface AgentRegistration {
 
 export interface PaneAgentMetadata {
   version: 1;
+  globalIdentity?: {
+    name: string;
+    canonicalName: string;
+  };
   workspaces?: Record<string, AgentRegistration>;
   teams?: Record<string, AgentRegistration>;
 }
@@ -145,6 +151,9 @@ export interface Tmux {
   listTeams: () => Record<string, string[]>;
   listTeamPanes: () => TeamPaneInfo[];
   removeTeam: (teamName: string) => { removed: number; agents: string[] };
+  listGlobalIdentities: () => ActiveRegistration[];
+  setGlobalIdentity: (paneId: string, name: string) => void;
+  clearGlobalIdentity: (paneId: string) => boolean;
 }
 
 export type RegistryScope =


### PR DESCRIPTION
## Summary

- add global tmux pane identity metadata independent of workspace and team registrations
- make `tmt name <global-name>` and supported `tmt this <global-name>` exact aliases
- change `tmt add` to `<pane-target> <global-name>` with canonical `%pane_id` resolution
- add `tmt whoami` and `tmt unbind`
- preserve existing metadata and treat pane-title updates as best-effort presentation only
- refresh CLI help, completions, README, and bundled skills

## Behavior and safety

- one global name per pane and one active pane per canonical name
- names are trimmed and compared case-insensitively after NFKC normalization
- stable structured errors cover invalid names, pane conflicts, name conflicts, unbound panes, and unresolved pane targets
- failed binds perform no metadata or title writes
- no daemon changes
- team, talk, check, and list rewrites remain outside this issue

## Verification

- `pnpm check` (0 errors; 5 pre-existing warnings)
- `pnpm test:run` (346/346; 92.41% statements, 85.95% branches)
- focused identity/CLI/tmux suite (168/168)
- `pnpm test:e2e` twice (6/6 each run)
- host-local isolated real CLI + real tmux lifecycle: name, whoami, NFKC-idempotent this, conflict exit 5, unbind, unbound whoami, add by `%pane_id`, rebound whoami
- `git diff --check`

## Follow-up

The permanent Docker identity lifecycle matrix remains tracked separately so this pull request stays within TMT-3's CLI and metadata scope.
