### PR TITLE
TMT-21: Require verified caller-pane context

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,8 +30,29 @@ identity memory, or durable inbox. Adding a command does not imply those feature
   injected preambles. Explicit durable role access works without tmux; implicit
   access requires verified caller identity.
 
-These are invariants to protect. Known caller-context and delivery
+These are invariants to protect. Known delivery
 gaps below remain limitations, not guarantees supplied by this document.
+
+## Caller context
+
+The tmux adapter owns current-pane evidence: a strict `TMUX_PANE` ID and the
+socket/server PID in `TMUX` must agree with a bounded, read-only query of that
+explicit pane. Missing, malformed, stale or mismatched evidence yields no caller;
+there is no ambient/default-pane fallback. Environment evidence selects local
+context, not an authenticated principal, and is not a defense against deliberate
+environment spoofing.
+
+`name`, `this`, `whoami` and `unbind` reject missing caller context with
+`PANE_NOT_FOUND` (exit 3) before opening identity storage. Implicit role access
+uses the same caller policy and returns `IDENTITY_REQUIRED` (exit 1) without
+bootstrapping storage or reconciling unrelated bindings. Context keeps repository
+access lazy until a selected operation needs it. A valid unbound pane is still
+distinct from an absent caller.
+
+Explicit `add`, `talk` and `check` target resolution remains available outside
+tmux; explicit `role --identity` access remains storage-only. These selectors
+choose a target or data owner, not the caller's identity. No listener, non-tmux
+identity binding, memory or inbox is implied by this boundary.
 
 ## Binding publication and recovery
 
@@ -151,7 +172,6 @@ a gap is resolved; do not leave a permanent exception or label a proposal as shi
 
 | Gap                                                                                                                                                      | Owning issue                                                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Some current-pane commands can fall back to an ambient pane outside a caller session; role selection guards this separately.                             | [TMT-21](https://linear.app/tigerpig-dev/issue/TMT-21)                                                                                                                 |
 | Numeric/flag validation needs hardening.                                                                                                                 | [TMT-22](https://linear.app/tigerpig-dev/issue/TMT-22)                                                                                                                 |
 | Message adaptation/fallback and JSON wait/counter updates have safety/concurrency gaps.                                                                  | [TMT-24](https://linear.app/tigerpig-dev/issue/TMT-24), [TMT-25](https://linear.app/tigerpig-dev/issue/TMT-25)                                                         |
 | JSON/process error boundaries are inconsistent; preamble/config still consume workspace registries after command retirement.                             | [TMT-26](https://linear.app/tigerpig-dev/issue/TMT-26), [TMT-27](https://linear.app/tigerpig-dev/issue/TMT-27)                                                         |

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ failed publication; do not delete their data to repair a binding.
 
 ### Pane targets
 
+`name`, `this`, `whoami` and `unbind` require a live caller pane whose
+`TMUX_PANE` and `TMUX` server context agree. Missing or stale caller context
+returns `PANE_NOT_FOUND` (exit 3), without selecting the default pane or
+changing identity data. Implicit `role` access returns `IDENTITY_REQUIRED`
+(exit 1) in that situation. Do not manufacture caller environment variables
+as a workaround: outside tmux, use explicit `add`, `talk`, `check`, or
+`role show|set|clear --identity <name>` as appropriate.
+
 Commands that accept a target recognize a global name or a tmux pane target:
 
 - `%pane_id`, such as `%12`

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -16,6 +16,14 @@ You are working in a multi-agent tmux environment. Use the `tmux-team` CLI to co
 
 ## Commands
 
+`name`, `this`, `whoami` and `unbind` require matching live `TMUX` and
+`TMUX_PANE` caller context. Missing, malformed or stale context returns
+`PANE_NOT_FOUND` (exit 3), not the default pane's identity. Implicit `role`
+access returns `IDENTITY_REQUIRED` (exit 1). Do not fabricate caller variables:
+outside tmux, use explicit `add <pane-target> <global-name>`, `talk <target>`,
+`check <target>`, or `role show|set|clear --identity <name>`. Explicit selection
+does not bind or authenticate the caller.
+
 ```bash
 # Send and wait for response (recommended)
 tmt talk codex "your message" --wait

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -13,6 +13,14 @@ Active presence also requires matching live tmux binding metadata.
 
 ## Commands
 
+`name`, `this`, `whoami` and `unbind` require matching live `TMUX` and
+`TMUX_PANE` caller context. Missing, malformed or stale context returns
+`PANE_NOT_FOUND` (exit 3), not the default pane's identity. Implicit `role`
+access returns `IDENTITY_REQUIRED` (exit 1). Do not fabricate caller variables:
+outside tmux, use explicit `add <pane-target> <global-name>`, `talk <target>`,
+`check <target>`, or `role show|set|clear --identity <name>`. Explicit selection
+does not bind or authenticate the caller.
+
 ```bash
 # Send a message to a global identity or direct pane target
 tmt talk codex "your message"

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -13,6 +13,14 @@ Active presence also requires matching live tmux binding metadata.
 
 ## Commands
 
+`name`, `this`, `whoami` and `unbind` require matching live `TMUX` and
+`TMUX_PANE` caller context. Missing, malformed or stale context returns
+`PANE_NOT_FOUND` (exit 3), not the default pane's identity. Implicit `role`
+access returns `IDENTITY_REQUIRED` (exit 1). Do not fabricate caller variables:
+outside tmux, use explicit `add <pane-target> <global-name>`, `talk <target>`,
+`check <target>`, or `role show|set|clear --identity <name>`. Explicit selection
+does not bind or authenticate the caller.
+
 ```bash
 # Send a message to a global identity or direct pane target
 tmt talk codex "your message"

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -9,6 +9,14 @@ Use `tmt` (the short alias for `tmux-team`) when the user asks you to communicat
 
 ## Commands
 
+`name`, `this`, `whoami` and `unbind` require matching live `TMUX` and
+`TMUX_PANE` caller context. Missing, malformed or stale context returns
+`PANE_NOT_FOUND` (exit 3), not the default pane's identity. Implicit `role`
+access returns `IDENTITY_REQUIRED` (exit 1). Do not fabricate caller variables:
+outside tmux, use explicit `add <pane-target> <global-name>`, `talk <target>`,
+`check <target>`, or `role show|set|clear --identity <name>`. Explicit selection
+does not bind or authenticate the caller.
+
 ```bash
 tmt list
 tmt name <global-name>               # bind the current pane globally

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -108,6 +108,9 @@ describe('declarative CLI parser', () => {
     expect(parseArgs(['completion', 'zsh']).metadata).toMatchObject({ capability: 'none' });
     expect(parseArgs(['learn']).metadata).toMatchObject({ capability: 'none' });
     expect(parseArgs(['config']).metadata).toMatchObject({ capability: 'storage' });
+    for (const args of [['name', 'Alice'], ['this', 'Alice'], ['whoami'], ['unbind']]) {
+      expect(parseArgs(args).metadata).toMatchObject({ capability: 'storage' });
+    }
     expect(parseArgs(['send', 'claude', 'hello']).metadata.commandPath).toEqual(['send']);
     expect(parseArgs(['ls']).invocation).toEqual({ kind: 'list' });
   });

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -163,6 +163,13 @@ function capabilityFor(invocation: ParsedInvocation): ParsedMetadata['capability
       // Keep context creation storage-only. Implicit current-pane resolution
       // obtains tmux lazily, preserving offline explicit identity behavior.
       return 'storage';
+    case 'name':
+    case 'this':
+    case 'whoami':
+    case 'unbind':
+      // These commands validate caller-pane evidence before opening identity
+      // storage or eager legacy config, so an absent caller cannot bootstrap state.
+      return 'storage';
     default:
       return 'tmux';
   }

--- a/src/commands/global-identity.ts
+++ b/src/commands/global-identity.ts
@@ -6,7 +6,7 @@ import { IdentityServiceError } from '../identity-service.js';
 
 export function resolveCurrentPane(ctx: Context): string | null {
   const current = ctx.tmux.getCurrentPaneId();
-  return current ? ctx.tmux.resolvePaneTarget(current) : null;
+  return current;
 }
 
 export function resolvePane(ctx: Context, target: string): string | null {
@@ -33,10 +33,17 @@ export function failIdentity(
   return ctx.exit(exitCode);
 }
 
-export function bindIdentity(ctx: Context, paneId: string, name: string): void {
+export function bindIdentity(
+  ctx: Context,
+  paneId: string,
+  name: string,
+  options: { readonly current?: boolean } = {}
+): void {
   if (ctx.identityService) {
     try {
-      const identity = ctx.identityService.bindPane(paneId, name);
+      const identity = options.current
+        ? ctx.identityService.bindCurrent(name)
+        : ctx.identityService.bindPane(paneId, name);
       try {
         ctx.tmux.setPaneTitle(paneId, identity.name);
       } catch {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -75,6 +75,11 @@ ${colors.yellow('ROLE USAGE')}
   tmt role clear [--identity <name>]
   Omit --identity only in a verified bound pane; explicit offline identities are supported.
 
+${colors.yellow('CALLER CONTEXT')}
+  name, this, whoami and unbind require matching live TMUX/TMUX_PANE context.
+  Missing or stale caller: PANE_NOT_FOUND (exit 3); implicit role: IDENTITY_REQUIRED (exit 1).
+  Outside tmux, use explicit add/talk/check targets or role --identity <name>.
+
 ${colors.yellow('TALK OPTIONS')}
   ${colors.green('--delay')} <seconds>           Wait before sending
   ${colors.green('--wait')}                      Force wait mode (block until response)

--- a/src/commands/name.test.ts
+++ b/src/commands/name.test.ts
@@ -74,6 +74,33 @@ describe('global identity commands', () => {
     expect(ctx.ui.success).toHaveBeenCalledWith("Bound 'Backend' to pane %1");
   });
 
+  it('uses the verified current-pane service path without resolving a target again', () => {
+    const ctx = context();
+    const identityService: NonNullable<Context['identityService']> = {
+      bindCurrent: vi.fn(() => ({
+        id: 'backend-id',
+        name: 'Backend',
+        canonicalName: 'backend',
+        createdAt: 'created',
+        updatedAt: 'updated',
+      })),
+      bindPane: vi.fn(),
+      unbindCurrent: vi.fn(),
+      currentIdentity: vi.fn(),
+      activeIdentities: vi.fn(() => []),
+      resolveActive: vi.fn(),
+      reconcile: vi.fn(),
+      close: vi.fn(),
+    };
+    ctx.identityService = identityService;
+
+    cmdName(ctx, 'Backend');
+
+    expect(identityService.bindCurrent).toHaveBeenCalledWith('Backend');
+    expect(identityService.bindPane).not.toHaveBeenCalled();
+    expect(ctx.tmux.resolvePaneTarget).not.toHaveBeenCalled();
+  });
+
   it('uses the exact same implementation for this', () => {
     const ctx = context();
     cmdThis(ctx, 'backend');

--- a/src/commands/name.ts
+++ b/src/commands/name.ts
@@ -8,5 +8,5 @@ export function cmdName(ctx: Context, name: string): void {
   if (!paneId) {
     failIdentity(ctx, 'PANE_NOT_FOUND', 'Not running inside a resolvable tmux pane.');
   }
-  bindIdentity(ctx, paneId, name);
+  bindIdentity(ctx, paneId, name, { current: true });
 }

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -135,4 +135,16 @@ describe('whoami and unbind', () => {
       error: { code: 'PANE_NOT_FOUND', message: 'Not running inside a resolvable tmux pane.' },
     });
   });
+
+  it('rejects the caller before constructing the durable identity service', () => {
+    const ctx = context([], true);
+    (ctx.tmux.getCurrentPaneId as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const identityService = vi.fn(() => {
+      throw new Error('identity service must remain unopened');
+    });
+    Object.defineProperty(ctx, 'identityService', { configurable: true, get: identityService });
+
+    expect(() => cmdWhoami(ctx)).toThrow('exit(3)');
+    expect(identityService).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -2,9 +2,10 @@ import type { Context } from '../types.js';
 import { failIdentity, resolveCurrentPane } from './global-identity.js';
 
 export function cmdWhoami(ctx: Context): void {
+  const paneId = resolveCurrentPane(ctx);
+  if (!paneId) failIdentity(ctx, 'PANE_NOT_FOUND', 'Not running inside a resolvable tmux pane.');
+
   if (ctx.identityService) {
-    const paneId = resolveCurrentPane(ctx);
-    if (!paneId) failIdentity(ctx, 'PANE_NOT_FOUND', 'Not running inside a resolvable tmux pane.');
     const current = ctx.identityService.currentIdentity();
     if (ctx.flags.json) {
       ctx.ui.json(
@@ -19,9 +20,6 @@ export function cmdWhoami(ctx: Context): void {
     }
     return;
   }
-  const paneId = resolveCurrentPane(ctx);
-  if (!paneId) failIdentity(ctx, 'PANE_NOT_FOUND', 'Not running inside a resolvable tmux pane.');
-
   const identity = ctx.tmux.listGlobalIdentities().find((entry) => entry.paneId === paneId);
   if (ctx.flags.json) {
     ctx.ui.json(

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -218,12 +218,10 @@ describe('createContext', () => {
     expect(exitSpy).toHaveBeenCalledWith(5);
   });
 
-  it('serves explicit offline roles and rejects missing caller context without constructing tmux', async () => {
+  it('serves explicit offline roles and rejects missing caller context', async () => {
     vi.resetModules();
     vi.stubEnv('TMUX_PANE', '');
-    const createTmux = vi.fn(() => {
-      throw new Error('unexpected tmux construction');
-    });
+    const createTmux = vi.fn(() => ({ getCurrentPaneId: vi.fn(() => null) }));
     vi.doMock('./tmux.js', () => ({ createTmux }));
     const identity = { id: 'id', name: 'Alice', canonicalName: 'alice' };
     const repository = {
@@ -243,14 +241,45 @@ describe('createContext', () => {
       identity,
       role: null,
     });
+    expect(createTmux).not.toHaveBeenCalled();
     expect(() => ctx.roleService!.show()).toThrowError(
       expect.objectContaining({ code: 'IDENTITY_REQUIRED' })
     );
-    expect(createTmux).not.toHaveBeenCalled();
+    expect(createTmux).toHaveBeenCalledOnce();
     expect(openIdentityRepository).toHaveBeenCalledOnce();
     ctx.dispose!();
     ctx.dispose!();
     expect(repository.close).toHaveBeenCalledOnce();
+  });
+
+  it('does not open storage for an implicit role without validated caller evidence', async () => {
+    vi.resetModules();
+    vi.stubEnv('TMUX', '/tmp/tmux.sock,321,0');
+    vi.stubEnv('TMUX_PANE', '%9');
+    const openIdentityRepository = vi.fn(() => {
+      throw new Error('storage must remain unopened');
+    });
+    const createIdentityService = vi.fn(() => {
+      throw new Error('identity service must remain unopened');
+    });
+    const createTmux = vi.fn(() => ({ getCurrentPaneId: vi.fn(() => null) }));
+    vi.doMock('./storage/identity-repository.js', () => ({ openIdentityRepository }));
+    vi.doMock('./identity-service.js', () => ({ createIdentityService }));
+    vi.doMock('./tmux.js', () => ({ createTmux }));
+    const { createContext } = await import('./context.js');
+    const ctx = createContext({
+      argv: [],
+      flags: { json: true, verbose: false },
+      capability: 'storage',
+    });
+
+    expect(() => ctx.roleService!.show()).toThrowError(
+      expect.objectContaining({ code: 'IDENTITY_REQUIRED' })
+    );
+    expect(openIdentityRepository).not.toHaveBeenCalled();
+    expect(createIdentityService).not.toHaveBeenCalled();
+    expect(createTmux).toHaveBeenCalledOnce();
+    ctx.dispose!();
   });
 
   it('shares one repository between services and closes it even if service cleanup fails', async () => {
@@ -268,7 +297,9 @@ describe('createContext', () => {
     };
     const createIdentityService = vi.fn(() => service);
     vi.doMock('./identity-service.js', () => ({ createIdentityService }));
-    vi.doMock('./tmux.js', () => ({ createTmux: vi.fn(() => ({})) }));
+    vi.doMock('./tmux.js', () => ({
+      createTmux: vi.fn(() => ({ getCurrentPaneId: vi.fn(() => '%1') })),
+    }));
     const { createContext } = await import('./context.js');
     const ctx = createContext({
       argv: [],

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,7 +9,7 @@ import { createTmux } from './tmux.js';
 import { ExitCodes } from './exits.js';
 import { createIdentityService } from './identity-service.js';
 import { openIdentityRepository, type IdentityRepository } from './storage/identity-repository.js';
-import { createRoleService } from './role-service.js';
+import { createRoleService, type RoleRepository } from './role-service.js';
 
 export interface CreateContextOptions {
   argv: string[];
@@ -60,13 +60,25 @@ export function createContext(options: CreateContextOptions): Context {
     identityRepository ??= openIdentityRepository(paths.databaseFile);
     return identityRepository;
   };
+  const roleRepository: RoleRepository = {
+    findByCanonicalName(canonicalName) {
+      return getIdentityRepository().findByCanonicalName(canonicalName);
+    },
+    findRole(identityId) {
+      return getIdentityRepository().findRole(identityId);
+    },
+    setRole(identityId, content) {
+      return getIdentityRepository().setRole(identityId, content);
+    },
+    clearRole(identityId) {
+      return getIdentityRepository().clearRole(identityId);
+    },
+  };
   const getRoleService = (): NonNullable<Context['roleService']> => {
     roleService ??= createRoleService({
-      repository: getIdentityRepository(),
-      // Role's implicit selector requires caller binding evidence. Do not let
-      // the tmux adapter's outside-shell fallback select an arbitrary pane.
+      repository: roleRepository,
       currentIdentity: () =>
-        process.env.TMUX_PANE ? getIdentityService().currentIdentity() : undefined,
+        getTmux().getCurrentPaneId() ? getIdentityService().currentIdentity() : undefined,
     });
     return roleService;
   };

--- a/src/identity-service.test.ts
+++ b/src/identity-service.test.ts
@@ -136,6 +136,41 @@ describe('durable identity service', () => {
     service.close();
   });
 
+  it('does not touch identity storage when current pane evidence is missing', () => {
+    const test = fixture();
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    const transaction = vi.spyOn(repository, 'withImmediateTransaction');
+    const snapshot = vi.spyOn(test.tmux, 'getEndpointSnapshot');
+    test.tmux.getCurrentPaneId = () => null;
+    const service = createIdentityService({ ...test, repository });
+
+    expect(() => service.bindCurrent('no-caller')).toThrow(
+      'Not running inside a resolvable tmux pane.'
+    );
+    expect(service.currentIdentity()).toBeUndefined();
+    expect(service.unbindCurrent()).toBeUndefined();
+    expect(transaction).not.toHaveBeenCalled();
+    expect(snapshot).not.toHaveBeenCalled();
+    expect(repository.listIdentities()).toEqual([]);
+    expect(repository.findBindings()).toEqual([]);
+
+    service.close();
+    repository.close();
+  });
+
+  it('uses verified current-pane evidence without resolving an ambient target', () => {
+    const test = fixture();
+    const resolvePaneTarget = vi.spyOn(test.tmux, 'resolvePaneTarget');
+    const service = createIdentityService(test);
+
+    const identity = service.bindCurrent('direct-current');
+    expect(service.currentIdentity()).toMatchObject({ identity: { id: identity.id } });
+    expect(service.unbindCurrent()).toMatchObject({ id: identity.id });
+    expect(resolvePaneTarget).not.toHaveBeenCalled();
+
+    service.close();
+  });
+
   it('creates one durable identity and a verified transient binding', () => {
     const test = fixture();
     const service = createIdentityService(test);

--- a/src/identity-service.ts
+++ b/src/identity-service.ts
@@ -434,13 +434,7 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
           'PANE_NOT_FOUND',
           'Not running inside a resolvable tmux pane.'
         );
-      const paneId = tmux.resolvePaneTarget(current);
-      if (!paneId)
-        throw new IdentityServiceError(
-          'PANE_NOT_FOUND',
-          'Not running inside a resolvable tmux pane.'
-        );
-      return bind(paneId, name);
+      return bind(current, name);
     },
     bindPane(pane, name) {
       const resolved = tmux.resolvePaneTarget(pane);
@@ -451,8 +445,7 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
     unbindCurrent() {
       const current = tmux.getCurrentPaneId();
       if (!current) return undefined;
-      const paneId = tmux.resolvePaneTarget(current);
-      if (!paneId) return undefined;
+      const paneId = current;
       return coordinated((options) => {
         const snapshot = reconcileWithinTransaction(options);
         const item = mapActive(repository, snapshot, repository.findBindings()).find(
@@ -485,8 +478,7 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
     currentIdentity() {
       const current = tmux.getCurrentPaneId();
       if (!current) return undefined;
-      const paneId = tmux.resolvePaneTarget(current);
-      return paneId ? active().find((entry) => entry.binding.paneId === paneId) : undefined;
+      return active().find((entry) => entry.binding.paneId === current);
     },
     activeIdentities: active,
     resolveActive(target) {

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -18,6 +18,7 @@ const mockedExecSync = vi.mocked(execSync);
 const mockedExecFileSync = vi.mocked(execFileSync);
 
 const ENDPOINT_SEPARATOR = '__TMT_FIELD_4f1c__';
+const CALLER_PANE_SEPARATOR = '__TMT_CALLER_PANE_4f1c__';
 const VALID_SERVER_ID = '123e4567-e89b-42d3-a456-426614174000';
 
 function endpointRow(
@@ -50,6 +51,7 @@ describe('createTmux', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   describe('send', () => {
@@ -503,41 +505,118 @@ describe('createTmux', () => {
   });
 
   describe('getCurrentPaneId', () => {
-    it('returns TMUX_PANE when set', () => {
-      const old = process.env.TMUX_PANE;
-      process.env.TMUX_PANE = '%9';
+    it('returns TMUX_PANE only when the caller socket, server, and pane agree', () => {
+      vi.stubEnv('TMUX', '/tmp/tmux,with,comma.sock,321,0');
+      vi.stubEnv('TMUX_PANE', '%9');
+      mockedExecFileSync.mockReturnValueOnce(
+        `%9${CALLER_PANE_SEPARATOR}/tmp/tmux,with,comma.sock${CALLER_PANE_SEPARATOR}321\n`
+      );
       const tmux = createTmux();
       expect(tmux.getCurrentPaneId()).toBe('%9');
-      process.env.TMUX_PANE = old;
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        'tmux',
+        [
+          'display-message',
+          '-p',
+          '-t',
+          '%9',
+          `#{pane_id}${CALLER_PANE_SEPARATOR}#{socket_path}${CALLER_PANE_SEPARATOR}#{pid}`,
+        ],
+        expect.objectContaining({ timeout: 1000, maxBuffer: 4096, killSignal: 'SIGKILL' })
+      );
     });
 
-    it('falls back to tmux display-message', () => {
-      const old = process.env.TMUX_PANE;
-      delete process.env.TMUX_PANE;
+    it('does not fall back to the ambient tmux server without caller evidence', () => {
+      vi.stubEnv('TMUX', '');
+      vi.stubEnv('TMUX_PANE', '');
       mockedExecSync.mockReturnValue('%7\n');
       const tmux = createTmux();
-      expect(tmux.getCurrentPaneId()).toBe('%7');
-      process.env.TMUX_PANE = old;
+      expect(tmux.getCurrentPaneId()).toBeNull();
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+      expect(mockedExecSync).not.toHaveBeenCalled();
     });
 
-    it('returns null on failure', () => {
-      const old = process.env.TMUX_PANE;
-      delete process.env.TMUX_PANE;
-      mockedExecSync.mockImplementationOnce(() => {
+    it.each([
+      {
+        label: 'missing TMUX context',
+        tmux: undefined,
+        pane: '%9',
+        output: undefined,
+        calls: 0,
+      },
+      {
+        label: 'malformed pane target',
+        tmux: '/tmp/tmux.sock,321,0',
+        pane: '0.0',
+        output: undefined,
+        calls: 0,
+      },
+      {
+        label: 'malformed TMUX context',
+        tmux: '/tmp/tmux.sock,321',
+        pane: '%9',
+        output: undefined,
+        calls: 0,
+      },
+      {
+        label: 'empty socket in TMUX context',
+        tmux: ',321,0',
+        pane: '%9',
+        output: undefined,
+        calls: 0,
+      },
+      {
+        label: 'stale pane',
+        tmux: '/tmp/tmux.sock,321,0',
+        pane: '%9',
+        output: `${CALLER_PANE_SEPARATOR}/tmp/tmux.sock${CALLER_PANE_SEPARATOR}321\n`,
+        calls: 1,
+      },
+      {
+        label: 'socket mismatch',
+        tmux: '/tmp/tmux.sock,321,0',
+        pane: '%9',
+        output: `%9${CALLER_PANE_SEPARATOR}/tmp/other.sock${CALLER_PANE_SEPARATOR}321\n`,
+        calls: 1,
+      },
+      {
+        label: 'server mismatch',
+        tmux: '/tmp/tmux.sock,321,0',
+        pane: '%9',
+        output: `%9${CALLER_PANE_SEPARATOR}/tmp/tmux.sock${CALLER_PANE_SEPARATOR}999\n`,
+        calls: 1,
+      },
+      {
+        label: 'extra fields',
+        tmux: '/tmp/tmux.sock,321,0',
+        pane: '%9',
+        output: `%9${CALLER_PANE_SEPARATOR}/tmp/tmux.sock${CALLER_PANE_SEPARATOR}321${CALLER_PANE_SEPARATOR}extra\n`,
+        calls: 1,
+      },
+      {
+        label: 'extra lines',
+        tmux: '/tmp/tmux.sock,321,0',
+        pane: '%9',
+        output: `%9${CALLER_PANE_SEPARATOR}/tmp/tmux.sock${CALLER_PANE_SEPARATOR}321\nextra\n`,
+        calls: 1,
+      },
+    ])('rejects $label caller evidence', ({ tmux: tmuxValue, pane, output, calls }) => {
+      vi.stubEnv('TMUX', tmuxValue ?? '');
+      vi.stubEnv('TMUX_PANE', pane);
+      if (output !== undefined) mockedExecFileSync.mockReturnValueOnce(output);
+      const tmux = createTmux();
+      expect(tmux.getCurrentPaneId()).toBeNull();
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(calls);
+    });
+
+    it('returns null when the caller pane query fails', () => {
+      vi.stubEnv('TMUX', '/tmp/tmux.sock,321,0');
+      vi.stubEnv('TMUX_PANE', '%9');
+      mockedExecFileSync.mockImplementationOnce(() => {
         throw new Error('fail');
       });
       const tmux = createTmux();
       expect(tmux.getCurrentPaneId()).toBeNull();
-      process.env.TMUX_PANE = old;
-    });
-
-    it('returns null when tmux output is empty', () => {
-      const old = process.env.TMUX_PANE;
-      delete process.env.TMUX_PANE;
-      mockedExecSync.mockReturnValue('   \n');
-      const tmux = createTmux();
-      expect(tmux.getCurrentPaneId()).toBeNull();
-      process.env.TMUX_PANE = old;
     });
   });
 

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -24,7 +24,11 @@ const PANE_FIELD_SEPARATOR = '__TMT_FIELD_4f1c__';
 const ENDPOINT_PROBE_TIMEOUT_MS = 1_000;
 const ENDPOINT_PROBE_MAX_BUFFER = 1024 * 1024;
 const TMUX_OPERATION_TIMEOUT_MS = 1_000;
+const CALLER_PANE_TIMEOUT_MS = 1_000;
+const CALLER_PANE_MAX_BUFFER = 4096;
+const CALLER_PANE_SEPARATOR = '__TMT_CALLER_PANE_4f1c__';
 const SERVER_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PANE_ID_PATTERN = /^%\d+$/;
 
 // Known agent patterns for auto-detection
 const KNOWN_AGENTS: Record<string, string[]> = {
@@ -267,6 +271,70 @@ function isMissingProcess(error: unknown): boolean {
   );
 }
 
+function callerTmuxContext(
+  value: string | undefined
+):
+  | { readonly socketPath: string; readonly serverPid: number; readonly sessionId: string }
+  | undefined {
+  if (!value) return undefined;
+  const lastComma = value.lastIndexOf(',');
+  const previousComma = value.lastIndexOf(',', lastComma - 1);
+  if (previousComma <= 0 || lastComma <= previousComma + 1 || lastComma === value.length - 1) {
+    return undefined;
+  }
+  const socketPath = value.slice(0, previousComma);
+  const serverPidText = value.slice(previousComma + 1, lastComma);
+  const sessionId = value.slice(lastComma + 1);
+  if (!socketPath || !/^\d+$/.test(serverPidText) || !/^\d+$/.test(sessionId)) {
+    return undefined;
+  }
+  const serverPid = Number(serverPidText);
+  if (!Number.isSafeInteger(serverPid) || serverPid <= 0) return undefined;
+  return { socketPath, serverPid, sessionId };
+}
+
+function callerPaneId(): string | null {
+  const paneId = process.env.TMUX_PANE;
+  if (!paneId || !PANE_ID_PATTERN.test(paneId)) return null;
+  const context = callerTmuxContext(process.env.TMUX);
+  if (!context) return null;
+
+  try {
+    const output = execFileSync(
+      'tmux',
+      [
+        'display-message',
+        '-p',
+        '-t',
+        paneId,
+        `#{pane_id}${CALLER_PANE_SEPARATOR}#{socket_path}${CALLER_PANE_SEPARATOR}#{pid}`,
+      ],
+      {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: CALLER_PANE_TIMEOUT_MS,
+        maxBuffer: CALLER_PANE_MAX_BUFFER,
+        killSignal: 'SIGKILL',
+      }
+    );
+    const text = output.trim();
+    if (!text || text.includes('\n')) return null;
+    const fields = text.split(CALLER_PANE_SEPARATOR);
+    if (fields.length !== 3) return null;
+    const [returnedPaneId, returnedSocketPath, returnedServerPid] = fields;
+    if (
+      returnedPaneId !== paneId ||
+      returnedSocketPath !== context.socketPath ||
+      returnedServerPid !== String(context.serverPid)
+    ) {
+      return null;
+    }
+    return paneId;
+  } catch {
+    return null;
+  }
+}
+
 function remainingTimeout(options: TmuxOperationOptions = {}): number {
   const remaining =
     options.deadlineMs === undefined
@@ -433,21 +501,9 @@ export function createTmux(): Tmux {
     },
 
     getCurrentPaneId(): string | null {
-      // First check environment variable
-      if (process.env.TMUX_PANE) {
-        return process.env.TMUX_PANE;
-      }
-
-      // Fall back to tmux command
-      try {
-        const output = execSync('tmux display-message -p "#{pane_id}"', {
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
-        return output.trim() || null;
-      } catch {
-        return null;
-      }
+      // Implicit commands may select only a pane proven by the caller's tmux
+      // environment. Never fall back to the ambient/default server.
+      return callerPaneId();
     },
 
     getAgentRegistry(scope: RegistryScope): TmuxRegistry {

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,7 @@ export interface Tmux {
   send: (paneId: string, message: string, options?: { enterDelayMs?: number }) => void;
   capture: (paneId: string, lines: number) => string;
   listPanes: () => PaneInfo[];
+  /** Return only the caller's verified pane; never an ambient/default pane. */
   getCurrentPaneId: () => string | null;
   resolvePaneTarget: (target: string) => string | null;
   setPaneTitle: (paneId: string, title: string) => void;

--- a/test/e2e/caller-context.e2e.test.ts
+++ b/test/e2e/caller-context.e2e.test.ts
@@ -1,0 +1,269 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { withE2EFixture, type CliResult, type E2EFixture } from './harness.js';
+
+interface CommandError {
+  error: { code: string; message: string };
+}
+
+interface DurableState {
+  identities: unknown[];
+  bindings: unknown[];
+  profiles: unknown[];
+}
+
+function json<T>(result: CliResult<T>): T {
+  expect(result.stdout.trim(), result.stderr).not.toBe('');
+  expect(result.stderr).toBe('');
+  expect(result.json).toBeDefined();
+  return result.json as T;
+}
+
+function databaseFile(fixture: E2EFixture): string {
+  return path.join(fixture.globalDir, 'tmux-team.db');
+}
+
+function durableState(fixture: E2EFixture): DurableState {
+  const file = databaseFile(fixture);
+  if (!fs.existsSync(file)) return { identities: [], bindings: [], profiles: [] };
+  const database = new Database(file, { readonly: true });
+  try {
+    return {
+      identities: database.prepare('SELECT * FROM identities ORDER BY canonical_name').all(),
+      bindings: database.prepare('SELECT * FROM bindings ORDER BY identity_id').all(),
+      profiles: database.prepare('SELECT * FROM role_profiles ORDER BY identity_id').all(),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function expectExactError<T>(
+  result: CliResult<T>,
+  code: string,
+  message: string,
+  exitCode: number
+) {
+  expect(result.code).toBe(exitCode);
+  expect(result.stderr).toBe('');
+  expect(result.json).toEqual({ error: { code, message } });
+}
+
+async function seedIdentity(fixture: E2EFixture, name: string, profile: string): Promise<void> {
+  const bound = await fixture.runJsonCli(['name', name]);
+  expect(bound.code, bound.stderr || bound.stdout).toBe(0);
+  const assigned = await fixture.runJsonCli(['role', 'set', profile]);
+  expect(assigned.code, assigned.stderr || assigned.stdout).toBe(0);
+}
+
+describe.sequential('strict caller context', () => {
+  it('uses real socket and selected-pane evidence for every implicit identity and role operation', async () => {
+    await withE2EFixture(async (fixture) => {
+      await seedIdentity(fixture, 'Current', 'initial caller profile');
+
+      const whoami = await fixture.runJsonCli<{ bound: boolean; name: string }>(['whoami']);
+      expect(whoami.code).toBe(0);
+      expect(json(whoami)).toMatchObject({ bound: true, name: 'Current', pane: fixture.pane });
+
+      const shown = await fixture.runJsonCli<{
+        identity: { name: string };
+        role: { content: string };
+      }>(['role', 'show']);
+      expect(shown.code).toBe(0);
+      expect(json(shown)).toMatchObject({
+        identity: { name: 'Current' },
+        role: { content: 'initial caller profile' },
+      });
+
+      const updated = await fixture.runJsonCli(['role', 'set', 'updated caller profile']);
+      expect(updated.code).toBe(0);
+      const cleared = await fixture.runJsonCli(['role', 'clear']);
+      expect(cleared.code).toBe(0);
+      const empty = await fixture.runJsonCli<{ role: null }>(['role', 'show']);
+      expect(empty.code).toBe(0);
+      expect(json(empty).role).toBeNull();
+
+      const nameIdempotent = await fixture.runJsonCli(['name', 'Current']);
+      expect(nameIdempotent.code).toBe(0);
+      const idempotent = await fixture.runJsonCli(['this', 'Current']);
+      expect(idempotent.code).toBe(0);
+
+      const peer = await fixture.createMockPane('peer');
+      const peerBound = await fixture.runJsonCli(['add', peer.pane, 'Peer']);
+      expect(peerBound.code).toBe(0);
+      const peerWhoami = await fixture.runJsonCli<{ bound: boolean; name: string }>(['whoami'], {
+        pane: peer.pane,
+      });
+      expect(peerWhoami.code).toBe(0);
+      expect(json(peerWhoami)).toMatchObject({ bound: true, name: 'Peer', pane: peer.pane });
+      const peerRole = await fixture.runJsonCli<{ identity: { name: string } }>(['role', 'show'], {
+        pane: peer.pane,
+      });
+      expect(peerRole.code).toBe(0);
+      expect(json(peerRole).identity.name).toBe('Peer');
+
+      const unbound = await fixture.runJsonCli(['unbind']);
+      expect(unbound.code).toBe(0);
+      const finalWhoami = await fixture.runJsonCli<{ bound: boolean }>(['whoami']);
+      expect(finalWhoami.code).toBe(0);
+      expect(json(finalWhoami)).toEqual({ bound: false, pane: fixture.pane });
+    });
+  }, 30_000);
+
+  it('rejects stale, aliased, and foreign caller evidence without durable or presentation mutation', async () => {
+    await withE2EFixture(async (fixture) => {
+      await seedIdentity(fixture, 'Stable', 'must survive invalid callers');
+      const before = durableState(fixture);
+      const metadataBefore = fixture.paneMetadata();
+      const titleBefore = fixture.paneTitle();
+      const callers = [
+        { label: 'missing caller context', caller: { tmux: null, pane: null } },
+        { label: 'stale pane', caller: { pane: '%99999' } },
+        { label: 'pane alias', caller: { pane: 'e2e:0.0' } },
+        {
+          label: 'foreign socket evidence',
+          caller: {
+            tmux: `${fixture.socketPath}-foreign,${fixture.serverPid},${fixture.paneSessionId()}`,
+          },
+        },
+        {
+          label: 'foreign server pid evidence',
+          caller: {
+            tmux: `${fixture.socketPath},${fixture.serverPid + 1},${fixture.paneSessionId()}`,
+          },
+        },
+      ];
+
+      for (const { label, caller } of callers) {
+        const commands = [['name', 'Replacement'], ['this', 'Replacement'], ['whoami'], ['unbind']];
+        for (const args of commands) {
+          const result = await fixture.runJsonCli<CommandError>(args, { caller });
+          expectExactError(
+            result,
+            'PANE_NOT_FOUND',
+            'Not running inside a resolvable tmux pane.',
+            3
+          );
+          expect(durableState(fixture), `${label}: ${args.join(' ')}`).toEqual(before);
+          expect(fixture.paneMetadata(), `${label}: metadata`).toBe(metadataBefore);
+          expect(fixture.paneTitle(), `${label}: title`).toBe(titleBefore);
+        }
+
+        for (const operation of ['show', 'set', 'clear'] as const) {
+          const args =
+            operation === 'set' ? ['role', operation, 'should not write'] : ['role', operation];
+          const result = await fixture.runJsonCli<CommandError>(args, { caller });
+          expectExactError(
+            result,
+            'IDENTITY_REQUIRED',
+            'An identity is required; use --identity or run from a verified bound pane.',
+            1
+          );
+          expect(durableState(fixture), `${label}: role ${operation}`).toEqual(before);
+          expect(fixture.paneMetadata(), `${label}: role metadata`).toBe(metadataBefore);
+          expect(fixture.paneTitle(), `${label}: role title`).toBe(titleBefore);
+        }
+      }
+    });
+  }, 45_000);
+
+  it('rejects an outside implicit caller before bootstrapping fresh storage', async () => {
+    await withE2EFixture(async (fixture) => {
+      const titleBefore = fixture.paneTitle();
+      const callerModes = [
+        { label: 'missing caller', options: { outsideTmux: true } },
+        { label: 'stale caller', options: { caller: { pane: '%99999' } } },
+      ];
+      for (const { label, options } of callerModes) {
+        const identityCommands = [
+          ['whoami'],
+          ['name', 'MustNotBind'],
+          ['this', 'MustNotBind'],
+          ['unbind'],
+        ];
+        for (const args of identityCommands) {
+          const result = await fixture.runJsonCli<CommandError>(args, options);
+          expectExactError(
+            result,
+            'PANE_NOT_FOUND',
+            'Not running inside a resolvable tmux pane.',
+            3
+          );
+          expect(fs.existsSync(databaseFile(fixture)), `${label}: database`).toBe(false);
+          expect(fixture.paneMetadata(), `${label}: metadata`).toBe('');
+          expect(fixture.paneTitle(), `${label}: title`).toBe(titleBefore);
+        }
+
+        for (const operation of ['show', 'set', 'clear'] as const) {
+          const args =
+            operation === 'set' ? ['role', operation, 'must not write'] : ['role', operation];
+          const role = await fixture.runJsonCli<CommandError>(args, options);
+          expectExactError(
+            role,
+            'IDENTITY_REQUIRED',
+            'An identity is required; use --identity or run from a verified bound pane.',
+            1
+          );
+          expect(fs.existsSync(databaseFile(fixture)), `${label}: role database`).toBe(false);
+          expect(fixture.paneMetadata(), `${label}: role metadata`).toBe('');
+          expect(fixture.paneTitle(), `${label}: role title`).toBe(titleBefore);
+        }
+      }
+    });
+  }, 15_000);
+
+  it('allows explicit targets and offline explicit roles without caller context', async () => {
+    await withE2EFixture(async (fixture) => {
+      const peer = await fixture.createMockPane('peer');
+      const added = await fixture.runJsonCli(['add', peer.pane, 'Peer'], {
+        outsideTmux: true,
+      });
+      expect(added.code).toBe(0);
+      expect(added.json).toMatchObject({ bound: true, name: 'Peer', pane: peer.pane });
+
+      const message = 'explicit outside caller';
+      const talk = await fixture.runJsonCli<{ response: string }>(
+        ['talk', 'Peer', message, '--wait', '--timeout', '5'],
+        { outsideTmux: true }
+      );
+      expect(talk.code).toBe(0);
+      expect(talk.json?.response).toContain(`mock-agent response: ${message}`);
+      await fixture.waitForEvent(
+        (event) => event.event === 'response' && event.pid === peer.pid && event.message === message
+      );
+
+      const checked = await fixture.runJsonCli<{ output: string }>(['check', 'Peer', '20'], {
+        outsideTmux: true,
+      });
+      expect(checked.code).toBe(0);
+      expect(checked.json?.output).toContain(`mock-agent response: ${message}`);
+
+      const offlineSet = await fixture.runJsonCli(
+        ['role', 'set', 'offline explicit profile', '--identity', 'Peer'],
+        {
+          withoutTmux: true,
+        }
+      );
+      expect(offlineSet.code).toBe(0);
+      const offlineShow = await fixture.runJsonCli<{ role: { content: string } }>(
+        ['role', 'show', '--identity', 'Peer'],
+        { withoutTmux: true }
+      );
+      expect(offlineShow.code).toBe(0);
+      expect(offlineShow.json?.role.content).toBe('offline explicit profile');
+      const offlineClear = await fixture.runJsonCli(['role', 'clear', '--identity', 'Peer'], {
+        withoutTmux: true,
+      });
+      expect(offlineClear.code).toBe(0);
+      const offlineEmpty = await fixture.runJsonCli<{ role: null }>(
+        ['role', 'show', '--identity', 'Peer'],
+        { withoutTmux: true }
+      );
+      expect(offlineEmpty.code).toBe(0);
+      expect(offlineEmpty.json?.role).toBeNull();
+      expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+    });
+  }, 30_000);
+});

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -34,6 +34,13 @@ export interface CliRunOptions {
   pane?: string;
   /** Remove pane context and fail visibly if the CLI attempts to invoke tmux. */
   withoutTmux?: boolean;
+  /** Remove caller context while keeping tmux available for explicit targets. */
+  outsideTmux?: boolean;
+  /** Narrow caller-context overrides for invalid-evidence scenarios. */
+  caller?: {
+    tmux?: string | null;
+    pane?: string | null;
+  };
   /** Touch this file when the child has made its first tmux invocation. */
   progressFile?: string;
 }
@@ -212,7 +219,21 @@ exit ${'$'}status
     options: CliRunOptions = {}
   ): CliProcess<T> {
     if (!this.started) throw new Error('E2E fixture must be started before invoking the CLI.');
-    const env: NodeJS.ProcessEnv = { ...this.env, TMUX_PANE: options.pane ?? this.pane };
+    const env: NodeJS.ProcessEnv = { ...this.env };
+    if (!options.outsideTmux && !options.withoutTmux) {
+      const callerPane = options.pane ?? this.pane;
+      env.TMUX = `${this.socketPath},${this.serverPid},${this.paneSessionId(callerPane)}`;
+      env.TMUX_PANE = callerPane;
+      if (options.caller) {
+        if (options.caller.tmux === null) delete env.TMUX;
+        else if (options.caller.tmux !== undefined) env.TMUX = options.caller.tmux;
+        if (options.caller.pane === null) delete env.TMUX_PANE;
+        else if (options.caller.pane !== undefined) env.TMUX_PANE = options.caller.pane;
+      }
+    } else {
+      delete env.TMUX;
+      delete env.TMUX_PANE;
+    }
     if (options.withoutTmux) {
       delete env.TMUX;
       delete env.TMUX_PANE;
@@ -408,12 +429,22 @@ exit ${'$'}status
     ]).trim();
   }
 
+  paneSessionId(pane = this.pane): string {
+    return this.tmux(['display-message', '-p', '-t', pane, '#{session_id}'])
+      .trim()
+      .replace(/^\$/, '');
+  }
+
   paneMetadata(pane = this.pane): string {
     try {
       return this.tmux(['show-options', '-p', '-t', pane, '-v', '@tmux-team.agent']).trim();
     } catch {
       return '';
     }
+  }
+
+  paneTitle(pane = this.pane): string {
+    return this.tmux(['display-message', '-p', '-t', pane, '#{pane_title}']).trim();
   }
 
   events(): MockEvent[] {


### PR DESCRIPTION
## Scope

- Issue: [TMT-21](https://linear.app/tigerpig-dev/issue/TMT-21).
- Require verified caller-pane evidence for implicit identity operations; reject absent, malformed, stale and mismatched caller context before opening identity storage.
- Preserve explicit add/talk/check targets, offline role selectors, and valid bound/unbound behavior.
- Areas: tmux caller adapter, service/command consumers, lazy context, parser capabilities, unit/E2E tests, architecture and English help/skills.
- No schema/dependency changes, daemon, listener, memory, inbox, transport rewrite or broad legacy-service removal.

## Architecture and review

- The existing tmux adapter owns one verified `getCurrentPaneId` policy. Parse TMUX from the right; require strict pane ID and valid socket/PID/session fields; query the explicit pane with a one-second/4 KiB limit and compare exact pane/socket/PID plus output shape.
- Query and subsequent operations use the same normal routing. No special endpoint override used only for validation; no ambient fallback, speculative realpath normalization or redundant process-liveness probe.
- Current service paths trust the verified adapter instead of generic target resolution. `name`/`this` use `bindCurrent`; explicit `add` retains `bindPane`.
- Parser capability metadata prevents eager legacy configuration access for implicit commands. `whoami` validates before requesting its service; narrow lazy role-repository forwarding prevents failed implicit role selection from bootstrapping SQLite.
- Caller selection is not authentication; environment variables are not credentials. CLI errors remain `PANE_NOT_FOUND`/exit 3 or implicit-role `IDENTITY_REQUIRED`/exit 1.
- Primary Codex reviewed every changed file and surrounding callers/contracts, resource lifetime, parser dispatch, state preservation, harness isolation and causal assertions. Mandatory Luna high pattern audit completed before edits. Gemini supplementary implementation review found no blockers; primary independently checked its claims against code and exact verification output.
- Findings resolved: endpoint routing mismatch, eager getters, repeated generic resolution, test environment leakage, fabricated harness session evidence, weak negative state assertions, incorrect pure-response assumption, and a partial test service hidden behind `as never`.
- Reviewed commit: `211d2157153dd67fb51a256871f5a74f8b6d1075`.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge.

Commands and results:

- `pnpm check`: passed (source/E2E TypeScript, lint, formatting and maintained docs).
- `pnpm test:run`: 457/457, 32 files; coverage 94.22% statements and 87.71% branches, threshold gate passed.
- Explicit Prettier check for README and changed shipped guidance plus `git diff --check`: passed.
- Skill creator `quick_validate.py`: all three changed SKILL.md files passed; missing PyYAML installed only in an isolated temporary virtualenv. Claude command frontmatter preserved and inspected manually.
- Baseline negative control on `a004850`: only the no-caller regression was applied in a temporary detached worktree; it failed with `expected '%7' to be null`, proving ambient selection on the old code. Temporary worktree restored/removed safely.
- Docker diagnostic initially passed 43/44: the failing assertion incorrectly assumed pure response text; existing transport includes request echo/framing. Corrected to unique agent-produced response plus independent event evidence, without changing transport. Subsequent diagnostic passed 44/44.
- Final Docker two-run gate passed: 44/44 across 8 files on both final-version runs (145.12 s and 145.31 s). Source hashes verified the tested image's caller-binding implementation. An earlier successful 146.39 s run predated final `bindCurrent` routing and is excluded from this final-version gate.
- Packed native installation on darwin/arm64 passed: `pnpm pack --pack-destination /private/tmp/tmt21-pack.L7f8jI` then `node scripts/verify-packed-native-install.mjs --package-tarball /private/tmp/tmt21-pack.L7f8jI/tmux-team-5.0.0-alpha.1.tgz --expected-arch arm64`. Packed production source hash matches the reviewed current routing implementation.
- Exact-head CI run [33950139864](https://github.com/wkh237/tmux-team/actions/runs/33950139864) passed all ten jobs on `211d2157153dd67fb51a256871f5a74f8b6d1075`: Code quality, Unit tests, Docker E2E, six packed native installs and Native package matrix. Protected merge state CLEAN; no bypass.

## Project lifecycle

- Updated `ARCHITECTURE.md`, README, help and shipped Claude/Codex/Gemini/plugin guidance for the intentional caller safety change. The skill update is narrow: caller limitations and explicit alternatives, not a second workflow.
- Linear records accepted audit/design, boundary refinements, baseline evidence and verification; PR and final CI/cleanup will be synchronized.
- Dedicated branch/worktree retained until clean, pushed and merged delivery is recorded.
- Next is TMT-35 reliable channel research. Existing terminal response limitations are explicitly deferred there, not concealed by a pure-body promise in these tests.
