### PR TITLE
fix(identity): preserve foreign tmux bindings (TMT-19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ tmux server removes the stale binding on reconciliation without deleting the
 identity record; the same name can be bound again later with its original
 identity ID.
 
+Names are unique across tmux servers that share the same local TMT database,
+but active discovery and `talk`/`check` routing remain scoped to the current
+server. A routine read reconciles only that server's socket; it does not
+remove another server's bindings. `%pane_id` alone is not globally unique
+across servers.
+
+Binding a name already recorded on another socket performs a bounded,
+read-only check of that endpoint. A verified live binding returns
+`NAME_ALREADY_ACTIVE` (exit 5). If its state cannot be verified, the operation
+returns `RECONCILIATION_FAILED` (exit 1) and preserves the binding. A proven
+stale endpoint can be rebound without replacing the durable identity or role
+profile. This does not add cross-server message routing or a background
+reconciler.
+
 Pane metadata is part of that presence check. A pane title may be updated as a
 best-effort presentation side effect, but titles are not the identity API.
 

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -49,6 +49,15 @@ The `add` argument order is `tmt add <pane-target> <global-name>`. The legacy
 name-first order is rejected with a usage error. The name `all` is an ordinary
 identity, not a special destination.
 
+Names are unique across servers sharing the same local TMT database, but
+`list`, `talk`, and `check` discover and address only the current tmux server.
+A `%pane_id` is stable within a server, not unique across servers. Routine
+reads preserve bindings on other sockets. Binding a foreign live name fails
+with `NAME_ALREADY_ACTIVE` (exit 5); an unverifiable foreign endpoint fails
+with `RECONCILIATION_FAILED` (exit 1). Do not delete the binding to bypass an
+uncertain check. Rebinding a proven stale endpoint retains its identity and
+profile; no cross-server routing or daemon is provided.
+
 ## Workflow
 
 1. Send message: `tmt talk codex "Review this code" --wait`

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -49,6 +49,15 @@ The `add` argument order is `tmt add <pane-target> <global-name>`. The legacy
 name-first order is rejected with a usage error. The name `all` is an ordinary
 identity, not a special destination.
 
+Names are unique across servers sharing the same local TMT database, but
+`list`, `talk`, and `check` discover and address only the current tmux server.
+A `%pane_id` is stable within a server, not unique across servers. Routine
+reads preserve bindings on other sockets. Binding a foreign live name fails
+with `NAME_ALREADY_ACTIVE` (exit 5); an unverifiable foreign endpoint fails
+with `RECONCILIATION_FAILED` (exit 1). Do not delete the binding to bypass an
+uncertain check. Rebinding a proven stale endpoint retains its identity and
+profile; no cross-server routing or daemon is provided.
+
 ## Workflow
 
 1. Send and wait: `tmt talk codex "Review this code" --wait`

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -35,6 +35,15 @@ name `all` is an ordinary identity; it is not a special destination. The
 current `add` order is `tmt add <pane-target> <global-name>`; the older
 name-first order is rejected with a usage error.
 
+Names are unique across servers sharing the same local TMT database, but
+`list`, `talk`, and `check` discover and address only the current tmux server.
+A `%pane_id` is stable within a server, not unique across servers. Routine
+reads preserve bindings on other sockets. Binding a foreign live name fails
+with `NAME_ALREADY_ACTIVE` (exit 5); an unverifiable foreign endpoint fails
+with `RECONCILIATION_FAILED` (exit 1). Do not delete the binding to bypass an
+uncertain check. Rebinding a proven stale endpoint retains its identity and
+profile; no cross-server routing or daemon is provided.
+
 `talk` sends text to another pane and can cause external input there. Only use
 it when the user has requested that communication or the surrounding task
 clearly authorizes it; do not infer permission for unrelated changes. Use

--- a/src/identity-service.test.ts
+++ b/src/identity-service.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createIdentityService, identityAwareTmux } from './identity-service.js';
 import { IdentityServiceError } from './identity-service.js';
 import { openIdentityRepository } from './storage/identity-repository.js';
@@ -54,7 +54,44 @@ function fixture() {
     globalDir,
     databaseFile: path.join(globalDir, 'tmux-team.db'),
   } as Paths;
-  return { tmux, paths, pane, setSnapshot: (next: TmuxEndpointSnapshot) => (snapshot = next) };
+  return {
+    tmux,
+    paths,
+    pane,
+    setSnapshot: (next: TmuxEndpointSnapshot) => (snapshot = next),
+    setProbe: (probe: NonNullable<Tmux['probeEndpoint']>) => (tmux.probeEndpoint = probe),
+  };
+}
+
+function seedForeignBinding(test: ReturnType<typeof fixture>, name = 'Foreign') {
+  const repository = openIdentityRepository(test.paths.databaseFile);
+  const identity = repository.createIdentity(name, name.toLowerCase());
+  const binding = repository.createBinding({
+    identityId: identity.id,
+    transport: 'tmux',
+    paneId: '%foreign',
+    serverId: 'server-foreign',
+    socketPath: '/tmp/tmt-foreign',
+    serverPid: 999999,
+    serverStartTime: 'foreign-start',
+    panePid: 8888,
+    boundAt: 'foreign-bound',
+    lastVerifiedAt: 'foreign-verified',
+  });
+  repository.close();
+  return { identity, binding };
+}
+
+function addSecondPane(test: ReturnType<typeof fixture>): void {
+  const second: PaneInfo = {
+    id: '%2',
+    command: 'mock-agent',
+    panePid: 2345,
+    suggestedName: null,
+  };
+  test.setSnapshot({ ...test.tmux.getEndpointSnapshot!(), panes: [test.pane, second] });
+  test.tmux.resolvePaneTarget = (target: string) =>
+    target === '%1' || target === '%2' ? target : null;
 }
 
 afterEach(() => {
@@ -181,7 +218,12 @@ describe('durable identity service', () => {
     expect(service.activeIdentities()).toEqual([]);
     const repository = openIdentityRepository(test.paths.databaseFile);
     expect(repository.listIdentities()).toMatchObject([{ id: identity.id }]);
-    expect(repository.findBindings()).toEqual([]);
+    expect(repository.findBindings()).toHaveLength(1);
+    expect(repository.findBindings()[0]).toMatchObject({
+      id: expect.any(String),
+      identityId: identity.id,
+      socketPath: '/tmp/tmt-a',
+    });
     repository.close();
     service.close();
   });
@@ -200,6 +242,171 @@ describe('durable identity service', () => {
       panes: [{ ...test.pane }],
     });
     expect(service.activeIdentities()).toEqual([]);
+    service.close();
+  });
+
+  it('preserves a binding owned by another live socket while discovering only the current server', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+    service.bindCurrent('local');
+    const foreign = seedForeignBinding(test);
+    const probe = vi.fn<[string, number], ReturnType<NonNullable<Tmux['probeEndpoint']>>>(() => ({
+      status: 'unknown',
+    }));
+    test.setProbe(probe);
+
+    expect(service.activeIdentities()).toMatchObject([
+      { identity: { canonicalName: 'local' }, binding: { socketPath: '/tmp/tmt-a' } },
+    ]);
+    expect(probe).not.toHaveBeenCalled();
+
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.findBindings()).toContainEqual(foreign.binding);
+    repository.close();
+    service.close();
+  });
+
+  it.each([
+    ['live', 'NAME_ALREADY_ACTIVE'],
+    ['unknown', 'RECONCILIATION_FAILED'],
+  ] as const)('does not steal a foreign identity when its endpoint is %s', (status, code) => {
+    const test = fixture();
+    addSecondPane(test);
+    const service = createIdentityService(test);
+    const foreign = seedForeignBinding(test);
+    test.setProbe(() =>
+      status === 'live'
+        ? {
+            status,
+            snapshot: {
+              server: {
+                serverId: foreign.binding.serverId,
+                socketPath: foreign.binding.socketPath,
+                serverPid: foreign.binding.serverPid,
+                serverStartTime: foreign.binding.serverStartTime,
+              },
+              panes: [
+                {
+                  id: foreign.binding.paneId,
+                  command: 'mock-agent',
+                  panePid: foreign.binding.panePid,
+                  suggestedName: null,
+                },
+              ],
+            },
+          }
+        : { status }
+    );
+
+    expect(() => service.bindPane('%2', foreign.identity.name)).toThrowError(
+      expect.objectContaining({ code })
+    );
+
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.findBindings()).toContainEqual(foreign.binding);
+    repository.close();
+    service.close();
+  });
+
+  it('releases a proven-dead foreign binding for reuse without deleting its identity', () => {
+    const test = fixture();
+    addSecondPane(test);
+    const service = createIdentityService(test);
+    const foreign = seedForeignBinding(test);
+    const profileRepository = openIdentityRepository(test.paths.databaseFile);
+    profileRepository.setRole(foreign.identity.id, 'foreign profile');
+    profileRepository.close();
+    test.setProbe(() => ({ status: 'dead' }));
+
+    expect(service.bindPane('%2', foreign.identity.name)).toEqual(foreign.identity);
+
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.findBindings()).toHaveLength(1);
+    expect(repository.findBindings()[0]).toMatchObject({
+      identityId: foreign.identity.id,
+      paneId: '%2',
+      socketPath: '/tmp/tmt-a',
+    });
+    expect(repository.findByCanonicalName('foreign')).toEqual(foreign.identity);
+    expect(repository.findRole(foreign.identity.id)).toMatchObject({ content: 'foreign profile' });
+    repository.close();
+    service.close();
+  });
+
+  it('releases a foreign binding when the known socket is live but its server instance is stale', () => {
+    const test = fixture();
+    addSecondPane(test);
+    const service = createIdentityService(test);
+    const foreign = seedForeignBinding(test);
+    test.setProbe(() => ({
+      status: 'live',
+      snapshot: {
+        server: {
+          serverId: 'server-foreign-restarted',
+          socketPath: foreign.binding.socketPath,
+          serverPid: foreign.binding.serverPid + 1,
+          serverStartTime: 'foreign-restarted',
+        },
+        panes: [
+          {
+            id: foreign.binding.paneId,
+            command: 'mock-agent',
+            panePid: foreign.binding.panePid,
+            suggestedName: null,
+          },
+        ],
+      },
+    }));
+
+    expect(service.bindPane('%2', foreign.identity.name)).toEqual(foreign.identity);
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.findBindings()[0]).toMatchObject({ paneId: '%2' });
+    repository.close();
+    service.close();
+  });
+
+  it.each(['missing', 'throwing'] as const)(
+    'treats a %s foreign endpoint probe as unknown and preserves the binding',
+    (probeMode) => {
+      const test = fixture();
+      addSecondPane(test);
+      const service = createIdentityService(test);
+      const foreign = seedForeignBinding(test);
+      if (probeMode === 'throwing') {
+        test.setProbe(() => {
+          throw new Error('probe failed');
+        });
+      }
+
+      expect(() => service.bindPane('%2', foreign.identity.name)).toThrowError(
+        expect.objectContaining({ code: 'RECONCILIATION_FAILED' })
+      );
+      const repository = openIdentityRepository(test.paths.databaseFile);
+      expect(repository.findBindings()).toContainEqual(foreign.binding);
+      repository.close();
+      service.close();
+    }
+  );
+
+  it('prunes stale bindings after a restart on the same socket', () => {
+    const test = fixture();
+    const service = createIdentityService(test);
+    const identity = service.bindCurrent('same-socket');
+    test.setSnapshot({
+      server: {
+        serverId: 'server-restarted',
+        socketPath: '/tmp/tmt-a',
+        serverPid: 11,
+        serverStartTime: 'two',
+      },
+      panes: [test.pane],
+    });
+
+    expect(service.activeIdentities()).toEqual([]);
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.findBindings()).toEqual([]);
+    expect(repository.findByCanonicalName('same-socket')).toEqual(identity);
+    repository.close();
     service.close();
   });
 

--- a/src/identity-service.ts
+++ b/src/identity-service.ts
@@ -5,6 +5,7 @@ import type {
   IdentityService,
   PaneInfo,
   Tmux,
+  TmuxEndpointProbe,
   TmuxEndpointSnapshot,
   TmuxServerEvidence,
 } from './types.js';
@@ -150,6 +151,15 @@ function paneEvidence(snapshot: TmuxEndpointSnapshot, paneId: string): PaneInfo 
   return pane;
 }
 
+function probeForeignEndpoint(tmux: Tmux, binding: TmuxBinding): TmuxEndpointProbe {
+  if (!tmux.probeEndpoint) return { status: 'unknown' };
+  try {
+    return tmux.probeEndpoint(binding.socketPath, binding.serverPid);
+  } catch {
+    return { status: 'unknown' };
+  }
+}
+
 /**
  * Adapt the legacy target resolver to the verified identity view. Commands
  * only consume this adapter; lifecycle and presence policy remain here.
@@ -216,6 +226,10 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
     }
 
     for (const binding of allBindings) {
+      // A command can observe only its current tmux server. Never prune a
+      // binding owned by another socket merely because its panes are absent
+      // from this endpoint snapshot.
+      if (binding.socketPath !== snapshot.server.socketPath) continue;
       const identity = identities.get(binding.identityId);
       const pane = findPane(snapshot, binding.paneId);
       if (
@@ -288,7 +302,34 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
           'Name is already active on another pane.'
         );
       }
-      repository.removeBinding(existingIdentityBinding.id);
+      if (existingIdentityBinding.socketPath === snapshot.server.socketPath) {
+        repository.removeBinding(existingIdentityBinding.id);
+      } else {
+        const probe = probeForeignEndpoint(tmux, existingIdentityBinding);
+        if (probe.status === 'live') {
+          const foreignPane = findPane(probe.snapshot, existingIdentityBinding.paneId);
+          if (
+            serverMatches(existingIdentityBinding, probe.snapshot.server) &&
+            foreignPane &&
+            paneMatches(existingIdentityBinding, foreignPane)
+          ) {
+            cleanupUnboundIdentity(repository, resolved.created, identity.id);
+            throw new IdentityServiceError(
+              'NAME_ALREADY_ACTIVE',
+              'Name is already active on another pane.'
+            );
+          }
+          repository.removeBinding(existingIdentityBinding.id);
+        } else if (probe.status === 'unknown') {
+          cleanupUnboundIdentity(repository, resolved.created, identity.id);
+          throw new IdentityServiceError(
+            'RECONCILIATION_FAILED',
+            'Could not verify the existing tmux binding.'
+          );
+        } else {
+          repository.removeBinding(existingIdentityBinding.id);
+        }
+      }
     }
     if (current) {
       if (tmux.setDurableIdentity && !metadataMatches(pane, identity, current)) {

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -15,6 +15,32 @@ vi.mock('child_process', () => ({
 const mockedExecSync = vi.mocked(execSync);
 const mockedExecFileSync = vi.mocked(execFileSync);
 
+const ENDPOINT_SEPARATOR = '__TMT_FIELD_4f1c__';
+const VALID_SERVER_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+function endpointRow(
+  overrides: {
+    serverId?: string;
+    socketPath?: string;
+    serverPid?: string;
+    paneId?: string;
+    panePid?: string;
+  } = {}
+): string {
+  return [
+    overrides.serverId ?? VALID_SERVER_ID,
+    overrides.socketPath ?? '/tmp/foreign.sock',
+    overrides.serverPid ?? '321',
+    '1700000000',
+    overrides.paneId ?? '%9',
+    'main:1.0',
+    '/foreign',
+    'node',
+    overrides.panePid ?? '654',
+    '',
+  ].join(ENDPOINT_SEPARATOR);
+}
+
 describe('createTmux', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -457,6 +483,110 @@ describe('createTmux', () => {
       expect(() => createTmux().getEndpointSnapshot?.()).toThrow(
         'tmux endpoint snapshot contains inconsistent server evidence'
       );
+    });
+
+    it('probes a known socket with bounded read-only evidence and no current-server metadata fallback', () => {
+      mockedExecFileSync.mockReturnValueOnce(`${endpointRow()}\n`);
+
+      const result = createTmux().probeEndpoint?.('/tmp/foreign.sock', 321);
+
+      expect(result).toMatchObject({
+        status: 'live',
+        snapshot: { server: { socketPath: '/tmp/foreign.sock' } },
+      });
+      expect(result?.status === 'live' && result.snapshot.panes[0]?.metadata).toBeUndefined();
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        'tmux',
+        ['-S', '/tmp/foreign.sock', 'list-panes', '-a', '-F', expect.any(String)],
+        expect.objectContaining({
+          timeout: 1000,
+          maxBuffer: 1024 * 1024,
+          killSignal: 'SIGKILL',
+        })
+      );
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+      expect(mockedExecSync).not.toHaveBeenCalled();
+      expect(
+        mockedExecFileSync.mock.calls.some(
+          ([, args]) => Array.isArray(args) && args.includes('show-options')
+        )
+      ).toBe(false);
+    });
+
+    it('classifies a failed probe as dead only when the recorded PID is gone', () => {
+      mockedExecFileSync.mockImplementationOnce(() => {
+        throw new Error('tmux probe timed out');
+      });
+      const kill = vi.spyOn(process, 'kill').mockImplementationOnce(() => {
+        throw Object.assign(new Error('no such process'), { code: 'ESRCH' });
+      });
+
+      expect(createTmux().probeEndpoint?.('/tmp/dead.sock', 321)).toEqual({ status: 'dead' });
+      kill.mockRestore();
+    });
+
+    it('preserves uncertainty when a failed probe cannot validate process death', () => {
+      mockedExecFileSync.mockImplementationOnce(() => {
+        throw new Error('tmux probe timed out');
+      });
+      const kill = vi.spyOn(process, 'kill').mockImplementationOnce(() => true);
+
+      expect(createTmux().probeEndpoint?.('/tmp/unknown.sock', 321)).toEqual({
+        status: 'unknown',
+      });
+      kill.mockRestore();
+    });
+
+    it.each([
+      ['invalid pane ID', endpointRow({ paneId: 'not-a-pane-id' })],
+      ['mismatched returned socket', endpointRow({ socketPath: '/tmp/different.sock' })],
+      ['invalid UUID', endpointRow({ serverId: 'not-a-uuid' })],
+      ['empty UUID', endpointRow({ serverId: '' })],
+      [
+        'truncated row',
+        endpointRow().split(ENDPOINT_SEPARATOR).slice(0, 9).join(ENDPOINT_SEPARATOR),
+      ],
+      ['fractional pane PID', endpointRow({ panePid: '654.5' })],
+      ['unsafe pane PID', endpointRow({ panePid: '9007199254740992' })],
+    ] as const)('returns unknown for %s endpoint evidence', (_label, row) => {
+      mockedExecFileSync.mockReturnValueOnce(`${row}\n`);
+
+      expect(createTmux().probeEndpoint?.('/tmp/foreign.sock', 321)).toEqual({
+        status: 'unknown',
+      });
+    });
+
+    it('returns unknown for duplicate pane evidence instead of treating a partial parse as live', () => {
+      mockedExecFileSync.mockReturnValueOnce(`${endpointRow()}\n${endpointRow()}\n`);
+
+      expect(createTmux().probeEndpoint?.('/tmp/foreign.sock', 321)).toEqual({
+        status: 'unknown',
+      });
+    });
+
+    it('rejects an invalid recorded PID before invoking tmux or signal zero', () => {
+      const kill = vi.spyOn(process, 'kill');
+
+      expect(createTmux().probeEndpoint?.('/tmp/foreign.sock', 321.5)).toEqual({
+        status: 'unknown',
+      });
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+      expect(kill).not.toHaveBeenCalled();
+      kill.mockRestore();
+    });
+
+    it('preserves unknown when signal zero is denied after a failed probe', () => {
+      mockedExecFileSync.mockImplementationOnce(() => {
+        throw new Error('tmux probe failed');
+      });
+      const kill = vi.spyOn(process, 'kill').mockImplementationOnce(() => {
+        throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' });
+      });
+
+      expect(createTmux().probeEndpoint?.('/tmp/foreign.sock', 321)).toEqual({
+        status: 'unknown',
+      });
+      kill.mockRestore();
     });
   });
 

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -11,12 +11,17 @@ import type {
   PaneInfo,
   RegistryScope,
   TmuxRegistry,
+  TmuxEndpointProbe,
+  TmuxEndpointSnapshot,
 } from './types.js';
 import { normalizeName } from './domain/service.js';
 
 const AGENT_METADATA_OPTION = '@tmux-team.agent';
 const SERVER_ID_OPTION = '@tmux-team.server-id';
 const PANE_FIELD_SEPARATOR = '__TMT_FIELD_4f1c__';
+const ENDPOINT_PROBE_TIMEOUT_MS = 1_000;
+const ENDPOINT_PROBE_MAX_BUFFER = 1024 * 1024;
+const SERVER_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 // Known agent patterns for auto-detection
 const KNOWN_AGENTS: Record<string, string[]> = {
@@ -130,7 +135,7 @@ function registryFromPanes(panes: PaneInfo[], scope: RegistryScope): TmuxRegistr
   return { paneRegistry, agents };
 }
 
-function parsePaneOutput(output: string): PaneInfo[] {
+function parsePaneOutput(output: string, allowMetadataFallback = true): PaneInfo[] {
   const seen = new Set<string>();
   return output
     .split('\n')
@@ -156,7 +161,9 @@ function parsePaneOutput(output: string): PaneInfo[] {
             : [fields[0], undefined, undefined, fields[1] ?? '', undefined, fields[2] ?? ''];
       // tmux 3.3 may omit pane user options in list formats. The fallback is
       // conservative because all independent evidence must still agree.
-      const metadata = safeParseMetadata(metadataText) ?? tryReadPaneMetadata(id || '');
+      const metadata =
+        safeParseMetadata(metadataText) ??
+        (allowMetadataFallback ? tryReadPaneMetadata(id || '') : undefined);
       return {
         id: id || '',
         ...(target && { target }),
@@ -173,6 +180,119 @@ function parsePaneOutput(output: string): PaneInfo[] {
       seen.add(pane.id);
       return true;
     });
+}
+
+function endpointFormat(): string {
+  return [
+    `#{${SERVER_ID_OPTION}}`,
+    '#{socket_path}',
+    '#{pid}',
+    '#{start_time}',
+    '#{pane_id}',
+    '#{session_name}:#{window_index}.#{pane_index}',
+    '#{pane_current_path}',
+    '#{pane_current_command}',
+    '#{pane_pid}',
+    `#{${AGENT_METADATA_OPTION}}`,
+  ].join(PANE_FIELD_SEPARATOR);
+}
+
+function parseEndpointSnapshot(
+  output: string,
+  options: {
+    readonly expectedServerId?: string;
+    readonly allowMetadataFallback: boolean;
+    readonly requireCompleteEvidence?: boolean;
+  }
+): TmuxEndpointSnapshot {
+  const rows = output.split('\n').filter((line) => line.trim());
+  if (rows.length === 0) throw new Error('tmux endpoint snapshot is empty');
+
+  const evidence = rows.map((line) => line.split(PANE_FIELD_SEPARATOR).slice(0, 4));
+  const [serverId = '', socketPath, serverPidText, serverStartTime] = evidence[0] ?? [];
+  const serverPid = Number(serverPidText);
+  const completeEvidence = rows.every((line) => line.split(PANE_FIELD_SEPARATOR).length >= 10);
+  if (
+    (options.expectedServerId !== undefined && serverId !== options.expectedServerId) ||
+    (options.requireCompleteEvidence && (!SERVER_ID_PATTERN.test(serverId) || !completeEvidence)) ||
+    !socketPath ||
+    !serverStartTime ||
+    !Number.isSafeInteger(serverPid) ||
+    serverPid <= 0 ||
+    evidence.some(
+      ([id, socket, pid, started]) =>
+        id !== serverId ||
+        socket !== socketPath ||
+        pid !== serverPidText ||
+        started !== serverStartTime
+    )
+  ) {
+    throw new Error('tmux endpoint snapshot contains inconsistent server evidence');
+  }
+
+  const paneOutput = rows
+    .map((line) => line.split(PANE_FIELD_SEPARATOR).slice(4).join(PANE_FIELD_SEPARATOR))
+    .join('\n');
+  const panes = parsePaneOutput(paneOutput, options.allowMetadataFallback);
+  if (
+    options.requireCompleteEvidence &&
+    (panes.length !== rows.length ||
+      panes.some(
+        (pane) =>
+          !/^%\d+$/.test(pane.id) ||
+          typeof pane.panePid !== 'number' ||
+          !Number.isSafeInteger(pane.panePid) ||
+          pane.panePid <= 0
+      ))
+  ) {
+    throw new Error('tmux endpoint snapshot contains incomplete pane evidence');
+  }
+  return {
+    server: { serverId, socketPath, serverPid, serverStartTime },
+    panes,
+  };
+}
+
+function isMissingProcess(error: unknown): boolean {
+  return (
+    typeof error === 'object' && error !== null && (error as NodeJS.ErrnoException).code === 'ESRCH'
+  );
+}
+
+function probeEndpoint(socketPath: string, serverPid: number): TmuxEndpointProbe {
+  if (!socketPath || !Number.isSafeInteger(serverPid) || serverPid <= 0) {
+    return { status: 'unknown' };
+  }
+
+  let output: string;
+  try {
+    output = execFileSync('tmux', ['-S', socketPath, 'list-panes', '-a', '-F', endpointFormat()], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: ENDPOINT_PROBE_TIMEOUT_MS,
+      maxBuffer: ENDPOINT_PROBE_MAX_BUFFER,
+      killSignal: 'SIGKILL',
+    });
+  } catch {
+    try {
+      process.kill(serverPid, 0);
+    } catch (signalError) {
+      if (isMissingProcess(signalError)) return { status: 'dead' };
+    }
+    return { status: 'unknown' };
+  }
+
+  try {
+    const snapshot = parseEndpointSnapshot(output, {
+      allowMetadataFallback: false,
+      requireCompleteEvidence: true,
+    });
+    return snapshot.server.socketPath === socketPath
+      ? { status: 'live', snapshot }
+      : { status: 'unknown' };
+  } catch {
+    return { status: 'unknown' };
+  }
 }
 
 export function createTmux(): Tmux {
@@ -358,6 +478,8 @@ export function createTmux(): Tmux {
       return readEndpointSnapshot();
     },
 
+    probeEndpoint,
+
     setDurableIdentity(paneId, identity, binding) {
       const metadata = readPaneMetadata(paneId);
       metadata.globalIdentity = {
@@ -399,7 +521,7 @@ function ensureServerId(): string {
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
   }
-  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(serverId)) {
+  if (!SERVER_ID_PATTERN.test(serverId)) {
     throw new Error('tmux server identity is unavailable');
   }
   return serverId;
@@ -407,52 +529,14 @@ function ensureServerId(): string {
 
 function readEndpointSnapshot() {
   const expectedServerId = ensureServerId();
-  const format = [
-    `#{${SERVER_ID_OPTION}}`,
-    '#{socket_path}',
-    '#{pid}',
-    '#{start_time}',
-    '#{pane_id}',
-    '#{session_name}:#{window_index}.#{pane_index}',
-    '#{pane_current_path}',
-    '#{pane_current_command}',
-    '#{pane_pid}',
-    `#{${AGENT_METADATA_OPTION}}`,
-  ].join(PANE_FIELD_SEPARATOR);
-  const output = execFileSync('tmux', ['list-panes', '-a', '-F', format], {
+  const output = execFileSync('tmux', ['list-panes', '-a', '-F', endpointFormat()], {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
-  const rows = output.split('\n').filter((line) => line.trim());
-  if (rows.length === 0) throw new Error('tmux endpoint snapshot is empty');
-
-  const evidence = rows.map((line) => line.split(PANE_FIELD_SEPARATOR).slice(0, 4));
-  const [serverId, socketPath, serverPidText, serverStartTime] = evidence[0] ?? [];
-  const serverPid = Number(serverPidText);
-  if (
-    serverId !== expectedServerId ||
-    !socketPath ||
-    !serverStartTime ||
-    !Number.isInteger(serverPid) ||
-    serverPid <= 0 ||
-    evidence.some(
-      ([id, socket, pid, started]) =>
-        id !== serverId ||
-        socket !== socketPath ||
-        pid !== serverPidText ||
-        started !== serverStartTime
-    )
-  ) {
-    throw new Error('tmux endpoint snapshot contains inconsistent server evidence');
-  }
-
-  const paneOutput = rows
-    .map((line) => line.split(PANE_FIELD_SEPARATOR).slice(4).join(PANE_FIELD_SEPARATOR))
-    .join('\n');
-  return {
-    server: { serverId, socketPath, serverPid, serverStartTime },
-    panes: parsePaneOutput(paneOutput),
-  };
+  return parseEndpointSnapshot(output, {
+    expectedServerId,
+    allowMetadataFallback: true,
+  });
 }
 
 function tryReadPaneMetadata(paneId: string): PaneAgentMetadata | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,8 @@ export interface Tmux {
   getEndpointSnapshot?: () => TmuxEndpointSnapshot;
   setDurableIdentity?: (paneId: string, identity: DurableIdentity, binding: TmuxBinding) => void;
   clearDurableIdentity?: (paneId: string, bindingId?: string) => boolean;
+  /** Probe a previously recorded socket without changing its server state. */
+  probeEndpoint?: (socketPath: string, serverPid: number) => TmuxEndpointProbe;
 }
 
 export interface TmuxServerEvidence {
@@ -158,6 +160,11 @@ export interface TmuxEndpointSnapshot {
   readonly server: TmuxServerEvidence;
   readonly panes: readonly PaneInfo[];
 }
+
+export type TmuxEndpointProbe =
+  | { readonly status: 'live'; readonly snapshot: TmuxEndpointSnapshot }
+  | { readonly status: 'dead' }
+  | { readonly status: 'unknown' };
 
 export interface IdentityService {
   bindCurrent(name: string): DurableIdentity;

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -46,7 +46,7 @@ export class E2EFixture {
     fs.mkdtempSync(path.join(process.platform === 'darwin' ? '/private/tmp' : os.tmpdir(), 'te2e-'))
   );
   readonly workspace = path.join(this.root, 'workspace');
-  readonly globalDir = path.join(this.root, 'global');
+  readonly globalDir: string;
   readonly logPath = path.join(this.root, 'mock-agent.jsonl');
   readonly forbiddenTmuxLogPath = path.join(this.root, 'forbidden-tmux.log');
   readonly socket = `tmt-e2e-${process.pid}-${Math.random().toString(16).slice(2)}`;
@@ -61,7 +61,8 @@ export class E2EFixture {
   private env: NodeJS.ProcessEnv = {};
   private panePids: number[] = [];
 
-  constructor() {
+  constructor(options: { globalDir?: string } = {}) {
+    this.globalDir = options.globalDir ?? path.join(this.root, 'global');
     try {
       this.tmuxPath = execFileSync('/bin/sh', ['-lc', 'command -v tmux'], {
         encoding: 'utf8',
@@ -414,9 +415,9 @@ export class E2EFixture {
 
 export async function withE2EFixture<T>(
   callback: (fixture: E2EFixture) => Promise<T> | T,
-  options: { mode?: 'respond' | 'silent' | 'malformed'; delayMs?: number } = {}
+  options: { mode?: 'respond' | 'silent' | 'malformed'; delayMs?: number; globalDir?: string } = {}
 ): Promise<T> {
-  const fixture = new E2EFixture();
+  const fixture = new E2EFixture(options);
   try {
     await fixture.start(options);
     return await callback(fixture);

--- a/test/e2e/multi-server.e2e.test.ts
+++ b/test/e2e/multi-server.e2e.test.ts
@@ -1,0 +1,231 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type E2EFixture, type CliResult } from './harness.js';
+
+function successful<T>(result: CliResult<T>): T {
+  expect(result.code, result.stderr || result.stdout).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.json).toBeDefined();
+  return result.json as T;
+}
+
+function durableState(fixture: E2EFixture) {
+  const database = new Database(path.join(fixture.globalDir, 'tmux-team.db'), { readonly: true });
+  try {
+    return {
+      identities: database.prepare('SELECT * FROM identities ORDER BY id').all(),
+      bindings: database.prepare('SELECT * FROM bindings ORDER BY id').all(),
+      profiles: database.prepare('SELECT * FROM role_profiles ORDER BY identity_id').all(),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+async function withTwoServers(callback: (a: E2EFixture, b: E2EFixture) => Promise<void>) {
+  const servers: E2EFixture[] = [];
+  try {
+    await withE2EFixture(async (a) => {
+      servers.push(a);
+      await withE2EFixture(
+        async (b) => {
+          servers.push(b);
+          expect(a.pane).toBe(b.pane);
+          expect(a.socketPath).not.toBe(b.socketPath);
+          expect(a.serverPid).not.toBe(b.serverPid);
+          await callback(a, b);
+        },
+        { globalDir: a.globalDir }
+      );
+    });
+  } finally {
+    for (const server of servers) {
+      await server.waitFor(
+        () => !server.serverProcessIsRunning() && !server.mockProcessIsRunning(),
+        2_000,
+        'both private server and mock process cleanup'
+      );
+      expect(fs.existsSync(server.root)).toBe(false);
+      expect(fs.existsSync(server.socketRoot)).toBe(false);
+    }
+  }
+}
+
+describe.sequential('global identities across isolated tmux servers', () => {
+  it('cleans both private servers and their shared storage when a scenario throws', async () => {
+    await expect(
+      withTwoServers(async (a, b) => {
+        successful(await a.runJsonCli(['name', 'Local']));
+        successful(await b.runJsonCli(['name', 'Remote']));
+        throw new Error('intentional multi-server scenario failure');
+      })
+    ).rejects.toThrow('intentional multi-server scenario failure');
+  });
+
+  it('preserves foreign bindings and refuses a live name collision despite identical pane IDs', async () => {
+    await withTwoServers(async (a, b) => {
+      successful(await b.runJsonCli(['name', 'Remote']));
+      successful(await b.runJsonCli(['role', 'set', 'Keep the remote profile.']));
+      const before = durableState(b);
+      const remoteMetadata = b.paneMetadata();
+
+      expect(successful(await a.runJsonCli(['list']))).toEqual({ identities: [] });
+      expect(durableState(a)).toEqual(before);
+      const collision = await a.runJsonCli(['name', 'REMOTE']);
+      expect(collision.code).toBe(5);
+      expect(collision.json).toMatchObject({ error: { code: 'NAME_ALREADY_ACTIVE' } });
+      expect(durableState(a)).toEqual(before);
+      expect(a.paneMetadata()).toBe('');
+      expect(b.paneMetadata()).toBe(remoteMetadata);
+
+      successful(await a.runJsonCli(['name', 'Local']));
+      const local = durableState(a).bindings.filter(
+        (row) => (row as { socket_path: string }).socket_path === a.socketPath
+      );
+      const listB = successful(await b.runJsonCli<{ identities: { name: string }[] }>(['list']));
+      expect(listB.identities.map((entry) => entry.name)).toEqual(['Remote']);
+      expect(
+        durableState(a).bindings.filter(
+          (row) => (row as { socket_path: string }).socket_path === a.socketPath
+        )
+      ).toEqual(local);
+
+      const foreignTalk = await a.runJsonCli(['talk', 'Remote', 'must-not-cross-servers']);
+      expect(foreignTalk.code).toBe(3);
+      expect(foreignTalk.json).toMatchObject({ error: { code: 'NAME_NOT_FOUND' } });
+      const message = 'local-server-only';
+      const talk = successful(
+        await a.runJsonCli<{ status: string; response: string }>([
+          'talk',
+          'Local',
+          message,
+          '--wait',
+          '--timeout',
+          '10',
+        ])
+      );
+      expect(talk.status).toBe('completed');
+      expect(talk.response).toContain(`mock-agent response: ${message}`);
+      await a.waitForEvent(
+        (event) =>
+          event.event === 'response' && event.pid === a.panePid && event.message === message
+      );
+      expect(b.events().filter((event) => event.event === 'request')).toEqual([]);
+    });
+  }, 30_000);
+
+  it.each(['hidden socket', 'suspended server'] as const)(
+    'fails closed with bounded probing for a %s while its process remains alive',
+    async (failure) => {
+      await withTwoServers(async (a, b) => {
+        successful(await b.runJsonCli(['name', 'Remote']));
+        successful(await b.runJsonCli(['role', 'set', 'Preserve on uncertain evidence.']));
+        const before = durableState(b);
+        const metadata = b.paneMetadata();
+        const hiddenSocket = `${b.socketPath}.unreachable`;
+        if (failure === 'hidden socket') fs.renameSync(b.socketPath, hiddenSocket);
+        else process.kill(b.serverPid, 'SIGSTOP');
+        try {
+          expect(b.serverProcessIsRunning()).toBe(true);
+          expect(successful(await a.runJsonCli(['list']))).toEqual({ identities: [] });
+          expect(successful(await a.runJsonCli(['whoami']))).toMatchObject({ bound: false });
+          expect(durableState(a)).toEqual(before);
+          const started = Date.now();
+          const result = await a.runJsonCli(['name', 'Remote']);
+          expect(Date.now() - started).toBeLessThan(5_000);
+          expect(result.code).toBe(1);
+          expect(result.json).toMatchObject({ error: { code: 'RECONCILIATION_FAILED' } });
+          expect(durableState(a)).toEqual(before);
+          expect(a.paneMetadata()).toBe('');
+        } finally {
+          if (failure === 'hidden socket') fs.renameSync(hiddenSocket, b.socketPath);
+          else process.kill(b.serverPid, 'SIGCONT');
+        }
+        expect(b.paneMetadata()).toBe(metadata);
+        expect(successful(await b.runJsonCli(['whoami']))).toMatchObject({
+          bound: true,
+          name: 'Remote',
+        });
+      });
+    },
+    30_000
+  );
+
+  it('reclaims a proven-dead foreign endpoint without replacing the identity or profile', async () => {
+    await withTwoServers(async (a, b) => {
+      successful(await b.runJsonCli(['name', 'Remote']));
+      const profile = successful(await b.runJsonCli(['role', 'set', 'Survive endpoint death.']));
+      const before = durableState(b);
+      b.tmux(['kill-server']);
+      await b.waitFor(() => !b.serverProcessIsRunning(), 2_000, 'foreign server process exit');
+      successful(await a.runJsonCli(['name', 'Remote']));
+      const after = durableState(a);
+      expect(after.identities).toEqual(before.identities);
+      expect(after.profiles).toEqual(before.profiles);
+      expect(after.bindings).toHaveLength(1);
+      expect(after.bindings[0]).toMatchObject({ socket_path: a.socketPath });
+      expect(after.bindings).not.toEqual(before.bindings);
+      expect(successful(await a.runJsonCli(['role', 'show']))).toEqual(profile);
+    });
+  }, 30_000);
+
+  it('prunes only the restarted socket while retaining another live server and both durable identities', async () => {
+    await withTwoServers(async (a, b) => {
+      successful(await a.runJsonCli(['name', 'Local']));
+      successful(await a.runJsonCli(['role', 'set', 'Survive local restart.']));
+      successful(await b.runJsonCli(['name', 'Remote']));
+      const before = durableState(a);
+      const foreign = before.bindings.filter(
+        (row) => (row as { socket_path: string }).socket_path === b.socketPath
+      );
+      expect(foreign).toHaveLength(1);
+      const oldSocket = a.socketPath;
+      await a.restartServer();
+      expect(a.socketPath).toBe(oldSocket);
+      expect(successful(await a.runJsonCli(['list']))).toEqual({ identities: [] });
+      const after = durableState(a);
+      expect(after.bindings).toEqual(foreign);
+      expect(after.identities).toEqual(before.identities);
+      expect(after.profiles).toEqual(before.profiles);
+      successful(await a.runJsonCli(['name', 'Local']));
+      expect(durableState(a).identities).toEqual(before.identities);
+      expect(successful(await b.runJsonCli(['whoami']))).toMatchObject({
+        bound: true,
+        name: 'Remote',
+      });
+    });
+  }, 30_000);
+
+  it('reclaims a dead foreign pane while its original server and another identity remain alive', async () => {
+    await withTwoServers(async (a, b) => {
+      successful(await b.runJsonCli(['name', 'Remote']));
+      const profile = successful(await b.runJsonCli(['role', 'set', 'Survive pane death.']));
+      const peer = await b.createMockPane('survivor');
+      successful(await b.runJsonCli(['add', peer.pane, 'Survivor']));
+      const before = durableState(b);
+      const survivor = before.bindings.filter(
+        (row) => (row as { pane_id: string }).pane_id === peer.pane
+      );
+      expect(survivor).toHaveLength(1);
+      b.tmux(['kill-pane', '-t', b.pane]);
+      await b.waitFor(() => !b.mockProcessIsRunning(), 2_000, 'foreign pane process exit');
+      expect(b.serverProcessIsRunning()).toBe(true);
+
+      expect(successful(await a.runJsonCli(['list']))).toEqual({ identities: [] });
+      expect(durableState(a)).toEqual(before);
+      successful(await a.runJsonCli(['name', 'Remote']));
+      const after = durableState(a);
+      expect(after.identities).toEqual(before.identities);
+      expect(after.profiles).toEqual(before.profiles);
+      expect(after.bindings).toHaveLength(2);
+      expect(after.bindings).toContainEqual(survivor[0]);
+      expect(successful(await a.runJsonCli(['role', 'show']))).toEqual(profile);
+      expect(successful(await b.runJsonCli(['whoami'], { pane: peer.pane }))).toMatchObject({
+        bound: true,
+        name: 'Survivor',
+      });
+    });
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- Preserve bindings on other tmux sockets during current-server reconciliation.
- Prevent cross-server name theft with bounded, read-only endpoint verification. Verified live bindings fail with `NAME_ALREADY_ACTIVE`; unknown evidence fails closed with `RECONCILIATION_FAILED`.
- Reclaim proven stale endpoints without replacing durable identity IDs or role profiles. Discovery and message routing remain current-server-only.
- Reuse the existing snapshot parser and Docker fixture; document the server boundary in the README and bundled agent skills.

## Verification

- Regression-first unit and Docker runs reproduced the original foreign-binding deletion and unsafe takeover defects.
- Unit tests cover live/dead/unknown probes, malformed evidence, missing adapters, no foreign writes/default-server metadata fallback, and same-socket restart.
- Docker scenarios use real isolated tmux servers sharing SQLite, colliding pane IDs, deterministic mock agents, causal delivery assertions, role/UUID preservation, inaccessible and suspended servers, live-server pane death, and cleanup after an intentional scenario error.
- Final local commands and results are recorded in the linked Linear issue; required CI must pass before merge.
- Primary review and supplementary Gemini review completed; accepted findings were addressed rather than weakening assertions.

## Scope

No daemon, cross-server routing, schema migration, or message/exclamation adaptation changes. Publication/reconciliation races and malformed legacy metadata remain separate follow-ups (TMT-20 and TMT-23).

Fixes TMT-19

https://linear.app/tigerpig-dev/issue/TMT-19/preserve-foreign-tmux-bindings-during-reconciliation-and-prevent-cross
