### PR TITLE
TMT-12: Add native SQLite storage foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,90 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run Docker end-to-end tests
         run: pnpm test:e2e
+
+  packed-native-install:
+    name: Packed install (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macOS x64
+            runner: macos-15-intel
+            arch: x64
+            libc: none
+            container: false
+          - label: macOS arm64
+            runner: macos-15
+            arch: arm64
+            libc: none
+            container: false
+          - label: Linux glibc x64
+            runner: ubuntu-latest
+            arch: x64
+            libc: glibc
+            container: false
+          - label: Linux glibc arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+            libc: glibc
+            container: false
+          - label: Linux musl x64
+            runner: ubuntu-latest
+            arch: x64
+            libc: musl
+            container: true
+          - label: Linux musl arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+            libc: musl
+            container: true
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.2
+      - name: Activate pinned pnpm
+        run: corepack enable && corepack prepare pnpm@10.33.0 --activate
+      - name: Pack release artifact
+        run: |
+          mkdir -p "$RUNNER_TEMP/tmt-pack"
+          pnpm pack --pack-destination "$RUNNER_TEMP/tmt-pack"
+      - name: Verify packed native install on host
+        if: ${{ !matrix.container }}
+        run: |
+          tarball="$(find "$RUNNER_TEMP/tmt-pack" -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+          test -n "$tarball"
+          node scripts/verify-packed-native-install.mjs \
+            --package-tarball "$tarball" \
+            --expected-arch "${{ matrix.arch }}" \
+            --expected-libc "${{ matrix.libc }}"
+      - name: Verify packed native install in native Alpine
+        if: ${{ matrix.container }}
+        run: |
+          tarball="$(find "$RUNNER_TEMP/tmt-pack" -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+          test -n "$tarball"
+          docker run --rm \
+            --volume "$tarball:/tmp/tmux-team.tgz:ro" \
+            --volume "$GITHUB_WORKSPACE/scripts:/scripts:ro" \
+            node:22-alpine \
+            node /scripts/verify-packed-native-install.mjs \
+              --package-tarball /tmp/tmux-team.tgz \
+              --expected-arch "${{ matrix.arch }}" \
+              --expected-libc "${{ matrix.libc }}"
+
+  native-install-gate:
+    name: Native package matrix
+    if: ${{ always() }}
+    needs: packed-native-install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every native target
+        env:
+          MATRIX_RESULT: ${{ needs.packed-native-install.result }}
+        run: test "$MATRIX_RESULT" = success

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Project Setup
 
-- Requirements: Node.js >= 18
+- Requirements: Node.js >= 22.12
 - Install dependencies:
 
 ```bash
@@ -51,6 +51,35 @@ its temporary state.
 ```bash
 pnpm check
 ```
+
+## Packed native-install verification
+
+TMT-12 includes a focused check for release artifacts. It installs the actual
+`.tgz` produced by `pnpm pack` into a clean temporary project, loads
+`better-sqlite3`'s native `.node` binding, creates an FTS5 virtual table, and
+executes a query, and invokes the packed `tmt` executable. Installation runs
+with lifecycle scripts disabled, and the verifier requires the exact bundled
+prebuild for the current platform, architecture, and libc. A successful run
+therefore proves that no source compilation is required. Temporary projects
+and caches are removed on every exit path.
+
+Example (after the storage dependency is present):
+
+```bash
+mkdir -p .tmp/tmt-pack
+pnpm pack --pack-destination .tmp/tmt-pack
+node scripts/verify-packed-native-install.mjs \
+  --package-tarball .tmp/tmt-pack/tmux-team-<version>.tgz \
+  --expected-arch x64 --expected-libc glibc
+rm -rf .tmp/tmt-pack
+```
+
+CI runs this check on macOS x64 and arm64, Linux glibc x64 and arm64, and
+Linux musl x64 and arm64. The Linux musl checks run in native Alpine
+containers on matching GitHub-hosted runner architectures. If GitHub-hosted
+arm64 capacity is unavailable for a pull request, the release gate must run
+the same command on a native arm64 runner; emulation does not satisfy this
+matrix.
 
 ## Testing Strategy
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ backed up only with `--force`. Use `tmt upgrade` to update the package; managed
 skill links immediately use the new bundled files. Interactive commands make a
 once-daily cached update check, while local drift checks work without network.
 
-**Requirements:** Node.js >= 18, tmux
+**Requirements:** Node.js >= 22.12, tmux
 
 **Alias:** `tmt` (shorthand for `tmux-team`)
 
@@ -144,6 +144,29 @@ delay is configurable:
 ```bash
 tmt config set pasteEnterDelayMs 500
 ```
+
+## Local SQLite storage
+
+TMT owns its local SQLite database. The database is deliberately local-file
+only: it is not a shared service, does not listen on a network socket, and is
+not accessed by a daemon. The default path is the global TMT directory
+selected by the XDG config resolution rules: `$XDG_CONFIG_HOME/tmux-team/tmux-team.db`,
+or `~/.config/tmux-team/tmux-team.db` when `XDG_CONFIG_HOME` is unset. The
+configuration file and legacy JSON state remain separate compatibility
+surfaces in that directory.
+
+The storage directory is created with mode `0700` and database files with mode
+`0600`; operators should not place the database on a shared or untrusted
+filesystem. SQLite WAL sidecar files must remain beside the database and must
+not be deleted manually. Writers use a bounded busy timeout and checkpoint
+after write work. Normal command shutdown uses a passive checkpoint; backup or
+export first obtains a consistent SQLite backup and may use a truncate
+checkpoint only after no active reader remains.
+
+Identity and memory tables are intentionally not specified by this section.
+They are delivered by their respective tickets behind the shared storage
+boundary. Until those tickets land, this is a storage ownership and recovery
+contract rather than a claim that those tables already exist.
 
 ## Managing global identities
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test:run": "vitest run --coverage && node scripts/check-coverage.mjs --threshold 90 --branches 85",
     "lint": "oxlint src/",
     "e2e:typecheck": "tsc --project tsconfig.e2e.json --noEmit",
-    "e2e:lint": "oxlint test/e2e/ scripts/run-e2e.mjs",
-    "e2e:format:check": "prettier --check test/e2e/ scripts/run-e2e.mjs tsconfig.e2e.json DEVELOPMENT.md AGENTS.md .agents/skills/tmt-e2e/SKILL.md .agents/skills/tmt-release/SKILL.md",
+    "e2e:lint": "oxlint test/e2e/ scripts/*.mjs",
+    "e2e:format:check": "prettier --check test/e2e/ scripts/*.mjs tsconfig.e2e.json DEVELOPMENT.md AGENTS.md .agents/skills/tmt-e2e/SKILL.md .agents/skills/tmt-release/SKILL.md",
     "lint:fix": "oxlint src/ --fix",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
@@ -52,10 +52,12 @@
     "skills"
   ],
   "dependencies": {
+    "better-sqlite3": "^13.0.3",
     "commander": "^15.0.0",
     "tsx": "^4.7.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^9.6.0",
     "@types/node": "^25.0.3",
     "@vitest/coverage-v8": "^1.6.1",
     "oxlint": "^1.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      better-sqlite3:
+        specifier: ^13.0.3
+        version: 13.0.3
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -15,6 +18,9 @@ importers:
         specifier: ^4.7.0
         version: 4.21.0
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^9.6.0
+        version: 9.6.0
       '@types/node':
         specifier: ^25.0.3
         version: 25.0.3
@@ -543,6 +549,9 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@types/better-sqlite3@9.6.0':
+    resolution: {integrity: sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -587,6 +596,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  better-sqlite3@13.0.3:
+    resolution: {integrity: sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==}
+    engines: {node: '>=22'}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -753,6 +766,10 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-addon-api@8.9.2:
+    resolution: {integrity: sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -1265,6 +1282,10 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@types/better-sqlite3@9.6.0':
+    dependencies:
+      '@types/node': 25.0.3
+
   '@types/estree@1.0.8': {}
 
   '@types/node@25.0.3':
@@ -1330,6 +1351,10 @@ snapshots:
   assertion-error@1.1.0: {}
 
   balanced-match@1.0.2: {}
+
+  better-sqlite3@13.0.3:
+    dependencies:
+      node-addon-api: 8.9.2
 
   brace-expansion@1.1.12:
     dependencies:
@@ -1548,6 +1573,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  node-addon-api@8.9.2: {}
 
   npm-run-path@5.3.0:
     dependencies:

--- a/scripts/verify-packed-native-install.mjs
+++ b/scripts/verify-packed-native-install.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+function usage() {
+  console.log(`verify-packed-native-install
+
+Usage:
+  node scripts/verify-packed-native-install.mjs --package-tarball <path>
+    [--expected-arch x64|arm64] [--expected-libc glibc|musl|none]
+
+The verifier installs the packed package into an isolated temporary project,
+blocks compiler fallback, loads better-sqlite3's native binding, and executes
+an FTS5 query.
+`);
+}
+
+function parseArgs(argv) {
+  const options = { expectedArch: null, expectedLibc: 'auto', packageTarball: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help' || argument === '-h') {
+      usage();
+      process.exit(0);
+    }
+    if (argument === '--package-tarball') {
+      options.packageTarball = argv[++index];
+    } else if (argument === '--expected-arch') {
+      options.expectedArch = argv[++index];
+    } else if (argument === '--expected-libc') {
+      options.expectedLibc = argv[++index];
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!options.packageTarball) throw new Error('--package-tarball is required');
+  if (options.expectedArch && !['x64', 'arm64'].includes(options.expectedArch)) {
+    throw new Error(`Unsupported --expected-arch: ${options.expectedArch}`);
+  }
+  if (!['auto', 'glibc', 'musl', 'none'].includes(options.expectedLibc)) {
+    throw new Error(`Unsupported --expected-libc: ${options.expectedLibc}`);
+  }
+  return options;
+}
+
+function findNpm() {
+  return execFileSync('which', ['npm'], { encoding: 'utf8' }).trim();
+}
+
+function installPackage({ projectDirectory, tarball, cacheDirectory }) {
+  const npmPath = findNpm();
+  const result = spawnSync(
+    npmPath,
+    ['install', '--no-audit', '--no-fund', '--no-package-lock', '--ignore-scripts', tarball],
+    {
+      cwd: projectDirectory,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        npm_config_cache: cacheDirectory,
+      },
+    }
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `Packed package installation failed (exit ${result.status}).\n${result.stdout ?? ''}${result.stderr ?? ''}`
+    );
+  }
+}
+
+function verifyArchitecture(expectedArch, expectedLibc) {
+  if (expectedArch && process.arch !== expectedArch) {
+    throw new Error(`Architecture mismatch: expected ${expectedArch}, got ${process.arch}`);
+  }
+  if (expectedLibc === 'auto' || expectedLibc === 'none') return;
+  const glibcVersion = process.report?.getReport?.().header?.glibcVersionRuntime;
+  const actualLibc = glibcVersion ? 'glibc' : 'musl';
+  if (actualLibc !== expectedLibc) {
+    throw new Error(`Libc mismatch: expected ${expectedLibc}, got ${actualLibc}`);
+  }
+}
+
+function expectedPrebuildTarget(expectedLibc) {
+  if (process.platform === 'darwin') return `darwin-${process.arch}`;
+  if (process.platform === 'linux') {
+    const glibcVersion = process.report?.getReport?.().header?.glibcVersionRuntime;
+    const libc = expectedLibc === 'auto' ? (glibcVersion ? 'glibc' : 'musl') : expectedLibc;
+    return `${libc === 'musl' ? 'linuxmusl' : 'linux'}-${process.arch}`;
+  }
+  throw new Error(`Unsupported prebuild platform: ${process.platform}`);
+}
+
+function loadAndVerifySqlite(projectDirectory, expectedLibc) {
+  const requireFromProject = createRequire(path.join(projectDirectory, 'verify.cjs'));
+  const packageEntry = requireFromProject.resolve('better-sqlite3');
+  const packageDirectory = path.dirname(path.dirname(packageEntry));
+  const target = expectedPrebuildTarget(expectedLibc);
+  const prebuild = path.join(packageDirectory, 'prebuilds', `${target}.node`);
+  if (!fs.existsSync(prebuild)) {
+    throw new Error(`Bundled better-sqlite3 prebuild is missing: ${target}`);
+  }
+
+  const Database = requireFromProject('better-sqlite3');
+  const database = new Database(':memory:');
+  try {
+    const compileOptions = database.pragma('compile_options');
+    const hasFts5 = compileOptions.some((option) =>
+      Object.values(option).some((value) => String(value).toUpperCase().includes('FTS5'))
+    );
+    if (!hasFts5) throw new Error('better-sqlite3 was loaded without FTS5 support');
+    database.exec('CREATE VIRTUAL TABLE documents USING fts5(body)');
+    database.prepare('INSERT INTO documents (body) VALUES (?)').run('native sqlite verification');
+    const matches = database
+      .prepare("SELECT body FROM documents WHERE documents MATCH 'native'")
+      .all();
+    if (matches.length !== 1 || matches[0].body !== 'native sqlite verification') {
+      throw new Error('FTS5 query returned an unexpected result');
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function verifyPackedCli(projectDirectory) {
+  const executable = path.join(projectDirectory, 'node_modules', '.bin', 'tmt');
+  const result = spawnSync(executable, ['--version'], {
+    cwd: projectDirectory,
+    encoding: 'utf8',
+    env: { ...process.env, TMUX_TEAM_HOME: path.join(projectDirectory, 'tmt-home') },
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0 || !/^\d+\.\d+\.\d+(?:-[\w.]+)?\s*$/.test(result.stdout ?? '')) {
+    throw new Error(
+      `Packed tmt executable failed (exit ${result.status}).\n${result.stdout ?? ''}${result.stderr ?? ''}`
+    );
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const tarball = path.resolve(options.packageTarball);
+  if (!fs.existsSync(tarball) || !tarball.endsWith('.tgz')) {
+    throw new Error(`Package tarball does not exist or is not a .tgz file: ${tarball}`);
+  }
+  verifyArchitecture(options.expectedArch, options.expectedLibc);
+
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tmux-team-packed-'));
+  const projectDirectory = path.join(temporaryRoot, 'project');
+  const cacheDirectory = path.join(temporaryRoot, 'npm-cache');
+  fs.mkdirSync(projectDirectory);
+  fs.mkdirSync(cacheDirectory);
+  try {
+    fs.writeFileSync(
+      path.join(projectDirectory, 'package.json'),
+      JSON.stringify({ name: 'tmux-team-packed-install-check', private: true, version: '0.0.0' }) +
+        '\n'
+    );
+    installPackage({ projectDirectory, tarball, cacheDirectory });
+    loadAndVerifySqlite(projectDirectory, options.expectedLibc);
+    verifyPackedCli(projectDirectory);
+    console.log(
+      `Packed install verified: ${process.platform}/${process.arch}/${
+        options.expectedLibc === 'auto' ? 'detected libc' : options.expectedLibc
+      }`
+    );
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -46,6 +46,7 @@ function makeStubContext(): Context {
       globalConfig: '/g/c.json',
       localConfig: '/p/t.json',
       stateFile: '/g/s.json',
+      databaseFile: '/g/tmux-team.db',
     },
     exit: ((code: number) => {
       const err = new Error(`exit(${code})`);

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -68,6 +68,7 @@ function createCtx(
     globalConfig: path.join(testDir, 'config.json'),
     localConfig: path.join(testDir, 'tmux-team.json'),
     stateFile: path.join(testDir, 'state.json'),
+    databaseFile: path.join(testDir, 'tmux-team.db'),
   };
   const baseConfig: ResolvedConfig = {
     mode: 'polling',

--- a/src/commands/config-command.test.ts
+++ b/src/commands/config-command.test.ts
@@ -35,6 +35,7 @@ function createCtx(
     globalConfig: path.join(testDir, 'global', 'config.json'),
     localConfig: path.join(testDir, 'tmux-team.json'),
     stateFile: path.join(testDir, 'global', 'state.json'),
+    databaseFile: path.join(testDir, 'global', 'tmux-team.db'),
   };
   const config: ResolvedConfig = {
     mode: 'polling',

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -22,6 +22,7 @@ function createCtx(testDir: string, overrides?: Partial<{ flags: Partial<Flags> 
     globalConfig: path.join(testDir, 'config.json'),
     localConfig: path.join(testDir, 'tmux-team.json'),
     stateFile: path.join(testDir, 'state.json'),
+    databaseFile: path.join(testDir, 'tmux-team.db'),
   };
   const config: ResolvedConfig = {
     mode: 'polling',

--- a/src/commands/name.test.ts
+++ b/src/commands/name.test.ts
@@ -46,7 +46,13 @@ function context(registrations: ActiveRegistration[] = [], json = false): Contex
       paneRegistry: {},
     },
     tmux,
-    paths: { globalDir: '', globalConfig: '', localConfig: '', stateFile: '' },
+    paths: {
+      globalDir: '',
+      globalConfig: '',
+      localConfig: '',
+      stateFile: '',
+      databaseFile: '',
+    },
     exit: ((code: number) => {
       throw Object.assign(new Error(`exit(${code})`), { exitCode: code });
     }) as Context['exit'],

--- a/src/commands/preamble.test.ts
+++ b/src/commands/preamble.test.ts
@@ -45,6 +45,7 @@ function createTestPaths(testDir: string): Paths {
     globalConfig: path.join(testDir, 'config.json'),
     localConfig: path.join(testDir, 'tmux-team.json'),
     stateFile: path.join(testDir, 'state.json'),
+    databaseFile: path.join(testDir, 'tmux-team.db'),
   };
 }
 

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -83,6 +83,7 @@ function createTestPaths(testDir: string): Paths {
     globalConfig: path.join(testDir, 'config.json'),
     localConfig: path.join(testDir, 'tmux-team.json'),
     stateFile: path.join(testDir, 'state.json'),
+    databaseFile: path.join(testDir, 'tmux-team.db'),
   };
 }
 

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -15,7 +15,13 @@ function context(json = false): Context {
     },
     config: {} as Context['config'],
     tmux: {} as Context['tmux'],
-    paths: { globalDir: '/tmp/tmt', globalConfig: '', localConfig: '', stateFile: '' },
+    paths: {
+      globalDir: '/tmp/tmt',
+      globalConfig: '',
+      localConfig: '',
+      stateFile: '',
+      databaseFile: '',
+    },
     exit: ((code: number) => {
       throw new Error(`exit(${code})`);
     }) as Context['exit'],

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -45,7 +45,13 @@ function context(registrations: ActiveRegistration[] = [], json = false): Contex
       paneRegistry: {},
     },
     tmux,
-    paths: { globalDir: '', globalConfig: '', localConfig: '', stateFile: '' },
+    paths: {
+      globalDir: '',
+      globalConfig: '',
+      localConfig: '',
+      stateFile: '',
+      databaseFile: '',
+    },
     exit: ((code: number) => {
       throw Object.assign(new Error(`exit(${code})`), { exitCode: code });
     }) as Context['exit'],

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -188,6 +188,7 @@ describe('loadConfig', () => {
     globalConfig: '/home/test/.config/tmux-team/config.json',
     localConfig: '/projects/myapp/tmux-team.json',
     stateFile: '/home/test/.config/tmux-team/state.json',
+    databaseFile: '/home/test/.config/tmux-team/tmux-team.db',
   };
 
   beforeEach(() => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ import type {
 const CONFIG_FILENAME = 'config.json';
 const LOCAL_CONFIG_FILENAME = 'tmux-team.json';
 const STATE_FILENAME = 'state.json';
+const DATABASE_FILENAME = 'tmux-team.db';
 
 // Default configuration values
 const DEFAULT_CONFIG: GlobalConfig = {
@@ -138,6 +139,7 @@ export function resolvePaths(cwd: string = process.cwd()): Paths {
     globalConfig: path.join(globalDir, CONFIG_FILENAME),
     localConfig: localConfigPath,
     stateFile: path.join(globalDir, STATE_FILENAME),
+    databaseFile: path.join(globalDir, DATABASE_FILENAME),
     workspaceRoot,
   };
 }

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -14,6 +14,7 @@ describe('createContext', () => {
       globalConfig: '/g/config.json',
       localConfig: '/p/tmux-team.json',
       stateFile: '/g/state.json',
+      databaseFile: '/g/tmux-team.db',
     };
     const config: ResolvedConfig = {
       mode: 'polling',
@@ -77,6 +78,7 @@ describe('createContext', () => {
       globalConfig: '/g/config.json',
       localConfig: '/repo/tmux-team.json',
       stateFile: '/g/state.json',
+      databaseFile: '/g/tmux-team.db',
       workspaceRoot: '/repo',
     };
     const config: ResolvedConfig = {

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -14,6 +14,7 @@ function ctx(overrides: Partial<Context>): Context {
       globalConfig: '/g/c',
       localConfig: '/r/tmux-team.json',
       stateFile: '/g/s',
+      databaseFile: '/g/tmux-team.db',
       workspaceRoot: '/repo',
     },
     exit: (() => {

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -29,6 +29,7 @@ describe('State Management', () => {
       globalConfig: path.join(testDir, 'config.json'),
       localConfig: path.join(testDir, 'tmux-team.json'),
       stateFile: path.join(testDir, 'state.json'),
+      databaseFile: path.join(testDir, 'tmux-team.db'),
     };
   });
 

--- a/src/storage/errors.test.ts
+++ b/src/storage/errors.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { classifyStorageError, incompatibleSchema, StorageError } from './errors.js';
+
+describe('storage error contract', () => {
+  it('marks busy and locked failures retryable', () => {
+    const cause = Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' });
+    const error = classifyStorageError(cause, 'Write');
+
+    expect(error).toMatchObject({ code: 'busy', retryable: true, cause });
+  });
+
+  it('maps open access failures separately from corruption', () => {
+    const cause = Object.assign(new Error('cannot open'), { code: 'SQLITE_CANTOPEN' });
+    const error = classifyStorageError(cause, 'Open storage');
+
+    expect(error).toMatchObject({ code: 'permission', retryable: false, cause });
+  });
+
+  it('retains migration version and cause for migration failures', () => {
+    const cause = new Error('constraint failed');
+    const error = new StorageError('migration', 'Migration failed', {
+      cause,
+      migrationVersion: 4,
+    });
+
+    expect(error).toMatchObject({ code: 'migration', migrationVersion: 4, cause });
+  });
+
+  it('provides a structured incompatible schema error', () => {
+    const cause = new Error('future schema');
+    expect(incompatibleSchema('Unsupported schema', cause)).toMatchObject({
+      code: 'incompatible-schema',
+      cause,
+      retryable: false,
+    });
+  });
+
+  it('does not mislabel an unknown native failure as a migration error', () => {
+    const cause = new Error('unexpected native failure');
+    expect(classifyStorageError(cause, 'Open storage')).toMatchObject({
+      code: 'unknown',
+      cause,
+      retryable: false,
+    });
+  });
+});

--- a/src/storage/errors.ts
+++ b/src/storage/errors.ts
@@ -1,0 +1,69 @@
+export type StorageErrorCode =
+  | 'busy'
+  | 'corrupt'
+  | 'permission'
+  | 'incompatible-schema'
+  | 'migration'
+  | 'unknown'
+  | 'closed';
+
+export interface StorageErrorOptions {
+  cause?: unknown;
+  migrationVersion?: number;
+  retryable?: boolean;
+}
+
+/** A stable error boundary for storage callers. The native driver's error is retained as cause. */
+export class StorageError extends Error {
+  readonly code: StorageErrorCode;
+  readonly migrationVersion?: number;
+  readonly retryable: boolean;
+
+  constructor(code: StorageErrorCode, message: string, options: StorageErrorOptions = {}) {
+    super(message, { cause: options.cause });
+    this.name = 'StorageError';
+    this.code = code;
+    this.migrationVersion = options.migrationVersion;
+    this.retryable = options.retryable ?? code === 'busy';
+  }
+}
+
+function nativeCode(error: unknown): string {
+  if (!error || typeof error !== 'object') return '';
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : '';
+}
+
+/** Convert better-sqlite3 and filesystem failures into the storage contract. */
+export function classifyStorageError(error: unknown, operation: string): StorageError {
+  if (error instanceof StorageError) return error;
+
+  const code = nativeCode(error);
+  if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') {
+    return new StorageError('busy', `${operation} is temporarily locked`, {
+      cause: error,
+      retryable: true,
+    });
+  }
+  if (code === 'SQLITE_CORRUPT' || code === 'SQLITE_NOTADB') {
+    return new StorageError('corrupt', `${operation} found a corrupt SQLite database`, {
+      cause: error,
+    });
+  }
+  if (
+    code === 'SQLITE_CANTOPEN' ||
+    code === 'SQLITE_READONLY' ||
+    code === 'SQLITE_PERM' ||
+    code === 'EACCES' ||
+    code === 'EPERM'
+  ) {
+    return new StorageError('permission', `${operation} cannot access the database`, {
+      cause: error,
+    });
+  }
+  return new StorageError('unknown', `${operation} failed`, { cause: error });
+}
+
+export function incompatibleSchema(message: string, cause?: unknown): StorageError {
+  return new StorageError('incompatible-schema', message, { cause });
+}

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,0 +1,3 @@
+export { openStorage } from './sqlite-adapter.js';
+export type { CheckpointMode, StorageHandle, StorageHealth, StorageLocation } from './ports.js';
+export { StorageError, type StorageErrorCode } from './errors.js';

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -1,0 +1,128 @@
+import type Database from 'better-sqlite3';
+import { classifyStorageError, incompatibleSchema, StorageError } from './errors.js';
+
+type SqliteDatabase = Database.Database;
+
+export interface MigrationDefinition {
+  readonly version: number;
+  readonly name: string;
+  readonly up: (database: SqliteDatabase) => void;
+}
+
+/** TMT-12 deliberately owns no domain tables. Later issues append migrations here. */
+export const CURRENT_MIGRATIONS: readonly MigrationDefinition[] = [];
+
+const CREATE_MIGRATIONS = `
+  CREATE TABLE IF NOT EXISTS _migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at TEXT NOT NULL
+  )
+`;
+
+function validateMigrationsTable(database: SqliteDatabase): void {
+  const columns = database.pragma('table_info(_migrations)') as Array<{
+    name: string;
+    type: string;
+    notnull: number;
+    pk: number;
+  }>;
+  const expected = [
+    { name: 'version', type: 'INTEGER', notnull: 0, pk: 1 },
+    { name: 'name', type: 'TEXT', notnull: 1, pk: 0 },
+    { name: 'applied_at', type: 'TEXT', notnull: 1, pk: 0 },
+  ];
+  if (
+    columns.length !== expected.length ||
+    columns.some((column, index) => {
+      const wanted = expected[index];
+      return (
+        !wanted ||
+        column.name !== wanted.name ||
+        column.type.toUpperCase() !== wanted.type ||
+        column.notnull !== wanted.notnull ||
+        column.pk !== wanted.pk
+      );
+    })
+  ) {
+    throw incompatibleSchema('The _migrations table does not match the supported schema');
+  }
+}
+
+function validateDefinitions(migrations: readonly MigrationDefinition[]): void {
+  for (let index = 0; index < migrations.length; index += 1) {
+    const migration = migrations[index];
+    if (!migration || migration.version !== index + 1 || !migration.name || !migration.up) {
+      throw incompatibleSchema('Migration definitions must be contiguous, forward-only, and named');
+    }
+  }
+}
+
+function validateHistory(
+  history: Array<{ version: number; name: string }>,
+  migrations: readonly MigrationDefinition[]
+): number {
+  let expected = 1;
+  for (const row of history) {
+    if (!Number.isSafeInteger(row.version) || row.version !== expected) {
+      throw incompatibleSchema(`Migration history is not contiguous at version ${row.version}`);
+    }
+    const definition = migrations[row.version - 1];
+    if (!definition) {
+      throw incompatibleSchema(`Database requires unsupported migration version ${row.version}`);
+    }
+    if (definition.name !== row.name) {
+      throw incompatibleSchema(
+        `Migration ${row.version} has changed from ${row.name} to ${definition.name}`
+      );
+    }
+    expected += 1;
+  }
+  return expected - 1;
+}
+
+export function applyMigrations(
+  database: SqliteDatabase,
+  migrations: readonly MigrationDefinition[] = CURRENT_MIGRATIONS
+): number {
+  validateDefinitions(migrations);
+
+  try {
+    database
+      .transaction(() => {
+        database.exec(CREATE_MIGRATIONS);
+        validateMigrationsTable(database);
+      })
+      .immediate();
+
+    const history = database
+      .prepare('SELECT version, name FROM _migrations ORDER BY version')
+      .all() as Array<{ version: number; name: string }>;
+    const currentVersion = validateHistory(history, migrations);
+    const insert = database.prepare(
+      'INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, ?)'
+    );
+
+    for (let index = currentVersion; index < migrations.length; index += 1) {
+      const migration = migrations[index];
+      const applyOne = database.transaction(() => {
+        try {
+          migration.up(database);
+          insert.run(migration.version, migration.name, new Date().toISOString());
+        } catch (error) {
+          const classified = classifyStorageError(error, `Migration ${migration.version}`);
+          throw new StorageError('migration', `Migration ${migration.version} failed`, {
+            cause: classified,
+            migrationVersion: migration.version,
+            retryable: classified.retryable,
+          });
+        }
+      });
+      applyOne.immediate();
+    }
+    return migrations.length;
+  } catch (error) {
+    if (error instanceof StorageError) throw error;
+    throw classifyStorageError(error, 'Database migration');
+  }
+}

--- a/src/storage/ports.ts
+++ b/src/storage/ports.ts
@@ -1,0 +1,24 @@
+import type { Paths } from '../types.js';
+
+export type CheckpointMode = 'passive' | 'truncate';
+
+export interface StorageHealth {
+  readonly path: string;
+  readonly open: boolean;
+  readonly schemaVersion: number;
+  readonly journalMode: 'wal';
+  readonly foreignKeys: true;
+  readonly busyTimeoutMs: number;
+  readonly synchronous: 'normal';
+  readonly fts5: true;
+}
+
+/** Narrow lifecycle port. Domain repositories are added separately by their owning tickets. */
+export interface StorageHandle {
+  readonly path: string;
+  health(): StorageHealth;
+  checkpoint(mode?: CheckpointMode): void;
+  close(): void;
+}
+
+export type StorageLocation = Pick<Paths, 'globalDir' | 'databaseFile'> | string;

--- a/src/storage/sqlite-adapter.ts
+++ b/src/storage/sqlite-adapter.ts
@@ -1,0 +1,169 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { applyMigrations, CURRENT_MIGRATIONS, type MigrationDefinition } from './migrations.js';
+import { classifyStorageError, incompatibleSchema, StorageError } from './errors.js';
+import type { CheckpointMode, StorageHandle, StorageHealth, StorageLocation } from './ports.js';
+
+export interface StorageOptions {
+  readonly migrations?: readonly MigrationDefinition[];
+}
+
+function resolveDatabasePath(location: StorageLocation): { directory: string; file: string } {
+  if (typeof location === 'string') return { directory: path.dirname(location), file: location };
+  return { directory: location.globalDir, file: location.databaseFile };
+}
+
+function ensurePrivateDirectory(directory: string): void {
+  try {
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    if (process.platform !== 'win32') fs.chmodSync(directory, 0o700);
+  } catch (error) {
+    throw new StorageError('permission', `Cannot secure storage directory ${directory}`, {
+      cause: error,
+    });
+  }
+}
+
+function secureFile(file: string): void {
+  if (process.platform === 'win32' || !fs.existsSync(file)) return;
+  try {
+    fs.chmodSync(file, 0o600);
+    for (const sidecar of [`${file}-wal`, `${file}-shm`]) {
+      if (fs.existsSync(sidecar)) fs.chmodSync(sidecar, 0o600);
+    }
+  } catch (error) {
+    throw new StorageError('permission', `Cannot secure storage file ${file}`, { cause: error });
+  }
+}
+
+function readSchemaVersion(database: Database.Database): number {
+  const row = database
+    .prepare('SELECT COALESCE(MAX(version), 0) AS version FROM _migrations')
+    .get() as {
+    version: number;
+  };
+  return row.version;
+}
+
+function verifyFts5(database: Database.Database): void {
+  try {
+    database.exec(
+      'CREATE VIRTUAL TABLE temp._tmt_fts5_check USING fts5(content); ' +
+        'DROP TABLE temp._tmt_fts5_check'
+    );
+  } catch (error) {
+    throw incompatibleSchema('The SQLite runtime does not provide FTS5', error);
+  }
+}
+
+/** SQLite is an implementation detail; callers receive only lifecycle and health operations. */
+function openStorageInternal(
+  location: StorageLocation,
+  options: StorageOptions = {}
+): StorageHandle {
+  const resolved = resolveDatabasePath(location);
+  ensurePrivateDirectory(resolved.directory);
+
+  let database: Database.Database | undefined;
+  try {
+    database = new Database(resolved.file);
+    database.pragma('foreign_keys = ON');
+    database.pragma('journal_mode = WAL');
+    database.pragma('busy_timeout = 5000');
+    database.pragma('synchronous = NORMAL');
+    verifyFts5(database);
+    applyMigrations(database, options.migrations ?? CURRENT_MIGRATIONS);
+    secureFile(resolved.file);
+  } catch (error) {
+    try {
+      if (database) database.close();
+    } catch {
+      // Preserve the original structured error.
+    }
+    throw error instanceof StorageError ? error : classifyStorageError(error, 'Open storage');
+  }
+
+  // The constructor and migration sequence above either assign a live handle or throw.
+  const openedDatabase = database;
+  if (!openedDatabase) throw new StorageError('closed', 'Storage did not open');
+  let closed = false;
+  const requireOpen = (): Database.Database => {
+    if (closed) throw new StorageError('closed', 'Storage is already closed');
+    return openedDatabase;
+  };
+
+  const checkpoint = (mode: CheckpointMode = 'passive'): void => {
+    const current = requireOpen();
+    try {
+      current.pragma(`wal_checkpoint(${mode.toUpperCase()})`);
+      secureFile(resolved.file);
+    } catch (error) {
+      throw classifyStorageError(error, 'Checkpoint storage');
+    }
+  };
+
+  return {
+    path: resolved.file,
+    health(): StorageHealth {
+      const current = requireOpen();
+      try {
+        const foreignKeys = current.pragma('foreign_keys', { simple: true }) as number;
+        const journalMode = String(current.pragma('journal_mode', { simple: true }));
+        const busyTimeoutMs = current.pragma('busy_timeout', { simple: true }) as number;
+        const synchronous = current.pragma('synchronous', { simple: true }) as number;
+        if (
+          journalMode !== 'wal' ||
+          foreignKeys !== 1 ||
+          busyTimeoutMs !== 5000 ||
+          synchronous !== 1
+        ) {
+          throw incompatibleSchema('The SQLite connection does not match storage policy');
+        }
+        return {
+          path: resolved.file,
+          open: true,
+          schemaVersion: readSchemaVersion(current),
+          journalMode: 'wal',
+          foreignKeys: true,
+          busyTimeoutMs,
+          synchronous: 'normal',
+          fts5: true,
+        };
+      } catch (error) {
+        throw classifyStorageError(error, 'Read storage health');
+      }
+    },
+    checkpoint,
+    close(): void {
+      if (closed) return;
+      let checkpointError: unknown;
+      try {
+        checkpoint('passive');
+      } catch (error) {
+        checkpointError = error;
+      } finally {
+        closed = true;
+        try {
+          openedDatabase.close();
+        } catch (error) {
+          checkpointError ??= classifyStorageError(error, 'Close storage');
+        }
+      }
+      if (checkpointError) throw checkpointError;
+    },
+  };
+}
+
+/** Open the user-scoped database with the repository's current migrations. */
+export function openStorage(location: StorageLocation): StorageHandle {
+  return openStorageInternal(location);
+}
+
+/** Test and migration harness entry point; intentionally omitted from the storage package port. */
+export function openStorageWithMigrations(
+  location: StorageLocation,
+  migrations: readonly MigrationDefinition[]
+): StorageHandle {
+  return openStorageInternal(location, { migrations });
+}

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -1,0 +1,241 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+import { StorageError } from './errors.js';
+import type { MigrationDefinition } from './migrations.js';
+import { openStorage, openStorageWithMigrations } from './sqlite-adapter.js';
+
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-storage-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function location(directory: string): { globalDir: string; databaseFile: string } {
+  return { globalDir: directory, databaseFile: path.join(directory, 'tmux-team.db') };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('SQLite storage adapter', () => {
+  it('opens a private database with required pragmas and only migration metadata', () => {
+    const directory = temporaryDirectory();
+    const storage = openStorage(location(directory));
+
+    expect(storage.health()).toMatchObject({
+      open: true,
+      schemaVersion: 0,
+      journalMode: 'wal',
+      foreignKeys: true,
+      busyTimeoutMs: 5000,
+      synchronous: 'normal',
+      fts5: true,
+    });
+    if (process.platform !== 'win32') {
+      for (const suffix of ['', '-wal', '-shm']) {
+        const file = path.join(directory, `tmux-team.db${suffix}`);
+        if (fs.existsSync(file)) expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+      }
+    }
+    storage.close();
+
+    const database = new Database(path.join(directory, 'tmux-team.db'), { readonly: true });
+    const tables = database
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
+      .all() as Array<{ name: string }>;
+    expect(tables.map((table) => table.name)).toEqual(['_migrations']);
+    database.close();
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(directory).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(path.join(directory, 'tmux-team.db')).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('applies contiguous migrations exactly once and remains idempotent', () => {
+    const directory = temporaryDirectory();
+    const migrations: MigrationDefinition[] = [
+      {
+        version: 1,
+        name: 'create test ledger',
+        up: (database) =>
+          database.exec('CREATE TABLE ledger (id INTEGER PRIMARY KEY, value TEXT NOT NULL)'),
+      },
+      {
+        version: 2,
+        name: 'add ledger index',
+        up: (database) => database.exec('CREATE INDEX ledger_value ON ledger(value)'),
+      },
+    ];
+
+    const first = openStorageWithMigrations(location(directory), migrations);
+    expect(first.health().schemaVersion).toBe(2);
+    first.close();
+    const second = openStorageWithMigrations(location(directory), migrations);
+    expect(second.health().schemaVersion).toBe(2);
+    second.close();
+
+    const database = new Database(path.join(directory, 'tmux-team.db'), { readonly: true });
+    expect(database.prepare('SELECT COUNT(*) AS count FROM _migrations').get()).toEqual({
+      count: 2,
+    });
+    database.close();
+  });
+
+  it('rejects future and non-contiguous schema history without changing it', () => {
+    const directory = temporaryDirectory();
+    const database = new Database(path.join(directory, 'tmux-team.db'));
+    database.exec(
+      'CREATE TABLE _migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL); ' +
+        "INSERT INTO _migrations VALUES (3, 'future', '2026-01-01T00:00:00.000Z')"
+    );
+    database.close();
+
+    expect(() => openStorage(location(directory))).toThrowError(StorageError);
+    try {
+      openStorage(location(directory));
+    } catch (error) {
+      expect(error).toMatchObject({ code: 'incompatible-schema' });
+    }
+  });
+
+  it('rejects a database with an incompatible migration table', () => {
+    const directory = temporaryDirectory();
+    const database = new Database(path.join(directory, 'tmux-team.db'));
+    database.exec('CREATE TABLE _migrations (version TEXT PRIMARY KEY, label TEXT NOT NULL)');
+    database.close();
+
+    expect(() => openStorage(location(directory))).toThrowError(StorageError);
+    try {
+      openStorage(location(directory));
+    } catch (error) {
+      expect(error).toMatchObject({ code: 'incompatible-schema' });
+    }
+  });
+
+  it('rolls back a failed migration and can recover on the next open', () => {
+    const directory = temporaryDirectory();
+    let shouldFail = true;
+    const migrations: MigrationDefinition[] = [
+      {
+        version: 1,
+        name: 'create recovery ledger',
+        up: (database) => database.exec('CREATE TABLE recovery_ledger (id INTEGER PRIMARY KEY)'),
+      },
+      {
+        version: 2,
+        name: 'recoverable migration',
+        up: (database) => {
+          if (shouldFail) throw new Error('simulated migration failure');
+          database.exec('CREATE INDEX recovery_ledger_id ON recovery_ledger(id)');
+        },
+      },
+    ];
+
+    try {
+      openStorageWithMigrations(location(directory), migrations);
+      expect.fail('expected the second migration to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(StorageError);
+      expect(error).toMatchObject({ code: 'migration', migrationVersion: 2, retryable: false });
+      expect((error as StorageError).cause).toMatchObject({ code: 'unknown' });
+    }
+    const afterFailure = new Database(path.join(directory, 'tmux-team.db'), { readonly: true });
+    expect(afterFailure.prepare('SELECT version, name FROM _migrations').all()).toEqual([
+      { version: 1, name: 'create recovery ledger' },
+    ]);
+    expect(
+      afterFailure
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'recovery_ledger_id'"
+        )
+        .get()
+    ).toBeUndefined();
+    afterFailure.close();
+
+    shouldFail = false;
+    const recovered = openStorageWithMigrations(location(directory), migrations);
+    expect(recovered.health().schemaVersion).toBe(2);
+    recovered.close();
+  });
+
+  it('maps corrupt databases while retaining the native cause', () => {
+    const directory = temporaryDirectory();
+    const databaseFile = path.join(directory, 'tmux-team.db');
+    fs.writeFileSync(databaseFile, 'not a sqlite database');
+
+    try {
+      openStorage(location(directory));
+      expect.fail('expected a structured corruption error');
+    } catch (error) {
+      expect(error).toBeInstanceOf(StorageError);
+      expect(error).toMatchObject({ code: 'corrupt', retryable: false });
+      expect((error as StorageError).cause).toBeDefined();
+    }
+  });
+
+  it('supports twenty-four concurrent short-lived writers with exact accounting', async () => {
+    const directory = temporaryDirectory();
+    const storage = openStorageWithMigrations(location(directory), [
+      {
+        version: 1,
+        name: 'create writer ledger',
+        up: (database) =>
+          database.exec(
+            'CREATE TABLE writer_ledger (id INTEGER PRIMARY KEY, writer TEXT NOT NULL)'
+          ),
+      },
+    ]);
+    storage.close();
+
+    const databaseFile = path.join(directory, 'tmux-team.db');
+    const writerCount = 24;
+    const workerSource = `
+      import Database from 'better-sqlite3';
+      const [databaseFile, writer] = process.argv.slice(1);
+      const connection = new Database(databaseFile);
+      connection.pragma('busy_timeout = 5000');
+      connection.pragma('journal_mode = WAL');
+      connection.transaction(() => {
+        connection.prepare('INSERT INTO writer_ledger (id, writer) VALUES (?, ?)')
+          .run(Number(writer), 'writer-' + writer);
+      }).immediate();
+      connection.close();
+    `;
+    const writers = Array.from(
+      { length: writerCount },
+      (_, writer) =>
+        new Promise<void>((resolve, reject) => {
+          const child = spawn(
+            process.execPath,
+            ['--input-type=module', '--eval', workerSource, databaseFile, String(writer)],
+            { stdio: ['ignore', 'ignore', 'pipe'] }
+          );
+          let stderr = '';
+          child.stderr.setEncoding('utf8');
+          child.stderr.on('data', (chunk) => (stderr += chunk));
+          child.once('error', reject);
+          child.once('exit', (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`writer ${writer} exited ${code}: ${stderr}`));
+          });
+        })
+    );
+    await Promise.all(writers);
+
+    const verification = new Database(databaseFile, { readonly: true });
+    const result = verification
+      .prepare('SELECT COUNT(*) AS count, COUNT(DISTINCT writer) AS writers FROM writer_ledger')
+      .get() as { count: number; writers: number };
+    expect(result).toEqual({ count: writerCount, writers: writerCount });
+    verification.close();
+  }, 20_000);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,8 @@ export interface Paths {
   globalConfig: string;
   localConfig: string;
   stateFile: string;
+  /** User-scoped SQLite database used by durable v5 features. */
+  databaseFile: string;
   workspaceRoot?: string;
 }
 


### PR DESCRIPTION
## Summary

- add a narrow `better-sqlite3` storage boundary with private files, WAL policy, runtime FTS5 verification, and structured failures
- add forward-only transactional migrations with incompatible-history detection and recoverable per-migration rollback
- verify real concurrent writers and packed no-build native installs across macOS, Linux glibc, and Linux musl architecture targets
- document the local-only, non-daemon storage ownership and recovery contract without adding identity, role, memory, or inbox schemas

## Verification

- `pnpm check`
- `pnpm test:run` (356 tests; coverage gates passed)
- `pnpm test:e2e` twice (15/15 each run)
- packed install: macOS arm64
- packed install: Alpine Linux arm64/musl
- independent Gemini read-only review: no blocking findings

## Linear

[TMT-12](https://linear.app/tigerpig-dev/issue/TMT-12/add-better-sqlite3-storage-migrations-and-native-install-verification)