### PR TITLE
TMT-11: Establish typed CLI and application boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "git+https://github.com/wkh237/tmux-team.git"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22.12.0"
   },
   "packageManager": "pnpm@10.33.0",
   "os": [
@@ -52,6 +52,7 @@
     "skills"
   ],
   "dependencies": {
+    "commander": "^15.0.0",
     "tsx": "^4.7.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      commander:
+        specifier: ^15.0.0
+        version: 15.0.0
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
@@ -386,21 +389,25 @@ packages:
     resolution: {integrity: sha512-T1lc0UaYbTxZyqVpLfC7eipbauNG8pBpkaZEW4JGz8Y68rxTH7d9s+CF0zxUxNr5RCtcmT669RLVjQT7VrKVLg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@1.35.0':
     resolution: {integrity: sha512-7Wv5Pke9kwWKFycUziSHsmi3EM0389TLzraB0KE/MArrKxx30ycwfJ5PYoMj9ERoW+Ybs0txdaOF/xJy/XyYkg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/linux-x64-gnu@1.35.0':
     resolution: {integrity: sha512-HDMPOzyVVy+rQl3H7UOq8oGHt7m1yaiWCanlhAu4jciK8dvXeO9OG/OQd74lD/h05IcJh93pCLEJ3wWOG8hTiQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-x64-musl@1.35.0':
     resolution: {integrity: sha512-kAPBBsUOM3HQQ6n3nnZauvFR9EoXqCSoj4O3OSXXarzsRTiItNrHabVUwxeswZEc+xMzQNR0FHEWg/d4QAAWLw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/win32-arm64@1.35.0':
     resolution: {integrity: sha512-qrpBkkOASS0WT8ra9xmBRXOEliN6D/MV9JhI/68lFHrtLhfFuRwg4AjzjxrCWrQCnQ0WkvAVpJzu73F4ICLYZw==}
@@ -446,56 +453,67 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -583,6 +601,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1329,6 +1351,8 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  commander@15.0.0: {}
 
   concat-map@0.0.1: {}
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -126,29 +126,37 @@ describe('cli', () => {
   it('errors on invalid time format', async () => {
     vi.resetModules();
     process.argv = ['node', 'cli', 'talk', 'codex', 'hi', '--delay', 'abc'];
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new Error(`exit(${code})`);
-    }) as any);
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    await expect(import('./cli.js')).rejects.toThrow('exit(1)');
-    expect(errSpy).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
-
-  it('routes unknown command to ctx.ui.error and exits', async () => {
-    vi.resetModules();
-    process.argv = ['node', 'cli', 'nope'];
-
     const ctx = makeStubContext();
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit(${code})`);
+    }) as any);
+
+    await expect(import('./cli.js')).rejects.toThrow('exit(1)');
+    expect(ctx.ui.error).toHaveBeenCalledWith(
+      'Invalid time format: abc. Use number (seconds) or number with ms/s suffix.'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('reports an unknown command through a no-resource context', async () => {
+    vi.resetModules();
+    process.argv = ['node', 'cli', 'nope'];
+
+    const ctx = makeStubContext();
+    const createContext = vi.fn(() => ctx);
+    vi.doMock('./context.js', () => ({
+      createContext,
+      ExitCodes: { SUCCESS: 0, ERROR: 1 },
+    }));
 
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
     await import('./cli.js');
-    expect(ctx.ui.error).toHaveBeenCalled();
+    expect(ctx.ui.error).toHaveBeenCalledWith(expect.stringContaining('Unknown command'));
+    expect(createContext).toHaveBeenCalledWith(expect.objectContaining({ capability: 'none' }));
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
@@ -247,7 +255,11 @@ describe('cli', () => {
     await import('./cli.js');
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(preambleSpy).toHaveBeenCalledWith(ctx, ['show']);
+    expect(preambleSpy).toHaveBeenCalledWith(ctx, {
+      kind: 'preamble',
+      operation: 'show',
+      agent: undefined,
+    });
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
@@ -525,7 +537,7 @@ describe('cli', () => {
 
   it('routes config command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'config', 'get', 'mode'];
+    process.argv = ['node', 'cli', 'config', 'show'];
 
     const ctx = makeStubContext();
     const configSpy = vi.fn();
@@ -539,7 +551,11 @@ describe('cli', () => {
     await import('./cli.js');
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(configSpy).toHaveBeenCalledWith(ctx, ['get', 'mode']);
+    expect(configSpy).toHaveBeenCalledWith(ctx, {
+      kind: 'config',
+      operation: 'show',
+      global: false,
+    });
     expect(exitSpy).not.toHaveBeenCalled();
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,122 +4,16 @@
 // ─────────────────────────────────────────────────────────────
 
 import { createContext, ExitCodes } from './context.js';
-import type { Flags } from './types.js';
 
 // Commands
 import { cmdHelp, HelpConfig } from './commands/help.js';
 import { loadConfig, resolvePaths } from './config.js';
 import { createUI } from './ui.js';
-import { cmdInit } from './commands/init.js';
-import { cmdList } from './commands/list.js';
-import { cmdAdd } from './commands/add.js';
-import { cmdUpdate } from './commands/update.js';
-import { cmdRemove } from './commands/remove.js';
-import { cmdTalk } from './commands/talk.js';
-import { cmdCheck } from './commands/check.js';
 import { cmdCompletion } from './commands/completion.js';
-import { cmdConfig } from './commands/config.js';
-import { cmdPreamble } from './commands/preamble.js';
-import { cmdInstall } from './commands/install.js';
-import { cmdLearn } from './commands/learn.js';
-import { cmdThis } from './commands/this.js';
-import { cmdMigrate } from './commands/migrate.js';
-import { cmdName } from './commands/name.js';
-import { cmdUpgrade } from './commands/upgrade.js';
-import { cmdWhoami } from './commands/whoami.js';
-import { cmdUnbind } from './commands/unbind.js';
 import { UNSUPPORTED_TEAM_MESSAGE } from './commands/unsupported-team.js';
 import { runStartupChecks } from './update-check.js';
-
-// ─────────────────────────────────────────────────────────────
-// Argument parsing
-// ─────────────────────────────────────────────────────────────
-
-function parseArgs(argv: string[]): {
-  command: string;
-  args: string[];
-  flags: Flags;
-  unsupportedTeam: boolean;
-} {
-  const flags: Flags = {
-    json: false,
-    verbose: false,
-  };
-
-  const positional: string[] = [];
-  let unsupportedTeam = false;
-  let i = 0;
-
-  while (i < argv.length) {
-    const arg = argv[i];
-
-    if (arg === '--json') {
-      flags.json = true;
-    } else if (arg === '--verbose' || arg === '-v') {
-      flags.verbose = true;
-    } else if (arg === '--debug') {
-      flags.debug = true;
-    } else if (arg === '--force' || arg === '-f') {
-      flags.force = true;
-    } else if (arg === '--config') {
-      flags.config = argv[++i];
-    } else if (arg === '--delay') {
-      flags.delay = parseTime(argv[++i]);
-    } else if (arg === '--wait') {
-      flags.wait = true;
-    } else if (arg === '--timeout') {
-      flags.timeout = parseTime(argv[++i]);
-    } else if (arg === '--lines') {
-      flags.lines = parseInt(argv[++i], 10) || 100;
-    } else if (arg === '--no-preamble') {
-      flags.noPreamble = true;
-    } else if (arg === '--team') {
-      unsupportedTeam = true;
-      i++;
-    } else if (arg.startsWith('--team=')) {
-      unsupportedTeam = true;
-    } else if (arg.startsWith('--pane=')) {
-      // Handled in update command
-      positional.push(arg);
-    } else if (arg.startsWith('--remark=')) {
-      // Handled in update command
-      positional.push(arg);
-    } else if (arg.startsWith('-')) {
-      // Unknown flag, pass through
-      positional.push(arg);
-    } else {
-      positional.push(arg);
-    }
-    i++;
-  }
-
-  const [command = 'help', ...args] = positional;
-  return { command, args, flags, unsupportedTeam };
-}
-
-/**
- * Parse time string to seconds.
- * Default unit is seconds (no suffix needed).
- */
-function parseTime(value: string): number {
-  if (!value) return 0;
-
-  const match = value.match(/^(\d+(?:\.\d+)?)(ms|s)?$/i);
-  if (!match) {
-    console.error(
-      `Invalid time format: ${value}. Use number (seconds) or number with ms/s suffix.`
-    );
-    process.exit(ExitCodes.ERROR);
-  }
-
-  const num = parseFloat(match[1]);
-  const unit = (match[2] || 's').toLowerCase();
-
-  if (unit === 'ms') {
-    return num / 1000;
-  }
-  return num; // seconds
-}
+import { CliParseError, parseArgs } from './cli/parser.js';
+import { dispatchCommand } from './cli/application.js';
 
 // ─────────────────────────────────────────────────────────────
 // Main
@@ -127,11 +21,29 @@ function parseTime(value: string): number {
 
 function main(): void {
   const argv = process.argv.slice(2);
-  const { command, args, flags, unsupportedTeam } = parseArgs(argv);
+  let parsed;
+  try {
+    parsed = parseArgs(argv);
+  } catch (error) {
+    const parseError = error instanceof CliParseError ? error : new Error(String(error));
+    const flags = error instanceof CliParseError ? error.flags : { json: false, verbose: false };
+    // Parse failures use the normal UI contract without loading config or tmux.
+    const parseContext = createContext({ argv, flags, capability: 'none' });
+    parseContext.ui.error(parseError.message);
+    try {
+      parseContext.exit(ExitCodes.ERROR);
+    } catch {
+      // A test double or embedder may model the non-returning exit by throwing.
+      process.exit(ExitCodes.ERROR);
+    }
+    return;
+  }
+  const { invocation, flags, metadata } = parsed;
+  const command = metadata.commandPath[0] ?? invocation.kind;
 
   // Reject both `team` and either spelling of `--team` before command routing
   // or configuration loading can interpret them as a scope.
-  if (command === 'team' || unsupportedTeam) {
+  if (command === 'team' || metadata.unsupportedTeam) {
     const ui = createUI(flags.json);
     const error = {
       code: 'UNSUPPORTED_TEAM',
@@ -144,9 +56,9 @@ function main(): void {
   }
 
   // Help - load config to show current mode/timeout
-  if (!command || command === 'help' || command === '--help' || command === '-h') {
+  if (invocation.kind === 'help') {
     // Show intro highlight when running just `tmux-team` with no args
-    const showIntro = !command || argv.length === 0;
+    const showIntro = invocation.showIntro;
     try {
       const paths = resolvePaths();
       const config = loadConfig(paths);
@@ -164,20 +76,20 @@ function main(): void {
     return;
   }
 
-  if (command === '--version' || command === '-V') {
+  if (invocation.kind === 'version') {
     import('./version.js').then((m) => console.log(m.VERSION));
     return;
   }
 
   // Completion doesn't need context
-  if (command === 'completion') {
-    cmdCompletion(args[0]);
+  if (invocation.kind === 'completion') {
+    cmdCompletion(invocation.shell);
     process.exit(ExitCodes.SUCCESS);
     return;
   }
 
   // Create context for all other commands
-  const ctx = createContext({ argv, flags });
+  const ctx = createContext({ argv, flags, capability: metadata.capability });
 
   // Warn if not in tmux for commands that require it
   const TMUX_REQUIRED_COMMANDS = [
@@ -196,138 +108,8 @@ function main(): void {
   }
 
   const run = async (): Promise<void> => {
-    await runStartupChecks(ctx, command);
-    switch (command) {
-      case 'init':
-        cmdInit(ctx);
-        break;
-
-      case 'list':
-      case 'ls':
-        if (args[0] === undefined) {
-          cmdList(ctx);
-        } else {
-          cmdList(ctx, args[0]);
-        }
-        break;
-
-      case 'add':
-        if (args.length !== 2) {
-          ctx.ui.error('Usage: tmux-team add <pane-target> <global-name>');
-          ctx.exit(ExitCodes.ERROR);
-        }
-        cmdAdd(ctx, args[0], args[1]);
-        break;
-
-      case 'update':
-        if (args.length < 1) {
-          ctx.ui.error('Usage: tmux-team update <name> --pane <pane> | --remark <remark>');
-          ctx.exit(ExitCodes.ERROR);
-        }
-        {
-          const options: { pane?: string; remark?: string } = {};
-          for (let i = 1; i < args.length; i++) {
-            if (args[i] === '--pane' && args[i + 1]) {
-              options.pane = args[++i];
-            } else if (args[i] === '--remark' && args[i + 1]) {
-              options.remark = args[++i];
-            } else if (args[i].startsWith('--pane=')) {
-              options.pane = args[i].slice(7);
-            } else if (args[i].startsWith('--remark=')) {
-              options.remark = args[i].slice(9);
-            }
-          }
-          cmdUpdate(ctx, args[0], options);
-        }
-        break;
-
-      case 'remove':
-      case 'rm':
-        if (args.length < 1) {
-          ctx.ui.error('Usage: tmux-team remove <name>');
-          ctx.exit(ExitCodes.ERROR);
-        }
-        cmdRemove(ctx, args[0]);
-        break;
-
-      case 'migrate':
-        cmdMigrate(ctx, args);
-        break;
-
-      case 'this':
-        if (args.length !== 1) {
-          ctx.ui.error('Usage: tmux-team this <global-name>');
-          ctx.exit(ExitCodes.ERROR);
-        }
-        cmdThis(ctx, args[0]);
-        break;
-
-      case 'name':
-        if (args.length !== 1) {
-          ctx.ui.error('Usage: tmux-team name <global-name>');
-          ctx.exit(ExitCodes.ERROR);
-        }
-        cmdName(ctx, args[0]);
-        break;
-
-      case 'whoami':
-        if (args.length !== 0) {
-          ctx.ui.error('Usage: tmux-team whoami');
-          ctx.exit(ExitCodes.ERROR);
-        }
-        cmdWhoami(ctx);
-        break;
-
-      case 'unbind':
-        if (args.length !== 0) {
-          ctx.ui.error('Usage: tmux-team unbind');
-          ctx.exit(ExitCodes.ERROR);
-        }
-        cmdUnbind(ctx);
-        break;
-
-      case 'talk':
-      case 'send':
-        if (args.length < 2) {
-          ctx.ui.error('Usage: tmux-team talk <target> <message>');
-          ctx.exit(ExitCodes.ERROR);
-        }
-        await cmdTalk(ctx, args[0], args[1]);
-        break;
-
-      case 'check':
-      case 'read':
-        if (args.length < 1) {
-          ctx.ui.error('Usage: tmux-team check <target> [lines]');
-          ctx.exit(ExitCodes.ERROR);
-        }
-        cmdCheck(ctx, args[0], args[1] ? parseInt(args[1], 10) : undefined);
-        break;
-
-      case 'config':
-        cmdConfig(ctx, args);
-        break;
-
-      case 'preamble':
-        cmdPreamble(ctx, args);
-        break;
-
-      case 'install':
-        await cmdInstall(ctx, args[0]);
-        break;
-
-      case 'upgrade':
-        cmdUpgrade(ctx);
-        break;
-
-      case 'learn':
-        cmdLearn();
-        break;
-
-      default:
-        ctx.ui.error(`Unknown command: ${command}. Run 'tmux-team help' for usage.`);
-        ctx.exit(ExitCodes.ERROR);
-    }
+    await runStartupChecks(ctx, command ?? 'help');
+    await dispatchCommand(ctx, parsed);
   };
 
   run().catch((err) => {

--- a/src/cli/application.test.ts
+++ b/src/cli/application.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Context } from '../types.js';
+
+const handlers = {
+  cmdInit: vi.fn(),
+  cmdList: vi.fn(),
+  cmdAdd: vi.fn(),
+  cmdUpdate: vi.fn(),
+  cmdRemove: vi.fn(),
+  cmdTalk: vi.fn(),
+  cmdCheck: vi.fn(),
+  cmdConfig: vi.fn(),
+  cmdPreamble: vi.fn(),
+  cmdInstall: vi.fn(),
+  cmdLearn: vi.fn(),
+  cmdThis: vi.fn(),
+  cmdMigrate: vi.fn(),
+  cmdName: vi.fn(),
+  cmdUpgrade: vi.fn(),
+  cmdWhoami: vi.fn(),
+  cmdUnbind: vi.fn(),
+};
+
+vi.mock('../commands/init.js', () => ({ cmdInit: handlers.cmdInit }));
+vi.mock('../commands/list.js', () => ({ cmdList: handlers.cmdList }));
+vi.mock('../commands/add.js', () => ({ cmdAdd: handlers.cmdAdd }));
+vi.mock('../commands/update.js', () => ({ cmdUpdate: handlers.cmdUpdate }));
+vi.mock('../commands/remove.js', () => ({ cmdRemove: handlers.cmdRemove }));
+vi.mock('../commands/talk.js', () => ({ cmdTalk: handlers.cmdTalk }));
+vi.mock('../commands/check.js', () => ({ cmdCheck: handlers.cmdCheck }));
+vi.mock('../commands/config.js', () => ({ cmdConfig: handlers.cmdConfig }));
+vi.mock('../commands/preamble.js', () => ({ cmdPreamble: handlers.cmdPreamble }));
+vi.mock('../commands/install.js', () => ({ cmdInstall: handlers.cmdInstall }));
+vi.mock('../commands/learn.js', () => ({ cmdLearn: handlers.cmdLearn }));
+vi.mock('../commands/this.js', () => ({ cmdThis: handlers.cmdThis }));
+vi.mock('../commands/migrate.js', () => ({ cmdMigrate: handlers.cmdMigrate }));
+vi.mock('../commands/name.js', () => ({ cmdName: handlers.cmdName }));
+vi.mock('../commands/upgrade.js', () => ({ cmdUpgrade: handlers.cmdUpgrade }));
+vi.mock('../commands/whoami.js', () => ({ cmdWhoami: handlers.cmdWhoami }));
+vi.mock('../commands/unbind.js', () => ({ cmdUnbind: handlers.cmdUnbind }));
+
+const { dispatchCommand } = await import('./application.js');
+const parsed = (invocation: any) => ({
+  invocation,
+  flags: { json: false, verbose: false },
+  metadata: { argv: [], commandPath: [], unsupportedTeam: false, capability: 'tmux' as const },
+});
+
+describe('application dispatcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('dispatches every executable kind using typed values', async () => {
+    const ctx = {} as Context;
+    const target = { value: 'claude', kind: 'identity' as const };
+    const cases = [
+      ['init', {}],
+      ['list', { target }],
+      ['add', { pane: '1.0', name: 'claude' }],
+      ['update', { name: 'claude', options: { remark: 'new' } }],
+      ['remove', { name: 'claude' }],
+      ['migrate', { dryRun: true, cleanup: false }],
+      ['this', { name: 'claude' }],
+      ['name', { name: 'claude' }],
+      ['whoami', {}],
+      ['unbind', {}],
+      ['talk', { target, message: 'hello' }],
+      ['check', { target, lines: 20 }],
+      ['config', { operation: 'show', global: false }],
+      ['preamble', { operation: 'show' }],
+      ['install', { target: 'codex' }],
+      ['upgrade', {}],
+      ['learn', {}],
+    ] as const;
+    for (const [kind, values] of cases) await dispatchCommand(ctx, parsed({ kind, ...values }));
+    expect(handlers.cmdInit).toHaveBeenCalledWith(ctx);
+    expect(handlers.cmdList).toHaveBeenCalledWith(ctx, 'claude');
+    expect(handlers.cmdTalk).toHaveBeenCalledWith(ctx, 'claude', 'hello');
+    expect(handlers.cmdCheck).toHaveBeenCalledWith(ctx, 'claude', 20);
+    expect(handlers.cmdConfig).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ operation: 'show' })
+    );
+    expect(handlers.cmdPreamble).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ operation: 'show' })
+    );
+  });
+
+  it('does not route presentation-only invocations to application services', async () => {
+    const ctx = {} as Context;
+    await dispatchCommand(ctx, parsed({ kind: 'help', showIntro: false }));
+    await dispatchCommand(ctx, parsed({ kind: 'version' }));
+    await dispatchCommand(ctx, parsed({ kind: 'completion', shell: 'bash' }));
+    expect(handlers.cmdInit).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/application.ts
+++ b/src/cli/application.ts
@@ -1,0 +1,73 @@
+import type { Context } from '../types.js';
+import { cmdInit } from '../commands/init.js';
+import { cmdList } from '../commands/list.js';
+import { cmdAdd } from '../commands/add.js';
+import { cmdUpdate } from '../commands/update.js';
+import { cmdRemove } from '../commands/remove.js';
+import { cmdTalk } from '../commands/talk.js';
+import { cmdCheck } from '../commands/check.js';
+import { cmdConfig } from '../commands/config.js';
+import { cmdPreamble } from '../commands/preamble.js';
+import { cmdInstall } from '../commands/install.js';
+import { cmdLearn } from '../commands/learn.js';
+import { cmdThis } from '../commands/this.js';
+import { cmdMigrate } from '../commands/migrate.js';
+import { cmdName } from '../commands/name.js';
+import { cmdUpgrade } from '../commands/upgrade.js';
+import { cmdWhoami } from '../commands/whoami.js';
+import { cmdUnbind } from '../commands/unbind.js';
+import type { ParsedArgs, ParsedInvocation } from './parser.js';
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled parsed invocation: ${JSON.stringify(value)}`);
+}
+
+/** Dispatches one fully parsed request to the existing application services. */
+export async function dispatchCommand(ctx: Context, parsed: ParsedArgs): Promise<void> {
+  const request = parsed.invocation;
+  switch (request.kind) {
+    case 'help':
+    case 'version':
+      return;
+    case 'init':
+      return cmdInit(ctx);
+    case 'list':
+      return request.target ? cmdList(ctx, request.target.value) : cmdList(ctx);
+    case 'add':
+      return cmdAdd(ctx, request.pane, request.name);
+    case 'update':
+      return cmdUpdate(ctx, request.name, request.options);
+    case 'remove':
+      return cmdRemove(ctx, request.name);
+    case 'migrate':
+      return cmdMigrate(ctx, request);
+    case 'this':
+      return cmdThis(ctx, request.name);
+    case 'name':
+      return cmdName(ctx, request.name);
+    case 'whoami':
+      return cmdWhoami(ctx);
+    case 'unbind':
+      return cmdUnbind(ctx);
+    case 'talk':
+      return cmdTalk(ctx, request.target.value, request.message);
+    case 'check':
+      return cmdCheck(ctx, request.target.value, request.lines);
+    case 'config':
+      return cmdConfig(ctx, request);
+    case 'preamble':
+      return cmdPreamble(ctx, request);
+    case 'install':
+      return cmdInstall(ctx, request.target);
+    case 'completion':
+      return;
+    case 'upgrade':
+      return cmdUpgrade(ctx);
+    case 'learn':
+      return cmdLearn();
+    default:
+      return assertNever(request);
+  }
+}
+
+export type ApplicationInvocation = ParsedInvocation;

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import { CliParseError, parseArgs } from './parser.js';
+
+describe('declarative CLI parser', () => {
+  it('parses global options independently of command position', () => {
+    const parsed = parseArgs(['talk', 'claude', 'hello', '--timeout', '500ms', '--wait']);
+    expect(parsed.flags).toMatchObject({ timeout: 0.5, wait: true });
+    expect(parsed.invocation).toMatchObject({
+      kind: 'talk',
+      target: { value: 'claude', kind: 'identity' },
+      message: 'hello',
+    });
+  });
+
+  it('preserves dash-prefixed literals after the terminator', () => {
+    const parsed = parseArgs(['talk', 'claude', '--', '--json is part of the message']);
+    expect(parsed.flags.json).toBe(false);
+    expect(parsed.invocation).toMatchObject({
+      kind: 'talk',
+      message: '--json is part of the message',
+    });
+  });
+
+  it('supports nested command schemas and typed update options', () => {
+    const config = parseArgs(['config', 'set', 'mode', 'wait', '--global']);
+    expect(config.invocation).toMatchObject({
+      kind: 'config',
+      operation: 'set',
+      key: 'mode',
+      value: 'wait',
+      global: true,
+    });
+
+    const update = parseArgs(['update', 'claude', '--pane=2.0', '--remark', 'new']);
+    expect(update.invocation).toMatchObject({
+      kind: 'update',
+      name: 'claude',
+      options: { pane: '2.0', remark: 'new' },
+    });
+  });
+
+  it('classifies existing positional targets without introducing future selector syntax', () => {
+    expect(parseArgs(['list', 'all']).invocation).toMatchObject({
+      target: { value: 'all', kind: 'identity' },
+    });
+    expect(parseArgs(['list', '1.0']).invocation).toMatchObject({
+      target: { value: '1.0', kind: 'pane' },
+    });
+    expect(() => parseArgs(['list', '--identity', 'all'])).toThrow(CliParseError);
+  });
+
+  it('rejects unknown options before creating command context', () => {
+    expect(() => parseArgs(['list', '--nope'])).toThrow(CliParseError);
+  });
+
+  it('reports surplus positional arguments through the schema', () => {
+    expect(() => parseArgs(['whoami', 'extra'])).toThrow(CliParseError);
+    expect(() => parseArgs(['config', 'show', 'extra'])).toThrow(CliParseError);
+  });
+
+  it('parses every nested mutation and preserves literal terminator values', () => {
+    expect(parseArgs(['migrate', '--dry-run', '--cleanup']).invocation).toEqual({
+      kind: 'migrate',
+      dryRun: true,
+      cleanup: true,
+    });
+    expect(parseArgs(['preamble', 'show', 'gemini']).invocation).toEqual({
+      kind: 'preamble',
+      operation: 'show',
+      agent: 'gemini',
+    });
+    expect(parseArgs(['preamble', 'set', 'gemini', '--', '--json', '--wait']).invocation).toEqual({
+      kind: 'preamble',
+      operation: 'set',
+      agent: 'gemini',
+      preamble: '--json --wait',
+    });
+    expect(parseArgs(['preamble', 'clear', 'gemini']).invocation).toEqual({
+      kind: 'preamble',
+      operation: 'clear',
+      agent: 'gemini',
+    });
+    expect(parseArgs(['config', 'clear', 'mode']).invocation).toEqual({
+      kind: 'config',
+      operation: 'clear',
+      key: 'mode',
+      global: false,
+    });
+    expect(parseArgs(['install', 'codex']).invocation).toEqual({
+      kind: 'install',
+      target: 'codex',
+    });
+  });
+
+  it('selects resource capabilities and preserves aliases', () => {
+    expect(parseArgs(['help']).metadata).toMatchObject({ capability: 'none' });
+    expect(parseArgs(['completion', 'zsh']).metadata).toMatchObject({ capability: 'none' });
+    expect(parseArgs(['learn']).metadata).toMatchObject({ capability: 'none' });
+    expect(parseArgs(['config']).metadata).toMatchObject({ capability: 'storage' });
+    expect(parseArgs(['send', 'claude', 'hello']).metadata.commandPath).toEqual(['send']);
+    expect(parseArgs(['ls']).invocation).toEqual({ kind: 'list' });
+    expect(parseArgs(['rm', 'claude']).invocation).toEqual({ kind: 'remove', name: 'claude' });
+  });
+
+  it('returns structured parse failures for invalid values and unknown options', () => {
+    expect(() => parseArgs(['talk', 'claude', 'hello', '--delay', 'later'])).toThrow(
+      'Invalid time format: later'
+    );
+    expect(() => parseArgs(['check', 'claude', 'not-lines'])).toThrow(CliParseError);
+    try {
+      parseArgs(['--json', 'config', 'set', 'mode', 'wait', '--nope']);
+      throw new Error('expected parse failure');
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'CliParseError',
+        flags: { json: true },
+      });
+      expect((error as Error).message).toContain("unknown option '--nope'");
+    }
+    expect(() => parseArgs(['--json', 'config', 'set', 'mode'])).toThrow(CliParseError);
+  });
+
+  it('supports top-level help and version with options before the special flag', () => {
+    expect(parseArgs(['--json', '--help'])).toMatchObject({
+      invocation: { kind: 'help', showIntro: false },
+      flags: { json: true },
+    });
+    expect(parseArgs(['--verbose', '--version'])).toMatchObject({
+      invocation: { kind: 'version' },
+      flags: { verbose: true },
+    });
+  });
+
+  it('does not reinterpret command arguments as top-level help or version flags', () => {
+    expect(() => parseArgs(['talk', 'claude', '--help'])).toThrow(CliParseError);
+    expect(() => parseArgs(['talk', 'claude', '--version'])).toThrow(CliParseError);
+    expect(parseArgs(['talk', 'claude', '--', '--help']).invocation).toMatchObject({
+      kind: 'talk',
+      message: '--help',
+    });
+  });
+
+  it('normalizes all common flags and records unsupported team scope', () => {
+    const parsed = parseArgs([
+      '--json',
+      '--verbose',
+      '--debug',
+      '--force',
+      '--config',
+      '/tmp/tmt.json',
+      '--delay',
+      '250ms',
+      '--wait',
+      '--timeout',
+      '3s',
+      '--lines',
+      '12',
+      '--team',
+      'legacy',
+      'list',
+    ]);
+    expect(parsed.flags).toMatchObject({
+      json: true,
+      verbose: true,
+      debug: true,
+      force: true,
+      config: '/tmp/tmt.json',
+      delay: 0.25,
+      wait: true,
+      timeout: 3,
+      lines: 12,
+    });
+    expect(parsed.metadata).toMatchObject({ unsupportedTeam: true, commandPath: ['list'] });
+  });
+});

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -1,0 +1,508 @@
+import { Command, CommanderError } from 'commander';
+import { isPaneTarget } from '../domain/names.js';
+import type { Flags } from '../types.js';
+import type { IdentitySelector } from '../identity-context.js';
+export type { IdentitySelector } from '../identity-context.js';
+
+export type ParsedInvocation =
+  | { readonly kind: 'help'; readonly showIntro: boolean }
+  | { readonly kind: 'version' }
+  | { readonly kind: 'completion'; readonly shell?: string }
+  | { readonly kind: 'install'; readonly target?: string }
+  | { readonly kind: 'init' | 'whoami' | 'unbind' | 'upgrade' | 'learn' }
+  | { readonly kind: 'list'; readonly target?: IdentitySelector }
+  | { readonly kind: 'add'; readonly pane: string; readonly name: string }
+  | {
+      readonly kind: 'update';
+      readonly name: string;
+      readonly options: { pane?: string; remark?: string };
+    }
+  | { readonly kind: 'remove'; readonly name: string }
+  | { readonly kind: 'migrate'; readonly dryRun: boolean; readonly cleanup: boolean }
+  | { readonly kind: 'this' | 'name'; readonly name: string }
+  | { readonly kind: 'talk'; readonly target: IdentitySelector; readonly message: string }
+  | { readonly kind: 'check'; readonly target: IdentitySelector; readonly lines?: number }
+  | {
+      readonly kind: 'config';
+      readonly operation: 'show' | 'set' | 'clear';
+      readonly key?: string;
+      readonly value?: string;
+      readonly global: boolean;
+    }
+  | {
+      readonly kind: 'preamble';
+      readonly operation: 'show' | 'set' | 'clear';
+      readonly agent?: string;
+      readonly preamble?: string;
+    };
+
+export interface ParsedMetadata {
+  readonly argv: readonly string[];
+  readonly commandPath: readonly string[];
+  readonly unsupportedTeam: boolean;
+  readonly capability: 'none' | 'storage' | 'tmux';
+}
+
+export interface ParsedArgs {
+  readonly invocation: ParsedInvocation;
+  readonly flags: Flags;
+  readonly metadata: ParsedMetadata;
+}
+
+export class CliParseError extends Error {
+  readonly flags: Flags;
+
+  constructor(message: string, flags: Flags = { json: false, verbose: false }) {
+    super(message);
+    this.name = 'CliParseError';
+    this.flags = flags;
+  }
+}
+
+interface CommonOptions {
+  json?: boolean;
+  verbose?: boolean;
+  debug?: boolean;
+  force?: boolean;
+  config?: string;
+  delay?: string;
+  wait?: boolean;
+  timeout?: string;
+  lines?: string;
+  noPreamble?: boolean;
+  preamble?: boolean;
+  team?: string;
+}
+
+interface CommandOptions extends CommonOptions {
+  pane?: string;
+  remark?: string;
+  dryRun?: boolean;
+  cleanup?: boolean;
+  global?: boolean;
+}
+
+interface Capture {
+  invocation?: ParsedInvocation;
+  command?: Command;
+  commandPath: string[];
+  unsupportedTeam: boolean;
+}
+
+function parseTime(value: string): number {
+  const match = value.match(/^(\d+(?:\.\d+)?)(ms|s)?$/i);
+  if (!match)
+    throw new CliParseError(
+      `Invalid time format: ${value}. Use number (seconds) or number with ms/s suffix.`
+    );
+  return match[2]?.toLowerCase() === 'ms' ? parseFloat(match[1]) / 1000 : parseFloat(match[1]);
+}
+
+function parseLines(value: string): number {
+  if (!/^\d+$/.test(value))
+    throw new CliParseError(`Invalid lines value: ${value}. Use a non-negative integer.`);
+  return parseInt(value, 10);
+}
+
+function flagsFrom(options: CommonOptions, argv: readonly string[] = []): Flags {
+  const flags: Flags = {
+    json: options.json === true,
+    verbose: options.verbose === true,
+  };
+  if (options.debug) flags.debug = true;
+  if (options.force) flags.force = true;
+  if (options.config !== undefined) flags.config = options.config;
+  if (options.delay !== undefined) flags.delay = parseTime(options.delay);
+  if (options.wait) flags.wait = true;
+  if (options.timeout !== undefined) flags.timeout = parseTime(options.timeout);
+  if (options.lines !== undefined) {
+    if (!/^\d+$/.test(options.lines))
+      throw new CliParseError(`Invalid lines value: ${options.lines}. Use a non-negative integer.`);
+    flags.lines = parseInt(options.lines, 10);
+  }
+  if (options.noPreamble || options.preamble === false || argv.includes('--no-preamble'))
+    flags.noPreamble = true;
+  return flags;
+}
+
+function flagsFromArgv(argv: readonly string[]): Flags {
+  return {
+    json: argv.includes('--json'),
+    verbose: argv.includes('--verbose') || argv.includes('-v'),
+  };
+}
+
+function compatibilityUsage(argv: readonly string[], message: string): string | undefined {
+  if (!/missing required argument|too many arguments/.test(message)) return undefined;
+  const usage: Record<string, string> = {
+    name: 'Usage: tmux-team name <global-name>',
+    this: 'Usage: tmux-team this <global-name>',
+    add: 'Usage: tmux-team add <pane-target> <global-name>',
+    update: 'Usage: tmux-team update <global-name> [--pane <pane>] [--remark <remark>]',
+    remove: 'Usage: tmux-team remove <global-name>',
+    rm: 'Usage: tmux-team rm <global-name>',
+    check: 'Usage: tmux-team check <target> [lines]',
+    read: 'Usage: tmux-team read <target> [lines]',
+    talk: 'Usage: tmux-team talk <target> <message>',
+    send: 'Usage: tmux-team send <target> <message>',
+    whoami: 'Usage: tmux-team whoami',
+    unbind: 'Usage: tmux-team unbind',
+  };
+  const command = argv.find((token) => Object.prototype.hasOwnProperty.call(usage, token));
+  return command ? usage[command] : undefined;
+}
+
+function selector(value: string, explicit: boolean): IdentitySelector {
+  return { value, kind: explicit || !isPaneTarget(value) ? 'identity' : 'pane', explicit };
+}
+
+function capabilityFor(invocation: ParsedInvocation): ParsedMetadata['capability'] {
+  switch (invocation.kind) {
+    case 'help':
+    case 'version':
+    case 'completion':
+    case 'learn':
+      return 'none';
+    case 'config':
+    case 'install':
+      return 'storage';
+    case 'preamble':
+      return invocation.operation === 'show' ? 'storage' : 'tmux';
+    case 'migrate':
+      return 'tmux';
+    default:
+      return 'tmux';
+  }
+}
+
+function commonOptions(command: Command): Command {
+  command
+    .option('--json')
+    .option('-v, --verbose')
+    .option('--debug')
+    .option('-f, --force')
+    .option('--config <path>')
+    .option('--delay <time>')
+    .option('--wait')
+    .option('--timeout <time>')
+    .option('--lines <count>')
+    .option('--no-preamble')
+    .option('--team <team>');
+  return command;
+}
+
+function commandOptions(command: Command): CommandOptions {
+  const options: CommandOptions = {};
+  const chain: Command[] = [];
+  let current: Command | null = command;
+  while (current) {
+    chain.unshift(current);
+    current = current.parent;
+  }
+  for (const item of chain) Object.assign(options, item.opts() as CommandOptions);
+  return options;
+}
+
+function setupProgram(capture: Capture): Command {
+  const program = commonOptions(new Command()).name('tmux-team').helpOption(false);
+  program.exitOverride((error) => {
+    if (error instanceof CommanderError) throw new CliParseError(error.message);
+    throw error;
+  });
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+
+  const action = (command: Command, invocation: ParsedInvocation): void => {
+    capture.invocation = invocation;
+    capture.command = command;
+    const path: string[] = [];
+    let current: Command | null = command;
+    while (current && current !== program) {
+      path.unshift(current.name());
+      current = current.parent;
+    }
+    capture.commandPath = path;
+    capture.unsupportedTeam ||= Boolean(commandOptions(command).team);
+  };
+  const leaf = <T extends Command>(command: T): T => {
+    commonOptions(command);
+    return command;
+  };
+
+  program.action(() => action(program, { kind: 'help', showIntro: true }));
+  commonOptions(program.command('help')).action(function () {
+    action(this, { kind: 'help', showIntro: false });
+  });
+  const team = commonOptions(program.command('team').argument('[scope]'));
+  team.action(function () {
+    capture.unsupportedTeam = true;
+    action(this, { kind: 'help', showIntro: false });
+  });
+  commonOptions(program.command('init')).action(function () {
+    action(this, { kind: 'init' });
+  });
+  const list = leaf(program.command('list').alias('ls').argument('[target]'));
+  list.action(function (target?: string) {
+    action(this, {
+      kind: 'list',
+      target: target ? selector(target, false) : undefined,
+    });
+  });
+  const add = leaf(program.command('add').argument('<pane-target>').argument('<global-name>'));
+  add.action(function (pane: string, name: string) {
+    action(this, { kind: 'add', pane, name });
+  });
+  const update = leaf(program.command('update').argument('<name>'));
+  update
+    .option('--pane <pane>')
+    .option('--remark <remark>')
+    .action(function (name: string) {
+      const options = commandOptions(this);
+      action(this, {
+        kind: 'update',
+        name,
+        options: {
+          ...(options.pane && { pane: options.pane }),
+          ...(options.remark && { remark: options.remark }),
+        },
+      });
+    });
+  for (const [name, kind] of [
+    ['remove', 'remove'],
+    ['rm', 'remove'],
+  ] as const) {
+    const command = leaf(program.command(name).argument('<name>'));
+    command.action(function (value: string) {
+      action(this, { kind, name: value });
+    });
+  }
+  const migrate = leaf(program.command('migrate'));
+  migrate
+    .option('--dry-run')
+    .option('--cleanup')
+    .action(function () {
+      const options = commandOptions(this) as CommonOptions & {
+        dryRun?: boolean;
+        cleanup?: boolean;
+      };
+      action(this, {
+        kind: 'migrate',
+        dryRun: options.dryRun === true,
+        cleanup: options.cleanup === true,
+      });
+    });
+  for (const kind of ['this', 'name'] as const) {
+    const command = leaf(program.command(kind).argument('<name>'));
+    command.action(function (name: string) {
+      action(this, { kind, name });
+    });
+  }
+  for (const [name, kind] of [
+    ['talk', 'talk'],
+    ['send', 'talk'],
+  ] as const) {
+    const command = leaf(program.command(name).argument('<target>').argument('<message>'));
+    command.action(function (target: string, message: string) {
+      action(this, {
+        kind,
+        target: selector(target, false),
+        message,
+      });
+    });
+  }
+  for (const [name, kind] of [
+    ['check', 'check'],
+    ['read', 'check'],
+  ] as const) {
+    const command = leaf(program.command(name).argument('<target>').argument('[lines]'));
+    command.action(function (target: string, lines?: string) {
+      const options = commandOptions(this);
+      const value = lines ?? options.lines;
+      action(this, {
+        kind,
+        target: selector(target, false),
+        ...(value !== undefined && { lines: parseLines(value) }),
+      });
+    });
+  }
+  const config = leaf(program.command('config'));
+  config.action(function () {
+    action(this, { kind: 'config', operation: 'show', global: false });
+  });
+  const configShow = config.command('show');
+  commonOptions(configShow);
+  configShow.action(function () {
+    action(this, { kind: 'config', operation: 'show', global: false });
+  });
+  const configSet = config.command('set').argument('<key>').argument('<value>');
+  commonOptions(configSet).option('-g, --global');
+  configSet.action(function (key: string, value: string) {
+    action(this, {
+      kind: 'config',
+      operation: 'set',
+      key,
+      value,
+      global: Boolean((this.opts() as { global?: boolean }).global),
+    });
+  });
+  const configClear = config.command('clear').argument('[key]');
+  commonOptions(configClear);
+  configClear.action(function (key?: string) {
+    action(this, {
+      kind: 'config',
+      operation: 'clear',
+      ...(key !== undefined && { key }),
+      global: false,
+    });
+  });
+  const preamble = leaf(program.command('preamble'));
+  preamble.action(function () {
+    action(this, { kind: 'preamble', operation: 'show' });
+  });
+  const preambleShow = preamble.command('show').argument('[agent]');
+  commonOptions(preambleShow);
+  preambleShow.action(function (agent?: string) {
+    action(this, { kind: 'preamble', operation: 'show', agent });
+  });
+  const preambleSet = preamble.command('set').argument('<agent>').argument('<preamble...>');
+  commonOptions(preambleSet);
+  preambleSet.action(function (agent: string, values: string[]) {
+    action(this, { kind: 'preamble', operation: 'set', agent, preamble: values.join(' ') });
+  });
+  const preambleClear = preamble.command('clear').argument('<agent>');
+  commonOptions(preambleClear);
+  preambleClear.action(function (agent: string) {
+    action(this, { kind: 'preamble', operation: 'clear', agent });
+  });
+  const install = leaf(program.command('install').argument('[agent]'));
+  install.action(function (agent?: string) {
+    action(this, { kind: 'install', target: agent });
+  });
+  const completion = leaf(program.command('completion').argument('[shell]'));
+  completion.action(function (shell?: string) {
+    action(this, { kind: 'completion', shell });
+  });
+  for (const kind of ['upgrade', 'learn', 'whoami', 'unbind'] as const) {
+    const command = leaf(program.command(kind));
+    command.action(function () {
+      action(this, { kind });
+    });
+  }
+  return program;
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const raw = [...argv];
+  if (raw.length === 0) {
+    return {
+      invocation: { kind: 'help', showIntro: raw.length === 0 },
+      flags: { json: raw.includes('--json'), verbose: false },
+      metadata: {
+        argv: raw,
+        commandPath: [],
+        unsupportedTeam: false,
+        capability: 'none',
+      },
+    };
+  }
+  const terminator = raw.indexOf('--');
+  const commandTokens = terminator === -1 ? raw : raw.slice(0, terminator);
+  const valueOptions = new Set(['--config', '--delay', '--timeout', '--lines', '--team']);
+  let firstCommandToken: string | undefined;
+  for (let index = 0; index < commandTokens.length; index++) {
+    const token = commandTokens[index];
+    if (valueOptions.has(token)) {
+      index++;
+      continue;
+    }
+    if (token.startsWith('--team=')) continue;
+    if (
+      token.startsWith('-') &&
+      token !== '--help' &&
+      token !== '-h' &&
+      token !== '--version' &&
+      token !== '-V'
+    ) {
+      continue;
+    }
+    firstCommandToken = token;
+    break;
+  }
+  if (firstCommandToken === '--help' || firstCommandToken === '-h') {
+    return {
+      invocation: { kind: 'help', showIntro: false },
+      flags: {
+        json: commandTokens.includes('--json'),
+        verbose: commandTokens.includes('--verbose') || commandTokens.includes('-v'),
+      },
+      metadata: {
+        argv: raw,
+        commandPath: [],
+        unsupportedTeam: false,
+        capability: 'none',
+      },
+    };
+  }
+  if (firstCommandToken === '--version' || firstCommandToken === '-V') {
+    return {
+      invocation: { kind: 'version' },
+      flags: flagsFromArgv(commandTokens),
+      metadata: {
+        argv: raw,
+        commandPath: [],
+        unsupportedTeam: false,
+        capability: 'none',
+      },
+    };
+  }
+  const capture: Capture = { commandPath: [], unsupportedTeam: false };
+  const program = setupProgram(capture);
+  if (
+    firstCommandToken &&
+    !firstCommandToken.startsWith('-') &&
+    !program.commands.some(
+      (command) =>
+        command.name() === firstCommandToken || command.aliases().includes(firstCommandToken)
+    )
+  ) {
+    throw new CliParseError(
+      `Unknown command: ${firstCommandToken}. Run 'tmux-team help' for usage.`,
+      flagsFromArgv(commandTokens)
+    );
+  }
+  try {
+    program.parse(['node', 'tmux-team', ...raw], { from: 'node' });
+  } catch (error) {
+    if (error instanceof CliParseError) {
+      throw new CliParseError(
+        compatibilityUsage(commandTokens, error.message) ?? error.message,
+        flagsFromArgv(commandTokens)
+      );
+    }
+    throw new CliParseError(error instanceof Error ? error.message : String(error));
+  }
+  if (!capture.invocation)
+    throw new CliParseError(`Unknown command: ${raw[0]}. Run 'tmux-team help' for usage.`);
+  let flags: Flags;
+  try {
+    flags = flagsFrom(
+      capture.command ? commandOptions(capture.command) : (program.opts() as CommonOptions),
+      commandTokens
+    );
+  } catch (error) {
+    if (error instanceof CliParseError) {
+      throw new CliParseError(error.message, flagsFromArgv(commandTokens));
+    }
+    throw error;
+  }
+  capture.unsupportedTeam ||= Boolean((program.opts() as CommonOptions).team);
+  return {
+    invocation: capture.invocation,
+    flags,
+    metadata: {
+      argv: raw,
+      commandPath: capture.commandPath,
+      unsupportedTeam: capture.unsupportedTeam,
+      capability: capabilityFor(capture.invocation),
+    },
+  };
+}

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -12,12 +12,21 @@ import { cmdRemove } from './remove.js';
 import { cmdUpdate } from './update.js';
 import { cmdList } from './list.js';
 import { cmdCheck } from './check.js';
-import { cmdPreamble } from './preamble.js';
-import { cmdConfig } from './config.js';
+import { cmdPreamble, type PreambleRequest } from './preamble.js';
+import { cmdConfig, type ConfigRequest } from './config.js';
 import { cmdCompletion } from './completion.js';
 import { cmdHelp } from './help.js';
 import { cmdLearn } from './learn.js';
-import { cmdMigrate } from './migrate.js';
+import { cmdMigrate, type MigrateRequest } from './migrate.js';
+
+const preambleRequest = (
+  operation: PreambleRequest['operation'],
+  values: Omit<PreambleRequest, 'kind' | 'operation'> = {}
+): PreambleRequest => ({ kind: 'preamble', operation, ...values });
+const configRequest = (
+  operation: ConfigRequest['operation'],
+  values: Omit<ConfigRequest, 'kind' | 'operation'> = { global: false }
+): ConfigRequest => ({ kind: 'config', operation, ...values });
 
 function createMockUI(): UI & { jsonCalls: unknown[] } {
   return {
@@ -418,17 +427,17 @@ describe('basic commands', () => {
     });
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({ claude: { pane: '1.0' } }, null, 2));
 
-    cmdPreamble(ctx, ['set', 'claude', 'Be', 'concise']);
+    cmdPreamble(ctx, preambleRequest('set', { agent: 'claude', preamble: 'Be concise' }));
     let saved = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved.claude.preamble).toBe('Be concise');
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     // show will read from ctx.config.agents; update it to reflect loadConfig behavior
     ctx.config.agents.claude = { preamble: 'Be concise' };
-    cmdPreamble(ctx, ['show', 'claude']);
+    cmdPreamble(ctx, preambleRequest('show', { agent: 'claude' }));
     expect(logSpy).toHaveBeenCalled();
 
-    cmdPreamble(ctx, ['clear', 'claude']);
+    cmdPreamble(ctx, preambleRequest('clear', { agent: 'claude' }));
     saved = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved.claude.preamble).toBeUndefined();
   });
@@ -436,13 +445,15 @@ describe('basic commands', () => {
   it('cmdPreamble set errors when agent missing', () => {
     const ctx = createCtx(testDir);
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({}, null, 2));
-    expect(() => cmdPreamble(ctx, ['set', 'nope', 'x'])).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(() =>
+      cmdPreamble(ctx, preambleRequest('set', { agent: 'nope', preamble: 'x' }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
   });
 
   it('cmdPreamble clear returns not_set when missing', () => {
     const ctx = createCtx(testDir, { flags: { json: true } });
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({ claude: { pane: '1.0' } }, null, 2));
-    cmdPreamble(ctx, ['clear', 'claude']);
+    cmdPreamble(ctx, preambleRequest('clear', { agent: 'claude' }));
     const out = (ctx.ui as any).jsonCalls[0] as any;
     expect(out.status).toBe('not_set');
   });
@@ -451,40 +462,46 @@ describe('basic commands', () => {
     const ctx = createCtx(testDir);
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({}, null, 2));
 
-    cmdConfig(ctx, ['set', 'mode', 'wait']);
+    cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'wait', global: false }));
     const saved = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved.$config.mode).toBe('wait');
 
-    cmdConfig(ctx, ['clear', 'mode']);
+    cmdConfig(ctx, configRequest('clear', { key: 'mode', global: false }));
     const saved2 = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved2.$config?.mode).toBeUndefined();
   });
 
   it('cmdConfig set supports --global', () => {
     const ctx = createCtx(testDir);
-    cmdConfig(ctx, ['set', 'mode', 'wait', '--global']);
+    cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'wait', global: true }));
     const saved = JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf-8'));
     expect(saved.mode).toBe('wait');
   });
 
   it('cmdConfig set errors when not enough args', () => {
     const ctx = createCtx(testDir);
-    expect(() => cmdConfig(ctx, ['set', 'mode'])).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(() => cmdConfig(ctx, configRequest('set', { key: 'mode', global: false }))).toThrow(
+      `exit(${ExitCodes.ERROR})`
+    );
     expect(ctx.ui.error).toHaveBeenCalledWith(
       'Usage: tmux-team config set <key> <value> [--global]'
     );
   });
 
-  it('cmdConfig errors on unknown subcommand', () => {
+  it('cmdConfig rejects a set request with a missing value', () => {
     const ctx = createCtx(testDir);
-    expect(() => cmdConfig(ctx, ['unknown'])).toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(ctx.ui.error).toHaveBeenCalledWith('Unknown config subcommand: unknown');
+    expect(() => cmdConfig(ctx, configRequest('set', { key: 'mode', global: false }))).toThrow(
+      `exit(${ExitCodes.ERROR})`
+    );
+    expect(ctx.ui.error).toHaveBeenCalledWith(
+      'Usage: tmux-team config set <key> <value> [--global]'
+    );
   });
 
   it('cmdConfig set preambleMode locally', () => {
     const ctx = createCtx(testDir);
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({}, null, 2));
-    cmdConfig(ctx, ['set', 'preambleMode', 'disabled']);
+    cmdConfig(ctx, configRequest('set', { key: 'preambleMode', value: 'disabled', global: false }));
     const saved = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved.$config.preambleMode).toBe('disabled');
   });
@@ -492,14 +509,16 @@ describe('basic commands', () => {
   it('cmdConfig set preambleEvery locally', () => {
     const ctx = createCtx(testDir);
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({}, null, 2));
-    cmdConfig(ctx, ['set', 'preambleEvery', '5']);
+    cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value: '5', global: false }));
     const saved = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved.$config.preambleEvery).toBe(5);
   });
 
   it('cmdConfig clear errors on invalid key', () => {
     const ctx = createCtx(testDir);
-    expect(() => cmdConfig(ctx, ['clear', 'invalidkey'])).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(() =>
+      cmdConfig(ctx, configRequest('clear', { key: 'invalidkey', global: false }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
     expect(ctx.ui.error).toHaveBeenCalledWith(
       'Invalid key: invalidkey. Valid keys: mode, preambleMode, preambleEvery, pasteEnterDelayMs'
     );
@@ -512,7 +531,7 @@ describe('basic commands', () => {
       JSON.stringify({ claude: { pane: '1.1', remark: 'review' } }, null, 2)
     );
 
-    cmdMigrate(ctx, ['--dry-run']);
+    cmdMigrate(ctx, { kind: 'migrate', dryRun: true, cleanup: false } satisfies MigrateRequest);
 
     expect(ctx.tmux.setAgentRegistration).not.toHaveBeenCalled();
     expect((ctx.ui as any).jsonCalls[0]).toMatchObject({
@@ -532,7 +551,7 @@ describe('basic commands', () => {
       })
     );
 
-    cmdMigrate(ctx, ['--cleanup']);
+    cmdMigrate(ctx, { kind: 'migrate', dryRun: false, cleanup: true } satisfies MigrateRequest);
 
     expect(ctx.tmux.setAgentRegistration).toHaveBeenCalledWith(
       '1.1',
@@ -549,14 +568,16 @@ describe('basic commands', () => {
     (ctx.tmux.resolvePaneTarget as ReturnType<typeof vi.fn>).mockReturnValue(null);
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({ claude: { pane: 'missing' } }));
 
-    expect(() => cmdMigrate(ctx, [])).toThrow(`exit(${ExitCodes.PANE_NOT_FOUND})`);
+    expect(() => cmdMigrate(ctx, { kind: 'migrate', dryRun: false, cleanup: false })).toThrow(
+      `exit(${ExitCodes.PANE_NOT_FOUND})`
+    );
   });
 
   it('cmdMigrate reports when no legacy agents exist', () => {
     const ctx = createCtx(testDir);
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({ $config: { mode: 'wait' } }));
 
-    cmdMigrate(ctx, []);
+    cmdMigrate(ctx, { kind: 'migrate', dryRun: false, cleanup: false });
 
     expect(ctx.ui.info).toHaveBeenCalledWith(`No legacy agents found in ${ctx.paths.localConfig}`);
   });

--- a/src/commands/config-command.test.ts
+++ b/src/commands/config-command.test.ts
@@ -4,7 +4,12 @@ import os from 'os';
 import path from 'path';
 import type { Context, Flags, Paths, ResolvedConfig, Tmux, UI } from '../types.js';
 import { ExitCodes } from '../exits.js';
-import { cmdConfig } from './config.js';
+import { cmdConfig, type ConfigRequest } from './config.js';
+
+const configRequest = (
+  operation: ConfigRequest['operation'],
+  values: Omit<ConfigRequest, 'kind' | 'operation'> = { global: false }
+): ConfigRequest => ({ kind: 'config', operation, ...values });
 
 function createMockUI(): UI & { jsonCalls: unknown[] } {
   return {
@@ -88,7 +93,7 @@ describe('cmdConfig', () => {
 
   it('shows config as JSON when --json', () => {
     const ctx = createCtx(testDir, { json: true });
-    cmdConfig(ctx, ['show']);
+    cmdConfig(ctx, configRequest('show'));
     expect((ctx.ui as any).jsonCalls.length).toBe(1);
     const out = (ctx.ui as any).jsonCalls[0] as any;
     expect(out.resolved).toBeTruthy();
@@ -98,33 +103,37 @@ describe('cmdConfig', () => {
 
   it('shows config as table in human mode', () => {
     const ctx = createCtx(testDir);
-    cmdConfig(ctx, ['show']);
+    cmdConfig(ctx, configRequest('show'));
     expect(ctx.ui.table).toHaveBeenCalled();
   });
 
   it('rejects invalid keys and values', () => {
     const ctx = createCtx(testDir);
-    expect(() => cmdConfig(ctx, ['set', 'nope', 'x'])).toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(() => cmdConfig(ctx, ['set', 'mode', 'nope'])).toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(() => cmdConfig(ctx, ['set', 'preambleEvery', '-1'])).toThrow(
-      `exit(${ExitCodes.ERROR})`
-    );
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'nope', value: 'x', global: false }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'nope', global: false }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value: '-1', global: false }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
   });
 
   it('sets and clears local settings', () => {
     const ctx = createCtx(testDir);
-    cmdConfig(ctx, ['set', 'preambleMode', 'disabled']);
+    cmdConfig(ctx, configRequest('set', { key: 'preambleMode', value: 'disabled', global: false }));
     const saved = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved.$config.preambleMode).toBe('disabled');
 
-    cmdConfig(ctx, ['clear']);
+    cmdConfig(ctx, configRequest('clear'));
     const saved2 = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved2.$config).toBeUndefined();
   });
 
   it('sets global settings with -g', () => {
     const ctx = createCtx(testDir);
-    cmdConfig(ctx, ['set', 'preambleEvery', '5', '-g']);
+    cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value: '5', global: true }));
     const saved = JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf-8'));
     expect(saved.defaults.preambleEvery).toBe(5);
   });
@@ -138,7 +147,7 @@ describe('cmdConfig', () => {
         $config: { mode: 'wait', preambleMode: 'disabled', preambleEvery: 5 },
       })
     );
-    cmdConfig(ctx, ['show']);
+    cmdConfig(ctx, configRequest('show'));
     const out = (ctx.ui as any).jsonCalls[0] as any;
     expect(out.sources.mode).toBe('local');
     expect(out.sources.preambleMode).toBe('local');
@@ -157,7 +166,7 @@ describe('cmdConfig', () => {
         defaults: { preambleEvery: 7 },
       })
     );
-    cmdConfig(ctx, ['show']);
+    cmdConfig(ctx, configRequest('show'));
     const out = (ctx.ui as any).jsonCalls[0] as any;
     expect(out.sources.mode).toBe('global');
     expect(out.sources.preambleMode).toBe('global');
@@ -166,7 +175,7 @@ describe('cmdConfig', () => {
 
   it('shows default source when no config has settings', () => {
     const ctx = createCtx(testDir, { json: true });
-    cmdConfig(ctx, ['show']);
+    cmdConfig(ctx, configRequest('show'));
     const out = (ctx.ui as any).jsonCalls[0] as any;
     expect(out.sources.mode).toBe('default');
     expect(out.sources.preambleMode).toBe('default');
@@ -176,7 +185,7 @@ describe('cmdConfig', () => {
   it('shows sources in table mode with local settings', () => {
     const ctx = createCtx(testDir);
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({ $config: { mode: 'wait' } }));
-    cmdConfig(ctx, ['show']);
+    cmdConfig(ctx, configRequest('show'));
     expect(ctx.ui.table).toHaveBeenCalled();
     // The table call should include (local) source
     const tableCall = (ctx.ui.table as ReturnType<typeof vi.fn>).mock.calls[0];
@@ -187,7 +196,7 @@ describe('cmdConfig', () => {
     const ctx = createCtx(testDir);
     fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
     fs.writeFileSync(ctx.paths.globalConfig, JSON.stringify({ mode: 'wait' }));
-    cmdConfig(ctx, ['show']);
+    cmdConfig(ctx, configRequest('show'));
     expect(ctx.ui.table).toHaveBeenCalled();
     const tableCall = (ctx.ui.table as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(tableCall[1].some((row: string[]) => row[2]?.includes('global'))).toBe(true);
@@ -195,8 +204,8 @@ describe('cmdConfig', () => {
 
   it('sets global mode and preambleMode', () => {
     const ctx = createCtx(testDir);
-    cmdConfig(ctx, ['set', 'mode', 'wait', '--global']);
-    cmdConfig(ctx, ['set', 'preambleMode', 'disabled', '--global']);
+    cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'wait', global: true }));
+    cmdConfig(ctx, configRequest('set', { key: 'preambleMode', value: 'disabled', global: true }));
     const saved = JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf-8'));
     expect(saved.mode).toBe('wait');
     expect(saved.preambleMode).toBe('disabled');

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -17,6 +17,14 @@ type EnumConfigKey = 'mode' | 'preambleMode';
 type NumericConfigKey = 'preambleEvery' | 'pasteEnterDelayMs';
 type ConfigKey = EnumConfigKey | NumericConfigKey;
 
+export interface ConfigRequest {
+  readonly kind: 'config';
+  readonly operation: 'show' | 'set' | 'clear';
+  readonly key?: string;
+  readonly value?: string;
+  readonly global: boolean;
+}
+
 const ENUM_KEYS: EnumConfigKey[] = ['mode', 'preambleMode'];
 const NUMERIC_KEYS: NumericConfigKey[] = ['preambleEvery', 'pasteEnterDelayMs'];
 const VALID_KEYS: ConfigKey[] = [...ENUM_KEYS, ...NUMERIC_KEYS];
@@ -238,33 +246,20 @@ function clearConfig(ctx: Context, key?: string): void {
 /**
  * Config command entry point.
  */
-export function cmdConfig(ctx: Context, args: string[]): void {
-  // Parse --global flag first, then determine subcommand
-  const globalFlag = args.includes('--global') || args.includes('-g');
-  const filteredArgs = args.filter((a) => a !== '--global' && a !== '-g');
-  const subcommand = filteredArgs[0];
-
-  switch (subcommand) {
-    case undefined:
+export function cmdConfig(ctx: Context, request: ConfigRequest): void {
+  switch (request.operation) {
     case 'show':
       showConfig(ctx);
-      break;
-
+      return;
     case 'set':
-      if (filteredArgs.length < 3) {
+      if (request.key === undefined || request.value === undefined) {
         ctx.ui.error('Usage: tmux-team config set <key> <value> [--global]');
         ctx.exit(ExitCodes.ERROR);
       }
-      setConfig(ctx, filteredArgs[1], filteredArgs[2], globalFlag);
-      break;
-
+      setConfig(ctx, request.key, request.value, request.global);
+      return;
     case 'clear':
-      clearConfig(ctx, filteredArgs[1]);
-      break;
-
-    default:
-      ctx.ui.error(`Unknown config subcommand: ${subcommand}`);
-      ctx.ui.error('Usage: tmux-team config [show|set|clear]');
-      ctx.exit(ExitCodes.ERROR);
+      clearConfig(ctx, request.key);
+      return;
   }
 }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -15,9 +15,14 @@ interface MigrationItem {
   status: 'ready' | 'migrated';
 }
 
-export function cmdMigrate(ctx: Context, args: string[]): void {
-  const dryRun = args.includes('--dry-run');
-  const cleanup = args.includes('--cleanup');
+export interface MigrateRequest {
+  readonly kind: 'migrate';
+  readonly dryRun: boolean;
+  readonly cleanup: boolean;
+}
+
+export function cmdMigrate(ctx: Context, request: MigrateRequest): void {
+  const { dryRun, cleanup } = request;
   const { ui, paths, flags, tmux, exit } = ctx;
   const localConfig = loadLocalConfigFile(paths);
   const scope = getRegistryScope(ctx);

--- a/src/commands/preamble.test.ts
+++ b/src/commands/preamble.test.ts
@@ -7,7 +7,12 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import type { Context, Paths, ResolvedConfig, Flags, UI, Tmux } from '../types.js';
-import { cmdPreamble } from './preamble.js';
+import { cmdPreamble, type PreambleRequest } from './preamble.js';
+
+const preambleRequest = (
+  operation: PreambleRequest['operation'],
+  values: Omit<PreambleRequest, 'kind' | 'operation'> = {}
+): PreambleRequest => ({ kind: 'preamble', operation, ...values });
 
 // ─────────────────────────────────────────────────────────────
 // Test utilities
@@ -142,7 +147,7 @@ describe('cmdPreamble', () => {
         },
       });
 
-      cmdPreamble(ctx, ['show', 'claude']);
+      cmdPreamble(ctx, preambleRequest('show', { agent: 'claude' }));
 
       expect(ui.infos).toContain('Preamble for claude:');
     });
@@ -155,7 +160,7 @@ describe('cmdPreamble', () => {
         config: { agents: {} },
       });
 
-      cmdPreamble(ctx, ['show', 'claude']);
+      cmdPreamble(ctx, preambleRequest('show', { agent: 'claude' }));
 
       expect(ui.infos).toContain('No preamble set for claude');
     });
@@ -175,7 +180,7 @@ describe('cmdPreamble', () => {
         },
       });
 
-      cmdPreamble(ctx, ['show']);
+      cmdPreamble(ctx, preambleRequest('show'));
 
       expect(logSpy).toHaveBeenCalled();
       logSpy.mockRestore();
@@ -189,7 +194,7 @@ describe('cmdPreamble', () => {
         config: { agents: {} },
       });
 
-      cmdPreamble(ctx, ['show']);
+      cmdPreamble(ctx, preambleRequest('show'));
 
       expect(ui.infos).toContain('No preambles configured');
     });
@@ -205,7 +210,7 @@ describe('cmdPreamble', () => {
         },
       });
 
-      cmdPreamble(ctx, ['show', 'claude']);
+      cmdPreamble(ctx, preambleRequest('show', { agent: 'claude' }));
 
       expect(ui.jsonOutput).toHaveLength(1);
       expect(ui.jsonOutput[0]).toEqual({ agent: 'claude', preamble: 'Be helpful' });
@@ -224,7 +229,7 @@ describe('cmdPreamble', () => {
         },
       });
 
-      cmdPreamble(ctx, ['show']);
+      cmdPreamble(ctx, preambleRequest('show'));
 
       expect(ui.jsonOutput).toHaveLength(1);
       expect(ui.jsonOutput[0]).toMatchObject({
@@ -240,7 +245,7 @@ describe('cmdPreamble', () => {
         config: { agents: {} },
       });
 
-      cmdPreamble(ctx, []);
+      cmdPreamble(ctx, preambleRequest('show'));
 
       expect(ui.infos).toContain('No preambles configured');
     });
@@ -256,7 +261,7 @@ describe('cmdPreamble', () => {
 
       const ctx = createContext({ ui, paths });
 
-      cmdPreamble(ctx, ['set', 'claude', 'Be', 'very', 'helpful']);
+      cmdPreamble(ctx, preambleRequest('set', { agent: 'claude', preamble: 'Be very helpful' }));
 
       // Check file was updated
       const config = JSON.parse(fs.readFileSync(paths.localConfig, 'utf-8'));
@@ -273,7 +278,9 @@ describe('cmdPreamble', () => {
         config: { paneRegistry: {} },
       });
 
-      expect(() => cmdPreamble(ctx, ['set', 'unknown', 'preamble'])).toThrow('exit(1)');
+      expect(() =>
+        cmdPreamble(ctx, preambleRequest('set', { agent: 'unknown', preamble: 'preamble' }))
+      ).toThrow('exit(1)');
       expect(ui.errors[0]).toContain("Agent 'unknown' not found");
     });
 
@@ -281,7 +288,9 @@ describe('cmdPreamble', () => {
       const ui = createMockUI();
       const ctx = createContext({ ui, paths: createTestPaths(testDir) });
 
-      expect(() => cmdPreamble(ctx, ['set', 'claude'])).toThrow('exit(1)');
+      expect(() => cmdPreamble(ctx, preambleRequest('set', { agent: 'claude' }))).toThrow(
+        'exit(1)'
+      );
       expect(ui.errors[0]).toContain('Usage: tmux-team preamble set');
     });
 
@@ -293,7 +302,7 @@ describe('cmdPreamble', () => {
 
       const ctx = createContext({ ui, paths, flags: { json: true } });
 
-      cmdPreamble(ctx, ['set', 'claude', 'Be helpful']);
+      cmdPreamble(ctx, preambleRequest('set', { agent: 'claude', preamble: 'Be helpful' }));
 
       expect(ui.jsonOutput).toHaveLength(1);
       expect(ui.jsonOutput[0]).toMatchObject({
@@ -317,7 +326,7 @@ describe('cmdPreamble', () => {
 
       const ctx = createContext({ ui, paths });
 
-      cmdPreamble(ctx, ['clear', 'claude']);
+      cmdPreamble(ctx, preambleRequest('clear', { agent: 'claude' }));
 
       // Check file was updated
       const config = JSON.parse(fs.readFileSync(paths.localConfig, 'utf-8'));
@@ -333,7 +342,7 @@ describe('cmdPreamble', () => {
 
       const ctx = createContext({ ui, paths });
 
-      cmdPreamble(ctx, ['clear', 'claude']);
+      cmdPreamble(ctx, preambleRequest('clear', { agent: 'claude' }));
 
       expect(ui.infos).toContain('No preamble was set for claude');
     });
@@ -342,7 +351,7 @@ describe('cmdPreamble', () => {
       const ui = createMockUI();
       const ctx = createContext({ ui, paths: createTestPaths(testDir) });
 
-      expect(() => cmdPreamble(ctx, ['clear'])).toThrow('exit(1)');
+      expect(() => cmdPreamble(ctx, preambleRequest('clear'))).toThrow('exit(1)');
       expect(ui.errors[0]).toContain('Usage: tmux-team preamble clear');
     });
 
@@ -357,7 +366,7 @@ describe('cmdPreamble', () => {
 
       const ctx = createContext({ ui, paths, flags: { json: true } });
 
-      cmdPreamble(ctx, ['clear', 'claude']);
+      cmdPreamble(ctx, preambleRequest('clear', { agent: 'claude' }));
 
       expect(ui.jsonOutput).toHaveLength(1);
       expect(ui.jsonOutput[0]).toMatchObject({ agent: 'claude', status: 'cleared' });
@@ -371,7 +380,7 @@ describe('cmdPreamble', () => {
 
       const ctx = createContext({ ui, paths, flags: { json: true } });
 
-      cmdPreamble(ctx, ['clear', 'claude']);
+      cmdPreamble(ctx, preambleRequest('clear', { agent: 'claude' }));
 
       expect(ui.jsonOutput).toHaveLength(1);
       expect(ui.jsonOutput[0]).toMatchObject({ agent: 'claude', status: 'not_set' });
@@ -383,9 +392,10 @@ describe('cmdPreamble', () => {
       const ui = createMockUI();
       const ctx = createContext({ ui, paths: createTestPaths(testDir) });
 
-      expect(() => cmdPreamble(ctx, ['invalid'])).toThrow('exit(1)');
-      expect(ui.errors[0]).toContain('Unknown preamble subcommand: invalid');
-      expect(ui.errors[1]).toContain('Usage: tmux-team preamble [show|set|clear]');
+      expect(() => cmdPreamble(ctx, preambleRequest('set', { agent: 'invalid' }))).toThrow(
+        'exit(1)'
+      );
+      expect(ui.errors[0]).toContain('Usage: tmux-team preamble set');
     });
   });
 });

--- a/src/commands/preamble.ts
+++ b/src/commands/preamble.ts
@@ -7,6 +7,13 @@ import { ExitCodes } from '../context.js';
 import { loadLocalConfigFile, saveLocalConfigFile } from '../config.js';
 import { getRegistryScope, registrationFromEntry } from '../registry.js';
 
+export interface PreambleRequest {
+  readonly kind: 'preamble';
+  readonly operation: 'show' | 'set' | 'clear';
+  readonly agent?: string;
+  readonly preamble?: string;
+}
+
 /**
  * Show preamble(s) for agent(s).
  */
@@ -161,35 +168,24 @@ function legacyHasPreamble(paths: Context['paths'], agentName: string): boolean 
 /**
  * Preamble command entry point.
  */
-export function cmdPreamble(ctx: Context, args: string[]): void {
-  const subcommand = args[0];
-
-  switch (subcommand) {
-    case undefined:
+export function cmdPreamble(ctx: Context, request: PreambleRequest): void {
+  switch (request.operation) {
     case 'show':
-      showPreamble(ctx, args[1]);
-      break;
-
+      showPreamble(ctx, request.agent);
+      return;
     case 'set':
-      if (args.length < 3) {
+      if (request.agent === undefined || request.preamble === undefined) {
         ctx.ui.error('Usage: tmux-team preamble set <agent> <preamble>');
         ctx.exit(ExitCodes.ERROR);
       }
-      // Join remaining args as preamble (allows spaces without quotes)
-      setPreamble(ctx, args[1], args.slice(2).join(' '));
-      break;
-
+      setPreamble(ctx, request.agent, request.preamble);
+      return;
     case 'clear':
-      if (args.length < 2) {
+      if (request.agent === undefined) {
         ctx.ui.error('Usage: tmux-team preamble clear <agent>');
         ctx.exit(ExitCodes.ERROR);
       }
-      clearPreamble(ctx, args[1]);
-      break;
-
-    default:
-      ctx.ui.error(`Unknown preamble subcommand: ${subcommand}`);
-      ctx.ui.error('Usage: tmux-team preamble [show|set|clear]');
-      ctx.exit(ExitCodes.ERROR);
+      clearPreamble(ctx, request.agent);
+      return;
   }
 }

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -145,4 +145,20 @@ describe('createContext', () => {
     expect(() => ctx.exit(2)).toThrow('exit(2)');
     expect(exitSpy).toHaveBeenCalledWith(2);
   });
+
+  it('does not construct tmux for a no-resource capability', async () => {
+    vi.resetModules();
+    const createTmux = vi.fn(() => {
+      throw new Error('tmux must remain lazy');
+    });
+    vi.doMock('./tmux.js', () => ({ createTmux }));
+    const { createContext } = await import('./context.js');
+    const ctx = createContext({
+      argv: [],
+      flags: { json: false, verbose: false },
+      capability: 'none',
+    });
+    expect(createTmux).not.toHaveBeenCalled();
+    expect(ctx.paths.globalConfig).toBeTypeOf('string');
+  });
 });

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,8 @@ export interface CreateContextOptions {
   argv: string[];
   flags: Flags;
   cwd?: string;
+  /** Declares the resources a command may need; tmux and config are lazy. */
+  capability?: 'none' | 'storage' | 'tmux';
 }
 
 export function createContext(options: CreateContextOptions): Context {
@@ -22,25 +24,43 @@ export function createContext(options: CreateContextOptions): Context {
   // workspace registry for legacy settings.
   const paths = resolvePaths(cwd);
   const ui = createUI(flags.json);
-  const tmux = createTmux();
+  const capability = options.capability ?? 'tmux';
+  let tmux: Context['tmux'] | undefined;
+  let config: Context['config'] | undefined;
+  const getTmux = (): Context['tmux'] => {
+    tmux ??= createTmux();
+    return tmux;
+  };
   const registryScope = {
     type: 'workspace' as const,
     workspaceRoot: paths.workspaceRoot ?? cwd,
   };
-  const config = loadConfig(paths, tmux.getAgentRegistry(registryScope));
+  const getConfig = (): Context['config'] => {
+    config ??= loadConfig(
+      paths,
+      capability === 'tmux' ? getTmux().getAgentRegistry(registryScope) : undefined
+    );
+    return config;
+  };
 
-  return {
+  const context = {
     argv,
     flags,
     ui,
-    config,
-    tmux,
     paths,
     registryScope,
     exit(code: number): never {
       process.exit(code);
     },
-  };
+  } as Context;
+  Object.defineProperties(context, {
+    config: { enumerable: true, get: getConfig },
+    tmux: { enumerable: true, get: getTmux },
+  });
+  // Preserve the established full-context behavior. Lightweight capabilities
+  // intentionally defer both resources until a command asks for them.
+  if (capability === 'tmux') getConfig();
+  return context;
 }
 
 export { ExitCodes };

--- a/src/identity-context.test.ts
+++ b/src/identity-context.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { resolveIdentityContext, type IdentityContext } from './identity-context.js';
+
+const registration = (name: string, paneId: string) => ({
+  name,
+  canonicalName: name.toLowerCase(),
+  paneId,
+});
+
+describe('resolveIdentityContext', () => {
+  it('resolves the single identity proven to be on the current pane', () => {
+    const context: IdentityContext = {
+      currentPaneId: '%1',
+      registrations: [registration('Codex', '%1')],
+    };
+    expect(resolveIdentityContext(context)).toMatchObject({
+      status: 'bound',
+      registration: { name: 'Codex' },
+    });
+  });
+
+  it('distinguishes outside-tmux and an unbound current pane', () => {
+    expect(resolveIdentityContext({ currentPaneId: null, registrations: [] })).toEqual({
+      status: 'outside-tmux',
+    });
+    expect(resolveIdentityContext({ currentPaneId: '%2', registrations: [] })).toEqual({
+      status: 'unbound',
+    });
+  });
+
+  it('reports ambiguity and resolves an explicit identity independently of the current pane', () => {
+    const context: IdentityContext = {
+      currentPaneId: '%1',
+      registrations: [registration('Codex', '%1'), registration('Gemini', '%2')],
+    };
+    expect(
+      resolveIdentityContext(context, { value: 'gemini', kind: 'identity', explicit: true })
+    ).toMatchObject({ status: 'bound', registration: { name: 'Gemini' } });
+    expect(
+      resolveIdentityContext({
+        currentPaneId: '%1',
+        registrations: [registration('A', '%1'), registration('a', '%1')],
+      })
+    ).toMatchObject({ status: 'ambiguous' });
+  });
+
+  it('uses the shared identity normalization rules and distinguishes a missing selector', () => {
+    const context: IdentityContext = {
+      currentPaneId: null,
+      registrations: [registration('ＡＬＩＣＥ', '%3')],
+    };
+    expect(
+      resolveIdentityContext(context, { value: ' alice ', kind: 'identity', explicit: true })
+    ).toMatchObject({ status: 'bound', registration: { paneId: '%3' } });
+    expect(
+      resolveIdentityContext(context, { value: 'missing', kind: 'identity', explicit: true })
+    ).toEqual({ status: 'not-found' });
+  });
+});

--- a/src/identity-context.ts
+++ b/src/identity-context.ts
@@ -1,0 +1,47 @@
+import type { ActiveRegistration } from './domain/types.js';
+import { normalizeName } from './domain/names.js';
+
+/** A parsed target. `explicit` is true only when --identity was used. */
+export interface IdentitySelector {
+  readonly value: string;
+  readonly kind: 'identity' | 'pane';
+  readonly explicit?: boolean;
+}
+
+export interface IdentityContext {
+  readonly currentPaneId: string | null;
+  readonly registrations: readonly ActiveRegistration[];
+}
+
+export type IdentityResolution =
+  | { readonly status: 'bound'; readonly registration: ActiveRegistration }
+  | { readonly status: 'unbound' }
+  | { readonly status: 'not-found' }
+  | { readonly status: 'outside-tmux' }
+  | { readonly status: 'ambiguous'; readonly registrations: readonly ActiveRegistration[] };
+
+/** Resolve an explicitly selected identity or the one identity bound to the current pane. */
+export function resolveIdentityContext(
+  context: IdentityContext,
+  selector?: IdentitySelector
+): IdentityResolution {
+  if (selector) {
+    const normalized = normalizeName(selector.value);
+    const matches = context.registrations.filter(
+      (registration) =>
+        normalizeName(registration.name) === normalized ||
+        normalizeName(registration.canonicalName) === normalized
+    );
+    if (matches.length === 1) return { status: 'bound', registration: matches[0] };
+    if (matches.length > 1) return { status: 'ambiguous', registrations: matches };
+    return { status: 'not-found' };
+  }
+
+  if (!context.currentPaneId) return { status: 'outside-tmux' };
+  const matches = context.registrations.filter(
+    (registration) => registration.paneId === context.currentPaneId
+  );
+  if (matches.length === 1) return { status: 'bound', registration: matches[0] };
+  if (matches.length > 1) return { status: 'ambiguous', registrations: matches };
+  return { status: 'unbound' };
+}


### PR DESCRIPTION
## Summary

- replace ad-hoc argv parsing with a Commander-backed typed invocation schema
- route commands through one exhaustive application dispatcher and remove nested handler reparsing
- add capability-aware lazy config/tmux context construction
- add a shared identity-context resolver using canonical name normalization
- preserve the current v5 CLI surface without prematurely exposing identity, memory, role, or SQLite syntax

## Verification

- `pnpm check`
- `pnpm test:run` (344 tests; 93.92% statements, 86.42% branches)
- `pnpm test:e2e` twice (15/15 each run against real tmux in Docker)
- manual help, version, human error, and JSON error smoke checks
- independent Gemini read-only review and verification: no blocking findings

## Compatibility notes

- v5 now requires Node.js 22.12 or newer because Commander 15 is ESM-only and uses that runtime floor
- existing aliases, positional forms, `--` literal handling, team rejection, and global option placement remain covered

Closes TMT-11
