### PR TITLE
TMT-13: Persist durable identities with transient tmux bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,17 @@ metadata, sends any requested message, and exits; there is no daemon or
 background service to start, stop, or keep healthy. tmux must be running when a
 command needs pane state.
 
-Identity metadata is authoritative. A pane title may be updated as a
+An identity record is durable, while its tmux binding and active presence are
+transient. TMT treats an identity as active only when SQLite, the live tmux
+server and pane, and the pane's identity metadata all agree. Pane targets are
+resolved to stable `%pane_id` values, so pane movement and window renumbering
+preserve the binding while the pane exists. Killing a pane or restarting its
+tmux server removes the stale binding on reconciliation without deleting the
+identity record; the same name can be bound again later with its original
+identity ID.
+
+Pane metadata is part of that presence check. A pane title may be updated as a
 best-effort presentation side effect, but titles are not the identity API.
-Pane targets are resolved to stable `%pane_id` values so pane movement and
-window renumbering do not silently change a stored binding while the pane
-exists.
 
 Messages use tmux buffer paste and then submit with Enter. This preserves
 multiline text and handles paste-safety windows in CLIs such as Gemini. The
@@ -163,10 +169,9 @@ after write work. Normal command shutdown uses a passive checkpoint; backup or
 export first obtains a consistent SQLite backup and may use a truncate
 checkpoint only after no active reader remains.
 
-Identity and memory tables are intentionally not specified by this section.
-They are delivered by their respective tickets behind the shared storage
-boundary. Until those tickets land, this is a storage ownership and recovery
-contract rather than a claim that those tables already exist.
+Durable identity records and transient tmux bindings use this storage boundary.
+Role, memory, and inbox schemas are intentionally deferred to their respective
+tickets; this release does not expose aliases or those later domain models.
 
 ## Managing global identities
 
@@ -186,8 +191,10 @@ tmt list %12
 tmt whoami
 ```
 
-Remove the current pane's binding with `tmt unbind`. If a pane is moved or
-renumbered, use its stable `%pane_id` in subsequent commands.
+Remove the current pane's binding with `tmt unbind`. This preserves the durable
+identity record so its name and ID can be rebound later. Repeating `tmt unbind`
+on an already-unbound pane returns `UNBOUND_PANE`. Pane movement and window
+renumbering preserve the binding's stable `%pane_id` while the pane lives.
 
 ## Legacy preambles
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,14 +112,16 @@ function main(): void {
     await dispatchCommand(ctx, parsed);
   };
 
-  run().catch((err) => {
-    if (!flags.json) {
-      console.error(err);
-    } else {
-      console.error(JSON.stringify({ error: String(err?.message ?? err) }));
-    }
-    process.exit(ExitCodes.ERROR);
-  });
+  run()
+    .catch((err) => {
+      if (!flags.json) {
+        console.error(err);
+      } else {
+        console.error(JSON.stringify({ error: String(err?.message ?? err) }));
+      }
+      process.exit(ExitCodes.ERROR);
+    })
+    .finally(() => ctx.dispose?.());
 }
 
 main();

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -7,10 +7,12 @@ import { ExitCodes } from '../exits.js';
 import { colors } from '../ui.js';
 import { resolveTarget } from '../target-resolver.js';
 import { normalizeName } from '../domain/names.js';
+import { identityAwareTmux } from '../identity-service.js';
 
 export function cmdCheck(ctx: Context, target: string, lines?: number): void {
   const { ui, config, tmux, flags, exit } = ctx;
-  const resolution = resolveTarget(tmux, target);
+  const runtimeTmux = identityAwareTmux(tmux, ctx.identityService);
+  const resolution = resolveTarget(runtimeTmux, target);
   if (!resolution.ok) {
     if (flags.json) ui.json({ error: resolution.error });
     else ui.error(resolution.error.message);

--- a/src/commands/global-identity.ts
+++ b/src/commands/global-identity.ts
@@ -2,6 +2,7 @@ import { bindGlobalName, unbindGlobalPane } from '../domain/service.js';
 import type { BindingErrorCode } from '../domain/types.js';
 import type { Context } from '../types.js';
 import { ExitCodes } from '../exits.js';
+import { IdentityServiceError } from '../identity-service.js';
 
 export function resolveCurrentPane(ctx: Context): string | null {
   const current = ctx.tmux.getCurrentPaneId();
@@ -14,7 +15,7 @@ export function resolvePane(ctx: Context, target: string): string | null {
 
 export function failIdentity(
   ctx: Context,
-  code: BindingErrorCode | 'PANE_NOT_FOUND',
+  code: BindingErrorCode | 'PANE_NOT_FOUND' | 'NAME_NOT_FOUND' | 'RECONCILIATION_FAILED',
   message: string
 ): never {
   if (ctx.flags.json) {
@@ -33,6 +34,22 @@ export function failIdentity(
 }
 
 export function bindIdentity(ctx: Context, paneId: string, name: string): void {
+  if (ctx.identityService) {
+    try {
+      const identity = ctx.identityService.bindPane(paneId, name);
+      try {
+        ctx.tmux.setPaneTitle(paneId, identity.name);
+      } catch {
+        // Identity metadata is authoritative; title synchronization is presentation only.
+      }
+      if (ctx.flags.json) ctx.ui.json({ bound: true, name: identity.name, pane: paneId });
+      else ctx.ui.success(`Bound '${identity.name}' to pane ${paneId}`);
+      return;
+    } catch (error) {
+      if (error instanceof IdentityServiceError) failIdentity(ctx, error.code, error.message);
+      throw error;
+    }
+  }
   const registrations = ctx.tmux.listGlobalIdentities();
   const result = bindGlobalName(registrations, name, paneId);
   if (!result.ok) failIdentity(ctx, result.error.code, result.error.message);
@@ -58,6 +75,21 @@ export function bindIdentity(ctx: Context, paneId: string, name: string): void {
 }
 
 export function unbindIdentity(ctx: Context, paneId: string): void {
+  if (ctx.identityService) {
+    try {
+      const identity = ctx.identityService.unbindCurrent();
+      if (!identity) {
+        failIdentity(ctx, 'UNBOUND_PANE', 'Pane has no active global name.');
+      }
+      if (ctx.flags.json) {
+        ctx.ui.json({ unbound: true, name: identity.name, pane: paneId });
+      } else ctx.ui.success(`Unbound pane ${paneId}`);
+      return;
+    } catch (error) {
+      if (error instanceof IdentityServiceError) failIdentity(ctx, error.code, error.message);
+      throw error;
+    }
+  }
   const registrations = ctx.tmux.listGlobalIdentities();
   const current = registrations.find((entry) => entry.paneId === paneId);
   const result = unbindGlobalPane(registrations, paneId);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -6,6 +6,7 @@ import type { Context, PaneInfo } from '../types.js';
 import { ExitCodes } from '../exits.js';
 import { resolveTarget, sortedGlobalIdentities } from '../target-resolver.js';
 import { normalizeName } from '../domain/names.js';
+import { identityAwareTmux } from '../identity-service.js';
 
 type PublicIdentity = { name: string; canonicalName: string };
 
@@ -29,9 +30,10 @@ function paneDetails(ctx: Context, paneId: string, panes?: Map<string, PaneInfo>
 
 export function cmdList(ctx: Context, target?: string): void {
   const { ui, tmux, flags, exit } = ctx;
+  const runtimeTmux = identityAwareTmux(tmux, ctx.identityService);
 
   if (target !== undefined) {
-    const resolution = resolveTarget(tmux, target);
+    const resolution = resolveTarget(runtimeTmux, target);
     if (!resolution.ok) {
       if (flags.json) ui.json({ error: resolution.error });
       else ui.error(resolution.error.message);
@@ -60,7 +62,7 @@ export function cmdList(ctx: Context, target?: string): void {
     return;
   }
 
-  const identities = sortedGlobalIdentities(tmux);
+  const identities = sortedGlobalIdentities(runtimeTmux);
   const panes = new Map(tmux.listPanes().map((pane) => [pane.id, pane]));
 
   if (flags.json) {

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -15,6 +15,7 @@ import {
 } from '../state.js';
 import { resolveTarget } from '../target-resolver.js';
 import { normalizeName } from '../domain/names.js';
+import { identityAwareTmux } from '../identity-service.js';
 
 function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -275,7 +276,8 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
   const waitEnabled = Boolean(flags.wait) || config.mode === 'wait';
   const enterDelayMs = config.defaults.pasteEnterDelayMs;
 
-  const resolution = resolveTarget(tmux, target);
+  const runtimeTmux = identityAwareTmux(tmux, ctx.identityService);
+  const resolution = resolveTarget(runtimeTmux, target);
   if (!resolution.ok) {
     if (flags.json) ui.json({ error: resolution.error });
     else ui.error(resolution.error.message);

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -107,6 +107,26 @@ describe('whoami and unbind', () => {
     });
   });
 
+  it('preserves UNBOUND_PANE when the durable identity service finds no active binding', () => {
+    const ctx = context([], true);
+    ctx.identityService = {
+      bindCurrent: vi.fn(),
+      bindPane: vi.fn(),
+      unbindCurrent: vi.fn(() => undefined),
+      currentIdentity: vi.fn(),
+      activeIdentities: vi.fn(() => []),
+      resolveActive: vi.fn(),
+      reconcile: vi.fn(),
+      close: vi.fn(),
+    };
+
+    expect(() => cmdUnbind(ctx)).toThrow('exit(1)');
+    expect(ctx.identityService.unbindCurrent).toHaveBeenCalledOnce();
+    expect(ctx.ui.json).toHaveBeenCalledWith({
+      error: { code: 'UNBOUND_PANE', message: 'Pane has no active global name.' },
+    });
+  });
+
   it('returns a pane-not-found error when outside tmux', () => {
     const ctx = context([], true);
     (ctx.tmux.getCurrentPaneId as ReturnType<typeof vi.fn>).mockReturnValue(null);

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -2,6 +2,23 @@ import type { Context } from '../types.js';
 import { failIdentity, resolveCurrentPane } from './global-identity.js';
 
 export function cmdWhoami(ctx: Context): void {
+  if (ctx.identityService) {
+    const paneId = resolveCurrentPane(ctx);
+    if (!paneId) failIdentity(ctx, 'PANE_NOT_FOUND', 'Not running inside a resolvable tmux pane.');
+    const current = ctx.identityService.currentIdentity();
+    if (ctx.flags.json) {
+      ctx.ui.json(
+        current
+          ? { bound: true, name: current.identity.name, pane: paneId }
+          : { bound: false, pane: paneId }
+      );
+    } else if (current) {
+      ctx.ui.info(`Bound identity '${current.identity.name}' on pane ${paneId}`);
+    } else {
+      ctx.ui.info(`Pane ${paneId} is unbound.`);
+    }
+    return;
+  }
   const paneId = resolveCurrentPane(ctx);
   if (!paneId) failIdentity(ctx, 'PANE_NOT_FOUND', 'Not running inside a resolvable tmux pane.');
 

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -163,4 +163,49 @@ describe('createContext', () => {
     expect(createTmux).not.toHaveBeenCalled();
     expect(ctx.paths.globalConfig).toBeTypeOf('string');
   });
+
+  it('disposes an opened identity service without eagerly opening it', async () => {
+    vi.resetModules();
+    const close = vi.fn();
+    const createTmux = vi.fn(() => ({}));
+    vi.doMock('./tmux.js', () => ({ createTmux }));
+    vi.doMock('./identity-service.js', () => ({
+      createIdentityService: vi.fn(() => ({ close })),
+    }));
+    const { createContext } = await import('./context.js');
+    const ctx = createContext({
+      argv: [],
+      flags: { json: false, verbose: false },
+      capability: 'none',
+    });
+    expect(createTmux).not.toHaveBeenCalled();
+    const service = ctx.identityService;
+    expect(createTmux).toHaveBeenCalledOnce();
+    ctx.dispose?.();
+    expect(close).toHaveBeenCalledOnce();
+    expect(service).toBeDefined();
+  });
+
+  it('disposes an opened identity service before an explicit process exit', async () => {
+    vi.resetModules();
+    const close = vi.fn();
+    vi.doMock('./tmux.js', () => ({ createTmux: () => ({}) }));
+    vi.doMock('./identity-service.js', () => ({
+      createIdentityService: vi.fn(() => ({ close })),
+    }));
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit(${code})`);
+    }) as never);
+    const { createContext } = await import('./context.js');
+    const ctx = createContext({
+      argv: [],
+      flags: { json: false, verbose: false },
+      capability: 'none',
+    });
+
+    expect(ctx.identityService).toBeDefined();
+    expect(() => ctx.exit(5)).toThrow('exit(5)');
+    expect(close).toHaveBeenCalledOnce();
+    expect(exitSpy).toHaveBeenCalledWith(5);
+  });
 });

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,6 +7,7 @@ import { resolvePaths, loadConfig } from './config.js';
 import { createUI } from './ui.js';
 import { createTmux } from './tmux.js';
 import { ExitCodes } from './exits.js';
+import { createIdentityService } from './identity-service.js';
 
 export interface CreateContextOptions {
   argv: string[];
@@ -27,6 +28,7 @@ export function createContext(options: CreateContextOptions): Context {
   const capability = options.capability ?? 'tmux';
   let tmux: Context['tmux'] | undefined;
   let config: Context['config'] | undefined;
+  let identityService: Context['identityService'] | undefined;
   const getTmux = (): Context['tmux'] => {
     tmux ??= createTmux();
     return tmux;
@@ -42,6 +44,10 @@ export function createContext(options: CreateContextOptions): Context {
     );
     return config;
   };
+  const getIdentityService = (): NonNullable<Context['identityService']> => {
+    identityService ??= createIdentityService({ tmux: getTmux(), paths });
+    return identityService;
+  };
 
   const context = {
     argv,
@@ -50,13 +56,20 @@ export function createContext(options: CreateContextOptions): Context {
     paths,
     registryScope,
     exit(code: number): never {
+      identityService?.close();
+      identityService = undefined;
       process.exit(code);
     },
   } as Context;
   Object.defineProperties(context, {
     config: { enumerable: true, get: getConfig },
     tmux: { enumerable: true, get: getTmux },
+    identityService: { enumerable: true, get: getIdentityService },
   });
+  (context as Context).dispose = (): void => {
+    identityService?.close();
+    identityService = undefined;
+  };
   // Preserve the established full-context behavior. Lightweight capabilities
   // intentionally defer both resources until a command asks for them.
   if (capability === 'tmux') getConfig();

--- a/src/domain/identity.ts
+++ b/src/domain/identity.ts
@@ -1,0 +1,23 @@
+/** Durable logical identity, independent from any currently reachable endpoint. */
+export interface DurableIdentity {
+  readonly id: string;
+  readonly name: string;
+  readonly canonicalName: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+/** Transient evidence that a durable identity is bound to one tmux pane instance. */
+export interface TmuxBinding {
+  readonly id: string;
+  readonly identityId: string;
+  readonly transport: 'tmux';
+  readonly paneId: string;
+  readonly serverId: string;
+  readonly socketPath: string;
+  readonly serverPid: number;
+  readonly serverStartTime: string;
+  readonly panePid: number;
+  readonly boundAt: string;
+  readonly lastVerifiedAt: string;
+}

--- a/src/identity-concurrency-worker.ts
+++ b/src/identity-concurrency-worker.ts
@@ -1,0 +1,65 @@
+/* c8 ignore file */
+import fs from 'node:fs';
+import path from 'node:path';
+import { createIdentityService } from './identity-service.js';
+import type { PaneInfo, Paths, Tmux } from './types.js';
+
+const [databaseFile, barrierDirectory, variant] = process.argv.slice(2);
+if (!databaseFile || !barrierDirectory || !variant) throw new Error('Invalid worker arguments.');
+
+const pane: PaneInfo = {
+  id: '%race',
+  command: 'mock-agent',
+  panePid: 4242,
+  suggestedName: null,
+};
+const tmux = {
+  getCurrentPaneId: () => pane.id,
+  resolvePaneTarget: (target: string) => (target === pane.id ? pane.id : null),
+  getEndpointSnapshot: () => ({
+    server: {
+      serverId: 'race-server',
+      socketPath: '/tmp/race-server',
+      serverPid: 77,
+      serverStartTime: 'race-start',
+    },
+    panes: [pane],
+  }),
+  setDurableIdentity: (_paneId: string, identity: any, binding: any) => {
+    pane.metadata = {
+      version: 1,
+      globalIdentity: {
+        name: identity.name,
+        canonicalName: identity.canonicalName,
+        identityId: identity.id,
+        bindingId: binding.id,
+        serverId: binding.serverId,
+        panePid: binding.panePid,
+      },
+    };
+  },
+  listGlobalIdentities: () => [],
+} as unknown as Tmux;
+const paths = {
+  globalDir: path.dirname(databaseFile),
+  databaseFile,
+} as Paths;
+
+fs.writeFileSync(path.join(barrierDirectory, `ready-${variant}`), 'ready');
+while (!fs.existsSync(path.join(barrierDirectory, 'go'))) {
+  // A short synchronous wait keeps both real processes behind the same
+  // barrier without introducing a test-only synchronization primitive.
+  const until = Date.now() + 5;
+  while (Date.now() < until) {}
+}
+
+const service = createIdentityService({ tmux, paths });
+try {
+  const identity = service.bindCurrent(variant === 'a' ? 'Ａｌｉｃｅ' : 'alice');
+  process.stdout.write(JSON.stringify({ ok: true, id: identity.id }) + '\n');
+} catch (error) {
+  process.stdout.write(JSON.stringify({ ok: false, error: String(error) }) + '\n');
+  process.exitCode = 1;
+} finally {
+  service.close();
+}

--- a/src/identity-concurrency.test.ts
+++ b/src/identity-concurrency.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+import { openIdentityRepository } from './storage/identity-repository.js';
+
+const directories: string[] = [];
+function runWorker(
+  worker: string,
+  databaseFile: string,
+  barrierDirectory: string,
+  variant: string
+): Promise<{ code: number | null; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', worker, databaseFile, barrierDirectory, variant],
+      {
+        cwd: process.cwd(),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    let output = '';
+    child.stdout.on('data', (chunk: Buffer) => (output += chunk.toString()));
+    child.stderr.on('data', (chunk: Buffer) => (output += chunk.toString()));
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe('identity repository multi-process races', () => {
+  it('converges equivalent names to one identity and one binding', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-concurrency-'));
+    directories.push(directory);
+    const barrier = path.join(directory, 'barrier');
+    fs.mkdirSync(barrier);
+    const databaseFile = path.join(directory, 'tmux-team.db');
+    const worker = path.join(process.cwd(), 'src/identity-concurrency-worker.ts');
+    const first = runWorker(worker, databaseFile, barrier, 'a');
+    const second = runWorker(worker, databaseFile, barrier, 'b');
+    for (
+      let i = 0;
+      i < 100 &&
+      (!fs.existsSync(path.join(barrier, 'ready-a')) ||
+        !fs.existsSync(path.join(barrier, 'ready-b')));
+      i++
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(fs.existsSync(path.join(barrier, 'ready-a'))).toBe(true);
+    expect(fs.existsSync(path.join(barrier, 'ready-b'))).toBe(true);
+    fs.writeFileSync(path.join(barrier, 'go'), 'go');
+    const results = await Promise.all([first, second]);
+    expect(results.every((result) => result.code === 0)).toBe(true);
+    const ids = results.map((result) => JSON.parse(result.output.trim()).id);
+    expect(ids[0]).toBe(ids[1]);
+    const repository = openIdentityRepository(databaseFile);
+    expect(repository.listIdentities()).toHaveLength(1);
+    expect(repository.findBindings()).toHaveLength(1);
+    expect(repository.findBindings()[0]?.identityId).toBe(ids[0]);
+    repository.close();
+  }, 15_000);
+});

--- a/src/identity-service.test.ts
+++ b/src/identity-service.test.ts
@@ -1,0 +1,317 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createIdentityService, identityAwareTmux } from './identity-service.js';
+import { IdentityServiceError } from './identity-service.js';
+import { openIdentityRepository } from './storage/identity-repository.js';
+import type { PaneInfo, Paths, Tmux, TmuxEndpointSnapshot } from './types.js';
+
+const directories: string[] = [];
+
+function fixture() {
+  const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-identity-'));
+  directories.push(globalDir);
+  const pane: PaneInfo = {
+    id: '%1',
+    command: 'mock-agent',
+    panePid: 1234,
+    suggestedName: null,
+  };
+  let snapshot: TmuxEndpointSnapshot = {
+    server: {
+      serverId: 'server-a',
+      socketPath: '/tmp/tmt-a',
+      serverPid: 10,
+      serverStartTime: 'one',
+    },
+    panes: [pane],
+  };
+  const tmux = {
+    getCurrentPaneId: () => '%1',
+    resolvePaneTarget: (target: string) => (target === '%1' ? '%1' : null),
+    getEndpointSnapshot: () => snapshot,
+    setDurableIdentity: (_paneId: string, identity: any, binding: any) => {
+      pane.metadata = {
+        version: 1,
+        globalIdentity: {
+          name: identity.name,
+          canonicalName: identity.canonicalName,
+          identityId: identity.id,
+          bindingId: binding.id,
+          serverId: binding.serverId,
+          panePid: binding.panePid,
+        },
+      };
+    },
+    clearDurableIdentity: () => {
+      pane.metadata = undefined;
+      return true;
+    },
+    listGlobalIdentities: () => [],
+  } as unknown as Tmux;
+  const paths = {
+    globalDir,
+    databaseFile: path.join(globalDir, 'tmux-team.db'),
+  } as Paths;
+  return { tmux, paths, pane, setSnapshot: (next: TmuxEndpointSnapshot) => (snapshot = next) };
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe('durable identity service', () => {
+  it('rejects invalid names before creating durable state', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+
+    expect(() => service.bindCurrent('%12')).toThrowError(
+      new IdentityServiceError('INVALID_NAME', 'Identity name must not look like a pane target.')
+    );
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.listIdentities()).toEqual([]);
+    expect(repository.findBindings()).toEqual([]);
+    repository.close();
+    service.close();
+  });
+
+  it('requires pane process evidence before creating durable state', () => {
+    const test = fixture();
+    test.setSnapshot({
+      ...test.tmux.getEndpointSnapshot!(),
+      panes: [{ ...test.pane, panePid: undefined }],
+    });
+    const service = createIdentityService(test);
+
+    expect(() => service.bindCurrent('missing-evidence')).toThrow("Pane '%1' was not found.");
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.listIdentities()).toEqual([]);
+    repository.close();
+    service.close();
+  });
+
+  it('creates one durable identity and a verified transient binding', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+    const first = service.bindCurrent('  Ｇｅｍｉｎｉ  ');
+    const second = service.bindCurrent('gemini');
+    expect(second.id).toBe(first.id);
+    expect(service.currentIdentity()).toMatchObject({
+      identity: { id: first.id, name: 'Ｇｅｍｉｎｉ' },
+    });
+    expect(identityAwareTmux(test.tmux, service).listGlobalIdentities()).toEqual([
+      { name: 'Ｇｅｍｉｎｉ', canonicalName: 'gemini', paneId: '%1' },
+    ]);
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.listIdentities()).toHaveLength(1);
+    expect(repository.findBindings()).toHaveLength(1);
+    repository.close();
+    service.close();
+  });
+
+  it('fails closed when the tmux adapter cannot provide endpoint evidence', () => {
+    const test = fixture();
+    const service = createIdentityService({
+      ...test,
+      tmux: { ...test.tmux, getEndpointSnapshot: undefined },
+    });
+    expect(() => service.reconcile()).toThrow('coherent endpoint snapshot');
+    expect(identityAwareTmux(test.tmux)).toBe(test.tmux);
+    service.close();
+  });
+
+  it('converts endpoint inspection failures into a structured service error', () => {
+    const test = fixture();
+    test.tmux.getEndpointSnapshot = () => {
+      throw new Error('tmux unavailable');
+    };
+    const service = createIdentityService(test);
+    expect(() => service.activeIdentities()).toThrow('Could not inspect the tmux endpoint.');
+    service.close();
+  });
+
+  it('prunes a changed pane process while preserving the durable identity', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+    const identity = service.bindCurrent('worker');
+    test.setSnapshot({
+      server: {
+        serverId: 'server-a',
+        socketPath: '/tmp/tmt-a',
+        serverPid: 10,
+        serverStartTime: 'one',
+      },
+      panes: [{ ...test.pane, panePid: 9876 }],
+    });
+    expect(service.activeIdentities()).toEqual([]);
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.listIdentities()).toMatchObject([
+      { id: identity.id, canonicalName: 'worker' },
+    ]);
+    expect(repository.findBindings()).toEqual([]);
+    repository.close();
+    service.close();
+  });
+
+  it('does not accept a binding from a different server instance with the same pane ID', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+    const identity = service.bindCurrent('server-bound');
+    test.setSnapshot({
+      server: {
+        serverId: 'server-b',
+        socketPath: '/tmp/tmt-b',
+        serverPid: 11,
+        serverStartTime: 'two',
+      },
+      panes: [
+        {
+          ...test.pane,
+          metadata: {
+            version: 1,
+            globalIdentity: {
+              ...(test.pane.metadata as NonNullable<PaneInfo['metadata']>).globalIdentity!,
+            },
+          },
+        },
+      ],
+    });
+    expect(service.activeIdentities()).toEqual([]);
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.listIdentities()).toMatchObject([{ id: identity.id }]);
+    expect(repository.findBindings()).toEqual([]);
+    repository.close();
+    service.close();
+  });
+
+  it('does not accept a binding when the tmux socket changes', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+    service.bindCurrent('socket-bound');
+    test.setSnapshot({
+      server: {
+        serverId: 'server-a',
+        socketPath: '/tmp/tmt-other-socket',
+        serverPid: 10,
+        serverStartTime: 'one',
+      },
+      panes: [{ ...test.pane }],
+    });
+    expect(service.activeIdentities()).toEqual([]);
+    service.close();
+  });
+
+  it('backfills name-only v5 metadata without changing the display name', () => {
+    const test = fixture();
+    test.pane.metadata = {
+      version: 1,
+      globalIdentity: { name: 'Legacy Agent', canonicalName: 'legacy agent' },
+    };
+    const service = createIdentityService(test);
+    const active = service.activeIdentities();
+    expect(active).toMatchObject([
+      { identity: { name: 'Legacy Agent', canonicalName: 'legacy agent' } },
+    ]);
+    expect(test.pane.metadata?.globalIdentity).toMatchObject({
+      name: 'Legacy Agent',
+      identityId: expect.any(String),
+      bindingId: expect.any(String),
+      serverId: 'server-a',
+      panePid: 1234,
+    });
+    service.close();
+  });
+
+  it('removes a database binding when the tmux metadata write fails', () => {
+    const test = fixture();
+    test.tmux.setDurableIdentity = () => {
+      throw new Error('simulated tmux write failure');
+    };
+    const service = createIdentityService(test);
+    expect(() => service.bindCurrent('partial')).toThrow('Could not write pane metadata.');
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.listIdentities()).toMatchObject([{ canonicalName: 'partial' }]);
+    expect(repository.findBindings()).toEqual([]);
+    repository.close();
+    service.close();
+  });
+
+  it('heals a metadata-only unbind interruption on the next reconciliation', () => {
+    const test = fixture();
+    const base = openIdentityRepository(test.paths.databaseFile);
+    let failRemoval = true;
+    const repository = {
+      ...base,
+      removeBinding(id: string): void {
+        if (failRemoval) {
+          failRemoval = false;
+          throw new Error('simulated SQLite interruption');
+        }
+        base.removeBinding(id);
+      },
+    };
+    const service = createIdentityService({ ...test, repository });
+    service.bindCurrent('interrupted');
+    expect(() => service.unbindCurrent()).toThrow('Could not remove tmux binding.');
+    expect(service.activeIdentities()).toEqual([]);
+    expect(base.findBindings()).toEqual([]);
+    service.close();
+    base.close();
+  });
+
+  it('rejects a second identity on one live pane and preserves the first binding', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+    service.bindCurrent('first');
+    expect(() => service.bindCurrent('second')).toThrowError(
+      new IdentityServiceError('PANE_ALREADY_BOUND', 'Pane is already bound to another name.')
+    );
+    expect(service.currentIdentity()?.identity.name).toBe('first');
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.listIdentities()).toMatchObject([{ canonicalName: 'first' }]);
+    repository.close();
+    service.close();
+  });
+
+  it('rejects a live identity on another pane', () => {
+    const test = fixture();
+    const secondPane = { ...test.pane, id: '%2', panePid: 5678 };
+    test.setSnapshot({ ...test.tmux.getEndpointSnapshot!(), panes: [test.pane, secondPane] });
+    (test.tmux.resolvePaneTarget as any) = (target: string) =>
+      target === '%1' || target === '%2' ? target : null;
+    const service = createIdentityService(test);
+    service.bindPane('%1', 'shared');
+    expect(() => service.bindPane('%2', 'shared')).toThrow(
+      'Name is already active on another pane.'
+    );
+    service.close();
+  });
+
+  it('makes explicit unbind idempotent while preserving the durable row', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+    const identity = service.bindCurrent('keep-me');
+    expect(service.unbindCurrent()).toMatchObject({ id: identity.id });
+    expect(service.unbindCurrent()).toBeUndefined();
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.listIdentities()).toMatchObject([{ id: identity.id }]);
+    expect(repository.findBindings()).toEqual([]);
+    repository.close();
+    service.close();
+  });
+
+  it('resolves only currently active names and direct pane targets', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+    service.bindCurrent('resolvable');
+    expect(service.resolveActive('resolvable')).toMatchObject({ identity: { name: 'resolvable' } });
+    expect(service.resolveActive('%1')).toMatchObject({ binding: { paneId: '%1' } });
+    expect(service.resolveActive('missing')).toBeUndefined();
+    expect(() => service.bindPane('%99', 'missing-pane')).toThrow(
+      "Pane target '%99' was not found."
+    );
+    service.close();
+  });
+});

--- a/src/identity-service.ts
+++ b/src/identity-service.ts
@@ -1,0 +1,447 @@
+import { normalizeName, validateName } from './domain/names.js';
+import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
+import { resolveTarget } from './target-resolver.js';
+import type {
+  IdentityService,
+  PaneInfo,
+  Tmux,
+  TmuxEndpointSnapshot,
+  TmuxServerEvidence,
+} from './types.js';
+import { openIdentityRepository, type IdentityRepository } from './storage/identity-repository.js';
+import type { Paths } from './types.js';
+
+export interface IdentityServiceOptions {
+  readonly tmux: Tmux;
+  readonly paths: Paths;
+  /** Test and embedding seam; production callers use the storage adapter. */
+  readonly repository?: IdentityRepository;
+}
+
+export class IdentityServiceError extends Error {
+  constructor(
+    public readonly code:
+      | 'INVALID_NAME'
+      | 'PANE_NOT_FOUND'
+      | 'NAME_NOT_FOUND'
+      | 'PANE_ALREADY_BOUND'
+      | 'NAME_ALREADY_ACTIVE'
+      | 'UNBOUND_PANE'
+      | 'RECONCILIATION_FAILED',
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = 'IdentityServiceError';
+  }
+}
+
+function serverMatches(expected: TmuxBinding, current: TmuxServerEvidence): boolean {
+  return (
+    expected.serverId === current.serverId &&
+    expected.socketPath === current.socketPath &&
+    expected.serverPid === current.serverPid &&
+    expected.serverStartTime === current.serverStartTime
+  );
+}
+
+function paneMatches(expected: TmuxBinding, pane: PaneInfo): boolean {
+  return expected.paneId === pane.id && expected.panePid === pane.panePid;
+}
+
+function metadataMatches(pane: PaneInfo, identity: DurableIdentity, binding: TmuxBinding): boolean {
+  const metadata = pane.metadata?.globalIdentity;
+  return (
+    metadata?.identityId === identity.id &&
+    metadata.bindingId === binding.id &&
+    metadata.serverId === binding.serverId &&
+    metadata.panePid === binding.panePid &&
+    normalizeName(metadata.name) === identity.canonicalName
+  );
+}
+
+function endpointSnapshot(tmux: Tmux): TmuxEndpointSnapshot {
+  if (tmux.getEndpointSnapshot) {
+    try {
+      return tmux.getEndpointSnapshot();
+    } catch (error) {
+      throw new IdentityServiceError(
+        'RECONCILIATION_FAILED',
+        'Could not inspect the tmux endpoint.',
+        {
+          cause: error,
+        }
+      );
+    }
+  }
+  throw new IdentityServiceError(
+    'RECONCILIATION_FAILED',
+    'The tmux adapter does not provide a coherent endpoint snapshot.'
+  );
+}
+
+function findPane(snapshot: TmuxEndpointSnapshot, paneId: string): PaneInfo | undefined {
+  return snapshot.panes.find((pane) => pane.id === paneId);
+}
+
+function mapActive(
+  repository: IdentityRepository,
+  snapshot: TmuxEndpointSnapshot,
+  bindings: readonly TmuxBinding[]
+): Array<{ identity: DurableIdentity; binding: TmuxBinding; pane: PaneInfo }> {
+  const identities = new Map(repository.listIdentities().map((item) => [item.id, item]));
+  return bindings.flatMap((binding) => {
+    const identity = identities.get(binding.identityId);
+    const pane = findPane(snapshot, binding.paneId);
+    if (
+      !identity ||
+      !pane ||
+      !serverMatches(binding, snapshot.server) ||
+      !paneMatches(binding, pane)
+    ) {
+      return [];
+    }
+    return metadataMatches(pane, identity, binding) ? [{ identity, binding, pane }] : [];
+  });
+}
+
+function createOrResolve(
+  repository: IdentityRepository,
+  name: string
+): { identity: DurableIdentity; created: boolean } {
+  const valid = validateName(name);
+  if (!valid.ok) throw new IdentityServiceError(valid.error.code, valid.error.message);
+  const existing = repository.findByCanonicalName(valid.value.canonicalName);
+  if (existing) return { identity: existing, created: false };
+  try {
+    return {
+      identity: repository.createIdentity(valid.value.name, valid.value.canonicalName),
+      created: true,
+    };
+  } catch (error) {
+    // A concurrent creator may win the canonical unique constraint.
+    const raced = repository.findByCanonicalName(valid.value.canonicalName);
+    if (raced) return { identity: raced, created: false };
+    throw new IdentityServiceError('RECONCILIATION_FAILED', 'Could not create durable identity.', {
+      cause: error,
+    });
+  }
+}
+
+function cleanupUnboundIdentity(
+  repository: IdentityRepository,
+  created: boolean,
+  id: string
+): void {
+  if (!created) return;
+  try {
+    repository.removeIdentityIfUnbound(id);
+  } catch {
+    // The identity may have been claimed by a concurrent binder. It is still
+    // safe because active routing requires a verified binding join.
+  }
+}
+
+function paneEvidence(snapshot: TmuxEndpointSnapshot, paneId: string): PaneInfo {
+  const pane = findPane(snapshot, paneId);
+  if (!pane || !pane.panePid) {
+    throw new IdentityServiceError('PANE_NOT_FOUND', `Pane '${paneId}' was not found.`);
+  }
+  return pane;
+}
+
+/**
+ * Adapt the legacy target resolver to the verified identity view. Commands
+ * only consume this adapter; lifecycle and presence policy remain here.
+ */
+export function identityAwareTmux(tmux: Tmux, service?: IdentityService): Tmux {
+  if (!service) return tmux;
+  return {
+    ...tmux,
+    listGlobalIdentities: () =>
+      service.activeIdentities().map(({ identity, binding }) => ({
+        name: identity.name,
+        canonicalName: identity.canonicalName,
+        paneId: binding.paneId,
+      })),
+  };
+}
+
+export function createIdentityService(options: IdentityServiceOptions): IdentityService {
+  const { tmux, paths } = options;
+  const repository = options.repository ?? openIdentityRepository(paths.databaseFile);
+  const ownsRepository = !options.repository;
+
+  const reconcile = (): void => {
+    const snapshot = endpointSnapshot(tmux);
+    const allBindings = repository.findBindings();
+    const identities = new Map(repository.listIdentities().map((item) => [item.id, item]));
+
+    // Backfill old v5 pane metadata lazily. A database-only binding is never
+    // active until this metadata marker is successfully written.
+    for (const pane of snapshot.panes) {
+      const legacy = pane.metadata?.globalIdentity;
+      if (!legacy || legacy.identityId || !pane.panePid) continue;
+      const { identity } = createOrResolve(repository, legacy.name);
+      const binding = repository.createBinding({
+        identityId: identity.id,
+        transport: 'tmux',
+        paneId: pane.id,
+        serverId: snapshot.server.serverId,
+        socketPath: snapshot.server.socketPath,
+        serverPid: snapshot.server.serverPid,
+        serverStartTime: snapshot.server.serverStartTime,
+        panePid: pane.panePid,
+        boundAt: new Date().toISOString(),
+        lastVerifiedAt: new Date().toISOString(),
+      });
+      try {
+        if (!tmux.setDurableIdentity) throw new Error('Durable tmux metadata is unavailable.');
+        tmux.setDurableIdentity(pane.id, identity, binding);
+      } catch (error) {
+        try {
+          repository.removeBinding(binding.id);
+        } catch {
+          // The legacy marker was not upgraded, so this row remains ineligible
+          // for active routing and will be retried by reconciliation.
+        }
+        throw new IdentityServiceError(
+          'RECONCILIATION_FAILED',
+          'Could not backfill pane metadata.',
+          {
+            cause: error,
+          }
+        );
+      }
+    }
+
+    for (const binding of allBindings) {
+      const identity = identities.get(binding.identityId);
+      const pane = findPane(snapshot, binding.paneId);
+      if (
+        !identity ||
+        !pane ||
+        !serverMatches(binding, snapshot.server) ||
+        !paneMatches(binding, pane) ||
+        !metadataMatches(pane, identity, binding)
+      ) {
+        repository.removeBinding(binding.id);
+      } else {
+        repository.touchBinding(binding.id, new Date().toISOString());
+      }
+    }
+  };
+
+  const safeReconcile = (): void => {
+    try {
+      reconcile();
+    } catch (error) {
+      if (error instanceof IdentityServiceError) throw error;
+      throw new IdentityServiceError(
+        'RECONCILIATION_FAILED',
+        'Could not reconcile identity state.',
+        {
+          cause: error,
+        }
+      );
+    }
+  };
+
+  const active = () => {
+    safeReconcile();
+    const snapshot = endpointSnapshot(tmux);
+    return mapActive(repository, snapshot, repository.findBindings());
+  };
+
+  const bind = (paneId: string, name: string): DurableIdentity => {
+    const snapshot = endpointSnapshot(tmux);
+    const pane = paneEvidence(snapshot, paneId);
+    const resolved = createOrResolve(repository, name);
+    const identity = resolved.identity;
+    const endpointBinding = repository
+      .findBindings()
+      .filter((item) => item.paneId === paneId && item.serverId === snapshot.server.serverId)[0];
+    let current: TmuxBinding | undefined = endpointBinding;
+    if (current && (!serverMatches(current, snapshot.server) || !paneMatches(current, pane))) {
+      repository.removeBinding(current.id);
+      current = undefined;
+    }
+    if (current && current.identityId !== identity.id) {
+      cleanupUnboundIdentity(repository, resolved.created, identity.id);
+      throw new IdentityServiceError(
+        'PANE_ALREADY_BOUND',
+        'Pane is already bound to another name.'
+      );
+    }
+    const existingIdentityBinding = repository
+      .findBindings()
+      .find((item) => item.identityId === identity.id);
+    if (existingIdentityBinding && existingIdentityBinding.id !== current?.id) {
+      const existingPane = findPane(snapshot, existingIdentityBinding.paneId);
+      if (
+        existingPane &&
+        serverMatches(existingIdentityBinding, snapshot.server) &&
+        paneMatches(existingIdentityBinding, existingPane)
+      ) {
+        throw new IdentityServiceError(
+          'NAME_ALREADY_ACTIVE',
+          'Name is already active on another pane.'
+        );
+      }
+      repository.removeBinding(existingIdentityBinding.id);
+    }
+    if (current) {
+      if (tmux.setDurableIdentity && !metadataMatches(pane, identity, current)) {
+        tmux.setDurableIdentity(paneId, identity, current);
+      }
+      repository.touchBinding(current.id, new Date().toISOString());
+      return identity;
+    }
+    const now = new Date().toISOString();
+    let binding: TmuxBinding;
+    try {
+      binding = repository.createBinding({
+        identityId: identity.id,
+        transport: 'tmux',
+        paneId,
+        serverId: snapshot.server.serverId,
+        socketPath: snapshot.server.socketPath,
+        serverPid: snapshot.server.serverPid,
+        serverStartTime: snapshot.server.serverStartTime,
+        panePid: pane.panePid as number,
+        boundAt: now,
+        lastVerifiedAt: now,
+      });
+    } catch (error) {
+      // SQLite uniqueness is the final arbiter for cross-process races. Turn
+      // the native constraint into the same deterministic domain result.
+      const endpoint = repository.findBindingByPane(paneId, snapshot.server.serverId);
+      if (endpoint && endpoint.identityId === identity.id) {
+        try {
+          if (!tmux.setDurableIdentity) throw new Error('Durable tmux metadata is unavailable.');
+          tmux.setDurableIdentity(paneId, identity, endpoint);
+        } catch (metadataError) {
+          throw new IdentityServiceError(
+            'RECONCILIATION_FAILED',
+            'Could not write pane metadata.',
+            { cause: metadataError }
+          );
+        }
+        return identity;
+      }
+      if (endpoint) {
+        cleanupUnboundIdentity(repository, resolved.created, identity.id);
+        throw new IdentityServiceError(
+          'PANE_ALREADY_BOUND',
+          'Pane is already bound to another name.'
+        );
+      }
+      const racedIdentityBinding = repository
+        .findBindings()
+        .find((item) => item.identityId === identity.id);
+      if (racedIdentityBinding) {
+        cleanupUnboundIdentity(repository, false, identity.id);
+        throw new IdentityServiceError(
+          'NAME_ALREADY_ACTIVE',
+          'Name is already active on another pane.'
+        );
+      }
+      cleanupUnboundIdentity(repository, resolved.created, identity.id);
+      throw new IdentityServiceError('RECONCILIATION_FAILED', 'Could not create tmux binding.', {
+        cause: error,
+      });
+    }
+    try {
+      if (!tmux.setDurableIdentity) throw new Error('Durable tmux metadata is unavailable.');
+      tmux.setDurableIdentity(paneId, identity, binding);
+    } catch (error) {
+      try {
+        repository.removeBinding(binding.id);
+      } catch {
+        // The missing durable metadata still makes this row ineligible for
+        // routing; reconciliation will retry cleanup on the next read.
+      }
+      throw new IdentityServiceError('RECONCILIATION_FAILED', 'Could not write pane metadata.', {
+        cause: error,
+      });
+    }
+    return identity;
+  };
+
+  return {
+    bindCurrent(name) {
+      const current = tmux.getCurrentPaneId();
+      if (!current)
+        throw new IdentityServiceError(
+          'PANE_NOT_FOUND',
+          'Not running inside a resolvable tmux pane.'
+        );
+      const paneId = tmux.resolvePaneTarget(current);
+      if (!paneId)
+        throw new IdentityServiceError(
+          'PANE_NOT_FOUND',
+          'Not running inside a resolvable tmux pane.'
+        );
+      return bind(paneId, name);
+    },
+    bindPane(pane, name) {
+      const resolved = tmux.resolvePaneTarget(pane);
+      if (!resolved)
+        throw new IdentityServiceError('PANE_NOT_FOUND', `Pane target '${pane}' was not found.`);
+      return bind(resolved, name);
+    },
+    unbindCurrent() {
+      const current = tmux.getCurrentPaneId();
+      if (!current) return undefined;
+      const paneId = tmux.resolvePaneTarget(current);
+      if (!paneId) return undefined;
+      const item = active().find((entry) => entry.binding.paneId === paneId);
+      if (!item) return undefined;
+      try {
+        if (tmux.clearDurableIdentity) tmux.clearDurableIdentity(paneId, item.binding.id);
+      } catch (error) {
+        throw new IdentityServiceError('RECONCILIATION_FAILED', 'Could not clear pane metadata.', {
+          cause: error,
+        });
+      }
+      try {
+        repository.removeBinding(item.binding.id);
+      } catch (error) {
+        // Metadata was cleared first. A subsequent reconciliation will remove
+        // the stale row, so this partial operation can never route a phantom.
+        throw new IdentityServiceError('RECONCILIATION_FAILED', 'Could not remove tmux binding.', {
+          cause: error,
+        });
+      }
+      return item.identity;
+    },
+    currentIdentity() {
+      const current = tmux.getCurrentPaneId();
+      if (!current) return undefined;
+      const paneId = tmux.resolvePaneTarget(current);
+      return paneId ? active().find((entry) => entry.binding.paneId === paneId) : undefined;
+    },
+    activeIdentities: active,
+    resolveActive(target) {
+      const items = active();
+      const identities = items.map(({ identity, binding }) => ({
+        name: identity.name,
+        canonicalName: identity.canonicalName,
+        paneId: binding.paneId,
+      }));
+      const result = resolveTarget(
+        {
+          ...tmux,
+          listGlobalIdentities: () => identities,
+        },
+        target
+      );
+      if (!result.ok) return undefined;
+      return items.find((item) => item.binding.paneId === result.value.paneId);
+    },
+    reconcile: safeReconcile,
+    close() {
+      if (ownsRepository) repository.close();
+    },
+  };
+}

--- a/src/storage/identity-repository.test.ts
+++ b/src/storage/identity-repository.test.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { openIdentityRepository } from './identity-repository.js';
+
+const directories: string[] = [];
+
+function databasePath(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-repository-'));
+  directories.push(directory);
+  return path.join(directory, 'tmux-team.db');
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe('identity repository contract', () => {
+  it('round-trips identities and bindings through the narrow repository API', () => {
+    const repository = openIdentityRepository(databasePath());
+    const now = new Date().toISOString();
+    const identity = repository.createIdentity('Alice', 'alice');
+    const binding = repository.createBinding({
+      identityId: identity.id,
+      transport: 'tmux',
+      paneId: '%3',
+      serverId: 'server',
+      socketPath: '/tmp/server',
+      serverPid: 42,
+      serverStartTime: now,
+      panePid: 99,
+      boundAt: now,
+      lastVerifiedAt: now,
+    });
+    expect(repository.findByCanonicalName('alice')).toEqual(identity);
+    expect(repository.findByCanonicalName('missing')).toBeUndefined();
+    expect(repository.findBindingByPane('%3', 'server')).toEqual(binding);
+    expect(repository.findBindingByPane('%4', 'server')).toBeUndefined();
+    repository.touchBinding(binding.id, 'later');
+    expect(repository.findBindings()[0]?.lastVerifiedAt).toBe('later');
+    repository.removeBinding(binding.id);
+    expect(repository.findBindings()).toEqual([]);
+    expect(repository.listIdentities()).toEqual([identity]);
+    repository.close();
+  });
+
+  it('rejects duplicate canonical identities and identity bindings atomically', () => {
+    const repository = openIdentityRepository(databasePath());
+    const identity = repository.createIdentity('Alice', 'alice');
+    expect(() => repository.createIdentity('ALICE', 'alice')).toThrow();
+    const value = {
+      identityId: identity.id,
+      transport: 'tmux' as const,
+      paneId: '%3',
+      serverId: 'server',
+      socketPath: '/tmp/server',
+      serverPid: 42,
+      serverStartTime: 'start',
+      panePid: 99,
+      boundAt: 'now',
+      lastVerifiedAt: 'now',
+    };
+    repository.createBinding(value);
+    expect(() => repository.createBinding(value)).toThrow();
+    expect(repository.findBindings()).toHaveLength(1);
+    repository.close();
+  });
+
+  it('rejects use after close', () => {
+    const repository = openIdentityRepository(databasePath());
+    repository.close();
+    expect(() => repository.listIdentities()).toThrow('Identity repository is closed.');
+    repository.close();
+  });
+});

--- a/src/storage/identity-repository.ts
+++ b/src/storage/identity-repository.ts
@@ -1,0 +1,187 @@
+import crypto from 'node:crypto';
+import Database from 'better-sqlite3';
+import type { DurableIdentity, TmuxBinding } from '../domain/identity.js';
+import { openStorage } from './sqlite-adapter.js';
+import { StorageError } from './errors.js';
+import type { StorageLocation } from './ports.js';
+
+export interface IdentityRepository {
+  findByCanonicalName(canonicalName: string): DurableIdentity | undefined;
+  createIdentity(name: string, canonicalName: string): DurableIdentity;
+  listIdentities(): DurableIdentity[];
+  findBindings(): TmuxBinding[];
+  findBindingByPane(paneId: string, serverId: string): TmuxBinding | undefined;
+  createBinding(binding: Omit<TmuxBinding, 'id'> & { id?: string }): TmuxBinding;
+  touchBinding(id: string, lastVerifiedAt: string): void;
+  removeBinding(id: string): void;
+  removeIdentityIfUnbound(id: string): void;
+  close(): void;
+}
+
+type IdentityRow = {
+  id: string;
+  name: string;
+  canonical_name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type BindingRow = {
+  id: string;
+  identity_id: string;
+  transport: 'tmux';
+  pane_id: string;
+  server_id: string;
+  socket_path: string;
+  server_pid: number;
+  server_start_time: string;
+  pane_pid: number;
+  bound_at: string;
+  last_verified_at: string;
+};
+
+function identity(row: IdentityRow): DurableIdentity {
+  return {
+    id: row.id,
+    name: row.name,
+    canonicalName: row.canonical_name,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function binding(row: BindingRow): TmuxBinding {
+  return {
+    id: row.id,
+    identityId: row.identity_id,
+    transport: row.transport,
+    paneId: row.pane_id,
+    serverId: row.server_id,
+    socketPath: row.socket_path,
+    serverPid: row.server_pid,
+    serverStartTime: row.server_start_time,
+    panePid: row.pane_pid,
+    boundAt: row.bound_at,
+    lastVerifiedAt: row.last_verified_at,
+  };
+}
+
+/** Storage-backed identity repository. SQL remains private to this module. */
+export function openIdentityRepository(location: StorageLocation): IdentityRepository {
+  let lifecycle;
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      lifecycle = openStorage(location);
+      break;
+    } catch (error) {
+      if (!(error instanceof StorageError) || error.code !== 'busy' || attempt >= 20) throw error;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+    }
+  }
+  const database = new Database(lifecycle.path);
+  database.pragma('foreign_keys = ON');
+  database.pragma('busy_timeout = 5000');
+  database.pragma('synchronous = NORMAL');
+  let closed = false;
+
+  const requireOpen = (): Database.Database => {
+    if (closed) throw new Error('Identity repository is closed.');
+    return database;
+  };
+
+  return {
+    findByCanonicalName(canonicalName) {
+      const row = requireOpen()
+        .prepare(
+          'SELECT id, name, canonical_name, created_at, updated_at FROM identities WHERE canonical_name = ?'
+        )
+        .get(canonicalName) as IdentityRow | undefined;
+      return row ? identity(row) : undefined;
+    },
+    createIdentity(name, canonicalName) {
+      const now = new Date().toISOString();
+      const value = {
+        id: crypto.randomUUID(),
+        name,
+        canonicalName,
+        createdAt: now,
+        updatedAt: now,
+      };
+      requireOpen()
+        .prepare(
+          'INSERT INTO identities (id, name, canonical_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
+        )
+        .run(value.id, value.name, value.canonicalName, value.createdAt, value.updatedAt);
+      return value;
+    },
+    listIdentities() {
+      const rows = requireOpen()
+        .prepare(
+          'SELECT id, name, canonical_name, created_at, updated_at FROM identities ORDER BY canonical_name'
+        )
+        .all() as IdentityRow[];
+      return rows.map(identity);
+    },
+    findBindings() {
+      const rows = requireOpen()
+        .prepare(
+          'SELECT id, identity_id, transport, pane_id, server_id, socket_path, server_pid, server_start_time, pane_pid, bound_at, last_verified_at FROM bindings'
+        )
+        .all() as BindingRow[];
+      return rows.map(binding);
+    },
+    findBindingByPane(paneId, serverId) {
+      const row = requireOpen()
+        .prepare(
+          'SELECT id, identity_id, transport, pane_id, server_id, socket_path, server_pid, server_start_time, pane_pid, bound_at, last_verified_at FROM bindings WHERE pane_id = ? AND server_id = ?'
+        )
+        .get(paneId, serverId) as BindingRow | undefined;
+      return row ? binding(row) : undefined;
+    },
+    createBinding(value) {
+      const id = value.id ?? crypto.randomUUID();
+      requireOpen()
+        .prepare(
+          'INSERT INTO bindings (id, identity_id, transport, pane_id, server_id, socket_path, server_pid, server_start_time, pane_pid, bound_at, last_verified_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        )
+        .run(
+          id,
+          value.identityId,
+          value.transport,
+          value.paneId,
+          value.serverId,
+          value.socketPath,
+          value.serverPid,
+          value.serverStartTime,
+          value.panePid,
+          value.boundAt,
+          value.lastVerifiedAt
+        );
+      return { ...value, id };
+    },
+    touchBinding(id, lastVerifiedAt) {
+      requireOpen()
+        .prepare('UPDATE bindings SET last_verified_at = ? WHERE id = ?')
+        .run(lastVerifiedAt, id);
+    },
+    removeBinding(id) {
+      requireOpen().prepare('DELETE FROM bindings WHERE id = ?').run(id);
+    },
+    removeIdentityIfUnbound(id) {
+      requireOpen()
+        .prepare(
+          'DELETE FROM identities WHERE id = ? AND NOT EXISTS (SELECT 1 FROM bindings WHERE identity_id = ?)'
+        )
+        .run(id, id);
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      try {
+        database.close();
+      } finally {
+        lifecycle.close();
+      }
+    },
+  };
+}

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,3 +1,5 @@
 export { openStorage } from './sqlite-adapter.js';
 export type { CheckpointMode, StorageHandle, StorageHealth, StorageLocation } from './ports.js';
 export { StorageError, type StorageErrorCode } from './errors.js';
+export { openIdentityRepository, type IdentityRepository } from './identity-repository.js';
+export type { DurableIdentity, TmuxBinding } from '../domain/identity.js';

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -9,8 +9,39 @@ export interface MigrationDefinition {
   readonly up: (database: SqliteDatabase) => void;
 }
 
-/** TMT-12 deliberately owns no domain tables. Later issues append migrations here. */
-export const CURRENT_MIGRATIONS: readonly MigrationDefinition[] = [];
+/** Domain tables are appended by their owning tickets, in migration order. */
+export const CURRENT_MIGRATIONS: readonly MigrationDefinition[] = [
+  {
+    version: 1,
+    name: 'create durable identities and transient tmux bindings',
+    up: (database) =>
+      database.exec(`
+        CREATE TABLE identities (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          canonical_name TEXT NOT NULL UNIQUE,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+        CREATE TABLE bindings (
+          id TEXT PRIMARY KEY,
+          identity_id TEXT NOT NULL REFERENCES identities(id) ON DELETE CASCADE,
+          transport TEXT NOT NULL CHECK (transport = 'tmux'),
+          pane_id TEXT NOT NULL,
+          server_id TEXT NOT NULL,
+          socket_path TEXT NOT NULL,
+          server_pid INTEGER NOT NULL,
+          server_start_time TEXT NOT NULL,
+          pane_pid INTEGER NOT NULL,
+          bound_at TEXT NOT NULL,
+          last_verified_at TEXT NOT NULL,
+          UNIQUE(identity_id),
+          UNIQUE(transport, server_id, pane_id)
+        );
+        CREATE INDEX bindings_endpoint ON bindings(transport, server_id, pane_id);
+      `),
+  },
+];
 
 const CREATE_MIGRATIONS = `
   CREATE TABLE IF NOT EXISTS _migrations (

--- a/src/storage/sqlite-adapter.ts
+++ b/src/storage/sqlite-adapter.ts
@@ -69,8 +69,8 @@ function openStorageInternal(
   try {
     database = new Database(resolved.file);
     database.pragma('foreign_keys = ON');
-    database.pragma('journal_mode = WAL');
     database.pragma('busy_timeout = 5000');
+    database.pragma('journal_mode = WAL');
     database.pragma('synchronous = NORMAL');
     verifyFts5(database);
     applyMigrations(database, options.migrations ?? CURRENT_MIGRATIONS);

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -27,13 +27,13 @@ afterEach(() => {
 });
 
 describe('SQLite storage adapter', () => {
-  it('opens a private database with required pragmas and only migration metadata', () => {
+  it('opens a private database with required pragmas and the durable identity schema', () => {
     const directory = temporaryDirectory();
     const storage = openStorage(location(directory));
 
     expect(storage.health()).toMatchObject({
       open: true,
-      schemaVersion: 0,
+      schemaVersion: 1,
       journalMode: 'wal',
       foreignKeys: true,
       busyTimeoutMs: 5000,
@@ -52,7 +52,11 @@ describe('SQLite storage adapter', () => {
     const tables = database
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
       .all() as Array<{ name: string }>;
-    expect(tables.map((table) => table.name)).toEqual(['_migrations']);
+    expect(tables.map((table) => table.name).sort()).toEqual([
+      '_migrations',
+      'bindings',
+      'identities',
+    ]);
     database.close();
     if (process.platform !== 'win32') {
       expect(fs.statSync(directory).mode & 0o777).toBe(0o700);

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -249,6 +249,15 @@ describe('createTmux', () => {
       ]);
     });
 
+    it('captures pane process evidence from modern list-panes output', () => {
+      mockedExecSync.mockReturnValue(
+        '%1__TMT_FIELD_4f1c__main:2.0__TMT_FIELD_4f1c__/repo__TMT_FIELD_4f1c__codex__TMT_FIELD_4f1c__4242__TMT_FIELD_4f1c__{"version":1}\n'
+      );
+      expect(createTmux().listPanes()).toMatchObject([
+        { id: '%1', panePid: 4242, metadata: { version: 1 } },
+      ]);
+    });
+
     it('falls back to pane options when list-panes omits user metadata', () => {
       mockedExecSync.mockReturnValue('%1\tmain:2.0\t/repo\tnode\t\n');
       mockedExecFileSync.mockReturnValue(
@@ -377,6 +386,77 @@ describe('createTmux', () => {
       const tmux = createTmux();
       expect(tmux.getCurrentPaneId()).toBeNull();
       process.env.TMUX_PANE = old;
+    });
+  });
+
+  describe('durable endpoint snapshots', () => {
+    it('reads server and pane evidence from one list-panes snapshot', () => {
+      const serverId = '123e4567-e89b-42d3-a456-426614174000';
+      mockedExecFileSync
+        .mockReturnValueOnce(`${serverId}\n`)
+        .mockReturnValueOnce(
+          [
+            serverId,
+            '/tmp/tmux.sock',
+            '321',
+            '1700000000',
+            '%9',
+            'main:1.0',
+            '/repo',
+            'codex',
+            '654',
+            '{"version":1}',
+          ].join('__TMT_FIELD_4f1c__') + '\n'
+        );
+
+      expect(createTmux().getEndpointSnapshot?.()).toEqual({
+        server: {
+          serverId,
+          socketPath: '/tmp/tmux.sock',
+          serverPid: 321,
+          serverStartTime: '1700000000',
+        },
+        panes: [
+          {
+            id: '%9',
+            target: 'main:1.0',
+            cwd: '/repo',
+            command: 'codex',
+            panePid: 654,
+            suggestedName: 'codex',
+            metadata: { version: 1 },
+          },
+        ],
+      });
+      expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+        'tmux',
+        ['list-panes', '-a', '-F', expect.stringContaining('#{socket_path}')],
+        expect.any(Object)
+      );
+    });
+
+    it('rejects mixed server evidence instead of constructing a torn snapshot', () => {
+      const serverId = '123e4567-e89b-42d3-a456-426614174000';
+      const row = (pid: string, pane: string) =>
+        [
+          serverId,
+          '/tmp/tmux.sock',
+          pid,
+          '1700000000',
+          pane,
+          `main:1.${pane.slice(1)}`,
+          '/repo',
+          'node',
+          '654',
+          '{"version":1}',
+        ].join('__TMT_FIELD_4f1c__');
+      mockedExecFileSync
+        .mockReturnValueOnce(`${serverId}\n`)
+        .mockReturnValueOnce(`${row('321', '%1')}\n${row('999', '%2')}\n`);
+
+      expect(() => createTmux().getEndpointSnapshot?.()).toThrow(
+        'tmux endpoint snapshot contains inconsistent server evidence'
+      );
     });
   });
 

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -15,6 +15,7 @@ import type {
 import { normalizeName } from './domain/service.js';
 
 const AGENT_METADATA_OPTION = '@tmux-team.agent';
+const SERVER_ID_OPTION = '@tmux-team.server-id';
 const PANE_FIELD_SEPARATOR = '__TMT_FIELD_4f1c__';
 
 // Known agent patterns for auto-detection
@@ -129,6 +130,51 @@ function registryFromPanes(panes: PaneInfo[], scope: RegistryScope): TmuxRegistr
   return { paneRegistry, agents };
 }
 
+function parsePaneOutput(output: string): PaneInfo[] {
+  const seen = new Set<string>();
+  return output
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      const fields = line.includes(PANE_FIELD_SEPARATOR)
+        ? line.split(PANE_FIELD_SEPARATOR)
+        : line.split('\t');
+      const [id, target, cwd, command, panePidText, metadataText] =
+        fields.length >= 6
+          ? [
+              fields[0],
+              fields[1],
+              fields[2],
+              fields[3],
+              fields[4],
+              line.includes(PANE_FIELD_SEPARATOR)
+                ? fields.slice(5).join(PANE_FIELD_SEPARATOR)
+                : fields[5],
+            ]
+          : fields.length >= 5
+            ? [fields[0], fields[1], fields[2], fields[3], undefined, fields[4]]
+            : [fields[0], undefined, undefined, fields[1] ?? '', undefined, fields[2] ?? ''];
+      // tmux 3.3 may omit pane user options in list formats. The fallback is
+      // conservative because all independent evidence must still agree.
+      const metadata = safeParseMetadata(metadataText) ?? tryReadPaneMetadata(id || '');
+      return {
+        id: id || '',
+        ...(target && { target }),
+        ...(cwd && { cwd }),
+        command: command || '',
+        ...(panePidText &&
+          Number.isInteger(Number(panePidText)) && { panePid: Number(panePidText) }),
+        suggestedName: detectAgentName(command || ''),
+        ...(metadata && { metadata }),
+      };
+    })
+    .filter((pane) => {
+      if (!pane.id || seen.has(pane.id)) return false;
+      seen.add(pane.id);
+      return true;
+    });
+}
+
 export function createTmux(): Tmux {
   function sleepMs(ms: number): void {
     if (ms <= 0) return;
@@ -192,51 +238,14 @@ export function createTmux(): Tmux {
       try {
         // Get all panes with stable IDs, human tmux targets, cwd, commands, and tmux-team metadata.
         const output = execSync(
-          `tmux list-panes -a -F "#{pane_id}${PANE_FIELD_SEPARATOR}#{session_name}:#{window_index}.#{pane_index}${PANE_FIELD_SEPARATOR}#{pane_current_path}${PANE_FIELD_SEPARATOR}#{pane_current_command}${PANE_FIELD_SEPARATOR}#{${AGENT_METADATA_OPTION}}"`,
+          `tmux list-panes -a -F "#{pane_id}${PANE_FIELD_SEPARATOR}#{session_name}:#{window_index}.#{pane_index}${PANE_FIELD_SEPARATOR}#{pane_current_path}${PANE_FIELD_SEPARATOR}#{pane_current_command}${PANE_FIELD_SEPARATOR}#{pane_pid}${PANE_FIELD_SEPARATOR}#{${AGENT_METADATA_OPTION}}"`,
           {
             encoding: 'utf-8',
             stdio: ['pipe', 'pipe', 'pipe'],
           }
         );
 
-        const seen = new Set<string>();
-        return output
-          .split('\n')
-          .filter((line) => line.trim())
-          .map((line) => {
-            const fields = line.includes(PANE_FIELD_SEPARATOR)
-              ? line.split(PANE_FIELD_SEPARATOR)
-              : line.split('\t');
-            const [id, target, cwd, command, metadataText] = line.includes(PANE_FIELD_SEPARATOR)
-              ? [
-                  fields[0],
-                  fields[1],
-                  fields[2],
-                  fields[3],
-                  fields.slice(4).join(PANE_FIELD_SEPARATOR),
-                ]
-              : fields.length >= 5
-                ? fields
-                : [fields[0], undefined, undefined, fields[1] ?? '', fields[2] ?? ''];
-            // tmux 3.3 does not reliably expand pane user options inside
-            // list-panes formats. Prefer the inline value on newer versions,
-            // then fall back to the pane-scoped option without consulting any
-            // legacy registry.
-            const metadata = safeParseMetadata(metadataText) ?? tryReadPaneMetadata(id || '');
-            return {
-              id: id || '',
-              ...(target && { target }),
-              ...(cwd && { cwd }),
-              command: command || '',
-              suggestedName: detectAgentName(command || ''),
-              ...(metadata && { metadata }),
-            };
-          })
-          .filter((pane) => {
-            if (!pane.id || seen.has(pane.id)) return false;
-            seen.add(pane.id);
-            return true;
-          });
+        return parsePaneOutput(output);
       } catch {
         return [];
       }
@@ -344,6 +353,105 @@ export function createTmux(): Tmux {
       writePaneMetadata(paneId, metadata);
       return true;
     },
+
+    getEndpointSnapshot() {
+      return readEndpointSnapshot();
+    },
+
+    setDurableIdentity(paneId, identity, binding) {
+      const metadata = readPaneMetadata(paneId);
+      metadata.globalIdentity = {
+        name: identity.name,
+        canonicalName: identity.canonicalName,
+        identityId: identity.id,
+        bindingId: binding.id,
+        serverId: binding.serverId,
+        panePid: binding.panePid,
+      };
+      writePaneMetadata(paneId, metadata);
+    },
+
+    clearDurableIdentity(paneId, bindingId) {
+      const metadata = readPaneMetadata(paneId);
+      if (!metadata.globalIdentity) return false;
+      if (bindingId && metadata.globalIdentity.bindingId !== bindingId) return false;
+      delete metadata.globalIdentity;
+      writePaneMetadata(paneId, metadata);
+      return true;
+    },
+  };
+}
+
+function ensureServerId(): string {
+  let serverId = '';
+  try {
+    serverId = execFileSync('tmux', ['show-options', '-s', '-v', SERVER_ID_OPTION], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    serverId = crypto.randomUUID();
+    execFileSync('tmux', ['set-option', '-s', '-o', SERVER_ID_OPTION, serverId], {
+      stdio: 'pipe',
+    });
+    serverId = execFileSync('tmux', ['show-options', '-s', '-v', SERVER_ID_OPTION], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  }
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(serverId)) {
+    throw new Error('tmux server identity is unavailable');
+  }
+  return serverId;
+}
+
+function readEndpointSnapshot() {
+  const expectedServerId = ensureServerId();
+  const format = [
+    `#{${SERVER_ID_OPTION}}`,
+    '#{socket_path}',
+    '#{pid}',
+    '#{start_time}',
+    '#{pane_id}',
+    '#{session_name}:#{window_index}.#{pane_index}',
+    '#{pane_current_path}',
+    '#{pane_current_command}',
+    '#{pane_pid}',
+    `#{${AGENT_METADATA_OPTION}}`,
+  ].join(PANE_FIELD_SEPARATOR);
+  const output = execFileSync('tmux', ['list-panes', '-a', '-F', format], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const rows = output.split('\n').filter((line) => line.trim());
+  if (rows.length === 0) throw new Error('tmux endpoint snapshot is empty');
+
+  const evidence = rows.map((line) => line.split(PANE_FIELD_SEPARATOR).slice(0, 4));
+  const [serverId, socketPath, serverPidText, serverStartTime] = evidence[0] ?? [];
+  const serverPid = Number(serverPidText);
+  if (
+    serverId !== expectedServerId ||
+    !socketPath ||
+    !serverStartTime ||
+    !Number.isInteger(serverPid) ||
+    serverPid <= 0 ||
+    evidence.some(
+      ([id, socket, pid, started]) =>
+        id !== serverId ||
+        socket !== socketPath ||
+        pid !== serverPidText ||
+        started !== serverStartTime
+    )
+  ) {
+    throw new Error('tmux endpoint snapshot contains inconsistent server evidence');
+  }
+
+  const paneOutput = rows
+    .map((line) => line.split(PANE_FIELD_SEPARATOR).slice(4).join(PANE_FIELD_SEPARATOR))
+    .join('\n');
+  return {
+    server: { serverId, socketPath, serverPid, serverStartTime },
+    panes: parsePaneOutput(paneOutput),
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { ActiveRegistration } from './domain/types.js';
+import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
 
 // ─────────────────────────────────────────────────────────────
 // Shared TypeScript interfaces for tmux-team
@@ -28,6 +29,10 @@ export interface PaneAgentMetadata {
   globalIdentity?: {
     name: string;
     canonicalName: string;
+    identityId?: string;
+    bindingId?: string;
+    serverId?: string;
+    panePid?: number;
   };
   workspaces?: Record<string, AgentRegistration>;
   teams?: Record<string, AgentRegistration>;
@@ -115,6 +120,7 @@ export interface PaneInfo {
   target?: string; // e.g., "main:1.0"
   cwd?: string; // pane_current_path
   command: string; // e.g., "node", "python", "zsh"
+  panePid?: number;
   suggestedName: string | null; // e.g., "codex" if detected from command
   metadata?: PaneAgentMetadata;
 }
@@ -136,6 +142,34 @@ export interface Tmux {
   listGlobalIdentities: () => ActiveRegistration[];
   setGlobalIdentity: (paneId: string, name: string) => void;
   clearGlobalIdentity: (paneId: string) => boolean;
+  getEndpointSnapshot?: () => TmuxEndpointSnapshot;
+  setDurableIdentity?: (paneId: string, identity: DurableIdentity, binding: TmuxBinding) => void;
+  clearDurableIdentity?: (paneId: string, bindingId?: string) => boolean;
+}
+
+export interface TmuxServerEvidence {
+  readonly serverId: string;
+  readonly socketPath: string;
+  readonly serverPid: number;
+  readonly serverStartTime: string;
+}
+
+export interface TmuxEndpointSnapshot {
+  readonly server: TmuxServerEvidence;
+  readonly panes: readonly PaneInfo[];
+}
+
+export interface IdentityService {
+  bindCurrent(name: string): DurableIdentity;
+  bindPane(pane: string, name: string): DurableIdentity;
+  unbindCurrent(): DurableIdentity | undefined;
+  currentIdentity(): { identity: DurableIdentity; binding: TmuxBinding } | undefined;
+  activeIdentities(): Array<{ identity: DurableIdentity; binding: TmuxBinding; pane: PaneInfo }>;
+  resolveActive(
+    target: string
+  ): { identity: DurableIdentity; binding: TmuxBinding; pane: PaneInfo } | undefined;
+  reconcile(): void;
+  close(): void;
 }
 
 export interface RegistryScope {
@@ -159,4 +193,6 @@ export interface Context {
   paths: Paths;
   registryScope?: RegistryScope;
   exit: (code: number) => never;
+  identityService?: IdentityService;
+  dispose?: () => void;
 }

--- a/test/e2e/identity-lifecycle.e2e.test.ts
+++ b/test/e2e/identity-lifecycle.e2e.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import path from 'node:path';
 import { E2EFixture, withE2EFixture, type CliResult, type MockPane } from './harness.js';
 
 interface Identity {
@@ -216,15 +218,15 @@ describe.sequential('global identity lifecycle', () => {
       expect(gammaAdd.code).toBe(0);
       expect(json(gammaAdd)).toEqual({ bound: true, name: 'Gamma', pane: gamma.pane });
 
-      expect(metadata(fixture, alpha)).toEqual({
+      expect(metadata(fixture, alpha)).toMatchObject({
         version: 1,
         globalIdentity: { name: 'Alpha', canonicalName: 'alpha' },
       });
-      expect(metadata(fixture, beta)).toEqual({
+      expect(metadata(fixture, beta)).toMatchObject({
         version: 1,
         globalIdentity: { name: 'Beta', canonicalName: 'beta' },
       });
-      expect(metadata(fixture, gamma)).toEqual({
+      expect(metadata(fixture, gamma)).toMatchObject({
         version: 1,
         globalIdentity: { name: 'Gamma', canonicalName: 'gamma' },
       });
@@ -448,6 +450,58 @@ describe.sequential('global identity lifecycle', () => {
           command: 'node',
         },
       ]);
+    });
+  }, 30_000);
+
+  it('preserves a durable identity across pane death and a later rebind', async () => {
+    await withE2EFixture(async (fixture) => {
+      const gone = await fixture.createMockPane('durable');
+      const original = await fixture.runJsonCli(['add', gone.pane, 'Durable']);
+      expect(original.code).toBe(0);
+      const database = new Database(path.join(fixture.globalDir, 'tmux-team.db'), {
+        readonly: true,
+      });
+      const identity = database
+        .prepare('SELECT id FROM identities WHERE canonical_name = ?')
+        .get('durable') as { id: string };
+      database.close();
+      expect(identity.id).toMatch(/^[0-9a-f-]{36}$/);
+
+      fixture.tmux(['kill-pane', '-t', gone.pane]);
+      await fixture.waitFor(
+        () => {
+          try {
+            return !fixture.tmux(['list-panes', '-a', '-F', '#{pane_id}']).includes(gone.pane);
+          } catch {
+            return true;
+          }
+        },
+        2_000,
+        'durable pane to disappear'
+      );
+      expect((await fixture.runJsonCli(['list'])).json).toEqual({ identities: [] });
+
+      const afterDeath = new Database(path.join(fixture.globalDir, 'tmux-team.db'), {
+        readonly: true,
+      });
+      expect(
+        afterDeath.prepare('SELECT id FROM identities WHERE canonical_name = ?').get('durable')
+      ).toEqual(identity);
+      expect(afterDeath.prepare('SELECT COUNT(*) AS count FROM bindings').get()).toEqual({
+        count: 0,
+      });
+      afterDeath.close();
+
+      const replacement = await fixture.createMockPane('replacement');
+      const rebound = await fixture.runJsonCli(['add', replacement.pane, 'durable']);
+      expect(rebound.code).toBe(0);
+      const afterRebind = new Database(path.join(fixture.globalDir, 'tmux-team.db'), {
+        readonly: true,
+      });
+      expect(
+        afterRebind.prepare('SELECT id FROM identities WHERE canonical_name = ?').get('durable')
+      ).toEqual(identity);
+      afterRebind.close();
     });
   }, 30_000);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     coverage: {
       all: true,
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/*-worker.ts'],
       reporter: ['text', 'json-summary'],
       reportsDirectory: 'coverage',
     },


### PR DESCRIPTION
## Summary

- persist global identities in SQLite while keeping tmux bindings transient
- require a strict join across SQLite, coherent tmux server and pane evidence, and pane metadata before routing
- reconcile pane death, server restart, PID reuse, legacy metadata, and partial failures
- reuse the verified identity view across talk, check, and list while preserving direct unnamed-pane targets
- document durable identity and transient presence semantics

## Verification

- pnpm check
- pnpm test:run (381 tests; 91.77% statements, 85.10% branches)
- pnpm test:e2e (16 Docker scenarios with real tmux 3.3a)
- git diff --check
- Gemini read-only review; no blocking findings after correcting repeated-unbind contract coverage

Linear: https://linear.app/tigerpig-dev/issue/TMT-13/persist-durable-identities-while-preserving-transient-tmux