### PR TITLE
fix: prevent uncertain tmux delivery replay (TMT-24)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,6 +44,30 @@ is not shipped: current marker behavior, JSON bookkeeping and CLI grammar remain
 unchanged until their bounded implementation issues land. Keep this distinction
 and the document's verification status current as those slices are delivered.
 
+## Message delivery and uncertainty
+
+The tmux message adapter prepares one payload with the existing ASCII `!` to
+fullwidth substitution and trailing-newline policy. This protects coding-agent
+shell-mode shortcuts; it is not literal code delivery or provider capability
+detection. Buffer paste is preferred. Only a set-buffer failure before paste
+has been invoked permits one literal-key fallback with that same payload.
+Normal and fallback paths share the configured delay and Enter submission.
+
+Once paste or literal input has been invoked, failures are uncertain and cannot
+trigger replay or another Enter. The narrow message-delivery error contract
+carries the failed stage without coupling commands to the concrete tmux adapter.
+Both wait and non-wait `talk` map it to `DELIVERY_UNCERTAIN` (exit 1), with
+inspection guidance; successful result shapes remain unchanged. Request-ID
+guarded JSON cleanup remains, but its concurrency limitations are not repaired
+by transport typing.
+
+Transport subprocesses have a one-second timeout, SIGKILL termination and a
+64 KiB output bound. Argv-based capture has a one-second timeout and 4 MiB output
+bound; overflow/failure does not return a successful partial capture. These
+bounds are separate from configured Enter delay and response timeout. Temporary
+buffer cleanup targets only the operation's unique buffer and cannot change
+the delivery outcome. There is no exactly-once agent-processing guarantee.
+
 ## Caller context
 
 The tmux adapter owns current-pane evidence: a strict `TMUX_PANE` ID and the
@@ -122,6 +146,7 @@ local `$config` settings remain supported in this staged removal.
 | [src/target-resolver.ts](src/target-resolver.ts)                                                                                         | Shared name/pane resolution; pane-shaped arguments are resolved before names.                                                                                                          |
 | [src/storage/](src/storage/)                                                                                                             | SQLite lifecycle, migrations, errors and repository SQL. Lifecycle ports exist; domain repository ports are not fully separated.                                                       |
 | [src/tmux.ts](src/tmux.ts)                                                                                                               | External tmux commands, snapshots, metadata, paste/capture, and compatibility registry adapter.                                                                                        |
+| [src/tmux-message.ts](src/tmux-message.ts), [src/message-delivery.ts](src/message-delivery.ts)                                           | Stageful protected input and shared submission policy; narrow delivery uncertainty contract consumed by commands without importing the tmux implementation.                            |
 | [src/role-content.ts](src/role-content.ts)                                                                                               | Bounded file reading/UTF-8 validation; pure normalization lives in `domain/role.ts`.                                                                                                   |
 | [src/config.ts](src/config.ts), [src/registry.ts](src/registry.ts), [src/state.ts](src/state.ts)                                         | Path/config resolution and legacy registry/request/counter state. JSON state is not transactional storage.                                                                             |
 | [src/ui.ts](src/ui.ts), [src/exits.ts](src/exits.ts)                                                                                     | Presentation helpers and exit-code registry; do not invent conflicting mappings.                                                                                                       |
@@ -181,14 +206,14 @@ These links identify owners of unresolved work, not permission to widen an
 unrelated PR. Update this section and the current map in the delivering PR when
 a gap is resolved; do not leave a permanent exception or label a proposal as shipped.
 
-| Gap                                                                                                                                                      | Owning issue                                                                                                                                                           |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Numeric/flag validation needs hardening.                                                                                                                 | [TMT-22](https://linear.app/tigerpig-dev/issue/TMT-22)                                                                                                                 |
-| Message adaptation/fallback and JSON wait/counter updates have safety/concurrency gaps.                                                                  | [TMT-24](https://linear.app/tigerpig-dev/issue/TMT-24), [TMT-25](https://linear.app/tigerpig-dev/issue/TMT-25)                                                         |
-| JSON/process error boundaries are inconsistent; preamble/config still consume workspace registries after command retirement.                             | [TMT-26](https://linear.app/tigerpig-dev/issue/TMT-26), [TMT-27](https://linear.app/tigerpig-dev/issue/TMT-27)                                                         |
-| Optional identity-service fallbacks, broad contracts and concrete repository coupling remain. The parser also imports a command-owned role request type. | [TMT-28](https://linear.app/tigerpig-dev/issue/TMT-28)                                                                                                                 |
-| Shipped skill/help inventories drift; packed verification does not yet prove application migrations.                                                     | [TMT-29](https://linear.app/tigerpig-dev/issue/TMT-29)                                                                                                                 |
-| Non-tmux identity management, memory and durable inbox are future capabilities, not installed APIs.                                                      | [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
+| Gap                                                                                                                                                      | Owning issue                                                                                                                                                                                                                   |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Numeric/flag validation needs hardening.                                                                                                                 | [TMT-22](https://linear.app/tigerpig-dev/issue/TMT-22)                                                                                                                                                                         |
+| JSON wait/counter updates still have concurrency gaps; terminal completion/extraction cannot guarantee a complete correlated body.                       | [TMT-25](https://linear.app/tigerpig-dev/issue/TMT-25), [TMT-35](https://linear.app/tigerpig-dev/issue/TMT-35), [TMT-36](https://linear.app/tigerpig-dev/issue/TMT-36), [TMT-37](https://linear.app/tigerpig-dev/issue/TMT-37) |
+| JSON/process error boundaries are inconsistent; preamble/config still consume workspace registries after command retirement.                             | [TMT-26](https://linear.app/tigerpig-dev/issue/TMT-26), [TMT-27](https://linear.app/tigerpig-dev/issue/TMT-27)                                                                                                                 |
+| Optional identity-service fallbacks, broad contracts and concrete repository coupling remain. The parser also imports a command-owned role request type. | [TMT-28](https://linear.app/tigerpig-dev/issue/TMT-28)                                                                                                                                                                         |
+| Shipped skill/help inventories drift; packed verification does not yet prove application migrations.                                                     | [TMT-29](https://linear.app/tigerpig-dev/issue/TMT-29)                                                                                                                                                                         |
+| Non-tmux identity management, memory and durable inbox are future capabilities, not installed APIs.                                                      | [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16)                                                         |
 
 ## Maintenance contract
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -53,7 +53,8 @@ Use the [development skill](.agents/skills/tmt-dev/SKILL.md) to apply them.
 - Message framing and adaptation belong to shared delivery implementation.
   Current waits use `RESPONSE-END-<nonce>`; do not invent a second marker.
   The `!` policy protects coding-agent shell/bash mode, not TTY cosmetics.
-  Consult the delivery gap in ARCHITECTURE before changing payload/fallback behavior.
+  Consult ARCHITECTURE's message delivery and uncertainty contract before
+  changing payload/fallback behavior.
 
 ## Dependencies and refactoring
 

--- a/README.md
+++ b/README.md
@@ -185,13 +185,29 @@ Malformed or unsupported identity metadata cannot establish presence; unrelated
 valid identities remain discoverable. Reads do not rewrite old pane markers or
 delete legacy files, and invalid presence does not delete durable role profiles.
 
-Messages use tmux buffer paste and then submit with Enter. This preserves
-multiline text and handles paste-safety windows in CLIs such as Gemini. The
-delay is configurable:
+Messages use tmux buffer paste and then submit with Enter. Line breaks are
+preserved, but ASCII `!` is deliberately converted to fullwidth `！` to protect
+coding-agent shell/bash-mode shortcuts, including on the literal-key fallback
+path. This means code such as `if (!ready)` is not delivered byte-for-byte.
+Bracketed paste is not assumed to disable every agent's shortcuts. The
+paste-to-Enter delay is configurable:
 
 ```bash
 tmt config set pasteEnterDelayMs 500
 ```
+
+Once paste or literal input may have reached a pane, TMT does not automatically
+replay it. A failed input/submission stage returns `DELIVERY_UNCERTAIN` (exit 1)
+in both wait and non-wait modes, with `error.stage` in JSON. Inspect the pane
+before deciding whether to retry; absent visible output does not prove that no
+work started. Successful submission does not promise exactly-once processing.
+Each transport/capture subprocess is bounded independently of the configured
+Enter delay and response wait timeout.
+
+Response waits still use best-effort terminal extraction: a completion marker
+does not guarantee a full body under virtual scrolling. `check` is a diagnostic
+snapshot, not durable response retrieval. See the
+[channel research and implementation plan](REQUEST-RESPONSE.md).
 
 ## Local SQLite storage
 

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -5,6 +5,14 @@ ship a provider integration, daemon, inbox, memory feature, or new CLI syntax.
 Exact schemas, limits, and compatibility decisions belong in implementation
 tickets after this boundary is accepted.
 
+TMT-24 implementation update: transport now prevents replay after an input
+stage may have acted, preserves the same `!` protection on fallback, reports
+`DELIVERY_UNCERTAIN`, and bounds argv-based capture. The current implementation
+map below describes the research baseline; its broad resend fallback is no
+longer present. Request/response storage, instruction-boundary extraction and
+structured final-body delivery remain unresolved. See ARCHITECTURE.md for the
+maintained shipped transport boundary.
+
 ## Current implementation map
 
 `cmdTalk` resolves one target, then either sends and returns (`talk` without

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -14,6 +14,24 @@ You are working in a multi-agent tmux environment. Use the `tmux-team` CLI to co
 - Checking responses from agents you've messaged
 - Coordinating parallel work across multiple agents
 
+## Delivery safety
+
+`talk` converts ASCII `!` to fullwidth `！` on both normal and fallback input
+paths to protect coding-agent shell/bash-mode shortcuts. Line breaks are
+preserved, but text such as `if (!ready)` is not delivered byte-for-byte. Do not
+assume bracketed paste or an agent's identity name makes literal `!` safe.
+
+`DELIVERY_UNCERTAIN` (exit 1) means input or Enter may already have reached the
+pane. JSON includes the failed `stage`. Do not automatically resend: inspect
+with `tmt check <target>` and establish whether work started before deciding
+what to do next. Missing visible output is not proof that nothing executed.
+Successful submission also does not guarantee exactly-once agent processing.
+
+`--wait` still extracts a best-effort terminal response. A completion marker
+can coexist with cropped content; increasing `check` lines cannot recover text
+that the agent never rendered. No durable structured response channel is
+implied by this transport safety behavior.
+
 ## Commands
 
 `name`, `this`, `whoami` and `unbind` require matching live `TMUX` and

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -11,6 +11,24 @@ Use the tmux-team CLI to communicate with other agents.
 Identities are durable SQLite records, independent of the working directory.
 Active presence also requires matching live tmux binding metadata.
 
+## Delivery safety
+
+`talk` converts ASCII `!` to fullwidth `！` on both normal and fallback input
+paths to protect coding-agent shell/bash-mode shortcuts. Line breaks are
+preserved, but text such as `if (!ready)` is not delivered byte-for-byte. Do not
+assume bracketed paste or an agent's identity name makes literal `!` safe.
+
+`DELIVERY_UNCERTAIN` (exit 1) means input or Enter may already have reached the
+pane. JSON includes the failed `stage`. Do not automatically resend: inspect
+with `tmt check <target>` and establish whether work started before deciding
+what to do next. Missing visible output is not proof that nothing executed.
+Successful submission also does not guarantee exactly-once agent processing.
+
+`--wait` still extracts a best-effort terminal response. A completion marker
+can coexist with cropped content; increasing `check` lines cannot recover text
+that the agent never rendered. No durable structured response channel is
+implied by this transport safety behavior.
+
 ## Commands
 
 `name`, `this`, `whoami` and `unbind` require matching live `TMUX` and

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -11,6 +11,24 @@ Use the tmux-team CLI to communicate with other agents.
 Identities are durable SQLite records, independent of the working directory.
 Active presence also requires matching live tmux binding metadata.
 
+## Delivery safety
+
+`talk` converts ASCII `!` to fullwidth `！` on both normal and fallback input
+paths to protect coding-agent shell/bash-mode shortcuts. Line breaks are
+preserved, but text such as `if (!ready)` is not delivered byte-for-byte. Do not
+assume bracketed paste or an agent's identity name makes literal `!` safe.
+
+`DELIVERY_UNCERTAIN` (exit 1) means input or Enter may already have reached the
+pane. JSON includes the failed `stage`. Do not automatically resend: inspect
+with `tmt check <target>` and establish whether work started before deciding
+what to do next. Missing visible output is not proof that nothing executed.
+Successful submission also does not guarantee exactly-once agent processing.
+
+`--wait` still extracts a best-effort terminal response. A completion marker
+can coexist with cropped content; increasing `check` lines cannot recover text
+that the agent never rendered. No durable structured response channel is
+implied by this transport safety behavior.
+
 ## Commands
 
 `name`, `this`, `whoami` and `unbind` require matching live `TMUX` and

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -7,6 +7,24 @@ description: Communicate with other AI agents in tmux panes through the tmt CLI.
 
 Use `tmt` (the short alias for `tmux-team`) when the user asks you to communicate with another agent in a tmux pane.
 
+## Delivery safety
+
+`talk` converts ASCII `!` to fullwidth `！` on both normal and fallback input
+paths to protect coding-agent shell/bash-mode shortcuts. Line breaks are
+preserved, but text such as `if (!ready)` is not delivered byte-for-byte. Do not
+assume bracketed paste or an agent's identity name makes literal `!` safe.
+
+`DELIVERY_UNCERTAIN` (exit 1) means input or Enter may already have reached the
+pane. JSON includes the failed `stage`. Do not automatically resend: inspect
+with `tmt check <target>` and establish whether work started before deciding
+what to do next. Missing visible output is not proof that nothing executed.
+Successful submission also does not guarantee exactly-once agent processing.
+
+`--wait` still extracts a best-effort terminal response. A completion marker
+can coexist with cropped content; increasing `check` lines cannot recover text
+that the agent never rendered. No durable structured response channel is
+implied by this transport safety behavior.
+
 ## Commands
 
 `name`, `this`, `whoami` and `unbind` require matching live `TMUX` and

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -8,6 +8,8 @@ import path from 'path';
 import os from 'os';
 import type { Context, Tmux, UI, Paths, ResolvedConfig, Flags } from '../types.js';
 import { ExitCodes } from '../exits.js';
+import { TmuxDeliveryError } from '../message-delivery.js';
+import { loadState, setActiveRequest } from '../state.js';
 import { cmdTalk } from './talk.js';
 
 // ─────────────────────────────────────────────────────────────
@@ -420,6 +422,54 @@ describe('cmdTalk - basic send', () => {
     ]);
   });
 
+  it('returns one structured uncertainty envelope for a typed send failure', async () => {
+    const tmux = createMockTmux();
+    const ui = createMockUI();
+    tmux.send = () => {
+      throw new TmuxDeliveryError('paste');
+    };
+    const ctx = createContext({
+      tmux,
+      ui,
+      paths: createTestPaths(testDir),
+      flags: { json: true },
+      config: { paneRegistry: { claude: { pane: '1.0' } } },
+    });
+
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(ui.jsonOutput).toEqual([
+      {
+        error: {
+          code: 'DELIVERY_UNCERTAIN',
+          message: 'Message delivery is uncertain during paste.',
+          stage: 'paste',
+          suggestion: 'Inspect the target pane before retrying.',
+        },
+      },
+    ]);
+    expect(ui.jsonOutput).toHaveLength(1);
+  });
+
+  it('shows an actionable inspection hint for human uncertainty output', async () => {
+    const tmux = createMockTmux();
+    const ui = createMockUI();
+    tmux.send = () => {
+      throw new TmuxDeliveryError('literal');
+    };
+    const ctx = createContext({
+      tmux,
+      ui,
+      paths: createTestPaths(testDir),
+      config: { paneRegistry: { claude: { pane: '1.0' } } },
+    });
+
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(ui.errors).toEqual([
+      'Message delivery is uncertain during literal. Inspect the target pane before retrying.',
+    ]);
+    expect(ui.jsonOutput).toEqual([]);
+  });
+
   it('preserves exclamation marks for gemini agent', async () => {
     const tmux = createMockTmux();
     const ctx = createContext({ tmux, paths: createTestPaths(testDir) });
@@ -519,6 +569,98 @@ describe('cmdTalk - --wait mode', () => {
     // Simulate: scrollback, user message with instruction, agent response, marker
     return `Some scrollback content\nUser message here\n\n${instruction}\n${response}\n${endMarker}`;
   }
+
+  it.each([
+    [
+      'generic',
+      () => new Error('tmux error'),
+      { code: 'ERROR', message: 'Failed to send to pane 1.0. Is tmux running?' },
+    ],
+    [
+      'typed',
+      () => new TmuxDeliveryError('submit'),
+      {
+        code: 'DELIVERY_UNCERTAIN',
+        message: 'Message delivery is uncertain during submit.',
+        stage: 'submit',
+        suggestion: 'Inspect the target pane before retrying.',
+      },
+    ],
+  ] as const)(
+    'maps %s send failure once in wait mode and clears request state',
+    async (_kind, makeError, expected) => {
+      const tmux = createMockTmux();
+      const ui = createMockUI();
+      tmux.send = () => {
+        throw makeError();
+      };
+      const paths = createTestPaths(testDir);
+      const unrelated = {
+        id: 'other-request',
+        nonce: 'other',
+        pane: '1.1',
+        startedAtMs: Date.now(),
+      };
+      setActiveRequest(paths, '1.1', unrelated);
+      const ctx = createContext({
+        tmux,
+        ui,
+        paths,
+        flags: { wait: true, json: true, timeout: 0.5 },
+        config: {
+          paneRegistry: { claude: { pane: '1.0' } },
+          defaults: {
+            timeout: 0.5,
+            pollInterval: 0.01,
+            captureLines: 100,
+            maxCaptureLines: 2000,
+            preambleEvery: 3,
+            pasteEnterDelayMs: 500,
+          },
+        },
+      });
+      ctx.exit = (code: number) => {
+        expect(code).toBe(ExitCodes.ERROR);
+        expect(loadState(paths).requests['1.0']).toBeUndefined();
+        expect(loadState(paths).requests['1.1']).toEqual(unrelated);
+        throw new Error(`exit(${code})`);
+      };
+
+      await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
+      expect(ui.jsonOutput).toEqual([{ error: expected }]);
+      expect(ui.jsonOutput).toHaveLength(1);
+      expect(fs.existsSync(paths.stateFile)).toBe(true);
+      const state = loadState(paths);
+      expect(state.requests['1.0']).toBeUndefined();
+      expect(state.requests['1.1']).toEqual(unrelated);
+    }
+  );
+
+  it('does not clear a newer pane request after an uncertain send', async () => {
+    const paths = createTestPaths(testDir);
+    const tmux = createMockTmux();
+    const replacement = {
+      id: 'newer-request',
+      nonce: 'newer',
+      pane: '1.0',
+      startedAtMs: Date.now(),
+    };
+    tmux.send = () => {
+      expect(loadState(paths).requests['1.0']?.id).not.toBe(replacement.id);
+      expect(loadState(paths).requests['1.0']?.pane).toBe('1.0');
+      setActiveRequest(paths, '1.0', replacement);
+      throw new TmuxDeliveryError('paste');
+    };
+    const ctx = createContext({ tmux, paths, flags: { wait: true, json: true } });
+    ctx.exit = (code: number) => {
+      expect(code).toBe(ExitCodes.ERROR);
+      expect(loadState(paths).requests['1.0']).toEqual(replacement);
+      throw new Error(`exit(${code})`);
+    };
+
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(loadState(paths).requests['1.0']).toEqual(replacement);
+  });
 
   it('appends nonce instruction to message', async () => {
     const tmux = createMockTmux();

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -16,9 +16,29 @@ import {
 import { resolveTarget } from '../target-resolver.js';
 import { normalizeName } from '../domain/names.js';
 import { identityAwareTmux } from '../identity-service.js';
+import { TmuxDeliveryError } from '../message-delivery.js';
 
 function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function failSend(ctx: Context, pane: string, error: unknown): never {
+  if (error instanceof TmuxDeliveryError) {
+    const detail = {
+      code: error.code,
+      message: error.message,
+      stage: error.stage,
+      suggestion: 'Inspect the target pane before retrying.',
+    };
+    if (ctx.flags.json) ctx.ui.json({ error: detail });
+    else ctx.ui.error(`${detail.message} ${detail.suggestion}`);
+    return ctx.exit(ExitCodes.ERROR);
+  }
+
+  const detail = { code: 'ERROR', message: `Failed to send to pane ${pane}. Is tmux running?` };
+  if (ctx.flags.json) ctx.ui.json({ error: detail });
+  else ctx.ui.error(detail.message);
+  return ctx.exit(ExitCodes.ERROR);
 }
 
 /**
@@ -317,11 +337,8 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
         console.log(`${colors.green('→')} Sent to ${colors.cyan(target)} (${pane})`);
       }
       return;
-    } catch {
-      const error = { code: 'ERROR', message: `Failed to send to pane ${pane}. Is tmux running?` };
-      if (flags.json) ui.json({ error });
-      else ui.error(error.message);
-      exit(ExitCodes.ERROR);
+    } catch (error) {
+      failSend(ctx, pane, error);
     }
   }
 
@@ -380,7 +397,15 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
       console.error(`[DEBUG] Message sent:\n${msg}`);
     }
 
-    tmux.send(pane, msg, { enterDelayMs });
+    try {
+      tmux.send(pane, msg, { enterDelayMs });
+    } catch (error) {
+      // process.exit() does not run the surrounding finally block. Clear only
+      // this request before reporting the send failure; the request ID guard
+      // preserves a newer request that may have replaced it concurrently.
+      clearActiveRequest(ctx.paths, pane, requestId);
+      failSend(ctx, pane, error);
+    }
 
     while (true) {
       const elapsedSeconds = (Date.now() - startedAt) / 1000;

--- a/src/message-delivery.ts
+++ b/src/message-delivery.ts
@@ -1,0 +1,15 @@
+export type TmuxDeliveryStage = 'paste' | 'literal' | 'submit';
+
+/** A send reached a stage where the pane may have received user input. */
+export class TmuxDeliveryError extends Error {
+  readonly code = 'DELIVERY_UNCERTAIN';
+  readonly outcome = 'uncertain';
+
+  constructor(
+    readonly stage: TmuxDeliveryStage,
+    options?: { readonly cause?: unknown }
+  ) {
+    super(`Message delivery is uncertain during ${stage}.`, options);
+    this.name = 'TmuxDeliveryError';
+  }
+}

--- a/src/tmux-message.test.ts
+++ b/src/tmux-message.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sendTmuxMessage } from './tmux-message.js';
+
+describe('message submission sequencing', () => {
+  it.each([false, true])(
+    'preserves configured delay before one Enter (fallback: %s)',
+    (fallback) => {
+      const sequence: string[] = [];
+      const execute = vi.fn((args: string[]) => {
+        sequence.push(
+          args[0] === 'send-keys' ? (args.includes('-l') ? 'literal' : 'submit') : args[0]
+        );
+        if (fallback && args[0] === 'set-buffer') throw new Error('buffer unavailable');
+      });
+      sendTmuxMessage({
+        paneId: '%7',
+        message: 'message!',
+        enterDelayMs: 731,
+        execute,
+        sleep: (milliseconds) => sequence.push(`delay:${milliseconds}`),
+      });
+      expect(sequence).toEqual(
+        fallback
+          ? ['set-buffer', 'delete-buffer', 'literal', 'delay:731', 'submit']
+          : ['set-buffer', 'paste-buffer', 'delay:731', 'submit']
+      );
+    }
+  );
+
+  it('retains the input failure cause when owned-buffer cleanup also fails', () => {
+    const inputError = new Error('input outcome unknown');
+    const execute = vi.fn((args: string[]) => {
+      if (args[0] === 'paste-buffer') throw inputError;
+      if (args[0] === 'delete-buffer') throw new Error('cleanup failed');
+    });
+    const sleep = vi.fn();
+    expect(() =>
+      sendTmuxMessage({
+        paneId: '%7',
+        message: 'message',
+        enterDelayMs: 10,
+        execute,
+        sleep,
+      })
+    ).toThrowError(expect.objectContaining({ stage: 'paste', cause: inputError }));
+    expect(sleep).not.toHaveBeenCalled();
+    expect(execute.mock.calls.map(([args]) => args[0])).toEqual([
+      'set-buffer',
+      'paste-buffer',
+      'delete-buffer',
+    ]);
+  });
+});

--- a/src/tmux-message.ts
+++ b/src/tmux-message.ts
@@ -1,0 +1,93 @@
+import crypto from 'node:crypto';
+import { TmuxDeliveryError } from './message-delivery.js';
+
+const TMUX_SEND_TIMEOUT_MS = 1_000;
+const TMUX_SEND_MAX_BUFFER = 64 * 1024;
+
+type SendCommandOptions = {
+  timeout: number;
+  maxBuffer: number;
+  killSignal: 'SIGKILL';
+  stdio: ['pipe', 'pipe', 'pipe'];
+};
+
+type ExecuteSendCommand = (args: string[], options: SendCommandOptions) => void;
+
+export interface TmuxMessageOptions {
+  readonly paneId: string;
+  readonly message: string;
+  readonly enterDelayMs: number;
+  readonly execute: ExecuteSendCommand;
+  readonly sleep: (ms: number) => void;
+}
+
+function commandOptions(): SendCommandOptions {
+  return {
+    timeout: TMUX_SEND_TIMEOUT_MS,
+    maxBuffer: TMUX_SEND_MAX_BUFFER,
+    killSignal: 'SIGKILL',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  };
+}
+
+function escapeExclamation(message: string): string {
+  // Coding-agent shells can interpret ! before the provider receives input.
+  return message.replace(/!/g, '\uff01');
+}
+
+function ensureTrailingNewline(message: string): string {
+  return message.endsWith('\n') ? message : `${message}\n`;
+}
+
+function makeBufferName(): string {
+  const nonce = crypto.randomBytes(4).toString('hex');
+  return `tmt-${process.pid}-${Date.now()}-${nonce}`;
+}
+
+export function sendTmuxMessage(options: TmuxMessageOptions): void {
+  const { paneId, message, enterDelayMs, execute, sleep } = options;
+  const bufferName = makeBufferName();
+  // The same protected payload is used by buffer paste and literal fallback.
+  const payload = ensureTrailingNewline(escapeExclamation(message));
+
+  const cleanupBuffer = (): void => {
+    try {
+      execute(['delete-buffer', '-b', bufferName], commandOptions());
+    } catch {
+      // Cleanup is best effort and must not change the delivery outcome.
+    }
+  };
+
+  const submit = (): void => {
+    try {
+      sleep(enterDelayMs);
+      execute(['send-keys', '-t', paneId, 'Enter'], commandOptions());
+    } catch (error) {
+      throw new TmuxDeliveryError('submit', { cause: error });
+    }
+  };
+
+  try {
+    execute(['set-buffer', '-b', bufferName, '--', payload], commandOptions());
+  } catch {
+    // Paste has not been invoked, so one literal fallback remains safe even if
+    // set-buffer's subprocess outcome was uncertain.
+    cleanupBuffer();
+    try {
+      execute(['send-keys', '-l', '-t', paneId, '--', payload], commandOptions());
+    } catch (error) {
+      throw new TmuxDeliveryError('literal', { cause: error });
+    }
+    submit();
+    return;
+  }
+
+  try {
+    execute(['paste-buffer', '-b', bufferName, '-d', '-t', paneId, '-p'], commandOptions());
+  } catch (error) {
+    cleanupBuffer();
+    throw new TmuxDeliveryError('paste', { cause: error });
+  }
+
+  submit();
+}

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -46,7 +46,7 @@ function endpointRow(
 
 describe('createTmux', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   afterEach(() => {
@@ -73,7 +73,11 @@ describe('createTmux', () => {
       expect(mockedExecFileSync).toHaveBeenCalledWith(
         'tmux',
         ['send-keys', '-t', '1.0', 'Enter'],
-        expect.any(Object)
+        expect.objectContaining({
+          timeout: 1000,
+          maxBuffer: 64 * 1024,
+          killSignal: 'SIGKILL',
+        })
       );
     });
 
@@ -107,25 +111,94 @@ describe('createTmux', () => {
       );
     });
 
-    it('falls back to send-keys when buffer paste fails', () => {
+    it('falls back once with the adapted literal payload when set-buffer fails', () => {
       const error = new Error('set-buffer failed');
       mockedExecFileSync.mockImplementationOnce(() => {
         throw error;
       });
       const tmux = createTmux();
 
-      tmux.send('1.0', 'Hello', { enterDelayMs: 0 });
+      tmux.send('1.0', '-n weird!\nLine two', { enterDelayMs: 0 });
 
-      expect(mockedExecFileSync).toHaveBeenCalledWith(
-        'tmux',
-        ['send-keys', '-t', '1.0', 'Hello'],
-        expect.any(Object)
+      const calls = mockedExecFileSync.mock.calls.map(([, args]) => args);
+      const bufferName = calls[0]?.[2];
+      expect(calls[0]).toEqual([
+        'set-buffer',
+        '-b',
+        expect.stringMatching(/^tmt-/),
+        '--',
+        '-n weird！\nLine two\n',
+      ]);
+      expect(calls[1]).toEqual(['delete-buffer', '-b', bufferName]);
+      expect(calls[2]).toEqual(['send-keys', '-l', '-t', '1.0', '--', '-n weird！\nLine two\n']);
+      expect(calls[3]).toEqual(['send-keys', '-t', '1.0', 'Enter']);
+      expect(calls.filter((args) => args?.[0] === 'paste-buffer')).toHaveLength(0);
+      expect(calls.filter((args) => args?.[0] === 'send-keys')).toEqual([calls[2], calls[3]]);
+    });
+
+    it('reports uncertain literal fallback without submitting or replaying', () => {
+      mockedExecFileSync.mockImplementation((_, args = []) => {
+        if (args[0] === 'set-buffer') throw new Error('set-buffer failed');
+        if (args[0] === 'send-keys' && args.includes('--')) throw new Error('literal failed');
+        return '';
+      });
+      const tmux = createTmux();
+
+      expect(() => tmux.send('1.0', 'Hello!', { enterDelayMs: 0 })).toThrowError(
+        expect.objectContaining({ code: 'DELIVERY_UNCERTAIN', stage: 'literal' })
       );
-      expect(mockedExecFileSync).toHaveBeenCalledWith(
-        'tmux',
+      const calls = mockedExecFileSync.mock.calls.map(([, args]) => args);
+      expect(calls.filter((args) => args?.[0] === 'send-keys')).toEqual([
+        ['send-keys', '-l', '-t', '1.0', '--', 'Hello！\n'],
+      ]);
+    });
+
+    it('reports uncertain paste failure without replaying input', () => {
+      mockedExecFileSync.mockImplementation((_, args = []) => {
+        if (args[0] === 'paste-buffer') throw new Error('paste failed');
+        return '';
+      });
+      const tmux = createTmux();
+
+      expect(() => tmux.send('1.0', 'Hello', { enterDelayMs: 0 })).toThrowError(
+        expect.objectContaining({ code: 'DELIVERY_UNCERTAIN', stage: 'paste' })
+      );
+      const calls = mockedExecFileSync.mock.calls.map(([, args]) => args);
+      expect(calls[0]?.[0]).toBe('set-buffer');
+      expect(calls[1]?.[0]).toBe('paste-buffer');
+      expect(calls[2]).toEqual(['delete-buffer', '-b', calls[0]?.[2]]);
+      expect(calls.filter((args) => args?.[0] === 'send-keys')).toEqual([]);
+    });
+
+    it('preserves uncertain paste outcome when cleanup fails', () => {
+      mockedExecFileSync.mockImplementation((_, args = []) => {
+        if (args[0] === 'paste-buffer') throw new Error('paste failed');
+        if (args[0] === 'delete-buffer') throw new Error('cleanup failed');
+        return '';
+      });
+      const tmux = createTmux();
+
+      expect(() => tmux.send('1.0', 'Hello', { enterDelayMs: 0 })).toThrowError(
+        expect.objectContaining({ code: 'DELIVERY_UNCERTAIN', stage: 'paste' })
+      );
+      const calls = mockedExecFileSync.mock.calls.map(([, args]) => args);
+      expect(calls[2]).toEqual(['delete-buffer', '-b', calls[0]?.[2]]);
+    });
+
+    it('does not replay after Enter submission becomes uncertain', () => {
+      mockedExecFileSync.mockImplementation((_, args = []) => {
+        if (args[0] === 'send-keys' && args.includes('Enter')) throw new Error('Enter failed');
+        return '';
+      });
+      const tmux = createTmux();
+
+      expect(() => tmux.send('1.0', 'Hello', { enterDelayMs: 0 })).toThrowError(
+        expect.objectContaining({ code: 'DELIVERY_UNCERTAIN', stage: 'submit' })
+      );
+      const calls = mockedExecFileSync.mock.calls.map(([, args]) => args);
+      expect(calls.filter((args) => args?.[0] === 'send-keys')).toEqual([
         ['send-keys', '-t', '1.0', 'Enter'],
-        expect.any(Object)
-      );
+      ]);
     });
 
     it('uses pipe stdio to suppress output', () => {
@@ -133,26 +206,40 @@ describe('createTmux', () => {
 
       tmux.send('1.0', 'Hello', { enterDelayMs: 0 });
 
-      expect(mockedExecFileSync).toHaveBeenCalledWith('tmux', expect.any(Array), { stdio: 'pipe' });
+      for (const [, , options] of mockedExecFileSync.mock.calls) {
+        expect(options).toEqual(
+          expect.objectContaining({
+            stdio: ['pipe', 'pipe', 'pipe'],
+            timeout: 1000,
+            maxBuffer: 64 * 1024,
+            killSignal: 'SIGKILL',
+          })
+        );
+      }
     });
   });
 
   describe('capture', () => {
     it('calls tmux capture-pane with pane ID and line count', () => {
-      mockedExecSync.mockReturnValue('captured output');
+      mockedExecFileSync.mockReturnValue('captured output');
       const tmux = createTmux();
 
       tmux.capture('1.0', 100);
 
-      expect(mockedExecSync).toHaveBeenCalledWith(
-        'tmux capture-pane -t "1.0" -p -S -100',
-        expect.any(Object)
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        'tmux',
+        ['capture-pane', '-t', '1.0', '-p', '-S', '-100'],
+        expect.objectContaining({
+          timeout: 1000,
+          maxBuffer: 4 * 1024 * 1024,
+          killSignal: 'SIGKILL',
+        })
       );
     });
 
     it('returns captured pane content', () => {
       const expectedOutput = 'Line 1\nLine 2\nLine 3';
-      mockedExecSync.mockReturnValue(expectedOutput);
+      mockedExecFileSync.mockReturnValue(expectedOutput);
       const tmux = createTmux();
 
       const result = tmux.capture('1.0', 50);
@@ -161,20 +248,36 @@ describe('createTmux', () => {
     });
 
     it('captures specified number of lines', () => {
-      mockedExecSync.mockReturnValue('');
+      mockedExecFileSync.mockReturnValue('');
       const tmux = createTmux();
 
       tmux.capture('2.1', 200);
 
-      expect(mockedExecSync).toHaveBeenCalledWith(
-        'tmux capture-pane -t "2.1" -p -S -200',
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        'tmux',
+        ['capture-pane', '-t', '2.1', '-p', '-S', '-200'],
+        expect.any(Object)
+      );
+    });
+
+    it('passes hostile pane targets as argv without shell interpretation', () => {
+      mockedExecFileSync.mockReturnValue('captured output');
+      const tmux = createTmux();
+      const hostilePane = '1.0; touch /tmp/tmt-should-not-run';
+
+      tmux.capture(hostilePane, 1);
+
+      expect(mockedExecSync).not.toHaveBeenCalled();
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        'tmux',
+        ['capture-pane', '-t', hostilePane, '-p', '-S', '-1'],
         expect.any(Object)
       );
     });
 
     it('throws when pane does not exist', () => {
       const error = new Error("can't find pane: 99.99");
-      mockedExecSync.mockImplementationOnce(() => {
+      mockedExecFileSync.mockImplementationOnce(() => {
         throw error;
       });
 
@@ -184,25 +287,27 @@ describe('createTmux', () => {
     });
 
     it('uses utf-8 encoding for output', () => {
-      mockedExecSync.mockReturnValue('');
+      mockedExecFileSync.mockReturnValue('');
       const tmux = createTmux();
 
       tmux.capture('1.0', 100);
 
-      expect(mockedExecSync).toHaveBeenCalledWith(
-        expect.any(String),
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        'tmux',
+        expect.any(Array),
         expect.objectContaining({ encoding: 'utf-8' })
       );
     });
 
     it('uses pipe stdio for all streams', () => {
-      mockedExecSync.mockReturnValue('');
+      mockedExecFileSync.mockReturnValue('');
       const tmux = createTmux();
 
       tmux.capture('1.0', 100);
 
-      expect(mockedExecSync).toHaveBeenCalledWith(
-        expect.any(String),
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        'tmux',
+        expect.any(Array),
         expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
       );
     });

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// Pure tmux wrapper - buffer paste, capture-pane, pane detection
+// External tmux adapter - message delivery, capture, and pane detection
 // ─────────────────────────────────────────────────────────────
 
 import { execFileSync, execSync } from 'child_process';
@@ -17,6 +17,7 @@ import type {
   TmuxOperationOptions,
 } from './types.js';
 import { normalizeName } from './domain/service.js';
+import { sendTmuxMessage } from './tmux-message.js';
 
 const AGENT_METADATA_OPTION = '@tmux-team.agent';
 const SERVER_ID_OPTION = '@tmux-team.server-id';
@@ -24,6 +25,8 @@ const PANE_FIELD_SEPARATOR = '__TMT_FIELD_4f1c__';
 const ENDPOINT_PROBE_TIMEOUT_MS = 1_000;
 const ENDPOINT_PROBE_MAX_BUFFER = 1024 * 1024;
 const TMUX_OPERATION_TIMEOUT_MS = 1_000;
+const TMUX_CAPTURE_TIMEOUT_MS = 1_000;
+const TMUX_CAPTURE_MAX_BUFFER = 4 * 1024 * 1024;
 const CALLER_PANE_TIMEOUT_MS = 1_000;
 const CALLER_PANE_MAX_BUFFER = 4096;
 const CALLER_PANE_SEPARATOR = '__TMT_CALLER_PANE_4f1c__';
@@ -399,60 +402,30 @@ function probeEndpoint(
 }
 
 export function createTmux(): Tmux {
-  function sleepMs(ms: number): void {
-    if (ms <= 0) return;
-    const buffer = new SharedArrayBuffer(4);
-    const view = new Int32Array(buffer);
-    Atomics.wait(view, 0, 0, ms);
-  }
-
-  function ensureTrailingNewline(message: string): string {
-    return message.endsWith('\n') ? message : `${message}\n`;
-  }
-
-  function escapeExclamation(message: string): string {
-    // Replace "!" with fullwidth "！" (U+FF01) to avoid shell history expansion
-    return message.replace(/!/g, '\uff01');
-  }
-
-  function makeBufferName(): string {
-    const nonce = crypto.randomBytes(4).toString('hex');
-    return `tmt-${process.pid}-${Date.now()}-${nonce}`;
-  }
-
   return {
     send(paneId: string, message: string, options?: { enterDelayMs?: number }): void {
       const enterDelayMs = Math.max(0, options?.enterDelayMs ?? 500);
-      const bufferName = makeBufferName();
-      const escaped = escapeExclamation(message);
-      const payload = ensureTrailingNewline(escaped);
-
-      try {
-        execFileSync('tmux', ['set-buffer', '-b', bufferName, '--', payload], {
-          stdio: 'pipe',
-        });
-        execFileSync('tmux', ['paste-buffer', '-b', bufferName, '-d', '-t', paneId, '-p'], {
-          stdio: 'pipe',
-        });
-        sleepMs(enterDelayMs);
-        execFileSync('tmux', ['send-keys', '-t', paneId, 'Enter'], {
-          stdio: 'pipe',
-        });
-      } catch {
-        // Fallback to legacy send-keys if buffer/paste fails
-        execFileSync('tmux', ['send-keys', '-t', paneId, message], {
-          stdio: 'pipe',
-        });
-        execFileSync('tmux', ['send-keys', '-t', paneId, 'Enter'], {
-          stdio: 'pipe',
-        });
-      }
+      sendTmuxMessage({
+        paneId,
+        message,
+        enterDelayMs,
+        execute: (args, commandOptions) => execFileSync('tmux', args, commandOptions),
+        sleep: (ms) => {
+          if (ms <= 0) return;
+          const buffer = new SharedArrayBuffer(4);
+          const view = new Int32Array(buffer);
+          Atomics.wait(view, 0, 0, ms);
+        },
+      });
     },
 
     capture(paneId: string, lines: number): string {
-      const output = execSync(`tmux capture-pane -t "${paneId}" -p -S -${lines}`, {
+      const output = execFileSync('tmux', ['capture-pane', '-t', paneId, '-p', '-S', `-${lines}`], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: TMUX_CAPTURE_TIMEOUT_MS,
+        maxBuffer: TMUX_CAPTURE_MAX_BUFFER,
+        killSignal: 'SIGKILL',
       });
       return output;
     },

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -16,8 +16,9 @@ export interface CliResult<T = unknown> {
 }
 
 export interface MockEvent {
-  event: 'ready' | 'request' | 'response' | 'silent' | 'malformed' | 'stopped';
+  event: 'ready' | 'request' | 'response' | 'silent' | 'malformed' | 'input' | 'stopped';
   message?: string;
+  line?: string;
   nonce?: string;
   mode?: string;
   pid?: number;
@@ -45,6 +46,11 @@ export interface CliRunOptions {
   };
   /** Touch this file when the child has made its first tmux invocation. */
   progressFile?: string;
+  /** Inject one transport-stage failure into this CLI process only. */
+  transportFault?: {
+    /** set-buffer is safe to fall back from; paste and submit are uncertain. */
+    readonly stage: 'set-buffer' | 'paste' | 'submit';
+  };
 }
 
 export interface CliProcess<T = unknown> {
@@ -73,6 +79,7 @@ export class E2EFixture {
   readonly workspace = path.join(this.root, 'workspace');
   readonly globalDir: string;
   readonly logPath = path.join(this.root, 'mock-agent.jsonl');
+  readonly transportTracePath = path.join(this.root, 'transport-trace.log');
   readonly forbiddenTmuxLogPath = path.join(this.root, 'forbidden-tmux.log');
   readonly metadataBarrierDirectory = path.join(this.root, 'metadata-barrier');
   readonly socket = `tmt-e2e-${process.pid}-${Math.random().toString(16).slice(2)}`;
@@ -108,7 +115,7 @@ export class E2EFixture {
 
   async start(
     options: {
-      mode?: 'respond' | 'silent' | 'malformed' | 'virtualized';
+      mode?: 'respond' | 'silent' | 'malformed' | 'virtualized' | 'input-log';
       delayMs?: number;
       metadataBarrier?: MetadataBarrierOptions;
     } = {}
@@ -145,7 +152,7 @@ if [ "${'$'}1" = "set-option" ]; then
     metadata_write=0
   fi
 fi
-if [ -z "${'$'}{TMT_E2E_PROGRESS_FILE:-}" ] && [ -z "${'$'}{TMT_E2E_METADATA_BARRIER_DIR:-}" ]; then
+if [ -z "${'$'}{TMT_E2E_PROGRESS_FILE:-}" ] && [ -z "${'$'}{TMT_E2E_METADATA_BARRIER_DIR:-}" ] && [ -z "${'$'}{TMT_E2E_TRANSPORT_TRACE_FILE:-}" ]; then
   exec ${shellQuote(this.tmuxPath)} -f /dev/null -L "${'$'}TMT_E2E_SOCKET" "${'$'}@"
 fi
 metadata_target=0
@@ -165,8 +172,54 @@ if [ "${'$'}metadata_target" = "1" ] && [ -n "${'$'}{TMT_E2E_METADATA_BARRIER_DI
     [ -e "${'$'}TMT_E2E_METADATA_BARRIER_DIR/release" ] || exit 124
   fi
 fi
+trace_transport() {
+  if [ -z "${'$'}{TMT_E2E_TRANSPORT_TRACE_FILE:-}" ]; then return; fi
+  trace_stage="${'$'}1"
+  shift
+  trace_argv=""
+  for trace_arg in "${'$'}@"; do
+    trace_arg=$(printf '%s' "${'$'}trace_arg" | tr '\n' ' ')
+    trace_argv="${'$'}trace_argv [${'$'}trace_arg]"
+  done
+  printf '%s|%s\n' "${'$'}trace_stage" "${'$'}trace_argv" >> "${'$'}TMT_E2E_TRANSPORT_TRACE_FILE"
+}
+transport_stage=""
+case "${'$'}1" in
+  set-buffer) transport_stage="set-buffer" ;;
+  paste-buffer) transport_stage="paste-buffer" ;;
+  send-keys)
+    if [ "${'$'}#" -eq 4 ] && [ "${'$'}4" = "Enter" ]; then
+      transport_stage="submit"
+    else
+      transport_stage="literal-input"
+    fi
+    ;;
+esac
+if [ "${'$'}transport_stage" = "set-buffer" ] && [ "${'$'}{TMT_E2E_TRANSPORT_FAULT_STAGE:-}" = "set-buffer" ]; then
+  trace_transport "set-buffer.fault-before" "${'$'}@"
+  exit 97
+fi
+if [ -n "${'$'}transport_stage" ]; then
+  trace_transport "${'$'}transport_stage.before" "${'$'}@"
+fi
 ${shellQuote(this.tmuxPath)} -f /dev/null -L "${'$'}TMT_E2E_SOCKET" "${'$'}@"
 status=${'$'}?
+if [ -n "${'$'}transport_stage" ]; then
+  trace_transport "${'$'}transport_stage.after.${'$'}status" "${'$'}@"
+fi
+fault_after=0
+if [ "${'$'}status" -eq 0 ]; then
+  if [ "${'$'}transport_stage" = "paste-buffer" ] && [ "${'$'}{TMT_E2E_TRANSPORT_FAULT_STAGE:-}" = "paste" ]; then
+    fault_after=1
+  fi
+  if [ "${'$'}transport_stage" = "submit" ] && [ "${'$'}{TMT_E2E_TRANSPORT_FAULT_STAGE:-}" = "submit" ]; then
+    fault_after=1
+  fi
+fi
+if [ "${'$'}fault_after" -eq 1 ]; then
+  trace_transport "${'$'}transport_stage.fault-after" "${'$'}@"
+  exit 98
+fi
 if [ "${'$'}metadata_target" = "1" ] && [ -n "${'$'}{TMT_E2E_METADATA_BARRIER_DIR:-}" ] && [ "${'$'}{TMT_E2E_METADATA_BARRIER_PHASE:-}" = "after" ]; then
   : > "${'$'}TMT_E2E_METADATA_BARRIER_DIR/applied"
   barrier_wait=0
@@ -243,6 +296,10 @@ exit ${'$'}status
       env.TMT_E2E_FORBIDDEN_TMUX_LOG = this.forbiddenTmuxLogPath;
     }
     if (options.progressFile) env.TMT_E2E_PROGRESS_FILE = options.progressFile;
+    if (options.transportFault) {
+      env.TMT_E2E_TRANSPORT_FAULT_STAGE = options.transportFault.stage;
+      env.TMT_E2E_TRANSPORT_TRACE_FILE = this.transportTracePath;
+    }
     const child = spawn(binPath, args, {
       cwd: options.cwd ?? this.workspace,
       env,
@@ -447,6 +504,11 @@ exit ${'$'}status
 
   paneTitle(pane = this.pane): string {
     return this.tmux(['display-message', '-p', '-t', pane, '#{pane_title}']).trim();
+  }
+
+  transportTrace(): string[] {
+    if (!fs.existsSync(this.transportTracePath)) return [];
+    return fs.readFileSync(this.transportTracePath, 'utf8').split('\n').filter(Boolean);
   }
 
   events(): MockEvent[] {
@@ -663,7 +725,7 @@ exit ${'$'}status
 export async function withE2EFixture<T>(
   callback: (fixture: E2EFixture) => Promise<T> | T,
   options: {
-    mode?: 'respond' | 'silent' | 'malformed' | 'virtualized';
+    mode?: 'respond' | 'silent' | 'malformed' | 'virtualized' | 'input-log';
     delayMs?: number;
     globalDir?: string;
     metadataBarrier?: MetadataBarrierOptions;

--- a/test/e2e/mock-agent.mjs
+++ b/test/e2e/mock-agent.mjs
@@ -53,6 +53,10 @@ let messageLines = [];
 appendEvent({ event: 'ready', mode, pid: process.pid });
 
 input.on('line', (line) => {
+  if (mode === 'input-log') {
+    appendEvent({ event: 'input', line, mode, pid: process.pid });
+    return;
+  }
   const instruction = line.match(
     /^When done, output exactly: RESPONSE-END-xxxx \(where xxxx = ([A-Za-z0-9]+)\)$/
   );

--- a/test/e2e/transport-safety.e2e.test.ts
+++ b/test/e2e/transport-safety.e2e.test.ts
@@ -1,0 +1,252 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { E2EFixture, withE2EFixture } from './harness.js';
+
+interface TalkResult {
+  nonce?: string;
+  response?: string;
+  status?: string;
+}
+
+interface ErrorResult {
+  error: {
+    code: string;
+    message: string;
+    stage?: string;
+  };
+}
+
+function protectedMessage(): string {
+  // Non-ASCII fixture text is intentional Unicode transport data.
+  return [
+    '! protected bang',
+    'Enter C-c --leading-dash "double" \'single\' $dollar `backtick` 日本語',
+    'second line with ! and --another-dash',
+  ].join('\n');
+}
+
+function expectedPayload(message: string): string {
+  return message.replaceAll('!', '！');
+}
+
+function stages(trace: string[]): string[] {
+  return trace.map((line) => line.split('|', 1)[0]);
+}
+
+function bufferName(trace: string[]): string {
+  const setBuffer = trace.find((line) => line.startsWith('set-buffer.'));
+  const match = setBuffer?.match(/\[(tmt-[^\]]+)\]/);
+  if (!match) throw new Error(`Transport trace has no buffer name: ${trace.join('\n')}`);
+  return match[1];
+}
+
+function bufferNames(fixture: E2EFixture): string[] {
+  return fixture
+    .tmux(['list-buffers', '-F', '#{buffer_name}'])
+    .split('\n')
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
+function showBuffer(fixture: { tmux(args: string[]): string }, name: string): string {
+  return fixture.tmux(['show-buffer', '-b', name]).trimEnd();
+}
+
+async function waitForInput(fixture: E2EFixture, pid: number, line: string): Promise<void> {
+  await fixture.waitForEvent(
+    (event) => event.event === 'input' && event.pid === pid && event.line === line
+  );
+}
+
+describe.sequential('TMT-24 safe transport', () => {
+  it('preserves protected multiline payloads across normal and literal fallback sends', async () => {
+    await withE2EFixture(async (fixture) => {
+      const normal = await fixture.createMockPane('normal');
+      const fallback = await fixture.createMockPane('fallback');
+      expect((await fixture.runJsonCli(['add', normal.pane, 'Normal'])).code).toBe(0);
+      expect((await fixture.runJsonCli(['add', fallback.pane, 'Fallback'])).code).toBe(0);
+
+      const message = protectedMessage();
+      const expected = expectedPayload(message);
+
+      const normalTalk = await fixture.runJsonCli<TalkResult>([
+        'talk',
+        'Normal',
+        message,
+        '--no-preamble',
+        '--wait',
+        '--timeout',
+        '8',
+      ]);
+      expect(normalTalk).toMatchObject({ code: 0, json: { status: 'completed' } });
+      const normalResponse = await fixture.waitForEvent(
+        (event) =>
+          event.event === 'response' &&
+          event.pid === normal.pid &&
+          event.nonce === normalTalk.json?.nonce
+      );
+      expect(normalResponse.message).toBe(expected);
+
+      const sentinel = 'tmt-e2e-transport-sentinel';
+      fixture.tmux(['set-buffer', '-b', sentinel, '--', 'keep-this-buffer']);
+      const traceStart = fixture.transportTrace().length;
+      const fallbackTalk = await fixture.runJsonCli<TalkResult>(
+        ['talk', 'Fallback', message, '--no-preamble', '--wait', '--timeout', '8'],
+        { transportFault: { stage: 'set-buffer' } }
+      );
+      expect(fallbackTalk).toMatchObject({ code: 0, json: { status: 'completed' } });
+      const fallbackResponse = await fixture.waitForEvent(
+        (event) =>
+          event.event === 'response' &&
+          event.pid === fallback.pid &&
+          event.nonce === fallbackTalk.json?.nonce
+      );
+      expect(fallbackResponse.message).toBe(expected);
+      expect(showBuffer(fixture, sentinel)).toBe('keep-this-buffer');
+
+      const fallbackTrace = fixture.transportTrace().slice(traceStart);
+      const fallbackStages = stages(fallbackTrace);
+      expect(fallbackStages).toEqual([
+        'set-buffer.fault-before',
+        'literal-input.before',
+        'literal-input.after.0',
+        'submit.before',
+        'submit.after.0',
+      ]);
+      expect(fallbackStages).not.toContain('paste-buffer.before');
+      expect(fallbackStages.filter((stage) => stage === 'literal-input.before')).toHaveLength(1);
+      expect(fallbackStages.filter((stage) => stage === 'submit.before')).toHaveLength(1);
+      expect(bufferNames(fixture)).not.toContain(bufferName(fallbackTrace));
+    });
+  }, 30_000);
+
+  it('reports uncertain paste and submit without replay in config-driven polling mode', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const configured = await fixture.runJsonCli(['config', 'set', 'mode', 'polling']);
+        expect(configured.code).toBe(0);
+
+        const literalPeer = await fixture.createMockPane('literal-fault');
+        const pastePeer = await fixture.createMockPane('paste-fault');
+        const submitPeer = await fixture.createMockPane('submit-fault');
+        expect((await fixture.runJsonCli(['add', literalPeer.pane, 'LiteralFault'])).code).toBe(0);
+        expect((await fixture.runJsonCli(['add', pastePeer.pane, 'PasteFault'])).code).toBe(0);
+        expect((await fixture.runJsonCli(['add', submitPeer.pane, 'SubmitFault'])).code).toBe(0);
+
+        const literalSentinel = 'tmt-e2e-literal-sentinel';
+        fixture.tmux(['set-buffer', '-b', literalSentinel, '--', 'keep-literal-buffer']);
+        const literalTraceStart = fixture.transportTrace().length;
+        const literal = await fixture.runJsonCli<TalkResult>(
+          ['talk', 'LiteralFault', 'Enter', '--no-preamble'],
+          { transportFault: { stage: 'set-buffer' } }
+        );
+        expect(literal).toMatchObject({ code: 0, json: { status: 'sent' } });
+        await waitForInput(fixture, literalPeer.pid, 'Enter');
+        expect(showBuffer(fixture, literalSentinel)).toBe('keep-literal-buffer');
+        const literalTrace = fixture.transportTrace().slice(literalTraceStart);
+        expect(stages(literalTrace)).toEqual([
+          'set-buffer.fault-before',
+          'literal-input.before',
+          'literal-input.after.0',
+          'submit.before',
+          'submit.after.0',
+        ]);
+        expect(bufferNames(fixture)).not.toContain(bufferName(literalTrace));
+
+        const pasteSentinel = 'tmt-e2e-paste-sentinel';
+        fixture.tmux(['set-buffer', '-b', pasteSentinel, '--', 'keep-paste-buffer']);
+        const pasteTraceStart = fixture.transportTrace().length;
+        const paste = await fixture.runJsonCli<ErrorResult>(
+          ['talk', 'PasteFault', 'C-c', '--no-preamble'],
+          { transportFault: { stage: 'paste' } }
+        );
+        expect(paste).toMatchObject({
+          code: 1,
+          json: { error: { code: 'DELIVERY_UNCERTAIN', stage: 'paste' } },
+        });
+        await waitForInput(fixture, pastePeer.pid, 'C-c');
+        expect(showBuffer(fixture, pasteSentinel)).toBe('keep-paste-buffer');
+        const pasteTrace = fixture.transportTrace().slice(pasteTraceStart);
+        expect(stages(pasteTrace)).toEqual([
+          'set-buffer.before',
+          'set-buffer.after.0',
+          'paste-buffer.before',
+          'paste-buffer.after.0',
+          'paste-buffer.fault-after',
+        ]);
+        expect(stages(pasteTrace)).not.toContain('literal-input.before');
+        expect(stages(pasteTrace)).not.toContain('submit.before');
+        expect(bufferNames(fixture)).not.toContain(bufferName(pasteTrace));
+        expect(
+          fixture
+            .events()
+            .filter(
+              (event) =>
+                event.event === 'input' && event.pid === pastePeer.pid && event.line === 'C-c'
+            )
+        ).toHaveLength(1);
+
+        const submitSentinel = 'tmt-e2e-submit-sentinel';
+        fixture.tmux(['set-buffer', '-b', submitSentinel, '--', 'keep-submit-buffer']);
+        const submitTraceStart = fixture.transportTrace().length;
+        const submit = await fixture.runJsonCli<ErrorResult>(
+          ['talk', 'SubmitFault', '--no-preamble', '--', '--leading-dash'],
+          { transportFault: { stage: 'submit' } }
+        );
+        expect(submit).toMatchObject({
+          code: 1,
+          json: { error: { code: 'DELIVERY_UNCERTAIN', stage: 'submit' } },
+        });
+        await waitForInput(fixture, submitPeer.pid, '--leading-dash');
+        expect(showBuffer(fixture, submitSentinel)).toBe('keep-submit-buffer');
+        const submitTrace = fixture.transportTrace().slice(submitTraceStart);
+        expect(stages(submitTrace)).toEqual([
+          'set-buffer.before',
+          'set-buffer.after.0',
+          'paste-buffer.before',
+          'paste-buffer.after.0',
+          'submit.before',
+          'submit.after.0',
+          'submit.fault-after',
+        ]);
+        expect(stages(submitTrace)).not.toContain('literal-input.before');
+        expect(bufferNames(fixture)).not.toContain(bufferName(submitTrace));
+        expect(
+          fixture
+            .events()
+            .filter(
+              (event) =>
+                event.event === 'input' &&
+                event.pid === submitPeer.pid &&
+                event.line === '--leading-dash'
+            )
+        ).toHaveLength(1);
+      },
+      { mode: 'input-log' }
+    );
+  }, 30_000);
+
+  it('clears wait request state after an uncertain submit', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const peer = await fixture.createMockPane('wait-submit-fault');
+        expect((await fixture.runJsonCli(['add', peer.pane, 'WaitSubmitFault'])).code).toBe(0);
+
+        const result = await fixture.runJsonCli<ErrorResult>(
+          ['talk', 'WaitSubmitFault', 'state cleanup', '--no-preamble', '--wait', '--timeout', '8'],
+          { transportFault: { stage: 'submit' } }
+        );
+        expect(result).toMatchObject({
+          code: 1,
+          json: { error: { code: 'DELIVERY_UNCERTAIN', stage: 'submit' } },
+        });
+        const state = JSON.parse(
+          fs.readFileSync(path.join(fixture.globalDir, 'state.json'), 'utf8')
+        ) as { requests: Record<string, unknown> };
+        expect(state.requests).toEqual({});
+      },
+      { mode: 'respond' }
+    );
+  }, 15_000);
+});


### PR DESCRIPTION
## Scope

Closes TMT-24: https://linear.app/tigerpig-dev/issue/TMT-24

- Preserve the existing ASCII `!` to fullwidth protection and trailing newline on both buffer paste and literal fallback.
- Permit fallback only before paste invocation; report uncertain paste, literal input, or Enter submission without replay.
- Bound transport subprocesses and use argv-based capture.
- Return one `DELIVERY_UNCERTAIN` envelope with stage and inspection guidance in wait and non-wait modes, retaining successful result shapes.
- Clear the matching wait request before process termination.

No daemon, provider capability detection, schema/dependency change, structured response channel, or preamble cadence redesign.

## Architecture and primary review

The primary reviewed every changed file and the adapter, Context exit boundary, talk callers, request cleanup, fault wrapper, causal mock events and shipped guidance. Luna high performed the pre-edit pattern audit and bounded implementation; Gemini supplied supplementary static review.

`tmux-message.ts` owns protected payload preparation and stageful input; `message-delivery.ts` provides the narrow shared uncertainty contract. Commands do not import the concrete tmux implementation for error typing. Normal and fallback input share one delay/Enter path. Existing request-ID guarded cleanup is reused; broader JSON state concurrency remains TMT-25.

Review corrections include removing duplicated submission and inconsistent fallback payload preparation, avoiding concrete adapter error coupling, replacing weak test assertions with exact traces and causal events, fixing leading-dash CLI test syntax, and testing cleanup at exit invocation. The first real Docker run exposed process.exit bypassing finally despite passing unit mocks and Gemini's initial approval. Explicit pre-exit cleanup fixes this; the Docker oracle was not weakened. Gemini subsequently reviewed the correction.

ARCHITECTURE.md, CONVENTIONS.md, README, request/response research status and all four shipped integration guidance surfaces now describe the implemented boundary. Terminal extraction remains best effort; neither successful submission nor these deterministic mocks prove exactly-once processing or every provider's keyboard semantics.

Reviewed commit: `55f8632bc89c5b1f965e00183cba3f75bac08e08`.

## Verification

- `pnpm check`: passed.
- `pnpm test:run`: 470 passed; statements 94.32%, branches 87.95%.
- Focused adapter/message/talk tests: 112 passed before the final pre-exit assertions; final talk suite: 40 passed.
- Same negative-control tests passed current transport and failed baseline b32ac04, exposing input replay and unprotected non-literal fallback. Temporary test/worktree removed.
- First Docker run: 47/48 passed, correctly exposing the wait cleanup bug. After correction, `pnpm test:e2e && pnpm test:e2e`: 48/48 passed twice (163.79 s and 163.83 s), with identical final runtime/test sources. Container and packed talk source hashes match the reviewed checkout.
- Local packed install: `pnpm pack` plus `verify-packed-native-install.mjs --expected-arch arm64 --expected-libc none` passed using the actual tarball and native SQLite/FTS5.
- Explicit changed Markdown formatting and three shipped SKILL.md frontmatter validations passed; Claude command frontmatter inspected.
- `git diff --check`: passed.

No host tmux tests, real provider execution tests, CI bypass, or remote trial-and-error runs. Final local verification precedes the first push. Required CI must pass on the reviewed head before merge.

## Lifecycle

Dedicated branch/worktree: `codex/tmt-24-safe-transport` / `/Users/benhsieh/dev/tmt-24-safe-transport`.
Linear contains bounded scope, audit decisions, review findings and verification evidence. Cleanup follows confirmed merge and clean/pushed tree verification.
