### PR TITLE
fix(identity): remove legacy auto-backfill and validate presence (TMT-23)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,6 +33,21 @@ identity memory, or durable inbox. Adding a command does not imply those feature
 These are invariants to protect. Known publication, caller-context and delivery
 gaps below remain limitations, not guarantees supplied by this document.
 
+## V5 compatibility policy
+
+V4 compatibility belongs to the maintenance branch, not a parallel v5 runtime.
+V5 has one durable SQLite identity model. Earlier name-only v5 pane markers
+are not automatically imported: discovery accepts only validated durable
+metadata that agrees with the recorded binding. Explicit `name`, `this`, or
+`add` can establish a supported binding; reads do not upgrade old markers.
+
+Remove obsolete compatibility paths through bounded, tested changes rather
+than adding fallbacks. Do not delete existing user files as part of code
+removal. Preserve supported product behavior, including the `this` alias,
+coding-agent `!` shell-mode protection, and durable identities/profiles.
+Workspace registry consumers and optional service fallbacks still exist pending
+TMT-27/TMT-28; their presence is tracked debt, not a compatibility commitment.
+
 ## Current module map
 
 | Location                                                                                                                                 | Responsibility and integration points                                                                                                                                                  |
@@ -86,7 +101,7 @@ failure semantics; merely introducing an interface is not an architectural fix.
   change retrieval/ranking, not fork CRUD or create another source of truth.
 - Use narrow injectable dependencies. New production capabilities must not silently
   fall back to legacy behavior because a test omitted a service. Correct the
-  fixture or define an explicit compatibility adapter instead.
+  fixture instead of introducing a compatibility adapter.
 - Split modules when they own independent policies/effects or lack a coherent
   testable contract, not at an arbitrary line count. Prefer a bounded, verified
   refactor over another special-case branch when the existing abstraction is wrong.
@@ -110,7 +125,7 @@ a gap is resolved; do not leave a permanent exception or label a proposal as shi
 | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Binding insert/metadata publication/reconciliation are not yet a coordinated crash-safe protocol. SQLite uniqueness alone does not supply it.            | [TMT-20](https://linear.app/tigerpig-dev/issue/TMT-20)                                                                                                                 |
 | Some current-pane commands can fall back to an ambient pane outside a caller session; role selection guards this separately.                             | [TMT-21](https://linear.app/tigerpig-dev/issue/TMT-21)                                                                                                                 |
-| Numeric/flag validation and legacy metadata/backfill need hardening.                                                                                     | [TMT-22](https://linear.app/tigerpig-dev/issue/TMT-22), [TMT-23](https://linear.app/tigerpig-dev/issue/TMT-23)                                                         |
+| Numeric/flag validation needs hardening.                                                                                                                 | [TMT-22](https://linear.app/tigerpig-dev/issue/TMT-22)                                                                                                                 |
 | Message adaptation/fallback and JSON wait/counter updates have safety/concurrency gaps.                                                                  | [TMT-24](https://linear.app/tigerpig-dev/issue/TMT-24), [TMT-25](https://linear.app/tigerpig-dev/issue/TMT-25)                                                         |
 | JSON/process error boundaries are inconsistent; update/remove still act on legacy registries.                                                            | [TMT-26](https://linear.app/tigerpig-dev/issue/TMT-26), [TMT-27](https://linear.app/tigerpig-dev/issue/TMT-27)                                                         |
 | Optional identity-service fallbacks, broad contracts and concrete repository coupling remain. The parser also imports a command-owned role request type. | [TMT-28](https://linear.app/tigerpig-dev/issue/TMT-28)                                                                                                                 |

--- a/README.md
+++ b/README.md
@@ -98,24 +98,24 @@ tmux display-message -p '#{pane_id}'
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `install [claude\|codex\|gemini\|all]` | Install or repair agent integrations |
-| `upgrade` | Upgrade tmux-team; managed skill links update automatically |
-| `name <global-name>` | Bind the current pane to a global identity |
-| `this <global-name>` | Exact supported alias for `name` |
-| `add <pane-target> <global-name>` | Bind an explicit pane to a global identity |
-| `whoami` | Show the current pane's global identity, if any |
-| `unbind` | Remove the current pane's global identity |
-| `role show [--identity <name>]` | Read an identity's optional role profile |
-| `role set <profile> [--identity <name>]` | Replace an identity's role profile |
-| `role set --file <path> [--identity <name>]` | Replace a profile from a UTF-8 file |
-| `role clear [--identity <name>]` | Remove only the role profile |
-| `talk <target> "msg"` | Send a message to a global name or pane target |
-| `check <target> [lines]` | Read output from a global name or pane target |
-| `list [target]` | List active identities, or one target's pane status |
-| `migrate [--dry-run] [--cleanup]` | Move legacy `tmux-team.json` entries into tmux metadata |
-| `learn` | Show the educational guide |
+| Command                                      | Description                                                 |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| `install [claude\|codex\|gemini\|all]`       | Install or repair agent integrations                        |
+| `upgrade`                                    | Upgrade tmux-team; managed skill links update automatically |
+| `name <global-name>`                         | Bind the current pane to a global identity                  |
+| `this <global-name>`                         | Exact supported alias for `name`                            |
+| `add <pane-target> <global-name>`            | Bind an explicit pane to a global identity                  |
+| `whoami`                                     | Show the current pane's global identity, if any             |
+| `unbind`                                     | Remove the current pane's global identity                   |
+| `role show [--identity <name>]`              | Read an identity's optional role profile                    |
+| `role set <profile> [--identity <name>]`     | Replace an identity's role profile                          |
+| `role set --file <path> [--identity <name>]` | Replace a profile from a UTF-8 file                         |
+| `role clear [--identity <name>]`             | Remove only the role profile                                |
+| `talk <target> "msg"`                        | Send a message to a global name or pane target              |
+| `check <target> [lines]`                     | Read output from a global name or pane target               |
+| `list [target]`                              | List active identities, or one target's pane status         |
+| `migrate [--dry-run] [--cleanup]`            | Move legacy `tmux-team.json` entries into tmux metadata     |
+| `learn`                                      | Show the educational guide                                  |
 
 `list` also has the `ls` alias. With no target it shows all active global
 identities. With a target it resolves a global name or direct pane target and
@@ -162,6 +162,13 @@ reconciler.
 
 Pane metadata is part of that presence check. A pane title may be updated as a
 best-effort presentation side effect, but titles are not the identity API.
+
+Earlier v5 name-only pane markers are not automatically imported into SQLite.
+They do not establish active identity routing. Use `tmt name <name>`, its
+`tmt this <name>` alias, or `tmt add <pane-target> <name>` to bind explicitly.
+Malformed or unsupported identity metadata cannot establish presence; unrelated
+valid identities remain discoverable. Reads do not rewrite old pane markers or
+delete legacy files, and invalid presence does not delete durable role profiles.
 
 Messages use tmux buffer paste and then submit with Enter. This preserves
 multiline text and handles paste-safety windows in CLIs such as Gemini. The
@@ -303,11 +310,11 @@ Install the plugin:
 
 ### /team Commands
 
-| Command | What it does |
-|---------|--------------|
-| `/team list [target]` | List active identities or one pane's status |
-| `/team talk <target> "msg"` | Send a message to a global name or pane target |
-| `/team check <target> [lines]` | Read output from a global name or pane target |
+| Command                        | What it does                                   |
+| ------------------------------ | ---------------------------------------------- |
+| `/team list [target]`          | List active identities or one pane's status    |
+| `/team talk <target> "msg"`    | Send a message to a global name or pane target |
+| `/team check <target> [lines]` | Read output from a global name or pane target  |
 
 Examples:
 

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -8,8 +8,8 @@ Execute this command: `tmt $ARGUMENTS` (`tmt` is the short alias for `tmux-team`
 You are working in a multi-agent tmux environment.
 Use the tmux-team CLI to communicate with other agents.
 
-Registrations use tmux pane metadata as global active identities, independent
-of the current working directory.
+Identities are durable SQLite records, independent of the working directory.
+Active presence also requires matching live tmux binding metadata.
 
 ## Commands
 
@@ -57,6 +57,11 @@ with `NAME_ALREADY_ACTIVE` (exit 5); an unverifiable foreign endpoint fails
 with `RECONCILIATION_FAILED` (exit 1). Do not delete the binding to bypass an
 uncertain check. Rebinding a proven stale endpoint retains its identity and
 profile; no cross-server routing or daemon is provided.
+
+Earlier name-only v5 pane markers are not automatically imported into durable
+identities. Use `name`, `this`, or `add` explicitly to bind such a pane. Invalid
+metadata is not active presence; do not delete durable data or old files to
+repair it. Direct pane targeting remains separate from identity discovery.
 
 ## Workflow
 

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -8,8 +8,8 @@ When invoked, execute the `tmt` (short for `tmux-team`) command with the provide
 You are working in a multi-agent tmux environment.
 Use the tmux-team CLI to communicate with other agents.
 
-Registrations live in tmux pane metadata as global active identities. They are
-independent of the current working directory.
+Identities are durable SQLite records, independent of the working directory.
+Active presence also requires matching live tmux binding metadata.
 
 ## Commands
 
@@ -57,6 +57,11 @@ with `NAME_ALREADY_ACTIVE` (exit 5); an unverifiable foreign endpoint fails
 with `RECONCILIATION_FAILED` (exit 1). Do not delete the binding to bypass an
 uncertain check. Rebinding a proven stale endpoint retains its identity and
 profile; no cross-server routing or daemon is provided.
+
+Earlier name-only v5 pane markers are not automatically imported into durable
+identities. Use `name`, `this`, or `add` explicitly to bind such a pane. Invalid
+metadata is not active presence; do not delete durable data or old files to
+repair it. Direct pane targeting remains separate from identity discovery.
 
 ## Workflow
 

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -44,6 +44,11 @@ with `RECONCILIATION_FAILED` (exit 1). Do not delete the binding to bypass an
 uncertain check. Rebinding a proven stale endpoint retains its identity and
 profile; no cross-server routing or daemon is provided.
 
+Earlier name-only v5 pane markers are not automatically imported into durable
+identities. Use `name`, `this`, or `add` explicitly to bind such a pane. Invalid
+metadata is not active presence; do not delete durable data or old files to
+repair it. Direct pane targeting remains separate from identity discovery.
+
 `talk` sends text to another pane and can cause external input there. Only use
 it when the user has requested that communication or the surrounding task
 clearly authorizes it; do not infer permission for unrelated changes. Use

--- a/src/identity-service.test.ts
+++ b/src/identity-service.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createIdentityService, identityAwareTmux } from './identity-service.js';
 import { IdentityServiceError } from './identity-service.js';
 import { openIdentityRepository } from './storage/identity-repository.js';
+import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
 import type { PaneInfo, Paths, Tmux, TmuxEndpointSnapshot } from './types.js';
 
 const directories: string[] = [];
@@ -31,8 +32,10 @@ function fixture() {
     getCurrentPaneId: () => '%1',
     resolvePaneTarget: (target: string) => (target === '%1' ? '%1' : null),
     getEndpointSnapshot: () => snapshot,
-    setDurableIdentity: (_paneId: string, identity: any, binding: any) => {
-      pane.metadata = {
+    setDurableIdentity: (paneId: string, identity: DurableIdentity, binding: TmuxBinding) => {
+      const target = snapshot.panes.find((item) => item.id === paneId);
+      if (!target) throw new Error(`Unknown pane '${paneId}'.`);
+      target.metadata = {
         version: 1,
         globalIdentity: {
           name: identity.name,
@@ -44,8 +47,11 @@ function fixture() {
         },
       };
     },
-    clearDurableIdentity: () => {
-      pane.metadata = undefined;
+    clearDurableIdentity: (paneId: string) => {
+      const target = snapshot.panes.find((item) => item.id === paneId);
+      if (!target?.metadata?.globalIdentity) return false;
+      delete target.metadata.globalIdentity;
+      if (Object.keys(target.metadata).length === 1) target.metadata = undefined;
       return true;
     },
     listGlobalIdentities: () => [],
@@ -410,24 +416,162 @@ describe('durable identity service', () => {
     service.close();
   });
 
-  it('backfills name-only v5 metadata without changing the display name', () => {
+  it('does not backfill duplicate name-only v5 metadata or mutate it on repeated reads', () => {
     const test = fixture();
+    addSecondPane(test);
+    const second = test.tmux.getEndpointSnapshot!().panes.find((item) => item.id === '%2');
+    if (!second) throw new Error('Second pane fixture is missing.');
     test.pane.metadata = {
       version: 1,
       globalIdentity: { name: 'Legacy Agent', canonicalName: 'legacy agent' },
     };
+    second.metadata = {
+      version: 1,
+      globalIdentity: { name: 'Legacy Agent', canonicalName: 'legacy agent' },
+    };
+    const firstMetadata = JSON.stringify(test.pane.metadata);
+    const secondMetadata = JSON.stringify(second.metadata);
     const service = createIdentityService(test);
-    const active = service.activeIdentities();
-    expect(active).toMatchObject([
-      { identity: { name: 'Legacy Agent', canonicalName: 'legacy agent' } },
-    ]);
-    expect(test.pane.metadata?.globalIdentity).toMatchObject({
-      name: 'Legacy Agent',
-      identityId: expect.any(String),
-      bindingId: expect.any(String),
-      serverId: 'server-a',
-      panePid: 1234,
-    });
+    expect(service.activeIdentities()).toEqual([]);
+    expect(service.activeIdentities()).toEqual([]);
+
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.listIdentities()).toEqual([]);
+    expect(repository.findBindings()).toEqual([]);
+    repository.close();
+    expect(JSON.stringify(test.pane.metadata)).toBe(firstMetadata);
+    expect(JSON.stringify(second.metadata)).toBe(secondMetadata);
+    service.close();
+  });
+
+  it.each([
+    [
+      'missing identity ID',
+      (metadata: NonNullable<PaneInfo['metadata']>['globalIdentity']) => ({
+        ...metadata,
+        identityId: '',
+      }),
+    ],
+    [
+      'null name',
+      (metadata: NonNullable<PaneInfo['metadata']>['globalIdentity']) => ({
+        ...metadata,
+        name: null,
+      }),
+    ],
+    [
+      'numeric name',
+      (metadata: NonNullable<PaneInfo['metadata']>['globalIdentity']) => ({
+        ...metadata,
+        name: 42,
+      }),
+    ],
+    [
+      'control character name',
+      (metadata: NonNullable<PaneInfo['metadata']>['globalIdentity']) => ({
+        ...metadata,
+        name: 'Primary\u0001',
+      }),
+    ],
+    [
+      'pane-shaped name',
+      (metadata: NonNullable<PaneInfo['metadata']>['globalIdentity']) => ({
+        ...metadata,
+        name: '%1',
+      }),
+    ],
+    [
+      'wrong pane PID type',
+      (metadata: NonNullable<PaneInfo['metadata']>['globalIdentity']) => ({
+        ...metadata,
+        panePid: '1234',
+      }),
+    ],
+    [
+      'non-positive pane PID',
+      (metadata: NonNullable<PaneInfo['metadata']>['globalIdentity']) => ({
+        ...metadata,
+        panePid: 0,
+      }),
+    ],
+    [
+      'unsafe pane PID',
+      (metadata: NonNullable<PaneInfo['metadata']>['globalIdentity']) => ({
+        ...metadata,
+        panePid: Number.MAX_SAFE_INTEGER + 1,
+      }),
+    ],
+    [
+      'mismatched canonical name',
+      (metadata: NonNullable<PaneInfo['metadata']>['globalIdentity']) => ({
+        ...metadata,
+        canonicalName: 'other',
+      }),
+    ],
+    ['null global marker', () => null],
+  ] as const)('rejects %s durable metadata without affecting a healthy peer', (_label, mutate) => {
+    const test = fixture();
+    addSecondPane(test);
+    const service = createIdentityService(test);
+    const primary = service.bindCurrent('Primary');
+    service.bindPane('%2', 'Peer');
+
+    const roleRepository = openIdentityRepository(test.paths.databaseFile);
+    roleRepository.setRole(primary.id, 'Preserve this profile.');
+    roleRepository.close();
+
+    const primaryMetadata = test.pane.metadata;
+    if (!primaryMetadata?.globalIdentity) throw new Error('Primary metadata is missing.');
+    test.pane.metadata = {
+      ...primaryMetadata,
+      globalIdentity: mutate(primaryMetadata.globalIdentity) as NonNullable<
+        PaneInfo['metadata']
+      >['globalIdentity'],
+    };
+    const unchangedMetadata = JSON.stringify(test.pane.metadata);
+
+    expect(service.activeIdentities().map(({ identity }) => identity.name)).toEqual(['Peer']);
+    expect(service.activeIdentities().map(({ identity }) => identity.name)).toEqual(['Peer']);
+    expect(JSON.stringify(test.pane.metadata)).toBe(unchangedMetadata);
+
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.findBindings()).toMatchObject([{ paneId: '%2' }]);
+    expect(repository.listIdentities()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: primary.id, canonicalName: 'primary' }),
+        expect.objectContaining({ canonicalName: 'peer' }),
+      ])
+    );
+    expect(repository.findRole(primary.id)).toMatchObject({ content: 'Preserve this profile.' });
+    repository.close();
+    service.close();
+  });
+
+  it('rejects an unsupported durable metadata version while preserving identity and profile', () => {
+    const test = fixture();
+    addSecondPane(test);
+    const service = createIdentityService(test);
+    const primary = service.bindCurrent('Versioned');
+    service.bindPane('%2', 'Peer');
+
+    const roleRepository = openIdentityRepository(test.paths.databaseFile);
+    roleRepository.setRole(primary.id, 'Preserve this profile.');
+    roleRepository.close();
+
+    const primaryMetadata = test.pane.metadata;
+    if (!primaryMetadata) throw new Error('Primary metadata is missing.');
+    test.pane.metadata = { ...primaryMetadata, version: 2 } as unknown as PaneInfo['metadata'];
+    const unchangedMetadata = JSON.stringify(test.pane.metadata);
+
+    expect(service.activeIdentities().map(({ identity }) => identity.name)).toEqual(['Peer']);
+    expect(service.activeIdentities().map(({ identity }) => identity.name)).toEqual(['Peer']);
+    expect(JSON.stringify(test.pane.metadata)).toBe(unchangedMetadata);
+
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    expect(repository.findBindings()).toMatchObject([{ paneId: '%2' }]);
+    expect(repository.findByCanonicalName('versioned')).toEqual(primary);
+    expect(repository.findRole(primary.id)).toMatchObject({ content: 'Preserve this profile.' });
+    repository.close();
     service.close();
   });
 

--- a/src/identity-service.ts
+++ b/src/identity-service.ts
@@ -1,4 +1,4 @@
-import { normalizeName, validateName } from './domain/names.js';
+import { validateName } from './domain/names.js';
 import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
 import { resolveTarget } from './target-resolver.js';
 import type {
@@ -50,14 +50,39 @@ function paneMatches(expected: TmuxBinding, pane: PaneInfo): boolean {
   return expected.paneId === pane.id && expected.panePid === pane.panePid;
 }
 
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 function metadataMatches(pane: PaneInfo, identity: DurableIdentity, binding: TmuxBinding): boolean {
+  const envelope = pane.metadata;
   const metadata = pane.metadata?.globalIdentity;
+  if (envelope?.version !== 1 || !metadata || typeof metadata !== 'object') return false;
+  if (
+    !nonEmptyString(metadata.name) ||
+    !nonEmptyString(metadata.canonicalName) ||
+    !nonEmptyString(metadata.identityId) ||
+    !nonEmptyString(metadata.bindingId) ||
+    !nonEmptyString(metadata.serverId) ||
+    typeof metadata.panePid !== 'number' ||
+    !Number.isSafeInteger(metadata.panePid) ||
+    metadata.panePid <= 0
+  ) {
+    return false;
+  }
+  const validatedName = validateName(metadata.name);
+  if (
+    !validatedName.ok ||
+    validatedName.value.canonicalName !== metadata.canonicalName ||
+    metadata.canonicalName !== identity.canonicalName
+  ) {
+    return false;
+  }
   return (
     metadata?.identityId === identity.id &&
     metadata.bindingId === binding.id &&
     metadata.serverId === binding.serverId &&
-    metadata.panePid === binding.panePid &&
-    normalizeName(metadata.name) === identity.canonicalName
+    metadata.panePid === binding.panePid
   );
 }
 
@@ -186,44 +211,6 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
     const snapshot = endpointSnapshot(tmux);
     const allBindings = repository.findBindings();
     const identities = new Map(repository.listIdentities().map((item) => [item.id, item]));
-
-    // Backfill old v5 pane metadata lazily. A database-only binding is never
-    // active until this metadata marker is successfully written.
-    for (const pane of snapshot.panes) {
-      const legacy = pane.metadata?.globalIdentity;
-      if (!legacy || legacy.identityId || !pane.panePid) continue;
-      const { identity } = createOrResolve(repository, legacy.name);
-      const binding = repository.createBinding({
-        identityId: identity.id,
-        transport: 'tmux',
-        paneId: pane.id,
-        serverId: snapshot.server.serverId,
-        socketPath: snapshot.server.socketPath,
-        serverPid: snapshot.server.serverPid,
-        serverStartTime: snapshot.server.serverStartTime,
-        panePid: pane.panePid,
-        boundAt: new Date().toISOString(),
-        lastVerifiedAt: new Date().toISOString(),
-      });
-      try {
-        if (!tmux.setDurableIdentity) throw new Error('Durable tmux metadata is unavailable.');
-        tmux.setDurableIdentity(pane.id, identity, binding);
-      } catch (error) {
-        try {
-          repository.removeBinding(binding.id);
-        } catch {
-          // The legacy marker was not upgraded, so this row remains ineligible
-          // for active routing and will be retried by reconciliation.
-        }
-        throw new IdentityServiceError(
-          'RECONCILIATION_FAILED',
-          'Could not backfill pane metadata.',
-          {
-            cause: error,
-          }
-        );
-      }
-    }
 
     for (const binding of allBindings) {
       // A command can observe only its current tmux server. Never prune a

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { execFileSync, execSync } from 'child_process';
 import { createTmux } from './tmux.js';
+import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
 
 // Mock child_process
 vi.mock('child_process', () => ({
@@ -374,6 +375,68 @@ describe('createTmux', () => {
         expect.any(Object)
       );
     });
+
+    it.each([
+      ['name-only', { name: 'Old' }],
+      ['malformed', { name: null }],
+    ] as const)(
+      'preserves sibling metadata when replacing a %s global marker',
+      (_label, marker) => {
+        const original = {
+          version: 1,
+          workspaces: { '/repo': { name: 'legacy' } },
+          teams: { egp: { name: 'codex' } },
+          customPluginData: { source: 'external', values: ['keep'] },
+          globalIdentity: marker,
+        };
+        mockedExecFileSync.mockReturnValueOnce(JSON.stringify(original));
+        const identity: DurableIdentity = {
+          id: 'identity-1',
+          name: 'Alice',
+          canonicalName: 'alice',
+          createdAt: 'created',
+          updatedAt: 'updated',
+        };
+        const binding: TmuxBinding = {
+          id: 'binding-1',
+          identityId: identity.id,
+          transport: 'tmux',
+          paneId: '%9',
+          serverId: 'server-1',
+          socketPath: '/tmp/tmux.sock',
+          serverPid: 321,
+          serverStartTime: 'started',
+          panePid: 654,
+          boundAt: 'bound',
+          lastVerifiedAt: 'verified',
+        };
+
+        createTmux().setDurableIdentity!('%9', identity, binding);
+
+        expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+          'tmux',
+          [
+            'set-option',
+            '-p',
+            '-t',
+            '%9',
+            '@tmux-team.agent',
+            JSON.stringify({
+              ...original,
+              globalIdentity: {
+                name: 'Alice',
+                canonicalName: 'alice',
+                identityId: 'identity-1',
+                bindingId: 'binding-1',
+                serverId: 'server-1',
+                panePid: 654,
+              },
+            }),
+          ],
+          expect.any(Object)
+        );
+      }
+    );
   });
 
   describe('getCurrentPaneId', () => {

--- a/test/e2e/identity-lifecycle.e2e.test.ts
+++ b/test/e2e/identity-lifecycle.e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
+import fs from 'node:fs';
 import path from 'node:path';
 import { E2EFixture, withE2EFixture, type CliResult, type MockPane } from './harness.js';
 
@@ -35,6 +36,41 @@ async function listIdentities(fixture: E2EFixture): Promise<IdentityListItem[]> 
 
 function metadata(fixture: E2EFixture, pane: MockPane): Record<string, unknown> {
   return JSON.parse(fixture.paneMetadata(pane.pane)) as Record<string, unknown>;
+}
+
+interface DurableState {
+  identities: Array<Record<string, unknown>>;
+  bindings: Array<Record<string, unknown>>;
+  profiles: Array<Record<string, unknown>>;
+}
+
+function durableState(fixture: E2EFixture): DurableState {
+  const database = new Database(path.join(fixture.globalDir, 'tmux-team.db'), {
+    readonly: true,
+  });
+  try {
+    return {
+      identities: database
+        .prepare('SELECT * FROM identities ORDER BY canonical_name')
+        .all() as Array<Record<string, unknown>>,
+      bindings: database.prepare('SELECT * FROM bindings ORDER BY identity_id').all() as Array<
+        Record<string, unknown>
+      >,
+      profiles: database.prepare('SELECT * FROM role_profiles ORDER BY identity_id').all() as Array<
+        Record<string, unknown>
+      >,
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function withoutVerificationTimestamp(
+  bindings: Array<Record<string, unknown>>
+): Array<Record<string, unknown>> {
+  return bindings
+    .map(({ last_verified_at: _lastVerifiedAt, ...binding }) => binding)
+    .sort((left, right) => String(left.id).localeCompare(String(right.id)));
 }
 
 function eventCount(
@@ -504,4 +540,232 @@ describe.sequential('global identity lifecycle', () => {
       afterRebind.close();
     });
   }, 30_000);
+
+  it('ignores old and malformed pane markers without backfilling, then supports explicit rebinding', async () => {
+    await withE2EFixture(async (fixture) => {
+      const oldPane = await fixture.createMockPane('legacy-marker');
+      const collidingOldPane = await fixture.createMockPane('legacy-collision');
+      const malformedPane = await fixture.createMockPane('malformed-marker');
+      const healthy = await fixture.runJsonCli<{ bound: true; name: string; pane: string }>([
+        'name',
+        'Healthy',
+      ]);
+      expect(healthy.code).toBe(0);
+      const profile = await fixture.runJsonCli(['role', 'set', 'Keep the healthy profile.']);
+      expect(profile.code).toBe(0);
+      const legacyPath = path.join(fixture.workspace, 'tmux-team.json');
+      const legacyBytes = '{\n  "legacy-file": {"pane": "%999", "remark": "keep"}\n}\n';
+      fs.writeFileSync(legacyPath, legacyBytes);
+
+      fixture.tmux([
+        'set-option',
+        '-p',
+        '-t',
+        oldPane.pane,
+        '@tmux-team.agent',
+        JSON.stringify({
+          version: 1,
+          globalIdentity: { name: 'LegacyOnly', canonicalName: 'legacyonly' },
+        }),
+      ]);
+      fixture.tmux([
+        'set-option',
+        '-p',
+        '-t',
+        collidingOldPane.pane,
+        '@tmux-team.agent',
+        JSON.stringify({
+          version: 1,
+          globalIdentity: { name: 'LEGACYONLY', canonicalName: 'legacyonly' },
+        }),
+      ]);
+      fixture.tmux([
+        'set-option',
+        '-p',
+        '-t',
+        malformedPane.pane,
+        '@tmux-team.agent',
+        JSON.stringify({ version: 1, globalIdentity: { name: 42, canonicalName: 'malformed' } }),
+      ]);
+
+      const oldMarkerBytes = fixture.paneMetadata(oldPane.pane);
+      const collidingOldMarkerBytes = fixture.paneMetadata(collidingOldPane.pane);
+      const malformedMarkerBytes = fixture.paneMetadata(malformedPane.pane);
+      const before = durableState(fixture);
+      expect(fs.readFileSync(legacyPath, 'utf8')).toBe(legacyBytes);
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const listed = await listIdentities(fixture);
+        expect(listed).toHaveLength(1);
+        expect(listed[0]).toMatchObject({
+          name: 'Healthy',
+          canonicalName: 'healthy',
+          pane: fixture.pane,
+          target: fixture.paneTarget(fixture.pane),
+          cwd: fixture.workspace,
+          command: 'node',
+        });
+        expect(fixture.paneMetadata(oldPane.pane)).toBe(oldMarkerBytes);
+        expect(fixture.paneMetadata(collidingOldPane.pane)).toBe(collidingOldMarkerBytes);
+        expect(fixture.paneMetadata(malformedPane.pane)).toBe(malformedMarkerBytes);
+        expect(fs.readFileSync(legacyPath, 'utf8')).toBe(legacyBytes);
+      }
+
+      const afterLists = durableState(fixture);
+      expect(afterLists.identities).toEqual(before.identities);
+      expect(withoutVerificationTimestamp(afterLists.bindings)).toEqual(
+        withoutVerificationTimestamp(before.bindings)
+      );
+      expect(afterLists.profiles).toEqual(before.profiles);
+
+      for (const [name, pid, message] of [
+        ['LegacyOnly', oldPane.pid, 'legacy-name-must-not-route'],
+        ['LEGACYONLY', collidingOldPane.pid, 'legacy-collision-must-not-route'],
+        ['Malformed', malformedPane.pid, 'malformed-marker-must-not-route'],
+      ] as const) {
+        const result = await fixture.runJsonCli<CommandError>(['talk', name, message]);
+        expect(result.code).toBe(3);
+        expect(json(result)).toMatchObject({ error: { code: 'NAME_NOT_FOUND' } });
+        expect(
+          fixture
+            .events()
+            .filter(
+              (event) =>
+                (event.event === 'request' || event.event === 'response') &&
+                event.pid === pid &&
+                event.message === message
+            )
+        ).toHaveLength(0);
+      }
+
+      await talkToIdentity(
+        fixture,
+        'Healthy',
+        fixture.panePid,
+        [oldPane.pid, collidingOldPane.pid, malformedPane.pid],
+        'healthy-causal-routing'
+      );
+
+      const explicit = await fixture.runJsonCli<{ bound: true; name: string; pane: string }>([
+        'add',
+        oldPane.pane,
+        'FreshExplicit',
+      ]);
+      expect(explicit.code).toBe(0);
+      expect(json(explicit)).toEqual({ bound: true, name: 'FreshExplicit', pane: oldPane.pane });
+      expect(fixture.paneMetadata(collidingOldPane.pane)).toBe(collidingOldMarkerBytes);
+      expect(fixture.paneMetadata(malformedPane.pane)).toBe(malformedMarkerBytes);
+      expect(fs.readFileSync(legacyPath, 'utf8')).toBe(legacyBytes);
+      await talkToIdentity(
+        fixture,
+        'FreshExplicit',
+        oldPane.pid,
+        [fixture.panePid, collidingOldPane.pid, malformedPane.pid],
+        'fresh-explicit-routing'
+      );
+    });
+  }, 45_000);
+
+  it('drops only a binding with malformed durable metadata while retaining its identity, profile, and healthy peer', async () => {
+    await withE2EFixture(async (fixture) => {
+      const affectedPane = await fixture.createMockPane('malformed-current');
+      const peerPane = await fixture.createMockPane('healthy-peer');
+      const healthy = await fixture.runJsonCli(['name', 'HealthyCurrent']);
+      expect(healthy.code).toBe(0);
+      expect((await fixture.runJsonCli(['role', 'set', 'Healthy current profile.'])).code).toBe(0);
+      const peer = await fixture.runJsonCli(['add', peerPane.pane, 'HealthyPeer']);
+      expect(peer.code).toBe(0);
+      expect(
+        (
+          await fixture.runJsonCli([
+            'role',
+            'set',
+            'Retain this peer profile.',
+            '--identity',
+            'HealthyPeer',
+          ])
+        ).code
+      ).toBe(0);
+      const affected = await fixture.runJsonCli(['add', affectedPane.pane, 'MalformedCurrent']);
+      expect(affected.code).toBe(0);
+      expect(
+        (
+          await fixture.runJsonCli([
+            'role',
+            'set',
+            'Retain this affected identity profile.',
+            '--identity',
+            'MalformedCurrent',
+          ])
+        ).code
+      ).toBe(0);
+      const affectedMetadataObject = metadata(fixture, affectedPane);
+      const affectedIdentityMetadata = affectedMetadataObject.globalIdentity as Record<
+        string,
+        unknown
+      >;
+      affectedIdentityMetadata.name = null;
+      fixture.tmux([
+        'set-option',
+        '-p',
+        '-t',
+        affectedPane.pane,
+        '@tmux-team.agent',
+        JSON.stringify(affectedMetadataObject),
+      ]);
+      const healthyMetadata = fixture.paneMetadata(fixture.pane);
+      const affectedMetadata = fixture.paneMetadata(affectedPane.pane);
+      const peerMetadata = fixture.paneMetadata(peerPane.pane);
+      const before = durableState(fixture);
+      const affectedIdentityId = before.identities.find(
+        (identity) => identity.canonical_name === 'malformedcurrent'
+      )?.id;
+      const expectedHealthyBindingIds = before.bindings
+        .filter((binding) => binding.identity_id !== affectedIdentityId)
+        .map((binding) => binding.identity_id);
+      expect(affectedIdentityId).toBeDefined();
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const listed = await listIdentities(fixture);
+        expect(listed.map(({ name }) => name)).toEqual(['HealthyCurrent', 'HealthyPeer']);
+        expect(fixture.paneMetadata(fixture.pane)).toBe(healthyMetadata);
+        expect(fixture.paneMetadata(affectedPane.pane)).toBe(affectedMetadata);
+        expect(fixture.paneMetadata(peerPane.pane)).toBe(peerMetadata);
+      }
+
+      const after = durableState(fixture);
+      expect(after.identities).toEqual(before.identities);
+      expect(after.profiles).toEqual(before.profiles);
+      expect(withoutVerificationTimestamp(after.bindings)).toEqual(
+        withoutVerificationTimestamp(before.bindings).filter(
+          (binding) => binding.identity_id !== affectedIdentityId
+        )
+      );
+      expect(after.bindings.map((binding) => binding.identity_id).sort()).toEqual(
+        expectedHealthyBindingIds.sort()
+      );
+
+      const affectedTalk = await fixture.runJsonCli<CommandError>([
+        'talk',
+        'MalformedCurrent',
+        'affected-must-not-route',
+      ]);
+      expect(affectedTalk.code).toBe(3);
+      expect(json(affectedTalk)).toMatchObject({ error: { code: 'NAME_NOT_FOUND' } });
+      await talkToIdentity(
+        fixture,
+        'HealthyCurrent',
+        fixture.panePid,
+        [peerPane.pid, affectedPane.pid],
+        'healthy-peer'
+      );
+      await talkToIdentity(
+        fixture,
+        'HealthyPeer',
+        peerPane.pid,
+        [fixture.panePid, affectedPane.pid],
+        'peer-healthy'
+      );
+    });
+  }, 45_000);
 });


### PR DESCRIPTION
## Summary

- Remove automatic backfill from earlier name-only v5 pane markers. V5 uses the durable SQLite identity model; reads do not import old registrations.
- Validate durable presence metadata with shared name validation and explicit evidence checks. Malformed metadata cannot disable healthy peer discovery.
- Preserve durable identities/profiles and raw sibling metadata; explicit name/this/add binding remains supported.
- Document the v5 clean-break policy and remaining TMT-27/TMT-28 debt. No daemon, migration command, legacy-file deletion, dependency change, or binding-publication protocol is introduced.

Fixes [TMT-23](https://linear.app/tigerpig-dev/issue/TMT-23).

## Architecture and primary review

Primary-reviewed commit: `140b562008f9af6dcad27a5a23117c5808f91839`.

The primary personally reviewed every changed file, identity-service reconciliation/bind/current/active paths, target routing and list/check/whoami callers, raw tmux metadata writes, real SQLite fixtures, and causal E2E event assertions. Durable validation stays in the authoritative identity-service view; raw metadata parsing is not destructively filtered. ARCHITECTURE.md records this boundary and the v5 compatibility policy.

Accepted audit findings: reuse validateName, preserve foreign-server guards and unrelated raw metadata, remove only the backfill loop. Primary review rejected manual SQL E2E seeding in favor of real name/add/role CLI setup, required matching-ID null/numeric-name regressions, removed duplicate normalization, and corrected fixture typing/identity comparisons. Gemini independently reviewed design and implementation; no blocking findings remained. Legacy service fallbacks and workspace registration retirement remain explicitly tracked, not claimed complete here.

## Verification

- [x] pnpm check: type checks, lint, formatting, and maintained docs checks passed.
- [x] pnpm test:run: passed, including coverage thresholds.
- [x] New regression proof: four tests run against original production code at 2371636 failed on the intended SQLite backfill conflict, null/numeric-name TypeError, and unsupported-version acceptance; fixed tests pass.
- [x] Docker E2E first run: 29/29 passed across five files, with real CLI/tmux/SQLite and deterministic mock agents.
- [x] Docker E2E second lifecycle/cleanup run: 29/29 passed on identical build content (97.63s and 96.64s).
- [x] Changed skill frontmatter validation and explicit Markdown formatting checks passed.
- [x] git diff --check passed.
- [x] Required CI passed on the exact reviewed head: Code quality, Unit tests, Docker E2E, Native package matrix. No bypass used.

The E2E cases verify no implicit identities/bindings, unchanged old marker/file bytes, healthy causal routing, explicit rebinding, and identity/profile retention when only corrupt presence is removed. Existing cross-server and lifecycle suites remain enabled.

## Delivery

Dedicated TMT-23 branch/worktree; Linear scope and audit decisions updated before implementation. Merge only after required CI and local verification complete. Record the merged result in Linear and remove the worktree only after clean, pushed handoff.
