### PR TITLE
feat: add durable per-identity role profiles (TMT-14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ once-daily cached update check, while local drift checks work without network.
 - `tmt list [target]` lists active identities or the runtime status of one
   pane.
 - `tmt whoami` and `tmt unbind` inspect and remove the current pane's identity.
+- `tmt role show|set|clear` manages an optional durable profile for an identity,
+  including identities that are currently offline.
 - Multiline messages preserve real line breaks when delivered.
 - Skills can be installed and refreshed with `tmt install` and `tmt upgrade`.
 
@@ -105,6 +107,10 @@ tmux display-message -p '#{pane_id}'
 | `add <pane-target> <global-name>` | Bind an explicit pane to a global identity |
 | `whoami` | Show the current pane's global identity, if any |
 | `unbind` | Remove the current pane's global identity |
+| `role show [--identity <name>]` | Read an identity's optional role profile |
+| `role set <profile> [--identity <name>]` | Replace an identity's role profile |
+| `role set --file <path> [--identity <name>]` | Replace a profile from a UTF-8 file |
+| `role clear [--identity <name>]` | Remove only the role profile |
 | `talk <target> "msg"` | Send a message to a global name or pane target |
 | `check <target> [lines]` | Read output from a global name or pane target |
 | `list [target]` | List active identities, or one target's pane status |
@@ -169,9 +175,10 @@ after write work. Normal command shutdown uses a passive checkpoint; backup or
 export first obtains a consistent SQLite backup and may use a truncate
 checkpoint only after no active reader remains.
 
-Durable identity records and transient tmux bindings use this storage boundary.
-Role, memory, and inbox schemas are intentionally deferred to their respective
-tickets; this release does not expose aliases or those later domain models.
+Durable identity records, optional role profiles, and transient tmux bindings
+use this storage boundary. Memory and inbox schemas are intentionally deferred
+to their respective tickets; this release does not expose aliases or those
+later domain models.
 
 ## Managing global identities
 
@@ -195,6 +202,40 @@ Remove the current pane's binding with `tmt unbind`. This preserves the durable
 identity record so its name and ID can be rebound later. Repeating `tmt unbind`
 on an already-unbound pane returns `UNBOUND_PANE`. Pane movement and window
 renumbering preserve the binding's stable `%pane_id` while the pane lives.
+
+## Optional role profiles
+
+Each identity can carry one optional role/profile document. A role is not a
+reusable catalog entry or an assignment to another identity. An identity with
+no role remains valid.
+
+```bash
+tmt role set "Review changes and preserve verification evidence."
+tmt role set --file reviewer.md --identity reviewer
+tmt role show --identity reviewer
+tmt role clear --identity reviewer
+```
+
+Omit `--identity` only when the current pane has a verified identity binding.
+Otherwise specify an existing identity explicitly. Explicit access works
+outside tmux and while an identity is offline; it does not create a missing
+identity. Profiles survive unbind, pane death, tmux server restart, and later
+rebind. `clear` removes only the profile and succeeds even when no profile was
+set. `show --json` returns `role: null` for an identity without a profile.
+
+Both inline and file input use the same validation. Each raw input and its
+normalized content must be at most 65,536 UTF-8 bytes. Files must be regular
+files containing valid UTF-8; symlinks to regular files are accepted. TMT
+removes one initial byte-order mark and normalizes CRLF/CR to LF, preserving
+other whitespace, tabs, indentation, and trailing newlines. Empty or
+whitespace-only content, malformed encoding, and binary control characters
+are rejected without changing the stored profile. Use `clear`, not an empty
+`set`, to remove a profile.
+
+Writes replace the whole profile atomically. Concurrent writes use
+last-committed-write-wins; there is no content merge or version-conflict check.
+The role document is stored data only: it is not automatically injected into
+`talk` messages and does not change legacy preambles.
 
 ## Legacy preambles
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -119,6 +119,9 @@ function main(): void {
       } else {
         console.error(JSON.stringify({ error: String(err?.message ?? err) }));
       }
+      // Dispose before process.exit; Node does not guarantee finally blocks
+      // will run after an explicit exit in embedding and test environments.
+      ctx.dispose?.();
       process.exit(ExitCodes.ERROR);
     })
     .finally(() => ctx.dispose?.());

--- a/src/cli/application.test.ts
+++ b/src/cli/application.test.ts
@@ -19,6 +19,7 @@ const handlers = {
   cmdUpgrade: vi.fn(),
   cmdWhoami: vi.fn(),
   cmdUnbind: vi.fn(),
+  cmdRole: vi.fn(),
 };
 
 vi.mock('../commands/init.js', () => ({ cmdInit: handlers.cmdInit }));
@@ -38,6 +39,7 @@ vi.mock('../commands/name.js', () => ({ cmdName: handlers.cmdName }));
 vi.mock('../commands/upgrade.js', () => ({ cmdUpgrade: handlers.cmdUpgrade }));
 vi.mock('../commands/whoami.js', () => ({ cmdWhoami: handlers.cmdWhoami }));
 vi.mock('../commands/unbind.js', () => ({ cmdUnbind: handlers.cmdUnbind }));
+vi.mock('../commands/role.js', () => ({ cmdRole: handlers.cmdRole }));
 
 const { dispatchCommand } = await import('./application.js');
 const parsed = (invocation: any) => ({
@@ -69,6 +71,7 @@ describe('application dispatcher', () => {
       ['check', { target, lines: 20 }],
       ['config', { operation: 'show', global: false }],
       ['preamble', { operation: 'show' }],
+      ['role', { operation: 'show' }],
       ['install', { target: 'codex' }],
       ['upgrade', {}],
       ['learn', {}],
@@ -83,6 +86,10 @@ describe('application dispatcher', () => {
       expect.objectContaining({ operation: 'show' })
     );
     expect(handlers.cmdPreamble).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ operation: 'show' })
+    );
+    expect(handlers.cmdRole).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({ operation: 'show' })
     );

--- a/src/cli/application.ts
+++ b/src/cli/application.ts
@@ -16,6 +16,7 @@ import { cmdName } from '../commands/name.js';
 import { cmdUpgrade } from '../commands/upgrade.js';
 import { cmdWhoami } from '../commands/whoami.js';
 import { cmdUnbind } from '../commands/unbind.js';
+import { cmdRole } from '../commands/role.js';
 import type { ParsedArgs, ParsedInvocation } from './parser.js';
 
 function assertNever(value: never): never {
@@ -57,6 +58,8 @@ export async function dispatchCommand(ctx: Context, parsed: ParsedArgs): Promise
       return cmdConfig(ctx, request);
     case 'preamble':
       return cmdPreamble(ctx, request);
+    case 'role':
+      return cmdRole(ctx, request);
     case 'install':
       return cmdInstall(ctx, request.target);
     case 'completion':

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -12,6 +12,29 @@ describe('declarative CLI parser', () => {
     });
   });
 
+  it('keeps role selectors explicit and preserves dash-prefixed profile literals', () => {
+    const parsed = parseArgs(['role', '--identity=show', 'set', '--', '--json profile']);
+    expect(parsed.invocation).toEqual({
+      kind: 'role',
+      operation: 'set',
+      content: '--json profile',
+      selector: { value: 'show', kind: 'identity', explicit: true },
+    });
+    expect(parsed.flags.json).toBe(false);
+    expect(parsed.metadata.capability).toBe('storage');
+    expect(parseArgs(['role', 'show']).metadata.capability).toBe('storage');
+    for (const args of [
+      ['role'],
+      ['role', 'Alice', 'show'],
+      ['role', 'show', 'Alice'],
+      ['role', 'show', '--file', 'profile.md'],
+      ['role', 'clear', '--file', 'profile.md'],
+      ['role', 'list'],
+      ['role', 'show', '--identity'],
+    ])
+      expect(() => parseArgs(args)).toThrow(CliParseError);
+  });
+
   it('preserves dash-prefixed literals after the terminator', () => {
     const parsed = parseArgs(['talk', 'claude', '--', '--json is part of the message']);
     expect(parsed.flags.json).toBe(false);
@@ -171,5 +194,30 @@ describe('declarative CLI parser', () => {
       lines: 12,
     });
     expect(parsed.metadata).toMatchObject({ unsupportedTeam: true, commandPath: ['list'] });
+  });
+
+  it('parses action-first role commands and enforces one set input source', () => {
+    expect(parseArgs(['role', 'show', '--identity', 'Alice']).invocation).toMatchObject({
+      kind: 'role',
+      operation: 'show',
+      selector: { value: 'Alice', kind: 'identity', explicit: true },
+    });
+    expect(parseArgs(['role', 'set', 'text', '--identity', 'Alice']).invocation).toMatchObject({
+      kind: 'role',
+      operation: 'set',
+      content: 'text',
+      selector: { value: 'Alice', kind: 'identity', explicit: true },
+    });
+    expect(parseArgs(['role', 'set', '--file', '/tmp/role.txt']).invocation).toMatchObject({
+      kind: 'role',
+      operation: 'set',
+      file: '/tmp/role.txt',
+    });
+    expect(parseArgs(['role', 'clear']).invocation).toEqual({ kind: 'role', operation: 'clear' });
+    expect(() => parseArgs(['role', 'set'])).toThrow(CliParseError);
+    expect(() => parseArgs(['role', 'set', 'text', '--file', '/tmp/role.txt'])).toThrow(
+      CliParseError
+    );
+    expect(() => parseArgs(['role', 'set', 'a', 'b'])).toThrow(CliParseError);
   });
 });

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -2,6 +2,7 @@ import { Command, CommanderError } from 'commander';
 import { isPaneTarget } from '../domain/names.js';
 import type { Flags } from '../types.js';
 import type { IdentitySelector } from '../identity-context.js';
+import type { RoleRequest } from '../commands/role.js';
 export type { IdentitySelector } from '../identity-context.js';
 
 export type ParsedInvocation =
@@ -34,7 +35,8 @@ export type ParsedInvocation =
       readonly operation: 'show' | 'set' | 'clear';
       readonly agent?: string;
       readonly preamble?: string;
-    };
+    }
+  | RoleRequest;
 
 export interface ParsedMetadata {
   readonly argv: readonly string[];
@@ -80,6 +82,8 @@ interface CommandOptions extends CommonOptions {
   dryRun?: boolean;
   cleanup?: boolean;
   global?: boolean;
+  identity?: string;
+  file?: string;
 }
 
 interface Capture {
@@ -147,6 +151,7 @@ function compatibilityUsage(argv: readonly string[], message: string): string | 
     send: 'Usage: tmux-team send <target> <message>',
     whoami: 'Usage: tmux-team whoami',
     unbind: 'Usage: tmux-team unbind',
+    role: 'Usage: tmux-team role show|set|clear [options]',
   };
   const command = argv.find((token) => Object.prototype.hasOwnProperty.call(usage, token));
   return command ? usage[command] : undefined;
@@ -168,6 +173,10 @@ function capabilityFor(invocation: ParsedInvocation): ParsedMetadata['capability
       return 'storage';
     case 'preamble':
       return invocation.operation === 'show' ? 'storage' : 'tmux';
+    case 'role':
+      // Keep context creation storage-only. Implicit current-pane resolution
+      // obtains tmux lazily, preserving offline explicit identity behavior.
+      return 'storage';
     case 'migrate':
       return 'tmux';
     default:
@@ -372,6 +381,45 @@ function setupProgram(capture: Capture): Command {
   commonOptions(preambleClear);
   preambleClear.action(function (agent: string) {
     action(this, { kind: 'preamble', operation: 'clear', agent });
+  });
+  const role = leaf(program.command('role')).option('--identity <name>');
+  const roleShow = role.command('show');
+  commonOptions(roleShow).option('--identity <name>');
+  roleShow.action(function () {
+    const options = commandOptions(this);
+    action(this, {
+      kind: 'role',
+      operation: 'show',
+      ...(options.identity !== undefined && { selector: selector(options.identity, true) }),
+    });
+  });
+  const roleSet = role.command('set').argument('[content]');
+  commonOptions(roleSet).option('--identity <name>').option('--file <path>');
+  roleSet.action(function (content?: string) {
+    const options = commandOptions(this);
+    const hasContent = content !== undefined;
+    const hasFile = options.file !== undefined;
+    if (hasContent === hasFile) {
+      throw new CliParseError(
+        'Usage: tmux-team role set [content] [--file <path>] [--identity <name>]'
+      );
+    }
+    action(this, {
+      kind: 'role',
+      operation: 'set',
+      ...(content !== undefined ? { content } : { file: options.file! }),
+      ...(options.identity !== undefined && { selector: selector(options.identity, true) }),
+    });
+  });
+  const roleClear = role.command('clear');
+  commonOptions(roleClear).option('--identity <name>');
+  roleClear.action(function () {
+    const options = commandOptions(this);
+    action(this, {
+      kind: 'role',
+      operation: 'clear',
+      ...(options.identity !== undefined && { selector: selector(options.identity, true) }),
+    });
   });
   const install = leaf(program.command('install').argument('[agent]'));
   install.action(function (agent?: string) {

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -27,6 +27,7 @@ _tmux-team() {
     'completion:Output shell completion script'
     'config:View or modify settings'
     'preamble:Manage identity preambles'
+    'role:Manage durable identity role profiles'
     'learn:Show the learning guide'
     'help:Show help message'
   )
@@ -51,6 +52,9 @@ _tmux-team() {
       install)
         compadd "claude" "codex" "gemini" "all"
         ;;
+      role)
+        compadd "show" "set" "clear"
+        ;;
     esac
   elif (( CURRENT == 4 )); then
     case \${words[2]} in
@@ -59,6 +63,10 @@ _tmux-team() {
         ;;
       talk)
         compadd -- "--delay" "--wait" "--timeout"
+        ;;
+      role)
+        compadd -- "--identity"
+        if [[ "\${words[3]}" == "set" ]]; then compadd -- "--file"; fi
         ;;
     esac
   fi
@@ -72,7 +80,7 @@ const bashCompletion = `_tmux_team() {
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
-  commands="talk check list add update remove migrate init completion help name this whoami unbind install upgrade config preamble learn"
+  commands="talk check list add update remove migrate init completion help name this whoami unbind install upgrade config preamble role learn"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "\${commands}" -- \${cur}) )
@@ -88,6 +96,9 @@ const bashCompletion = `_tmux_team() {
       install)
         COMPREPLY=( $(compgen -W "claude codex gemini all" -- \${cur}) )
         ;;
+      role)
+        COMPREPLY=( $(compgen -W "show set clear" -- \${cur}) )
+        ;;
     esac
   elif [[ \${COMP_CWORD} -eq 3 ]]; then
     case "\${COMP_WORDS[1]}" in
@@ -96,6 +107,13 @@ const bashCompletion = `_tmux_team() {
         ;;
       talk)
         COMPREPLY=( $(compgen -W "--delay --wait --timeout" -- \${cur}) )
+        ;;
+      role)
+        if [[ "\${COMP_WORDS[2]}" == "set" ]]; then
+          COMPREPLY=( $(compgen -W "--identity --file" -- \${cur}) )
+        else
+          COMPREPLY=( $(compgen -W "--identity" -- \${cur}) )
+        fi
         ;;
     esac
   fi

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -61,6 +61,7 @@ ${colors.yellow('COMMANDS')}
   ${colors.green('init')}                        Create empty tmux-team.json
   ${colors.green('config')} [show|set|clear]     View/modify settings
   ${colors.green('preamble')} [show|set|clear]   Manage legacy workspace preambles
+  ${colors.green('role')} <show|set|clear>      Manage durable identity role profiles
   ${colors.green('completion')}                  Output shell completion script
   ${colors.green('learn')}                       Show educational guide
   ${colors.green('help')}                        Show this help message
@@ -69,6 +70,13 @@ ${colors.yellow('OPTIONS')}
   ${colors.green('--json')}                      Output in JSON format
   ${colors.green('--verbose')}                   Show detailed output
   ${colors.green('--force')}                     Skip warnings
+
+${colors.yellow('ROLE USAGE')}
+  tmt role show [--identity <name>]
+  tmt role set <profile> [--identity <name>]
+  tmt role set --file <path> [--identity <name>]
+  tmt role clear [--identity <name>]
+  Omit --identity only in a verified bound pane; explicit offline identities are supported.
 
 ${colors.yellow('TALK OPTIONS')}
   ${colors.green('--delay')} <seconds>           Wait before sending

--- a/src/commands/role.test.ts
+++ b/src/commands/role.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Context, RoleResult, RoleService, UI } from '../types.js';
+import { cmdRole } from './role.js';
+import { IdentitySelectionError } from '../identity-context.js';
+import { IdentityServiceError } from '../identity-service.js';
+
+function context(service: RoleService, json = true): Context & { output: unknown[] } {
+  const output: unknown[] = [];
+  const ui: UI = {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    table: vi.fn(),
+    json: (value: unknown) => output.push(value),
+  };
+  return {
+    output,
+    argv: [],
+    flags: { json, verbose: false },
+    ui,
+    config: {} as Context['config'],
+    tmux: {} as Context['tmux'],
+    paths: {} as Context['paths'],
+    roleService: service,
+    exit: ((code: number) => {
+      throw Object.assign(new Error(`exit(${code})`), { exitCode: code });
+    }) as Context['exit'],
+  };
+}
+
+const result: RoleResult = {
+  identity: { id: 'id', name: 'Alice', canonicalName: 'alice' },
+  role: { content: 'Review code', updatedAt: 'now' },
+};
+
+describe('cmdRole', () => {
+  it('prints the exact structured result for show/set/clear', () => {
+    const service: RoleService = {
+      show: vi.fn(() => result),
+      set: vi.fn(() => result),
+      clear: vi.fn(() => ({ identity: result.identity, role: null })),
+    };
+    const ctx = context(service);
+    cmdRole(ctx, { kind: 'role', operation: 'show' });
+    cmdRole(ctx, { kind: 'role', operation: 'set', content: 'Review code' });
+    cmdRole(ctx, { kind: 'role', operation: 'clear' });
+    expect(ctx.output).toEqual([result, result, { identity: result.identity, role: null }]);
+  });
+
+  it('reads file input before invoking the role service', () => {
+    const service: RoleService = {
+      show: vi.fn(() => result),
+      set: vi.fn(() => result),
+      clear: vi.fn(() => ({ identity: result.identity, role: null })),
+    };
+    const ctx = context(service);
+    expect(() =>
+      cmdRole(ctx, { kind: 'role', operation: 'set', file: '/definitely/missing/role' })
+    ).toThrow('exit(1)');
+    expect(service.set).not.toHaveBeenCalled();
+    expect(ctx.output[0]).toMatchObject({ error: { code: 'ROLE_FILE_ERROR' } });
+  });
+
+  it.each([
+    ['NAME_NOT_FOUND', 3],
+    ['IDENTITY_REQUIRED', 1],
+    ['IDENTITY_AMBIGUOUS', 5],
+  ] as const)('maps %s to exit %i without a second error', (code, exitCode) => {
+    const service: RoleService = {
+      show: vi.fn(() => {
+        throw new IdentitySelectionError(code, 'selection failed');
+      }),
+      set: vi.fn(),
+      clear: vi.fn(),
+    };
+    const ctx = context(service);
+    expect(() => cmdRole(ctx, { kind: 'role', operation: 'show' })).toThrow(`exit(${exitCode})`);
+    expect(ctx.output).toEqual([{ error: { code, message: 'selection failed' } }]);
+  });
+
+  it('keeps reconciliation failures distinct from a missing identity', () => {
+    const service: RoleService = {
+      show: vi.fn(() => {
+        throw new IdentityServiceError('RECONCILIATION_FAILED', 'snapshot failed');
+      }),
+      set: vi.fn(),
+      clear: vi.fn(),
+    };
+    const ctx = context(service);
+    expect(() => cmdRole(ctx, { kind: 'role', operation: 'show' })).toThrow('exit(1)');
+    expect(ctx.output).toEqual([
+      { error: { code: 'RECONCILIATION_FAILED', message: 'snapshot failed' } },
+    ]);
+  });
+
+  it('shows content or absence and confirms mutations in human output', () => {
+    const service: RoleService = {
+      show: vi.fn(() => result),
+      set: vi.fn(() => result),
+      clear: vi.fn(() => ({ identity: result.identity, role: null })),
+    };
+    const ctx = context(service, false);
+    cmdRole(ctx, { kind: 'role', operation: 'show' });
+    expect(ctx.ui.info).toHaveBeenCalledWith(result.role!.content);
+    vi.mocked(service.show).mockReturnValue({ identity: result.identity, role: null });
+    cmdRole(ctx, { kind: 'role', operation: 'show' });
+    expect(ctx.ui.info).toHaveBeenCalledWith('No role profile is set.');
+    cmdRole(ctx, { kind: 'role', operation: 'set', content: 'Review code' });
+    cmdRole(ctx, { kind: 'role', operation: 'clear' });
+    expect(ctx.ui.success).toHaveBeenCalledWith("Set role profile for 'Alice'.");
+    expect(ctx.ui.success).toHaveBeenCalledWith("Cleared role profile for 'Alice'.");
+    expect(ctx.output).toEqual([]);
+  });
+
+  it('reports file failures in human output without invoking mutation', () => {
+    const service: RoleService = { show: vi.fn(), set: vi.fn(), clear: vi.fn() };
+    const ctx = context(service, false);
+    expect(() =>
+      cmdRole(ctx, { kind: 'role', operation: 'set', file: '/definitely/missing/role' })
+    ).toThrow('exit(1)');
+    expect(ctx.ui.error).toHaveBeenCalledWith(expect.stringContaining('Could not read role file'));
+    expect(service.set).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -1,0 +1,75 @@
+import type { Context, RoleResult } from '../types.js';
+import { ExitCodes } from '../exits.js';
+import { readRoleFile, RoleFileError } from '../role-content.js';
+import { RoleContentError } from '../domain/role.js';
+import { IdentitySelectionError, type IdentitySelector } from '../identity-context.js';
+import { IdentityServiceError } from '../identity-service.js';
+
+type RoleTarget = {
+  readonly kind: 'role';
+  readonly selector?: IdentitySelector;
+};
+
+export type RoleRequest = RoleTarget &
+  (
+    | { readonly operation: 'show' }
+    | { readonly operation: 'clear' }
+    | { readonly operation: 'set'; readonly content: string; readonly file?: never }
+    | { readonly operation: 'set'; readonly file: string; readonly content?: never }
+  );
+
+function printResult(ctx: Context, result: RoleResult, operation: RoleRequest['operation']): void {
+  const value = result;
+  if (ctx.flags.json) {
+    ctx.ui.json(value);
+    return;
+  }
+  if (operation === 'show') {
+    ctx.ui.info(`Identity '${value.identity.name}'`);
+    if (value.role) ctx.ui.info(value.role.content);
+    else ctx.ui.info('No role profile is set.');
+  } else if (operation === 'set') {
+    ctx.ui.success(`Set role profile for '${value.identity.name}'.`);
+  } else {
+    ctx.ui.success(`Cleared role profile for '${value.identity.name}'.`);
+  }
+}
+
+function fail(ctx: Context, error: unknown): never {
+  const code =
+    error instanceof IdentitySelectionError ||
+    error instanceof IdentityServiceError ||
+    error instanceof RoleContentError ||
+    error instanceof RoleFileError
+      ? error.code
+      : 'ROLE_ERROR';
+  const message = error instanceof Error ? error.message : String(error);
+  if (ctx.flags.json) ctx.ui.json({ error: { code, message } });
+  else ctx.ui.error(message);
+  const exitCode =
+    code === 'NAME_NOT_FOUND'
+      ? ExitCodes.NAME_NOT_FOUND
+      : code === 'IDENTITY_AMBIGUOUS'
+        ? ExitCodes.CONFLICT
+        : ExitCodes.ERROR;
+  return ctx.exit(exitCode);
+}
+
+export function cmdRole(ctx: Context, request: RoleRequest): void {
+  try {
+    const service = ctx.roleService;
+    if (!service) throw new Error('Role service is unavailable.');
+    if (request.operation === 'show') {
+      printResult(ctx, service.show(request.selector), request.operation);
+      return;
+    }
+    if (request.operation === 'clear') {
+      printResult(ctx, service.clear(request.selector), request.operation);
+      return;
+    }
+    const content = request.file !== undefined ? readRoleFile(request.file) : request.content;
+    printResult(ctx, service.set(request.selector, content), request.operation);
+  } catch (error) {
+    fail(ctx, error);
+  }
+}

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Paths, ResolvedConfig, UI, Tmux } from './types.js';
 
 describe('createContext', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
   beforeEach(() => {
     vi.restoreAllMocks();
   });
@@ -172,6 +175,9 @@ describe('createContext', () => {
     vi.doMock('./identity-service.js', () => ({
       createIdentityService: vi.fn(() => ({ close })),
     }));
+    vi.doMock('./storage/identity-repository.js', () => ({
+      openIdentityRepository: vi.fn(() => ({ close: vi.fn() })),
+    }));
     const { createContext } = await import('./context.js');
     const ctx = createContext({
       argv: [],
@@ -193,6 +199,9 @@ describe('createContext', () => {
     vi.doMock('./identity-service.js', () => ({
       createIdentityService: vi.fn(() => ({ close })),
     }));
+    vi.doMock('./storage/identity-repository.js', () => ({
+      openIdentityRepository: vi.fn(() => ({ close: vi.fn() })),
+    }));
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`exit(${code})`);
     }) as never);
@@ -207,5 +216,71 @@ describe('createContext', () => {
     expect(() => ctx.exit(5)).toThrow('exit(5)');
     expect(close).toHaveBeenCalledOnce();
     expect(exitSpy).toHaveBeenCalledWith(5);
+  });
+
+  it('serves explicit offline roles and rejects missing caller context without constructing tmux', async () => {
+    vi.resetModules();
+    vi.stubEnv('TMUX_PANE', '');
+    const createTmux = vi.fn(() => {
+      throw new Error('unexpected tmux construction');
+    });
+    vi.doMock('./tmux.js', () => ({ createTmux }));
+    const identity = { id: 'id', name: 'Alice', canonicalName: 'alice' };
+    const repository = {
+      findByCanonicalName: vi.fn(() => identity),
+      findRole: vi.fn(() => undefined),
+      close: vi.fn(),
+    };
+    const openIdentityRepository = vi.fn(() => repository);
+    vi.doMock('./storage/identity-repository.js', () => ({ openIdentityRepository }));
+    const { createContext } = await import('./context.js');
+    const ctx = createContext({
+      argv: [],
+      flags: { json: true, verbose: false },
+      capability: 'storage',
+    });
+    expect(ctx.roleService!.show({ value: 'Alice', kind: 'identity', explicit: true })).toEqual({
+      identity,
+      role: null,
+    });
+    expect(() => ctx.roleService!.show()).toThrowError(
+      expect.objectContaining({ code: 'IDENTITY_REQUIRED' })
+    );
+    expect(createTmux).not.toHaveBeenCalled();
+    expect(openIdentityRepository).toHaveBeenCalledOnce();
+    ctx.dispose!();
+    ctx.dispose!();
+    expect(repository.close).toHaveBeenCalledOnce();
+  });
+
+  it('shares one repository between services and closes it even if service cleanup fails', async () => {
+    vi.resetModules();
+    vi.stubEnv('TMUX_PANE', '%1');
+    const repository = { findRole: vi.fn(() => undefined), close: vi.fn() };
+    const openIdentityRepository = vi.fn(() => repository);
+    vi.doMock('./storage/identity-repository.js', () => ({ openIdentityRepository }));
+    const identity = { id: 'id', name: 'Alice', canonicalName: 'alice' };
+    const service = {
+      currentIdentity: vi.fn(() => ({ identity })),
+      close: vi.fn(() => {
+        throw new Error('service cleanup failed');
+      }),
+    };
+    const createIdentityService = vi.fn(() => service);
+    vi.doMock('./identity-service.js', () => ({ createIdentityService }));
+    vi.doMock('./tmux.js', () => ({ createTmux: vi.fn(() => ({})) }));
+    const { createContext } = await import('./context.js');
+    const ctx = createContext({
+      argv: [],
+      flags: { json: true, verbose: false },
+      capability: 'storage',
+    });
+    expect(ctx.roleService!.show()).toEqual({ identity, role: null });
+    expect(ctx.identityService).toBe(service);
+    expect(createIdentityService).toHaveBeenCalledWith(expect.objectContaining({ repository }));
+    expect(openIdentityRepository).toHaveBeenCalledOnce();
+    expect(() => ctx.dispose!()).toThrow('service cleanup failed');
+    expect(repository.close).toHaveBeenCalledOnce();
+    expect(() => ctx.dispose!()).not.toThrow();
   });
 });

--- a/src/context.ts
+++ b/src/context.ts
@@ -8,6 +8,8 @@ import { createUI } from './ui.js';
 import { createTmux } from './tmux.js';
 import { ExitCodes } from './exits.js';
 import { createIdentityService } from './identity-service.js';
+import { openIdentityRepository, type IdentityRepository } from './storage/identity-repository.js';
+import { createRoleService } from './role-service.js';
 
 export interface CreateContextOptions {
   argv: string[];
@@ -29,6 +31,8 @@ export function createContext(options: CreateContextOptions): Context {
   let tmux: Context['tmux'] | undefined;
   let config: Context['config'] | undefined;
   let identityService: Context['identityService'] | undefined;
+  let identityRepository: IdentityRepository | undefined;
+  let roleService: Context['roleService'] | undefined;
   const getTmux = (): Context['tmux'] => {
     tmux ??= createTmux();
     return tmux;
@@ -45,8 +49,38 @@ export function createContext(options: CreateContextOptions): Context {
     return config;
   };
   const getIdentityService = (): NonNullable<Context['identityService']> => {
-    identityService ??= createIdentityService({ tmux: getTmux(), paths });
+    identityService ??= createIdentityService({
+      tmux: getTmux(),
+      paths,
+      repository: getIdentityRepository(),
+    });
     return identityService;
+  };
+  const getIdentityRepository = (): IdentityRepository => {
+    identityRepository ??= openIdentityRepository(paths.databaseFile);
+    return identityRepository;
+  };
+  const getRoleService = (): NonNullable<Context['roleService']> => {
+    roleService ??= createRoleService({
+      repository: getIdentityRepository(),
+      // Role's implicit selector requires caller binding evidence. Do not let
+      // the tmux adapter's outside-shell fallback select an arbitrary pane.
+      currentIdentity: () =>
+        process.env.TMUX_PANE ? getIdentityService().currentIdentity() : undefined,
+    });
+    return roleService;
+  };
+  const dispose = (): void => {
+    const service = identityService;
+    const repository = identityRepository;
+    identityService = undefined;
+    identityRepository = undefined;
+    roleService = undefined;
+    try {
+      service?.close();
+    } finally {
+      repository?.close();
+    }
   };
 
   const context = {
@@ -55,9 +89,9 @@ export function createContext(options: CreateContextOptions): Context {
     ui,
     paths,
     registryScope,
+    dispose,
     exit(code: number): never {
-      identityService?.close();
-      identityService = undefined;
+      dispose();
       process.exit(code);
     },
   } as Context;
@@ -65,11 +99,8 @@ export function createContext(options: CreateContextOptions): Context {
     config: { enumerable: true, get: getConfig },
     tmux: { enumerable: true, get: getTmux },
     identityService: { enumerable: true, get: getIdentityService },
+    roleService: { enumerable: true, get: getRoleService },
   });
-  (context as Context).dispose = (): void => {
-    identityService?.close();
-    identityService = undefined;
-  };
   // Preserve the established full-context behavior. Lightweight capabilities
   // intentionally defer both resources until a command asks for them.
   if (capability === 'tmux') getConfig();

--- a/src/domain/identity.ts
+++ b/src/domain/identity.ts
@@ -21,3 +21,9 @@ export interface TmuxBinding {
   readonly boundAt: string;
   readonly lastVerifiedAt: string;
 }
+
+/** Optional durable role profile attached to one identity. */
+export interface RoleProfile {
+  readonly content: string;
+  readonly updatedAt: string;
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,3 +1,4 @@
 export * from './names.js';
 export * from './service.js';
 export * from './types.js';
+export * from './role.js';

--- a/src/domain/role.ts
+++ b/src/domain/role.ts
@@ -1,0 +1,64 @@
+export const MAX_ROLE_BYTES = 65_536;
+
+export type RoleContentErrorCode = 'ROLE_INPUT_INVALID' | 'ROLE_INPUT_TOO_LARGE';
+
+export class RoleContentError extends Error {
+  constructor(
+    public readonly code: RoleContentErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'RoleContentError';
+  }
+}
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code < 0xd800 || code > 0xdfff) continue;
+    if (code >= 0xdc00 || index + 1 >= value.length) return true;
+    const next = value.charCodeAt(index + 1);
+    if (next < 0xdc00 || next > 0xdfff) return true;
+    index += 1;
+  }
+  return false;
+}
+
+function hasForbiddenControl(value: string): boolean {
+  for (const character of value) {
+    const code = character.codePointAt(0) ?? 0;
+    if ((code < 0x20 && code !== 0x09 && code !== 0x0a) || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/** Normalize and validate role content while preserving meaningful whitespace. */
+export function normalizeRoleContent(value: string): string {
+  if (Buffer.byteLength(value, 'utf8') > MAX_ROLE_BYTES) {
+    throw new RoleContentError('ROLE_INPUT_TOO_LARGE', 'Role content must not exceed 65536 bytes.');
+  }
+  if (hasLoneSurrogate(value)) {
+    throw new RoleContentError(
+      'ROLE_INPUT_INVALID',
+      'Role content must be valid Unicode and must not contain control characters.'
+    );
+  }
+  let normalized = value.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  if (normalized.startsWith('\ufeff')) normalized = normalized.slice(1);
+  if (hasForbiddenControl(normalized)) {
+    throw new RoleContentError(
+      'ROLE_INPUT_INVALID',
+      'Role content must not contain control characters.'
+    );
+  }
+  if (!normalized.trim()) {
+    throw new RoleContentError(
+      'ROLE_INPUT_INVALID',
+      'Role content must not be empty or whitespace-only.'
+    );
+  }
+  if (Buffer.byteLength(normalized, 'utf8') > MAX_ROLE_BYTES) {
+    throw new RoleContentError('ROLE_INPUT_TOO_LARGE', 'Role content must not exceed 65536 bytes.');
+  }
+  return normalized;
+}

--- a/src/identity-context.ts
+++ b/src/identity-context.ts
@@ -1,4 +1,5 @@
 import type { ActiveRegistration } from './domain/types.js';
+import type { DurableIdentity } from './domain/identity.js';
 import { normalizeName } from './domain/names.js';
 
 /** A parsed target. `explicit` is true only when --identity was used. */
@@ -44,4 +45,76 @@ export function resolveIdentityContext(
   if (matches.length === 1) return { status: 'bound', registration: matches[0] };
   if (matches.length > 1) return { status: 'ambiguous', registrations: matches };
   return { status: 'unbound' };
+}
+
+export type DurableIdentityResolution =
+  | { readonly status: 'bound'; readonly identity: DurableIdentity }
+  | { readonly status: 'not-found' }
+  | { readonly status: 'required' }
+  | { readonly status: 'ambiguous' };
+
+export type IdentitySelectionErrorCode =
+  | 'NAME_NOT_FOUND'
+  | 'IDENTITY_REQUIRED'
+  | 'IDENTITY_AMBIGUOUS';
+
+export class IdentitySelectionError extends Error {
+  constructor(
+    public readonly code: IdentitySelectionErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'IdentitySelectionError';
+  }
+}
+
+export interface DurableIdentityContext {
+  readonly findByCanonicalName: (canonicalName: string) => DurableIdentity | undefined;
+  readonly currentIdentity: () =>
+    | { readonly identity: DurableIdentity }
+    | { readonly status: 'ambiguous' }
+    | undefined;
+}
+
+/** Shared selector boundary for durable explicit and verified implicit identity access. */
+export function resolveDurableIdentity(
+  context: DurableIdentityContext,
+  selector?: IdentitySelector
+): DurableIdentityResolution {
+  if (selector) {
+    const identity = context.findByCanonicalName(normalizeName(selector.value));
+    return identity ? { status: 'bound', identity } : { status: 'not-found' };
+  }
+  const current = context.currentIdentity();
+  if (current && 'status' in current && current.status === 'ambiguous') {
+    return { status: 'ambiguous' };
+  }
+  if (!current || 'status' in current) return { status: 'required' };
+  return { status: 'bound', identity: current.identity };
+}
+
+export function requireDurableIdentity(
+  context: DurableIdentityContext,
+  selector?: IdentitySelector
+): DurableIdentity {
+  const resolution = resolveDurableIdentity(context, selector);
+  if (resolution.status === 'not-found') {
+    throw new IdentitySelectionError(
+      'NAME_NOT_FOUND',
+      `Identity '${selector?.value}' was not found.`
+    );
+  }
+  if (resolution.status === 'required') {
+    throw new IdentitySelectionError(
+      'IDENTITY_REQUIRED',
+      'An identity is required; use --identity or run from a verified bound pane.'
+    );
+  }
+  if (resolution.status === 'ambiguous') {
+    throw new IdentitySelectionError(
+      'IDENTITY_AMBIGUOUS',
+      'Current pane has ambiguous identity binding.'
+    );
+  }
+  return resolution.identity;
 }

--- a/src/role-content.test.ts
+++ b/src/role-content.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { MAX_ROLE_BYTES, RoleContentError, normalizeRoleContent } from './domain/role.js';
+import { readRoleFile, RoleFileError } from './role-content.js';
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+function temporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-role-input-'));
+  directories.push(directory);
+  return directory;
+}
+
+function expectContentError(action: () => unknown, code: RoleContentError['code']): void {
+  try {
+    action();
+    expect.fail('expected role content validation to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(RoleContentError);
+    expect((error as RoleContentError).code).toBe(code);
+  }
+}
+
+// Non-ASCII fixture text exercises UTF-8 byte counts and valid surrogate pairs.
+describe('role content input', () => {
+  it('normalizes CRLF/CR, preserves allowed whitespace, and strips exactly one initial BOM', () => {
+    expect(normalizeRoleContent('\ufeff\ufeff\t one\r\ntwo\r\n')).toBe('\ufeff\t one\ntwo\n');
+    expect(normalizeRoleContent('role\rnext\n')).toBe('role\nnext\n');
+  });
+
+  it('rejects whitespace-only content, C0/DEL controls, and lone surrogates', () => {
+    expectContentError(() => normalizeRoleContent(' \n\t\r'), 'ROLE_INPUT_INVALID');
+    for (const value of ['bad\u0000', 'bad\u0001', 'bad\u007f']) {
+      expectContentError(() => normalizeRoleContent(value), 'ROLE_INPUT_INVALID');
+    }
+    for (const value of ['bad\ud800', 'bad\udc00', '\ud800\udc00\ud800']) {
+      expectContentError(() => normalizeRoleContent(value), 'ROLE_INPUT_INVALID');
+    }
+    expect(normalizeRoleContent('valid 😀 pair')).toBe('valid 😀 pair');
+  });
+
+  it('enforces the raw UTF-8 byte limit before normalization', () => {
+    const exact = 'a'.repeat(MAX_ROLE_BYTES);
+    expect(normalizeRoleContent(exact)).toBe(exact);
+    expectContentError(() => normalizeRoleContent(`${exact}a`), 'ROLE_INPUT_TOO_LARGE');
+
+    const multibyte = '😀'.repeat(Math.floor(MAX_ROLE_BYTES / 4));
+    expect(Buffer.byteLength(multibyte, 'utf8')).toBe(MAX_ROLE_BYTES);
+    expect(normalizeRoleContent(multibyte)).toBe(multibyte);
+    expectContentError(() => normalizeRoleContent(`${multibyte}😀`), 'ROLE_INPUT_TOO_LARGE');
+
+    // Removing CRs would make this fit, but raw input is what is bounded.
+    const rawOversized = `${'a'.repeat(MAX_ROLE_BYTES - 1)}\r\n`;
+    expect(Buffer.byteLength(rawOversized, 'utf8')).toBe(MAX_ROLE_BYTES + 1);
+    expect(Buffer.byteLength(rawOversized.replace('\r\n', '\n'), 'utf8')).toBe(MAX_ROLE_BYTES);
+    expectContentError(() => normalizeRoleContent(rawOversized), 'ROLE_INPUT_TOO_LARGE');
+  });
+
+  it('strictly decodes UTF-8 and leaves normalization to the service', () => {
+    const directory = temporaryDirectory();
+    const file = path.join(directory, 'role.txt');
+    fs.writeFileSync(file, Buffer.from([0xef, 0xbb, 0xbf, 0xef, 0xbb, 0xbf, 0x41, 0x0d]));
+    expect(readRoleFile(file)).toBe('\ufeff\ufeffA\r');
+    fs.writeFileSync(file, Buffer.from([0xc3, 0x28]));
+    expectContentError(() => readRoleFile(file), 'ROLE_INPUT_INVALID');
+  });
+
+  it('keeps inline and file normalization identical, including a double BOM', () => {
+    const directory = temporaryDirectory();
+    const file = path.join(directory, 'role.txt');
+    const input = '\ufeff\ufeff# Profile\r\n\tline\r\n';
+    fs.writeFileSync(file, Buffer.from(input, 'utf8'));
+    expect(normalizeRoleContent(readRoleFile(file))).toBe(normalizeRoleContent(input));
+  });
+
+  it('bounds regular-file reads at exactly 65536 raw bytes', () => {
+    const directory = temporaryDirectory();
+    const exact = path.join(directory, 'exact.txt');
+    const oversized = path.join(directory, 'oversized.txt');
+    fs.writeFileSync(exact, Buffer.alloc(MAX_ROLE_BYTES, 0x61));
+    fs.writeFileSync(oversized, Buffer.alloc(MAX_ROLE_BYTES + 1, 0x61));
+    expect(readRoleFile(exact)).toHaveLength(MAX_ROLE_BYTES);
+    expectContentError(() => readRoleFile(oversized), 'ROLE_INPUT_TOO_LARGE');
+
+    const multibyte = path.join(directory, 'multibyte.txt');
+    const emoji = Buffer.from('😀', 'utf8');
+    fs.writeFileSync(multibyte, Buffer.concat([Buffer.alloc(MAX_ROLE_BYTES - 4, 0x61), emoji]));
+    expect(Buffer.byteLength(readRoleFile(multibyte), 'utf8')).toBe(MAX_ROLE_BYTES);
+  });
+
+  it('allows symlinked regular files and rejects directories, devices, and FIFOs promptly', () => {
+    const directory = temporaryDirectory();
+    const regular = path.join(directory, 'regular.txt');
+    const symlink = path.join(directory, 'link.txt');
+    fs.writeFileSync(regular, 'role');
+    fs.symlinkSync(regular, symlink);
+    expect(readRoleFile(symlink)).toBe('role');
+    expect(() => readRoleFile(directory)).toThrow(RoleFileError);
+    expect(() => readRoleFile('/dev/null')).toThrow(RoleFileError);
+
+    const fifo = path.join(directory, 'role.fifo');
+    execFileSync('mkfifo', [fifo]);
+    // A blocking-open regression must fail within a bound, not hang Vitest itself.
+    const moduleUrl = pathToFileURL(path.resolve('src/role-content.ts')).href;
+    const script = `import { readRoleFile } from ${JSON.stringify(moduleUrl)};
+      try { readRoleFile(process.argv[1]); process.exit(2); }
+      catch (error) { if (error.code !== 'ROLE_FILE_ERROR') throw error; }`;
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        ['--import', 'tsx', '--input-type=module', '-e', script, fifo],
+        { timeout: 3000, stdio: 'pipe' }
+      )
+    ).not.toThrow();
+  });
+
+  it('closes the descriptor when decode fails', () => {
+    const directory = temporaryDirectory();
+    const file = path.join(directory, 'invalid.txt');
+    fs.writeFileSync(file, Buffer.from([0xc3, 0x28]));
+    const close = vi.spyOn(fs, 'closeSync');
+    try {
+      expectContentError(() => readRoleFile(file), 'ROLE_INPUT_INVALID');
+      expect(close).toHaveBeenCalledTimes(1);
+    } finally {
+      close.mockRestore();
+    }
+  });
+});

--- a/src/role-content.ts
+++ b/src/role-content.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import { TextDecoder } from 'node:util';
+import { MAX_ROLE_BYTES, RoleContentError } from './domain/role.js';
+
+export type RoleFileErrorCode = 'ROLE_FILE_ERROR';
+
+export class RoleFileError extends Error {
+  constructor(
+    public readonly code: RoleFileErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = 'RoleFileError';
+  }
+}
+
+/** Read one bounded regular file and reject malformed UTF-8 before normalization. */
+export function readRoleFile(filePath: string): string {
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+  } catch (_error) {
+    throw new RoleFileError('ROLE_FILE_ERROR', `Could not read role file '${filePath}'.`, {
+      cause: _error,
+    });
+  }
+  try {
+    const stat = fs.fstatSync(descriptor);
+    if (!stat.isFile()) {
+      throw new RoleFileError('ROLE_FILE_ERROR', `Role file '${filePath}' must be a regular file.`);
+    }
+    const buffer = Buffer.alloc(MAX_ROLE_BYTES + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const count = fs.readSync(descriptor, buffer, offset, buffer.length - offset, null);
+      if (count === 0) break;
+      offset += count;
+    }
+    if (offset > MAX_ROLE_BYTES) {
+      throw new RoleContentError(
+        'ROLE_INPUT_TOO_LARGE',
+        'Role content must not exceed 65536 bytes.'
+      );
+    }
+    let decoded: string;
+    try {
+      decoded = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(
+        buffer.subarray(0, offset)
+      );
+    } catch {
+      throw new RoleContentError(
+        'ROLE_INPUT_INVALID',
+        `Role file '${filePath}' is not valid UTF-8.`
+      );
+    }
+    return decoded;
+  } catch (error) {
+    if (error instanceof RoleFileError || error instanceof RoleContentError) throw error;
+    throw new RoleFileError('ROLE_FILE_ERROR', `Could not read role file '${filePath}'.`, {
+      cause: error,
+    });
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}

--- a/src/role-service.test.ts
+++ b/src/role-service.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRoleService, type RoleRepository } from './role-service.js';
+import { IdentitySelectionError } from './identity-context.js';
+import { RoleContentError } from './domain/role.js';
+import type { DurableIdentity } from './domain/identity.js';
+
+const identity: DurableIdentity = {
+  id: 'id-1',
+  name: 'Alice',
+  canonicalName: 'alice',
+  createdAt: 'created',
+  updatedAt: 'updated',
+};
+
+function repository(): RoleRepository & { role?: { content: string; updatedAt: string } } {
+  const value: RoleRepository & { role?: { content: string; updatedAt: string } } = {
+    findByCanonicalName: vi.fn((name: string) => (name === 'alice' ? identity : undefined)),
+    findRole: vi.fn(() => value.role),
+    setRole: vi.fn((_id: string, content: string) => {
+      value.role = { content, updatedAt: 'now' };
+      return value.role;
+    }),
+    clearRole: vi.fn(() => {
+      value.role = undefined;
+      return null;
+    }),
+  };
+  return value;
+}
+
+describe('role service', () => {
+  it('resolves an explicit durable identity without invoking current-pane lookup', () => {
+    const currentIdentity = vi.fn(() => {
+      throw new Error('tmux should not be consulted');
+    });
+    const service = createRoleService({ repository: repository(), currentIdentity });
+    expect(service.show({ value: ' ALICE ', kind: 'identity', explicit: true })).toMatchObject({
+      identity: { id: 'id-1', name: 'Alice', canonicalName: 'alice' },
+      role: null,
+    });
+    expect(currentIdentity).not.toHaveBeenCalled();
+  });
+
+  it('requires a verified current identity when the selector is omitted', () => {
+    const service = createRoleService({
+      repository: repository(),
+      currentIdentity: () => undefined,
+    });
+    expect(() => service.show()).toThrow('An identity is required');
+  });
+
+  it('normalizes content, replaces atomically, and clear returns null directly', () => {
+    const repo = repository();
+    const service = createRoleService({
+      repository: repo,
+      currentIdentity: () => ({ identity }),
+    });
+    const set = service.set(undefined, '\ufeffa\r\nb\r');
+    expect(set.role?.content).toBe('a\nb\n');
+    expect(service.clear()?.role).toBeNull();
+    expect(repo.findRole).not.toHaveBeenCalled();
+  });
+
+  it('preserves the prior profile when validation rejects a replacement', () => {
+    const repo = repository();
+    repo.role = { content: 'last committed profile', updatedAt: 'before' };
+    const service = createRoleService({
+      repository: repo,
+      currentIdentity: () => ({ identity }),
+    });
+
+    expect(() => service.set(undefined, 'invalid\u0000profile')).toThrow(RoleContentError);
+    expect(repo.setRole).not.toHaveBeenCalled();
+    expect(service.show()?.role).toEqual({
+      content: 'last committed profile',
+      updatedAt: 'before',
+    });
+  });
+
+  it('rejects missing names and ambiguous current identity', () => {
+    const missing = createRoleService({
+      repository: repository(),
+      currentIdentity: () => undefined,
+    });
+    expect(() => missing.show({ value: 'missing', kind: 'identity', explicit: true })).toThrow(
+      'was not found'
+    );
+    expect(() => missing.show({ value: 'missing', kind: 'identity', explicit: true })).toThrowError(
+      expect.objectContaining({ code: 'NAME_NOT_FOUND' })
+    );
+    const ambiguous = createRoleService({
+      repository: repository(),
+      currentIdentity: () => ({ status: 'ambiguous' }),
+    });
+    expect(() => ambiguous.show()).toThrowError(IdentitySelectionError);
+    expect(() => ambiguous.show()).toThrowError(
+      expect.objectContaining({ code: 'IDENTITY_AMBIGUOUS' })
+    );
+    const required = createRoleService({
+      repository: repository(),
+      currentIdentity: () => undefined,
+    });
+    expect(() => required.show()).toThrowError(
+      expect.objectContaining({ code: 'IDENTITY_REQUIRED' })
+    );
+  });
+});

--- a/src/role-service.ts
+++ b/src/role-service.ts
@@ -1,0 +1,59 @@
+import type { DurableIdentity } from './domain/identity.js';
+import {
+  requireDurableIdentity,
+  type DurableIdentityContext,
+  type IdentitySelector,
+} from './identity-context.js';
+import { normalizeRoleContent } from './domain/role.js';
+import type { IdentityRepository } from './storage/identity-repository.js';
+import type { RoleResult, RoleService } from './types.js';
+
+export type RoleRepository = Pick<
+  IdentityRepository,
+  'findByCanonicalName' | 'findRole' | 'setRole' | 'clearRole'
+>;
+
+export interface RoleServiceOptions {
+  readonly repository: RoleRepository;
+  readonly currentIdentity: DurableIdentityContext['currentIdentity'];
+}
+
+function resolveIdentity(
+  repository: RoleRepository,
+  currentIdentity: RoleServiceOptions['currentIdentity'],
+  selector?: IdentitySelector
+): DurableIdentity {
+  return requireDurableIdentity(
+    { findByCanonicalName: (name) => repository.findByCanonicalName(name), currentIdentity },
+    selector
+  );
+}
+
+export function createRoleService(options: RoleServiceOptions): RoleService {
+  const resolve = (selector?: IdentitySelector): DurableIdentity =>
+    resolveIdentity(options.repository, options.currentIdentity, selector);
+  const result = (identity: DurableIdentity): RoleResult => ({
+    identity: { id: identity.id, name: identity.name, canonicalName: identity.canonicalName },
+    role: options.repository.findRole(identity.id) ?? null,
+  });
+  return {
+    show(selector) {
+      return result(resolve(selector));
+    },
+    set(selector, content) {
+      const identity = resolve(selector);
+      return {
+        identity: { id: identity.id, name: identity.name, canonicalName: identity.canonicalName },
+        role: options.repository.setRole(identity.id, normalizeRoleContent(content)),
+      };
+    },
+    clear(selector) {
+      const identity = resolve(selector);
+      options.repository.clearRole(identity.id);
+      return {
+        identity: { id: identity.id, name: identity.name, canonicalName: identity.canonicalName },
+        role: null,
+      };
+    },
+  };
+}

--- a/src/storage/identity-repository.test.ts
+++ b/src/storage/identity-repository.test.ts
@@ -74,4 +74,44 @@ describe('identity repository contract', () => {
     expect(() => repository.listIdentities()).toThrow('Identity repository is closed.');
     repository.close();
   });
+
+  it('stores, replaces, clears, and protects an unbound identity with a role', () => {
+    const repository = openIdentityRepository(databasePath());
+    const identity = repository.createIdentity('RoleOwner', 'roleowner');
+    expect(repository.findRole(identity.id)).toBeUndefined();
+    const first = repository.setRole(identity.id, 'first');
+    expect(first).toMatchObject({ content: 'first', updatedAt: expect.any(String) });
+    expect(repository.findRole(identity.id)).toEqual(first);
+    const second = repository.setRole(identity.id, 'second');
+    expect(second.content).toBe('second');
+    expect(repository.findRole(identity.id)).toEqual(second);
+    repository.removeIdentityIfUnbound(identity.id);
+    expect(repository.findByCanonicalName('roleowner')).toEqual(identity);
+    expect(repository.clearRole(identity.id)).toBeNull();
+    expect(repository.findRole(identity.id)).toBeUndefined();
+    repository.removeIdentityIfUnbound(identity.id);
+    expect(repository.findByCanonicalName('roleowner')).toBeUndefined();
+    repository.close();
+  });
+
+  it('persists profiles across reopen and rejects orphan writes without affecting another identity', () => {
+    const file = databasePath();
+    const repository = openIdentityRepository(file);
+    const identity = repository.createIdentity('Owner', 'owner');
+    const profile = repository.setRole(identity.id, 'durable profile');
+    expect(() => repository.setRole('missing-id', 'orphan')).toThrow();
+    expect(repository.findRole(identity.id)).toEqual(profile);
+    expect(repository.findRole('missing-id')).toBeUndefined();
+    repository.close();
+    const reopened = openIdentityRepository(file);
+    try {
+      expect(reopened.findRole(identity.id)).toEqual(profile);
+      reopened.clearRole(identity.id);
+      reopened.clearRole(identity.id);
+      expect(reopened.findRole(identity.id)).toBeUndefined();
+      expect(reopened.findByCanonicalName('owner')).toEqual(identity);
+    } finally {
+      reopened.close();
+    }
+  });
 });

--- a/src/storage/identity-repository.ts
+++ b/src/storage/identity-repository.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import Database from 'better-sqlite3';
-import type { DurableIdentity, TmuxBinding } from '../domain/identity.js';
-import { openStorage } from './sqlite-adapter.js';
+import type { DurableIdentity, RoleProfile, TmuxBinding } from '../domain/identity.js';
+import { openStorageWithDatabase } from './sqlite-adapter.js';
 import { StorageError } from './errors.js';
 import type { StorageLocation } from './ports.js';
 
@@ -15,6 +15,9 @@ export interface IdentityRepository {
   touchBinding(id: string, lastVerifiedAt: string): void;
   removeBinding(id: string): void;
   removeIdentityIfUnbound(id: string): void;
+  findRole(identityId: string): RoleProfile | undefined;
+  setRole(identityId: string, content: string): RoleProfile;
+  clearRole(identityId: string): null;
   close(): void;
 }
 
@@ -39,6 +42,8 @@ type BindingRow = {
   bound_at: string;
   last_verified_at: string;
 };
+
+type RoleRow = { content: string; updated_at: string };
 
 function identity(row: IdentityRow): DurableIdentity {
   return {
@@ -71,17 +76,14 @@ export function openIdentityRepository(location: StorageLocation): IdentityRepos
   let lifecycle;
   for (let attempt = 0; ; attempt += 1) {
     try {
-      lifecycle = openStorage(location);
+      lifecycle = openStorageWithDatabase(location);
       break;
     } catch (error) {
       if (!(error instanceof StorageError) || error.code !== 'busy' || attempt >= 20) throw error;
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
     }
   }
-  const database = new Database(lifecycle.path);
-  database.pragma('foreign_keys = ON');
-  database.pragma('busy_timeout = 5000');
-  database.pragma('synchronous = NORMAL');
+  const database = lifecycle.database;
   let closed = false;
 
   const requireOpen = (): Database.Database => {
@@ -170,18 +172,40 @@ export function openIdentityRepository(location: StorageLocation): IdentityRepos
     removeIdentityIfUnbound(id) {
       requireOpen()
         .prepare(
-          'DELETE FROM identities WHERE id = ? AND NOT EXISTS (SELECT 1 FROM bindings WHERE identity_id = ?)'
+          'DELETE FROM identities WHERE id = ? AND NOT EXISTS (SELECT 1 FROM bindings WHERE identity_id = ?) AND NOT EXISTS (SELECT 1 FROM role_profiles WHERE identity_id = ?)'
         )
-        .run(id, id);
+        .run(id, id, id);
+    },
+    findRole(identityId) {
+      const row = requireOpen()
+        .prepare('SELECT content, updated_at FROM role_profiles WHERE identity_id = ?')
+        .get(identityId) as RoleRow | undefined;
+      return row ? { content: row.content, updatedAt: row.updated_at } : undefined;
+    },
+    setRole(identityId, content) {
+      const write = requireOpen().transaction(() => {
+        const now = new Date().toISOString();
+        requireOpen()
+          .prepare(
+            'INSERT INTO role_profiles (identity_id, content, updated_at) VALUES (?, ?, ?) ' +
+              'ON CONFLICT(identity_id) DO UPDATE SET content = excluded.content, updated_at = excluded.updated_at'
+          )
+          .run(identityId, content, now);
+        return { content, updatedAt: now };
+      });
+      return write.immediate();
+    },
+    clearRole(identityId) {
+      const clear = requireOpen().transaction(() => {
+        requireOpen().prepare('DELETE FROM role_profiles WHERE identity_id = ?').run(identityId);
+        return null;
+      });
+      return clear.immediate();
     },
     close() {
       if (closed) return;
       closed = true;
-      try {
-        database.close();
-      } finally {
-        lifecycle.close();
-      }
+      lifecycle.close();
     },
   };
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -2,4 +2,4 @@ export { openStorage } from './sqlite-adapter.js';
 export type { CheckpointMode, StorageHandle, StorageHealth, StorageLocation } from './ports.js';
 export { StorageError, type StorageErrorCode } from './errors.js';
 export { openIdentityRepository, type IdentityRepository } from './identity-repository.js';
-export type { DurableIdentity, TmuxBinding } from '../domain/identity.js';
+export type { DurableIdentity, RoleProfile, TmuxBinding } from '../domain/identity.js';

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -41,6 +41,18 @@ export const CURRENT_MIGRATIONS: readonly MigrationDefinition[] = [
         CREATE INDEX bindings_endpoint ON bindings(transport, server_id, pane_id);
       `),
   },
+  {
+    version: 2,
+    name: 'create optional identity role profiles',
+    up: (database) =>
+      database.exec(`
+        CREATE TABLE role_profiles (
+          identity_id TEXT NOT NULL PRIMARY KEY REFERENCES identities(id) ON DELETE CASCADE,
+          content TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+      `),
+  },
 ];
 
 const CREATE_MIGRATIONS = `
@@ -138,6 +150,12 @@ export function applyMigrations(
       const migration = migrations[index];
       const applyOne = database.transaction(() => {
         try {
+          // Recheck while holding the write transaction. Another process may
+          // have applied this migration after the initial history read.
+          const latest = database
+            .prepare('SELECT version, name FROM _migrations ORDER BY version')
+            .all() as Array<{ version: number; name: string }>;
+          if (validateHistory(latest, migrations) >= migration.version) return;
           migration.up(database);
           insert.run(migration.version, migration.name, new Date().toISOString());
         } catch (error) {

--- a/src/storage/sqlite-adapter.ts
+++ b/src/storage/sqlite-adapter.ts
@@ -9,6 +9,11 @@ export interface StorageOptions {
   readonly migrations?: readonly MigrationDefinition[];
 }
 
+/** Internal repository seam; the public storage lifecycle port remains narrow. */
+export interface InternalStorageHandle extends StorageHandle {
+  readonly database: Database.Database;
+}
+
 function resolveDatabasePath(location: StorageLocation): { directory: string; file: string } {
   if (typeof location === 'string') return { directory: path.dirname(location), file: location };
   return { directory: location.globalDir, file: location.databaseFile };
@@ -61,7 +66,7 @@ function verifyFts5(database: Database.Database): void {
 function openStorageInternal(
   location: StorageLocation,
   options: StorageOptions = {}
-): StorageHandle {
+): InternalStorageHandle {
   const resolved = resolveDatabasePath(location);
   ensurePrivateDirectory(resolved.directory);
 
@@ -105,6 +110,7 @@ function openStorageInternal(
 
   return {
     path: resolved.file,
+    database: openedDatabase,
     health(): StorageHealth {
       const current = requireOpen();
       try {
@@ -157,6 +163,12 @@ function openStorageInternal(
 
 /** Open the user-scoped database with the repository's current migrations. */
 export function openStorage(location: StorageLocation): StorageHandle {
+  const { database: _database, ...lifecycle } = openStorageInternal(location);
+  return lifecycle;
+}
+
+/** Internal-only entry point for repositories sharing the lifecycle connection. */
+export function openStorageWithDatabase(location: StorageLocation): InternalStorageHandle {
   return openStorageInternal(location);
 }
 
@@ -165,5 +177,6 @@ export function openStorageWithMigrations(
   location: StorageLocation,
   migrations: readonly MigrationDefinition[]
 ): StorageHandle {
-  return openStorageInternal(location, { migrations });
+  const { database: _database, ...lifecycle } = openStorageInternal(location, { migrations });
+  return lifecycle;
 }

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -3,9 +3,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { StorageError } from './errors.js';
-import type { MigrationDefinition } from './migrations.js';
+import { applyMigrations, CURRENT_MIGRATIONS, type MigrationDefinition } from './migrations.js';
 import { openStorage, openStorageWithMigrations } from './sqlite-adapter.js';
 
 const temporaryDirectories: string[] = [];
@@ -30,10 +30,11 @@ describe('SQLite storage adapter', () => {
   it('opens a private database with required pragmas and the durable identity schema', () => {
     const directory = temporaryDirectory();
     const storage = openStorage(location(directory));
+    expect(storage).not.toHaveProperty('database');
 
     expect(storage.health()).toMatchObject({
       open: true,
-      schemaVersion: 1,
+      schemaVersion: 2,
       journalMode: 'wal',
       foreignKeys: true,
       busyTimeoutMs: 5000,
@@ -56,6 +57,7 @@ describe('SQLite storage adapter', () => {
       '_migrations',
       'bindings',
       'identities',
+      'role_profiles',
     ]);
     database.close();
     if (process.platform !== 'win32') {
@@ -169,6 +171,43 @@ describe('SQLite storage adapter', () => {
     const recovered = openStorageWithMigrations(location(directory), migrations);
     expect(recovered.health().schemaVersion).toBe(2);
     recovered.close();
+  });
+
+  it('rechecks schema history under the write lock when another connection upgrades first', () => {
+    const file = location(temporaryDirectory()).databaseFile;
+    const first = new Database(file);
+    const second = new Database(file);
+    try {
+      applyMigrations(first, CURRENT_MIGRATIONS.slice(0, 1));
+      const prepare = first.prepare.bind(first);
+      let interleave = true;
+      const spy = vi.spyOn(first, 'prepare').mockImplementation((sql: string) => {
+        const statement = prepare(sql);
+        if (sql === 'SELECT version, name FROM _migrations ORDER BY version' && interleave) {
+          const all = statement.all.bind(statement);
+          vi.spyOn(statement, 'all').mockImplementation(() => {
+            const staleHistory = all();
+            interleave = false;
+            applyMigrations(second);
+            return staleHistory;
+          });
+        }
+        return statement;
+      });
+      expect(applyMigrations(first)).toBe(2);
+      spy.mockRestore();
+      expect(interleave).toBe(false);
+      expect(first.prepare('SELECT version FROM _migrations ORDER BY version').all()).toEqual([
+        { version: 1 },
+        { version: 2 },
+      ]);
+      expect(
+        first.prepare("SELECT name FROM sqlite_master WHERE name = 'role_profiles'").all()
+      ).toEqual([{ name: 'role_profiles' }]);
+    } finally {
+      first.close();
+      second.close();
+    }
   });
 
   it('maps corrupt databases while retaining the native cause', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { ActiveRegistration } from './domain/types.js';
-import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
+import type { DurableIdentity, RoleProfile, TmuxBinding } from './domain/identity.js';
 
 // ─────────────────────────────────────────────────────────────
 // Shared TypeScript interfaces for tmux-team
@@ -172,6 +172,20 @@ export interface IdentityService {
   close(): void;
 }
 
+export interface RoleService {
+  show(selector?: import('./identity-context.js').IdentitySelector): RoleResult;
+  set(
+    selector: import('./identity-context.js').IdentitySelector | undefined,
+    content: string
+  ): RoleResult;
+  clear(selector?: import('./identity-context.js').IdentitySelector): RoleResult;
+}
+
+export interface RoleResult {
+  readonly identity: Pick<DurableIdentity, 'id' | 'name' | 'canonicalName'>;
+  readonly role: RoleProfile | null;
+}
+
 export interface RegistryScope {
   type: 'workspace';
   workspaceRoot: string;
@@ -194,5 +208,6 @@ export interface Context {
   registryScope?: RegistryScope;
   exit: (code: number) => never;
   identityService?: IdentityService;
+  roleService?: RoleService;
   dispose?: () => void;
 }

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -32,6 +32,8 @@ export interface MockPane {
 export interface CliRunOptions {
   cwd?: string;
   pane?: string;
+  /** Remove pane context and fail visibly if the CLI attempts to invoke tmux. */
+  withoutTmux?: boolean;
 }
 
 function shellQuote(value: string): string {
@@ -46,6 +48,7 @@ export class E2EFixture {
   readonly workspace = path.join(this.root, 'workspace');
   readonly globalDir = path.join(this.root, 'global');
   readonly logPath = path.join(this.root, 'mock-agent.jsonl');
+  readonly forbiddenTmuxLogPath = path.join(this.root, 'forbidden-tmux.log');
   readonly socket = `tmt-e2e-${process.pid}-${Math.random().toString(16).slice(2)}`;
   readonly wrapperDir = path.join(this.root, 'bin');
   readonly tmuxPath: string;
@@ -83,7 +86,7 @@ export class E2EFixture {
       fs.mkdirSync(this.wrapperDir, { recursive: true });
       fs.writeFileSync(
         path.join(this.wrapperDir, 'tmux'),
-        `#!/bin/sh\nexec ${shellQuote(this.tmuxPath)} -f /dev/null -L "$TMT_E2E_SOCKET" "$@"\n`
+        `#!/bin/sh\nif [ "${'$'}{TMT_E2E_FORBID_TMUX:-}" = "1" ]; then\n  echo "unexpected tmux invocation" >> "$TMT_E2E_FORBIDDEN_TMUX_LOG"\n  exit 97\nfi\nexec ${shellQuote(this.tmuxPath)} -f /dev/null -L "$TMT_E2E_SOCKET" "$@"\n`
       );
       fs.chmodSync(path.join(this.wrapperDir, 'tmux'), 0o755);
 
@@ -117,9 +120,16 @@ export class E2EFixture {
     options: CliRunOptions = {}
   ): Promise<CliResult<T>> {
     if (!this.started) throw new Error('E2E fixture must be started before invoking the CLI.');
+    const env: NodeJS.ProcessEnv = { ...this.env, TMUX_PANE: options.pane ?? this.pane };
+    if (options.withoutTmux) {
+      delete env.TMUX;
+      delete env.TMUX_PANE;
+      env.TMT_E2E_FORBID_TMUX = '1';
+      env.TMT_E2E_FORBIDDEN_TMUX_LOG = this.forbiddenTmuxLogPath;
+    }
     const child = spawn(binPath, args, {
       cwd: options.cwd ?? this.workspace,
-      env: { ...this.env, TMUX_PANE: options.pane ?? this.pane },
+      env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let stdout = '';

--- a/test/e2e/role-lifecycle.e2e.test.ts
+++ b/test/e2e/role-lifecycle.e2e.test.ts
@@ -1,0 +1,231 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type E2EFixture, type CliResult } from './harness.js';
+
+interface RoleResult {
+  identity: { id: string; name: string; canonicalName: string };
+  role: { content: string; updatedAt: string } | null;
+}
+
+function successful(result: CliResult<RoleResult>): RoleResult {
+  expect(result.code, result.stderr || result.stdout).toBe(0);
+  expect(result.json).toBeDefined();
+  return result.json!;
+}
+
+function storedProfiles(fixture: E2EFixture): unknown[] {
+  const database = new Database(path.join(fixture.globalDir, 'tmux-team.db'), { readonly: true });
+  try {
+    return database
+      .prepare('SELECT identity_id, content, updated_at FROM role_profiles ORDER BY identity_id')
+      .all();
+  } finally {
+    database.close();
+  }
+}
+
+async function showOffline(fixture: E2EFixture, identity: string): Promise<RoleResult> {
+  return successful(
+    await fixture.runJsonCli<RoleResult>(['role', 'show', '--identity', identity], {
+      withoutTmux: true,
+    })
+  );
+}
+
+describe.sequential('durable role profiles', () => {
+  it('preserves one identity profile through unbind, pane death, restart, and rebind', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect((await fixture.runJsonCli(['name', 'Alice'])).code).toBe(0);
+      const empty = successful(await fixture.runJsonCli<RoleResult>(['role', 'show']));
+      expect(empty.role).toBeNull();
+      const content = '# Reviewer\n\tPreserve evidence.\n';
+      const assigned = successful(await fixture.runJsonCli<RoleResult>(['role', 'set', content]));
+      expect(assigned.identity).toEqual(empty.identity);
+      expect(assigned.role?.content).toBe(content);
+      expect(assigned.role?.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      const talk = await fixture.runJsonCli([
+        'talk',
+        'Alice',
+        'profile-not-injected',
+        '--wait',
+        '--timeout',
+        '5',
+      ]);
+      expect(talk.code, talk.stderr || talk.stdout).toBe(0);
+      const request = fixture.events().find((event) => event.event === 'request');
+      expect(request?.message).toContain('profile-not-injected');
+      expect(request?.message).not.toContain('Preserve evidence.');
+
+      const peer = await fixture.createMockPane('peer');
+      expect((await fixture.runJsonCli(['add', peer.pane, 'Bob'])).code).toBe(0);
+      const bob = successful(
+        await fixture.runJsonCli<RoleResult>([
+          'role',
+          'set',
+          'Independent profile',
+          '--identity',
+          'Bob',
+        ])
+      );
+      const before = storedProfiles(fixture);
+      expect(before).toHaveLength(2);
+      expect((await fixture.runJsonCli(['unbind'])).code).toBe(0);
+      expect(await showOffline(fixture, 'ALICE')).toEqual(assigned);
+      expect(storedProfiles(fixture)).toEqual(before);
+
+      const replacement = await fixture.createMockPane('replacement');
+      expect((await fixture.runJsonCli(['add', replacement.pane, 'alice'])).code).toBe(0);
+      fixture.tmux(['kill-pane', '-t', replacement.pane]);
+      expect(await showOffline(fixture, 'Alice')).toEqual(assigned);
+      await fixture.restartServer();
+      expect(await showOffline(fixture, 'Alice')).toEqual(assigned);
+      expect(await showOffline(fixture, 'Bob')).toEqual(bob);
+      expect((await fixture.runJsonCli(['name', 'alice'])).code).toBe(0);
+      expect(successful(await fixture.runJsonCli<RoleResult>(['role', 'show']))).toEqual(assigned);
+
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const cleared = successful(await fixture.runJsonCli<RoleResult>(['role', 'clear']));
+        expect(cleared).toEqual({ identity: assigned.identity, role: null });
+      }
+      expect(storedProfiles(fixture)).toEqual([
+        {
+          identity_id: bob.identity.id,
+          content: bob.role!.content,
+          updated_at: bob.role!.updatedAt,
+        },
+      ]);
+      expect((await fixture.runJsonCli(['whoami'])).json).toMatchObject({
+        bound: true,
+        name: 'Alice',
+      });
+      expect(await showOffline(fixture, 'Bob')).toEqual(bob);
+      expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+    });
+  }, 30_000);
+
+  it('shares inline/file normalization and rejects invalid writes without changing stored data', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect((await fixture.runJsonCli(['name', 'Writer'])).code).toBe(0);
+      const raw = '\uFEFF# Profile\r\n\tIndented text  \rFinal line\r\n';
+      const normalized = '# Profile\n\tIndented text  \nFinal line\n';
+      const inline = successful(
+        await fixture.runJsonCli<RoleResult>(['role', 'set', raw, '--identity', 'Writer'])
+      );
+      const file = path.join(fixture.workspace, 'profile.md');
+      fs.writeFileSync(file, raw);
+      const fromFile = successful(
+        await fixture.runJsonCli<RoleResult>(
+          ['role', '--identity=Writer', 'set', '--file=profile.md'],
+          {
+            withoutTmux: true,
+          }
+        )
+      );
+      expect(inline.role?.content).toBe(normalized);
+      expect(fromFile.role?.content).toBe(normalized);
+      expect(fromFile.identity).toEqual(inline.identity);
+      const human = await fixture.runCli(['role', 'show', '--identity', 'Writer'], {
+        withoutTmux: true,
+      });
+      expect(human.code).toBe(0);
+      expect(human.stdout).toContain(normalized);
+      const before = storedProfiles(fixture);
+
+      const invalidFiles: Array<[string, Buffer | string, string]> = [
+        ['malformed', Buffer.from([0xc3, 0x28]), 'ROLE_INPUT_INVALID'],
+        ['binary', Buffer.from([0x61, 0x00, 0x62]), 'ROLE_INPUT_INVALID'],
+        ['empty', ' \r\n\t', 'ROLE_INPUT_INVALID'],
+        ['large', 'a'.repeat(65_537), 'ROLE_INPUT_TOO_LARGE'],
+      ];
+      for (const [name, data, code] of invalidFiles) {
+        const invalidPath = path.join(fixture.workspace, name);
+        fs.writeFileSync(invalidPath, data);
+        const failed = await fixture.runJsonCli([
+          'role',
+          'set',
+          '--file',
+          invalidPath,
+          '--identity',
+          'Writer',
+        ]);
+        expect(failed.code).toBe(1);
+        expect(failed.json).toMatchObject({ error: { code } });
+        expect(storedProfiles(fixture)).toEqual(before);
+      }
+      for (const invalidPath of [fixture.workspace, path.join(fixture.workspace, 'missing')]) {
+        const failed = await fixture.runJsonCli([
+          'role',
+          'set',
+          '--file',
+          invalidPath,
+          '--identity',
+          'Writer',
+        ]);
+        expect(failed.code).toBe(1);
+        expect(failed.json).toMatchObject({ error: { code: 'ROLE_FILE_ERROR' } });
+        expect(storedProfiles(fixture)).toEqual(before);
+      }
+      expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+    });
+  }, 30_000);
+
+  it('distinguishes missing identity, absent role, and missing implicit context without invoking tmux offline', async () => {
+    await withE2EFixture(async (fixture) => {
+      const invalid = await fixture.runJsonCli(['role', 'set', 'inline', '--file', 'file.md']);
+      expect(invalid.code).toBe(1);
+      expect(fs.existsSync(path.join(fixture.globalDir, 'tmux-team.db'))).toBe(false);
+      const missing = await fixture.runJsonCli(['role', 'show', '--identity', 'missing'], {
+        withoutTmux: true,
+      });
+      expect(missing.code).toBe(3);
+      expect(missing.json).toMatchObject({ error: { code: 'NAME_NOT_FOUND' } });
+      const outside = await fixture.runJsonCli(['role', 'show'], { withoutTmux: true });
+      expect(outside.code).toBe(1);
+      expect(outside.json).toMatchObject({ error: { code: 'IDENTITY_REQUIRED' } });
+      const unbound = await fixture.runJsonCli(['role', 'show']);
+      expect(unbound.code).toBe(1);
+      expect(unbound.json).toMatchObject({ error: { code: 'IDENTITY_REQUIRED' } });
+      expect((await fixture.runJsonCli(['name', 'Empty'])).code).toBe(0);
+      const outsideWithBoundDefault = await fixture.runJsonCli(['role', 'show'], {
+        withoutTmux: true,
+      });
+      expect(outsideWithBoundDefault.code).toBe(1);
+      expect(outsideWithBoundDefault.json).toMatchObject({ error: { code: 'IDENTITY_REQUIRED' } });
+      expect((await showOffline(fixture, 'Empty')).role).toBeNull();
+      expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+      // Calibrate the guard: a command that actually needs tmux must trip it.
+      await fixture.runJsonCli(['list'], { withoutTmux: true });
+      expect(fs.readFileSync(fixture.forbiddenTmuxLogPath, 'utf8')).toContain(
+        'unexpected tmux invocation'
+      );
+    });
+  }, 30_000);
+
+  it('keeps concurrent CLI updates whole and returns each transaction own profile', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect((await fixture.runJsonCli(['name', 'Concurrent'])).code).toBe(0);
+      const contents = ['A', 'B', 'C', 'D'].map((letter) => `${letter.repeat(4096)}\n${letter}`);
+      const results = await Promise.all(
+        contents.map((content) =>
+          fixture.runJsonCli<RoleResult>(['role', 'set', content, '--identity', 'Concurrent'], {
+            withoutTmux: true,
+          })
+        )
+      );
+      const committed = results.map(successful);
+      committed.forEach((result, index) => expect(result.role?.content).toBe(contents[index]));
+      const final = await showOffline(fixture, 'Concurrent');
+      expect(committed).toContainEqual(final);
+      expect(storedProfiles(fixture)).toEqual([
+        {
+          identity_id: final.identity.id,
+          content: final.role!.content,
+          updated_at: final.role!.updatedAt,
+        },
+      ]);
+      expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+    });
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- Add action-first `tmt role show|set|clear` commands with optional explicit identity selection and bounded UTF-8 file input.
- Reuse shared durable identity selection and application services. Explicit identities work offline without invoking tmux; implicit selection requires a verified current pane.
- Append the role-profile migration and share one SQLite connection across identity and role services. Profile writes are atomic, whole-document, last-committed-write-wins.
- Preserve profiles through unbind, pane death, restart, and rebind. Clearing a profile does not remove its identity. Roles are not injected into talk messages.
- Document the CLI contract in README, help, and completion. Consolidated bundled skill updates remain in TMT-17.

## Verification

- Read-only Luna pattern audit, primary integration review, and final Gemini review via tmt completed.
- `pnpm check`: passed (TypeScript, Oxlint, Prettier).
- `pnpm test:run`: 409 tests passed; coverage gates unchanged.
- Docker E2E: two consecutive final-snapshot runs passed 20/20 scenarios each (61.20s and 60.55s).
- Representative coverage includes strict encoding and byte limits, bounded FIFO rejection, no-tmux offline access with a calibrated guard, state preservation after invalid writes, lifecycle/rebind, two-identity isolation, concurrent CLI writes, and interleaved migration startup.

## Scope

No daemon, memory, inbox, role catalog, aliases, automatic prompt injection, or new dependencies.

Closes TMT-14
https://linear.app/tigerpig-dev/issue/TMT-14/add-optional-per-identity-role-profiles-through-shared-application
