### PR TITLE
docs: define reliable response channel foundation (TMT-35)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,6 +33,17 @@ identity memory, or durable inbox. Adding a command does not imply those feature
 These are invariants to protect. Known delivery
 gaps below remain limitations, not guarantees supplied by this document.
 
+## Request/response research boundary
+
+Current `talk --wait` completion and body extraction rely on terminal capture;
+a matching end marker is not proof of a complete, isolated response body.
+`check` is a diagnostic pane snapshot, not correlated response retrieval.
+The [request/response decision document](REQUEST-RESPONSE.md) records TMT-35's
+source evidence, capability limits and staged proposal. Its structured service
+is not shipped: current marker behavior, JSON bookkeeping and CLI grammar remain
+unchanged until their bounded implementation issues land. Keep this distinction
+and the document's verification status current as those slices are delivered.
+
 ## Caller context
 
 The tmux adapter owns current-pane evidence: a strict `TMUX_PANE` ID and the

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -1,0 +1,205 @@
+# TMT-35 request/response channel research
+
+Status: research only, based on `cecaec7` (2026-09-05). This document does not
+ship a provider integration, daemon, inbox, memory feature, or new CLI syntax.
+Exact schemas, limits, and compatibility decisions belong in implementation
+tickets after this boundary is accepted.
+
+## Current implementation map
+
+`cmdTalk` resolves one target, then either sends and returns (`talk` without
+`--wait`) or creates a request ID, random nonce, and
+`RESPONSE-END-<nonce>` marker. Wait mode stores `{id, nonce, pane,
+startedAtMs}` in the shared JSON state file, sends through the tmux adapter, and
+polls pane capture until it sees the nonce-specific marker and a debounce
+period has elapsed.
+
+The request ID is returned in completed and timeout JSON, but it is not carried
+by a durable response record. Active state is keyed by pane and updated with
+whole-file read/modify/write operations. Existing requests produce a warning;
+the warning is not a lock. Cleanup is request-ID guarded, but concurrent
+writers can overwrite state and a crashed process leaves only a TTL-cleaned
+entry.
+
+The current body extractor searches for the instruction and marker in terminal
+scrollback. It expands capture when the instruction has scrolled away, then
+falls back to the last configured lines and marks the result truncated. On a
+timeout, `partialResponse` is taken from scrollback and may contain unrelated
+history. Terminal capture therefore cannot establish full request/body
+causality under concurrent same-pane waits.
+
+Two baseline corrections are material:
+
+1. `src/tmux.ts` has a broad send catch that retries the original message with
+   legacy `send-keys` after buffer/paste/Enter failure. This is an existing
+   transport fallback owned by TMT-24; it is not an authoritative response
+   retry and must not be mistaken for one.
+2. The generated instruction contains `RESPONSE-END-xxxx (where xxxx = N)`,
+   while `isInstructionLine` looks for the literal `RESPONSE-END-N` in that
+   line. The start boundary is therefore defective even before scrollback
+   expansion. Fixing it is separate from choosing an authoritative response
+   source.
+
+The existing E2E harness is reusable: each scenario gets a private tmux server,
+real CLI subprocesses, deterministic mock agents, JSONL request/response events
+with pane PID and nonce, bounded polling, and cleanup. Existing talk tests use
+temporary state directories and derive a mock response from the nonce in the
+sent instruction. Neither suite currently proves two waiters competing for one
+pane without response mixing.
+
+## Capability matrix
+
+| Capability           | Current behavior                                                                   | Proposed research boundary                                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Request identity     | CLI request ID plus short nonce; nonce appears in the prompt and marker            | Keep an explicit request and attempt identity; do not make short nonce format the permanent protocol contract                       |
+| Transport attempt    | Tmux buffer/paste/Enter with a legacy resend fallback                              | TMT-24 owns bounded transport, attempt outcome, and uncertain-send reporting; uncertain send must not be replayed automatically     |
+| Authoritative body   | Scrollback marker extraction, including truncated/history fallback                 | A completed body must come from a request-correlated final source; terminal output is diagnostic evidence only                      |
+| Terminal diagnostics | `capture` is used both for detection and body extraction                           | Preserve capture for progress/debugging, but keep it separate from the authoritative response body                                  |
+| Persistence          | JSON state tracks one active request per pane; no durable response                 | TMT-25 should provide one short-transaction SQLite request/response service; no unbounded transaction around tmux                   |
+| Wait lifecycle       | Timeout returns partial scrollback; cleanup is best effort and TTL-based           | Distinguish waiter timeout, cancellation, expiry, completed, and uncertain send; late replies must be fenced                        |
+| Provider output      | No provider adapter; marker protocol is injected into pane input                   | Thin future adapters may map final outputs into the same response contract; the first slice can use explicit cooperating submission |
+| Roles/preambles      | Legacy preambles can modify sent text; durable roles are separate and not injected | Do not use roles or preambles as request identity, transport state, or response storage                                             |
+| Inbox/headless       | No daemon, durable inbox, or owned headless runner                                 | Defer broad inbox (TMT-16/31/32), advanced identity management (TMT-30), memory (TMT-15), and provider runner rollout               |
+
+## Alternatives and supported limits
+
+| Candidate                             | Full-body source and cooperation                                         | Correlation and cost                                                                                                   | Recommendation                                                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Unmodified interactive pane           | Only rendered screen/history; hidden semantic text is unavailable        | Marker heuristic, no authoritative body ownership                                                                      | Keep existing behavior explicit as best effort; do not silently upgrade its guarantee                               |
+| Explicit cooperating final submission | Agent/tool submits its complete final text outside the terminal renderer | Explicit request/attempt plus recipient validation; one shared repository, no listener                                 | First bounded live-channel candidate; agent cooperation is required                                                 |
+| Provider final-response hook          | Supported hook supplies final text independently of the viewport         | Must bind the actual provider turn to a TMT attempt; unrelated turns and hook retries must be rejected or deduplicated | Optional thin adapter after core contract; no automatic configuration installation                                  |
+| Owned headless process                | Structured output/final file from a process whose lifecycle TMT owns     | Stronger run association but requires a runner and provider-specific decoding                                          | Useful later; cannot transparently attach arbitrary existing interactive panes                                      |
+| Raw PTY/pipe output                   | Bytes emitted while recording is active                                  | Requires lifecycle ownership and parsing redraws; cannot recover semantic text never emitted                           | Diagnostics, not the universal response channel                                                                     |
+| Local response artifact or IPC        | Artifact can carry a full response; IPC can deliver an envelope          | Artifact needs bounded validation, publication and ingestion; a listener adds lifecycle complexity                     | A file may be an input adapter, not another authoritative store; no daemon needed for short-lived SQLite submission |
+
+These are architectural inferences from the source capabilities below, not
+claims of verified provider integration. A completion event alone never proves
+body completeness. Session ID, pane identity, a display name, or an idle screen
+alone cannot associate a response with a particular request.
+
+## Staged architecture option
+
+The smallest coherent path is one local SQLite request/response service behind a
+narrow application port. A request has an explicit immutable request ID; each
+send has an explicit attempt ID and is fenced to that request and recorded
+recipient/endpoint instance (not a `%pane` alone).
+Fencing must use the recorded request/attempt identity, never “the latest
+request for this pane.” A final submission with the same request and identical
+content is idempotent; a conflicting final submission for the same request is
+rejected and diagnosed.
+
+The minimum final body is one bounded UTF-8 text submission, committed together
+with its completion state. Its exact size cap and rejection/output schemas must
+be set before implementation; oversize, invalid input or partial writes must not
+produce a completed record. Avoid streaming/chunk assembly until an actual
+consumer requires it. Later chunk adapters must prove ordering, completeness
+and terminal outcome before calling the same finalization operation.
+
+Use the existing database path/lifecycle and parser. A narrow response service
+owns validation and transitions; commands and provider adapters do not implement
+their own SQL or state machines. Correlation/attempt fencing is not strong
+authentication against other processes running as the same local user. Do not
+log reusable submission tokens or ingest arbitrary transcript paths by default.
+
+Transactions should record or finalize state briefly, then release the lock
+before tmux/provider subprocess work. A waiter timeout is local observation
+expiry, not cancellation of a provider attempt. Cancellation and expiry need
+distinct states and fencing rules. If the send result is uncertain, the caller
+records uncertainty and does not replay the prompt automatically. An accepted
+late reply remains retrievable after its original waiter exits. A later explicit
+retry requires a specified attempt policy; request idempotency does not promise
+exactly-once execution of agent tools. Retention must be explicit and bounded,
+not a copy of the current one-hour active-state cleanup.
+
+Suggested delivery order:
+
+1. TMT-24: preserve `!` shell-mode protection, eliminate unsafe replay and bound
+   transport stages with sent/failed/uncertain outcomes.
+2. TMT-27/28: retain preambles through the specified identity-owned model and
+   establish narrow shared resource/repository ports. Sequence only prerequisites
+   needed by the next slice; TMT-26 owns broad CLI error unification.
+3. TMT-25: replace JSON bookkeeping with short-transaction SQLite request
+   ownership. Do not add a second store when final responses are introduced.
+4. [TMT-36](https://linear.app/tigerpig-dev/issue/TMT-36) owns immutable final
+   responses in the shared service;
+   [TMT-37](https://linear.app/tigerpig-dev/issue/TMT-37) owns opt-in live CLI
+   integration, exact-body retrieval and shipped skill guidance. These are
+   bounded children of TMT-31/32, not the broader inbox/offline-routing rollout.
+   Their preparation gates require exact types, limits and CLI contracts before
+   implementation. Prove timeout/late replies and fencing before expanding modes.
+5. Broad inbox, non-tmux identity management (TMT-30), memory (TMT-15), and owned
+   headless runners remain later work; memory is not a prerequisite of replies.
+
+No stage requires a daemon. No stage authorizes automatic resend, provider
+parallel state, or a new CLI spelling.
+
+## Source capability notes
+
+Source verification date: 2026-09-05. These are capability findings only; no
+provider integration test was run.
+
+- [OpenAI non-interactive mode](https://learn.chatgpt.com/docs/non-interactive-mode): JSON exposes an `agent_message` item and turn outcome, with `-o` support for a final file. This is a non-interactive result surface, not an instruction to attach an existing TUI.
+- [Claude headless mode](https://code.claude.com/docs/en/headless): Claude can return result JSON suitable for a final-response adapter. The adapter still needs request/attempt ownership outside the provider process.
+- [Claude hooks](https://code.claude.com/docs/en/hooks): the Stop hook exposes `last_assistant_message`; transcript persistence is not guaranteed to have flushed, and continuation hooks require care to avoid loops or duplicate work.
+- [Gemini hooks reference](https://geminicli.com/docs/hooks/reference/): `AfterAgent` provides the prompt response and original prompt. Hook retry behavior must not be treated as an idempotent TMT submission without request fencing.
+- [Gemini headless CLI](https://geminicli.com/docs/cli/headless/): headless operation can provide response JSON or message chunks plus a result. TMT should consume a bounded final result, not invent a second chunk protocol.
+- [tmux manual](https://raw.githubusercontent.com/tmux/tmux/master/tmux.1): capture reads pane screen/history, while pipe-pane receives program output. A pane supports one pipe command at a time. Neither supplies semantic request ownership; neither can recover text never rendered or emitted. Correlation alone also cannot restore missing text.
+
+## User-observable contract: current versus proposal
+
+Current behavior is observable as `status: sent` for non-wait sends,
+`status: completed` with `requestId`, `nonce`, `endMarker`, and `response` for
+marker-detected waits, and `status: timeout` with optional `partialResponse`.
+Human output also prints a response extracted from the pane.
+
+Proposed behavior is intentionally a contract direction, not a schema change:
+`completed` would mean a correlated final body was durably accepted; terminal
+diagnostics would not be presented as that body. Timeout, cancellation, expiry,
+and uncertain send would remain distinguishable from completion, and a late or
+conflicting final submission would not complete a newer request. Exact JSON
+fields, status names, and limits must be specified in the implementation issue;
+this document does not commit to them.
+
+## Verification matrix
+
+### Research diagnostic, not a delivered channel
+
+`test/e2e/response-integrity.e2e.test.ts` exercises the real CLI against the
+existing private-server fixture in `virtualized` mock mode. The mock constructs
+a full 202-line plain-text body, renders only its last three lines and the
+completion marker, then records the full body in its causal event. The scenario
+checks exact event text, matching nonce/PID, visible tail, completed/truncated
+output, and the missing interior in both 100-line and 2,000-line captures.
+
+A passing diagnostic proves a limitation of the current terminal source, not
+reliability of a replacement. The event log is a test oracle, not a production
+response store. This synthetic case is not a diagnosis of a particular provider.
+TMT-37 must use exact returned/retrieved body equality against this oracle and
+durable request/attempt association; it cannot reuse the missing-body assertion
+as its success criterion. The reproduction does not depend on the separate
+instruction-boundary bug: enlarging or correcting extraction cannot recover an
+interior that the mock never emitted.
+
+### Implementation acceptance
+
+Implementation work should add deterministic tests for:
+
+- exact text, Unicode, multiline content, and empty bodies;
+- redraws, scrollback/history, marker-like user text, and the current
+  placeholder/nonce boundary;
+- two concurrent requests to one pane, plus independent requests to different
+  panes;
+- identical duplicate final submissions and conflicting final submissions;
+- late replies after waiter timeout, cancellation, expiry, and process restart;
+- request/attempt fencing so a stale writer cannot clear or complete a newer
+  request;
+- tmux paste/Enter failure, legacy transport fallback, and uncertain-send
+  handling without automatic replay;
+- durable state preservation after failed finalization and cleanup after
+  success, timeout, cancellation, and thrown errors.
+
+The E2E cases should assert JSON fields plus causal mock-agent events keyed by
+nonce and PID, not terminal echo alone. Use barriers and bounded polling rather
+than fixed sleeps, and run the Docker suite twice when lifecycle/cleanup code
+changes. Provider-source adapters should use recorded fixtures and remain
+network-free; no actual provider integration result is claimed here.

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -21,6 +21,8 @@ export interface MockEvent {
   nonce?: string;
   mode?: string;
   pid?: number;
+  response?: string;
+  responseLength?: number;
 }
 
 export interface MockPane {
@@ -106,7 +108,7 @@ export class E2EFixture {
 
   async start(
     options: {
-      mode?: 'respond' | 'silent' | 'malformed';
+      mode?: 'respond' | 'silent' | 'malformed' | 'virtualized';
       delayMs?: number;
       metadataBarrier?: MetadataBarrierOptions;
     } = {}
@@ -661,7 +663,7 @@ exit ${'$'}status
 export async function withE2EFixture<T>(
   callback: (fixture: E2EFixture) => Promise<T> | T,
   options: {
-    mode?: 'respond' | 'silent' | 'malformed';
+    mode?: 'respond' | 'silent' | 'malformed' | 'virtualized';
     delayMs?: number;
     globalDir?: string;
     metadataBarrier?: MetadataBarrierOptions;

--- a/test/e2e/mock-agent.mjs
+++ b/test/e2e/mock-agent.mjs
@@ -6,6 +6,7 @@ import readline from 'node:readline';
 const mode = process.env.TMT_MOCK_MODE ?? 'respond';
 const delayMs = Number(process.env.TMT_MOCK_DELAY_MS ?? 0);
 const logPath = process.env.TMT_MOCK_LOG;
+const virtualizedLineCount = 200;
 
 function appendEvent(event) {
   if (!logPath) return;
@@ -13,6 +14,33 @@ function appendEvent(event) {
 }
 
 function respond(message, nonce) {
+  if (mode === 'virtualized') {
+    const responseLines = [
+      `VIRTUALIZED-BEGIN:${message}`,
+      ...Array.from(
+        { length: virtualizedLineCount },
+        (_, index) => `VIRTUALIZED-LINE-${String(index + 1).padStart(3, '0')}:${message}`
+      ),
+      `VIRTUALIZED-END:${message}`,
+    ];
+    const response = responseLines.join('\n');
+    const visibleLines = responseLines.slice(-3).join('\n');
+    // The virtualized response replaces the terminal surface before rendering its
+    // short tail. The full plain-text body remains available only in the event log.
+    const output = `\u001b[2J\u001b[3J\u001b[H${visibleLines}\nRESPONSE-END-${nonce}\n`;
+    process.stdout.write(output, () =>
+      appendEvent({
+        event: 'response',
+        message,
+        nonce,
+        mode,
+        pid: process.pid,
+        response,
+        responseLength: response.length,
+      })
+    );
+    return;
+  }
   const output = `mock-agent response: ${message || '(empty)'}\nRESPONSE-END-${nonce}\n`;
   process.stdout.write(output, () =>
     appendEvent({ event: 'response', message, nonce, mode, pid: process.pid })

--- a/test/e2e/response-integrity.e2e.test.ts
+++ b/test/e2e/response-integrity.e2e.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture } from './harness.js';
+
+interface TalkResult {
+  nonce: string;
+  pane: string;
+  response: string;
+  status: string;
+  truncated: boolean;
+}
+
+interface CheckResult {
+  output: string;
+}
+
+function expectedVirtualizedResponse(token: string): string {
+  return [
+    `VIRTUALIZED-BEGIN:${token}`,
+    ...Array.from(
+      { length: 200 },
+      (_, index) => `VIRTUALIZED-LINE-${String(index + 1).padStart(3, '0')}:${token}`
+    ),
+    `VIRTUALIZED-END:${token}`,
+  ].join('\n');
+}
+
+describe.sequential('TMT-35 response-channel research characterization', () => {
+  it('shows that terminal capture cannot recover a virtualized full response', async () => {
+    // This is deliberately a research characterization of the current terminal-source
+    // limitation, not a complete-response acceptance test. A future structured-channel
+    // test must assert this exact full body and durable request correlation before delivery.
+    await withE2EFixture(
+      async (fixture) => {
+        const peer = await fixture.createMockPane('virtualized-agent');
+        const binding = await fixture.runJsonCli(['add', peer.pane, 'Virtualized']);
+        expect(binding.code).toBe(0);
+
+        const token = 'tmt35-virtualized-response';
+        const expectedResponse = expectedVirtualizedResponse(token);
+        const talk = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          'Virtualized',
+          token,
+          '--no-preamble',
+          '--wait',
+          '--timeout',
+          '8',
+        ]);
+
+        expect(talk.code).toBe(0);
+        expect(talk.json).toMatchObject({ status: 'completed', truncated: true });
+        expect(talk.json?.pane).toBe(peer.pane);
+        expect(talk.json?.nonce).toMatch(/^[a-f0-9]+$/);
+        expect(talk.json?.response).toContain(`VIRTUALIZED-END:${token}`);
+        expect(talk.json?.response).not.toContain(`VIRTUALIZED-LINE-100:${token}`);
+
+        const requestEvent = await fixture.waitForEvent(
+          (event) =>
+            event.event === 'request' && event.pid === peer.pid && event.nonce === talk.json?.nonce
+        );
+        expect(requestEvent).toMatchObject({
+          message: token,
+          mode: 'virtualized',
+          nonce: talk.json?.nonce,
+          pid: peer.pid,
+        });
+        const responseEvent = await fixture.waitForEvent(
+          (event) =>
+            event.event === 'response' && event.pid === peer.pid && event.nonce === talk.json?.nonce
+        );
+        expect(responseEvent.message).toBe(token);
+        expect(responseEvent.response).toBe(expectedResponse);
+        expect(responseEvent.responseLength).toBe(expectedResponse.length);
+        expect(responseEvent.response).toContain(`VIRTUALIZED-LINE-100:${token}`);
+
+        const capturedAtDefault = await fixture.runJsonCli<CheckResult>([
+          'check',
+          'Virtualized',
+          '100',
+        ]);
+        const capturedAtMax = await fixture.runJsonCli<CheckResult>([
+          'check',
+          'Virtualized',
+          '2000',
+        ]);
+        for (const captured of [capturedAtDefault, capturedAtMax]) {
+          expect(captured.code).toBe(0);
+          expect(captured.json?.output).toContain(`VIRTUALIZED-END:${token}`);
+          expect(captured.json?.output).not.toContain(`VIRTUALIZED-LINE-100:${token}`);
+        }
+      },
+      { mode: 'virtualized' }
+    );
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

- Record the current request/correlation/extraction boundaries and compare official provider hooks, structured headless output, cooperating submission, artifacts, and terminal capture.
- Recommend one shared SQLite request/response service, with explicit attempt fencing, immutable final text, idempotent identical replies, and late replies independent of waiter timeout.
- Add a deterministic Docker diagnostic proving a completed marker cannot recover a full body that the mock's virtualized surface never rendered.

Resolves TMT-35. Follow-up implementation is bounded by TMT-36 and TMT-37; no new production command, provider integration, daemon, dependency, persistence schema, or runtime behavior ships here.

## Architecture and review

Primary review inspected all five changed files and surrounding `talk`, `state`, tmux send/capture, fixture startup/environment/cleanup and current test consumers. Reused the existing private-server harness and causal event log rather than creating a replacement transport in tests. ARCHITECTURE.md links the maintained REQUEST-RESPONSE.md and explicitly labels the structured channel as proposed, not shipped.

Luna high completed the read-only pattern audit. Primary corrected the audit's missed resend fallback and instruction-placeholder mismatch, rejected implicit latest-pane correlation, and strengthened diagnostics with successful-command and visible-tail assertions so missing/error output cannot create a false positive. Gemini provided supplementary static review; primary rejected its earlier timeout-expiry, arbitrary retention, and provider-specific-state assumptions. No new CLI spelling suggested by a reviewer is accepted here.

The green diagnostic intentionally demonstrates the current source limitation. It is not a green reliability gate for the unimplemented channel. TMT-37 must assert exact returned and retrieved body equality with durable request/attempt association. Official documentation establishes candidate capabilities only; no real provider integration test is claimed.

## Verification

- `pnpm check`: passed.
- `pnpm test:run`: 457 tests passed; statements 94.22%, branches 87.71%, coverage gates passed.
- `pnpm exec prettier --check --ignore-path .gitignore REQUEST-RESPONSE.md`: passed.
- `git diff --check`: passed.
- `pnpm test:e2e`: two Docker runs on unchanged test/runtime sources passed 45/45 (150.84 and 150.19 seconds), with fixture and image cleanup.
- Reviewed head: `898bc8a` (all five files personally reviewed; only documentation changed after the first Docker image snapshot).
- Runtime, package manifests, lockfile and CI workflow are unchanged. All required CI, including the native package matrix, must pass on this reviewed PR head before merge.
