### PR TITLE
Prepare v5 alpha metadata and release workflow guidance

### DIFF
--- a/.agents/skills/tmt-release/SKILL.md
+++ b/.agents/skills/tmt-release/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: tmt-release
+description: Maintain and promote tmux-team release lines, versions, and prerelease readiness without assuming publish authorization.
+---
+
+# tmux-team release management
+
+Use this skill for release-line maintenance, v4 compatibility fixes, v5 promotion, version synchronization, or prerelease readiness in this repository.
+
+## Long-lived branch policy
+
+- `main` is the active v5 line after promotion.
+- `v4` is the maintenance line rooted at commit `7056679dfa816a1acef8e7c978cf1733a578115b`.
+- If remote `v4` does not exist, create it at that exact anchor only when the user has explicitly requested the maintenance line, then verify the remote ref before continuing.
+- Before any branch mutation, verify the relevant remote refs and ancestry. Never force-push or repoint a long-lived line.
+- A v4 maintenance fix requires a tracked issue, a dedicated branch and worktree, and a reviewable pull request. Keep the fix on the v4 line unless an explicitly scoped backport is requested.
+- Use the checks available on the v4 line for maintenance pull requests; do not require contexts that the target branch cannot produce. Record any coverage gap in the issue.
+- Synchronize `package.json`, `.claude-plugin/marketplace.json`, `plugins/tmux-team/.claude-plugin/plugin.json`, the `src/version.ts` fallback, and its test whenever a release version changes.
+- Follow `AGENTS.md` for Linear state, branch and pull-request links, verification evidence, and safe worktree cleanup.
+
+## Promotion and prerelease checks
+
+- Promotion requires passing Code quality, Unit tests, and Docker E2E checks.
+- Tags, GitHub Releases, npm publishing, and npm dist-tags are separate operations that require explicit authorization; this skill never assumes permission for them.
+- Update user-facing installation or channel documentation whenever a version change would make it inaccurate.
+- A future prerelease publish must use a non-`latest` npm dist-tag. Before declaring it available, inspect the registry dist-tags and install the exact published version in a clean temporary environment.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "tmux-team",
       "source": "./plugins/tmux-team",
       "description": "Coordinate AI agents in tmux panes - talk to agents and wait for responses",
-      "version": "4.3.0",
+      "version": "5.0.0-alpha.1",
       "author": {
         "name": "Ben Hsieh",
         "email": "xeiyan@gmail.com"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ npm install -g tmux-team
 tmt install
 ```
 
+The npm `latest` channel remains the stable v4 release. This source tree is the
+v5 alpha line (`5.0.0-alpha.1`); the `@alpha` channel is not claimed to be
+published. Tags, GitHub Releases, npm publishing, and npm dist-tags are
+separate release operations.
+
 `tmt install` auto-detects Claude Code, Codex, and Gemini. Codex and Gemini
 share a managed skill link at `~/.agents/skills/tmux-team`; Claude gets its own
 integration. Repeating the command is idempotent, and unmanaged files are

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-team",
-  "version": "4.3.0",
+  "version": "5.0.0-alpha.1",
   "description": "CLI tool for AI agent collaboration in tmux - manage cross-pane communication",
   "type": "module",
   "bin": {
@@ -17,7 +17,7 @@
     "lint": "oxlint src/",
     "e2e:typecheck": "tsc --project tsconfig.e2e.json --noEmit",
     "e2e:lint": "oxlint test/e2e/ scripts/run-e2e.mjs",
-    "e2e:format:check": "prettier --check test/e2e/ scripts/run-e2e.mjs tsconfig.e2e.json DEVELOPMENT.md AGENTS.md .agents/skills/tmt-e2e/SKILL.md",
+    "e2e:format:check": "prettier --check test/e2e/ scripts/run-e2e.mjs tsconfig.e2e.json DEVELOPMENT.md AGENTS.md .agents/skills/tmt-e2e/SKILL.md .agents/skills/tmt-release/SKILL.md",
     "lint:fix": "oxlint src/ --fix",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",

--- a/plugins/tmux-team/.claude-plugin/plugin.json
+++ b/plugins/tmux-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-team",
-  "version": "4.3.0",
+  "version": "5.0.0-alpha.1",
   "description": "Coordinate AI agents in tmux panes - talk to agents and wait for responses",
   "author": {
     "name": "Ben Hsieh",

--- a/skills/README.md
+++ b/skills/README.md
@@ -7,6 +7,11 @@ npm install -g tmux-team
 tmt install
 ```
 
+The npm `latest` channel remains the stable v4 release. This source tree is the
+v5 alpha line (`5.0.0-alpha.1`), but `@alpha` is not claimed to be published.
+Tags, GitHub Releases, npm publishing, and npm dist-tags remain separate
+release operations.
+
 `tmt install` auto-detects Claude Code, Codex, and Gemini CLI. It manages a
 symlink at `~/.agents/skills/tmux-team` for Codex and Gemini, and installs the
 Claude command where needed. Repeating it is idempotent; unmanaged paths are

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,4 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function readJson(relativePath: string): Record<string, unknown> {
+  const filePath = path.join(repoRoot, relativePath);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+}
+
+const packageVersion = readJson('package.json').version;
+
+if (typeof packageVersion !== 'string') {
+  throw new TypeError('package.json must define a string version');
+}
 
 describe('version', () => {
   beforeEach(() => {
@@ -8,8 +24,22 @@ describe('version', () => {
   it('reads VERSION from package.json when possible', async () => {
     vi.resetModules();
     const { VERSION } = await import('./version.js');
-    expect(typeof VERSION).toBe('string');
-    expect(VERSION.length).toBeGreaterThan(0);
+
+    expect(VERSION).toBe(packageVersion);
+  });
+
+  it('keeps package and Claude plugin manifest versions synchronized', () => {
+    const marketplaceJson = readJson('.claude-plugin/marketplace.json');
+    const pluginJson = readJson('plugins/tmux-team/.claude-plugin/plugin.json');
+    const marketplacePlugins = marketplaceJson.plugins;
+
+    expect(Array.isArray(marketplacePlugins)).toBe(true);
+    const marketplacePlugin = (marketplacePlugins as Array<Record<string, unknown>>).find(
+      (plugin) => plugin.name === 'tmux-team'
+    );
+    expect(marketplacePlugin).toBeDefined();
+    expect(marketplacePlugin?.version).toBe(packageVersion);
+    expect(pluginJson.version).toBe(packageVersion);
   });
 
   it('falls back to hardcoded version when package.json read fails', async () => {
@@ -26,6 +56,6 @@ describe('version', () => {
     }));
 
     const { VERSION } = await import('./version.js');
-    expect(VERSION).toBe('4.3.0');
+    expect(VERSION).toBe(packageVersion);
   });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,7 +14,7 @@ function getVersion(): string {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     return pkg.version;
   } catch {
-    return '4.3.0';
+    return '5.0.0-alpha.1';
   }
 }
 


### PR DESCRIPTION
## Summary

- set the source and plugin metadata to 5.0.0-alpha.1
- add a structured cross-manifest version drift test
- add a repo-local branch and release management skill
- clarify that npm latest remains v4 and that the alpha channel is not yet published

## Scope

This prepares the verified v5 line for promotion. It does not create or move long-lived branches, publish npm packages, change dist-tags, create Git tags or GitHub Releases, or change product behavior.

## Verification

- pnpm check
- pnpm test:run (325/325)
- pnpm test:e2e twice (15/15 each run)
- skill quick validation
- npm pack --dry-run --json reports tmux-team@5.0.0-alpha.1
- git diff --check
- independent Gemini review: no findings

Linear: TMT-9