### PR TITLE
fix(cli): unify JSON results and invocation cleanup (TMT-26)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -231,7 +231,7 @@ storage. Role's lazy repository adapter also preserves no-storage rejection for
 invalid implicit callers; explicit role and preamble operations do not construct
 tmux. Missing required dependencies fail closed instead of selecting legacy
 behavior. Role and preamble commands retain their existing unavailable-service
-error mappings; a uniform process error envelope remains TMT-26 work.
+error mappings within the shared invocation output boundary.
 
 `TargetResolverPort` contains only pane resolution and the verified active-name
 view. The shared target resolver retains pane-first ordering; `identityAwareTmux`
@@ -240,11 +240,41 @@ live in the CLI layer, not in the command handler. Focused AST import checks
 cover direct literal imports/re-exports in maintained production sources; they
 are not a complete semantic dependency or dynamically computed-import analysis.
 
+## CLI output and lifecycle
+
+The invocation runner owns parsing, initialization, startup checks, dispatch and
+final disposal. Context remains the sole repository lifetime owner; the runner
+injects its UI and non-returning exit control flow, then disposes once before
+publishing the result. Commands do not own process termination. The executable
+sets the returned exit status and allows output pipes to drain naturally.
+
+JSON output is buffered per invocation, not captured through global console
+patching. Exactly one document goes to stdout after cleanup. Expected command
+errors preserve their codes, details and meaningful exit statuses. Parser errors
+use `USAGE_ERROR` without constructing Context; configuration parsing uses
+`CONFIG_ERROR`; unexpected failures use `INTERNAL_ERROR`. Diagnostics belong on
+stderr when requested. Successful commands without a detailed result emit
+`{ok:true}`. A cleanup failure replaces a pending success with `CLEANUP_ERROR`
+and an effects warning, but cannot replace an existing primary failure/status.
+This is output consistency, not rollback of command effects.
+
+The alpha timeout envelope intentionally changes only its `error` string to
+`{code: "TIMEOUT", message}`. Exit 4, status, correlation/target fields and
+nullable partial response remain. SIGINT only signals and wakes the talk poll;
+the awaited command flow releases its waiter and exits through the runner.
+It must not throw exit control flow across an event callback. Neither timeout
+nor interruption cancels recipient work or alters recorded delivery certainty.
+
+Text-only help/version/completion/learn reject JSON mode with `JSON_UNSUPPORTED`
+before effects; upgrade retains its JSON rejection. No new text-command schemas
+or grammar are introduced. Runtime boot failures before application loading and
+unwritable output streams are outside the one-document guarantee.
+
 ## Current module map
 
 | Location                                                                                                                                 | Responsibility and integration points                                                                                                                                   |
 | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [bin/tmux-team](bin/tmux-team), [src/cli.ts](src/cli.ts)                                                                                 | Executable/process boundary, startup checks, dispatch, disposal and exit. Some top-level error paths remain inconsistent.                                               |
+| [bin/tmux-team](bin/tmux-team), [src/cli.ts](src/cli.ts), [src/cli-runner.ts](src/cli-runner.ts), [src/cli-output.ts](src/cli-output.ts) | Executable entry, guarded invocation lifetime and one buffered JSON result after disposal; natural output draining.                                                     |
 | [src/cli/parser.ts](src/cli/parser.ts), [src/cli/application.ts](src/cli/application.ts)                                                 | Repository-owned Commander adapter produces typed invocations and capability metadata; dispatcher routes them. Do not create another positional parser.                 |
 | [src/context.ts](src/context.ts), [src/types.ts](src/types.ts)                                                                           | Composition and lazy resource lifetime; shared UI, adapter, service and configuration contracts. The shared types module is not a dumping ground for new domain models. |
 | [src/commands/](src/commands/)                                                                                                           | CLI orchestration, error mapping and presentation. Some delivery policy still lives in commands; they are effectful adapters, not pure functions.                       |
@@ -320,7 +350,6 @@ a gap is resolved; do not leave a permanent exception or label a proposal as shi
 | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Numeric/flag validation needs hardening.                                                                                     | [TMT-22](https://linear.app/tigerpig-dev/issue/TMT-22)                                                                                                                 |
 | Terminal completion/extraction cannot guarantee a complete correlated body; transactional bookkeeping does not resolve this. | [TMT-36](https://linear.app/tigerpig-dev/issue/TMT-36), [TMT-37](https://linear.app/tigerpig-dev/issue/TMT-37)                                                         |
-| JSON/process error boundaries remain inconsistent outside the bounded preamble and transport mappings.                       | [TMT-26](https://linear.app/tigerpig-dev/issue/TMT-26)                                                                                                                 |
 | Shipped skill/help inventories drift; packed verification does not yet prove application migrations.                         | [TMT-29](https://linear.app/tigerpig-dev/issue/TMT-29)                                                                                                                 |
 | Non-tmux identity management, memory and durable inbox are future capabilities, not installed APIs.                          | [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,33 @@ Old preambles in JSON or workspace metadata are ignored, not automatically
 imported or deleted. Reapply desired text using `preamble set`. A preamble lookup
 failure stops delivery rather than silently sending without it.
 
+## JSON result contract
+
+For commands using `--json`, stdout contains one JSON document after cleanup.
+Errors use `{ "error": { "code": "...", "message": "..." } }`; optional
+diagnostics use stderr. Preserve and inspect additional error fields such as
+delivery `stage` and `suggestion`. Successful operations without a detailed
+result, such as `config set`, return `{ "ok": true }`.
+
+Exit statuses remain meaningful: 1 is a general failure, 3 a missing target,
+4 a timeout, and 5 a conflict. Parse errors now use `USAGE_ERROR` on stdout,
+not a flat string error on stderr. Initialization errors are also handled by
+the command boundary. `CLEANUP_ERROR` after successful work does not roll back
+its effects; inspect state before retrying. A cleanup failure alongside an
+existing command failure preserves that primary error and status.
+
+This v5 alpha intentionally changes the timeout `error` field from a string to
+`{ "code": "TIMEOUT", "message": "..." }`. The existing `status`, target,
+pane, identity when present, request ID, nonce, end marker and nullable
+`partialResponse` remain. Read `error.message` instead of treating `error` as
+text. Timeout and Ctrl+C release the waiter, not recipient work.
+
+`help`, `version`, `completion`, and `learn` remain text-only; combining them
+with `--json` returns `JSON_UNSUPPORTED` before output or effects. `upgrade`
+also rejects JSON because its installer streams text. Run these without
+`--json`. This contract covers the running application, not a broken runtime
+installation or an unwritable output pipe.
+
 ## Retired registry commands
 
 V5 no longer supports `update`, `remove` (or `rm`), or `migrate`, including

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -32,6 +32,24 @@ can coexist with cropped content; increasing `check` lines cannot recover text
 that the agent never rendered. No durable structured response channel is
 implied by this transport safety behavior.
 
+## JSON results and failures
+
+With `--json`, parse the entire stdout as one JSON document. Errors contain
+`error.code` and `error.message`; stderr is reserved for optional diagnostics.
+Check the exit status too: missing targets use 3, timeout 4, and conflicts 5.
+Successful commands without a detailed result return `{ok:true}`.
+
+The v5 alpha timeout contract now uses
+`error: {code: "TIMEOUT", message: "..."}` instead of a string. It retains
+`status: "timeout"`, correlation fields and nullable `partialResponse`.
+Timeout and interruption do not cancel recipient work. A `CLEANUP_ERROR`
+after successful work does not mean its effects were undone; inspect before
+retrying. Existing delivery-uncertainty guidance still applies.
+
+`help`, `version`, `completion` and `learn` are text-only and reject
+`--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
+also rejects JSON mode because it streams installer output.
+
 ## Identity preambles
 
 Preambles are separate from role profiles and belong to existing durable global

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -29,6 +29,24 @@ can coexist with cropped content; increasing `check` lines cannot recover text
 that the agent never rendered. No durable structured response channel is
 implied by this transport safety behavior.
 
+## JSON results and failures
+
+With `--json`, parse the entire stdout as one JSON document. Errors contain
+`error.code` and `error.message`; stderr is reserved for optional diagnostics.
+Check the exit status too: missing targets use 3, timeout 4, and conflicts 5.
+Successful commands without a detailed result return `{ok:true}`.
+
+The v5 alpha timeout contract now uses
+`error: {code: "TIMEOUT", message: "..."}` instead of a string. It retains
+`status: "timeout"`, correlation fields and nullable `partialResponse`.
+Timeout and interruption do not cancel recipient work. A `CLEANUP_ERROR`
+after successful work does not mean its effects were undone; inspect before
+retrying. Existing delivery-uncertainty guidance still applies.
+
+`help`, `version`, `completion` and `learn` are text-only and reject
+`--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
+also rejects JSON mode because it streams installer output.
+
 ## Identity preambles
 
 Preambles are separate from role profiles and belong to existing durable global

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -29,6 +29,24 @@ can coexist with cropped content; increasing `check` lines cannot recover text
 that the agent never rendered. No durable structured response channel is
 implied by this transport safety behavior.
 
+## JSON results and failures
+
+With `--json`, parse the entire stdout as one JSON document. Errors contain
+`error.code` and `error.message`; stderr is reserved for optional diagnostics.
+Check the exit status too: missing targets use 3, timeout 4, and conflicts 5.
+Successful commands without a detailed result return `{ok:true}`.
+
+The v5 alpha timeout contract now uses
+`error: {code: "TIMEOUT", message: "..."}` instead of a string. It retains
+`status: "timeout"`, correlation fields and nullable `partialResponse`.
+Timeout and interruption do not cancel recipient work. A `CLEANUP_ERROR`
+after successful work does not mean its effects were undone; inspect before
+retrying. Existing delivery-uncertainty guidance still applies.
+
+`help`, `version`, `completion` and `learn` are text-only and reject
+`--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
+also rejects JSON mode because it streams installer output.
+
 ## Identity preambles
 
 Preambles are separate from role profiles and belong to existing durable global

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -25,6 +25,24 @@ can coexist with cropped content; increasing `check` lines cannot recover text
 that the agent never rendered. No durable structured response channel is
 implied by this transport safety behavior.
 
+## JSON results and failures
+
+With `--json`, parse the entire stdout as one JSON document. Errors contain
+`error.code` and `error.message`; stderr is reserved for optional diagnostics.
+Check the exit status too: missing targets use 3, timeout 4, and conflicts 5.
+Successful commands without a detailed result return `{ok:true}`.
+
+The v5 alpha timeout contract now uses
+`error: {code: "TIMEOUT", message: "..."}` instead of a string. It retains
+`status: "timeout"`, correlation fields and nullable `partialResponse`.
+Timeout and interruption do not cancel recipient work. A `CLEANUP_ERROR`
+after successful work does not mean its effects were undone; inspect before
+retrying. Existing delivery-uncertainty guidance still applies.
+
+`help`, `version`, `completion` and `learn` are text-only and reject
+`--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
+also rejects JSON mode because it streams installer output.
+
 ## Identity preambles
 
 Preambles are separate from role profiles and belong to existing durable global

--- a/src/cli-contract.test.ts
+++ b/src/cli-contract.test.ts
@@ -1,0 +1,420 @@
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { CURRENT_MIGRATIONS } from './storage/migrations.js';
+import { openStorageWithMigrations } from './storage/sqlite-adapter.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const binPath = path.join(repoRoot, 'bin', 'tmux-team');
+const maxSubprocessOutputBytes = 1024 * 1024;
+
+interface Sandbox {
+  readonly root: string;
+  readonly cwd: string;
+  readonly home: string;
+  readonly xdgConfigHome: string;
+  readonly globalDir: string;
+  readonly globalConfig: string;
+  readonly database: string;
+  readonly localConfig: string;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+interface CliResult {
+  readonly status: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type JsonDocument = Record<string, unknown>;
+
+function createSandbox(): Sandbox {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tmux-team-cli-contract-'));
+  try {
+    const cwd = path.join(root, 'cwd');
+    const home = path.join(root, 'home');
+    const xdgConfigHome = path.join(root, 'xdg');
+    mkdirSync(cwd);
+    mkdirSync(home);
+
+    const globalDir = path.join(xdgConfigHome, 'tmux-team');
+    return {
+      root,
+      cwd,
+      home,
+      xdgConfigHome,
+      globalDir,
+      globalConfig: path.join(globalDir, 'config.json'),
+      database: path.join(globalDir, 'tmux-team.db'),
+      localConfig: path.join(cwd, 'tmux-team.json'),
+      env: {
+        ...process.env,
+        HOME: home,
+        XDG_CONFIG_HOME: xdgConfigHome,
+        // The contract suite removes inherited tmux/config overrides before each
+        // child starts, so it never depends on the developer's session.
+      },
+    };
+  } catch (error) {
+    rmSync(root, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function runCli(sandbox: Sandbox, args: readonly string[]): Promise<CliResult> {
+  for (const key of ['TMUX', 'TMUX_PANE', 'TMUX_TEAM_HOME']) delete sandbox.env[key];
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [binPath, ...args], {
+      cwd: sandbox.cwd,
+      env: sandbox.env,
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    // Decode at the stream boundary so a multibyte UTF-8 character split
+    // across OS chunks cannot be corrupted by per-buffer toString() calls.
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let outputLimitExceeded = false;
+    const killProcessGroup = (): void => {
+      if (child.pid === undefined) return;
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        child.kill('SIGKILL');
+      }
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // The wrapper launches the TypeScript child; kill the process group so a
+      // timeout cannot leave that descendant running after the test exits.
+      killProcessGroup();
+    }, 5_000);
+    const readOutput =
+      (stream: 'stdout' | 'stderr') =>
+      (chunk: Buffer | string): void => {
+        const text = chunk.toString();
+        const nextBytes =
+          Buffer.byteLength(text) + Buffer.byteLength(stdout) + Buffer.byteLength(stderr);
+        if (nextBytes > maxSubprocessOutputBytes) {
+          outputLimitExceeded = true;
+          killProcessGroup();
+          return;
+        }
+        if (stream === 'stdout') stdout += text;
+        else stderr += text;
+      };
+    child.stdout.on('data', readOutput('stdout'));
+    child.stderr.on('data', readOutput('stderr'));
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      if (outputLimitExceeded) {
+        reject(
+          new Error(`CLI subprocess exceeded the ${maxSubprocessOutputBytes}-byte output bound.`)
+        );
+      } else reject(error);
+    });
+    child.on('close', (status, signal) => {
+      clearTimeout(timer);
+      if (outputLimitExceeded) {
+        reject(
+          new Error(`CLI subprocess exceeded the ${maxSubprocessOutputBytes}-byte output bound.`)
+        );
+      } else if (timedOut) {
+        reject(new Error('CLI subprocess exceeded the 5 second test bound.'));
+        return;
+      }
+      resolve({ status, signal, stdout, stderr });
+    });
+  });
+}
+
+function parseWholeStdout(result: CliResult): JsonDocument {
+  expect(result.signal).toBeNull();
+  expect(result.stderr).toBe('');
+  expect(result.stdout.trim()).not.toBe('');
+  // Parse the complete stream. Parsing only the final line would allow human
+  // output or a second JSON document to leak into JSON mode unnoticed.
+  const document = JSON.parse(result.stdout) as unknown;
+  expect(document).toBeTypeOf('object');
+  expect(document).not.toBeNull();
+  return document as JsonDocument;
+}
+
+function expectError(result: CliResult, code: string, message?: string): JsonDocument {
+  const document = parseWholeStdout(result);
+  expect(document.error).toMatchObject({ code });
+  expect(document.error).toHaveProperty('message', expect.any(String));
+  expect((document.error as { message: string }).message.length).toBeGreaterThan(0);
+  if (message !== undefined) expect((document.error as { message: string }).message).toBe(message);
+  return document;
+}
+
+function expectJsonSuccess(result: CliResult, value: JsonDocument): void {
+  expect(result.status).toBe(0);
+  expect(parseWholeStdout(result)).toEqual(value);
+}
+
+function fileSnapshot(root: string): Record<string, string> {
+  const snapshot: Record<string, string> = {};
+  const visit = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) visit(entryPath);
+      else snapshot[path.relative(root, entryPath)] = readFileSync(entryPath, 'utf8');
+    }
+  };
+  visit(root);
+  return snapshot;
+}
+
+async function withSandbox<T>(callback: (sandbox: Sandbox) => T | Promise<T>): Promise<T> {
+  const sandbox = createSandbox();
+  try {
+    return await callback(sandbox);
+  } finally {
+    rmSync(sandbox.root, { recursive: true, force: true });
+  }
+}
+
+function initializeDatabase(sandbox: Sandbox): void {
+  let storage: ReturnType<typeof openStorageWithMigrations> | undefined;
+  try {
+    storage = openStorageWithMigrations(sandbox.database, CURRENT_MIGRATIONS);
+  } finally {
+    storage?.close();
+  }
+}
+
+function readMigrationHistory(sandbox: Sandbox): Array<{ version: number; name: string }> {
+  const database = new Database(sandbox.database, { readonly: true });
+  try {
+    return database
+      .prepare('SELECT version, name FROM _migrations ORDER BY version')
+      .all() as Array<{ version: number; name: string }>;
+  } finally {
+    database.close();
+  }
+}
+
+describe('real CLI process contract', () => {
+  it(
+    'reports JSON parse errors regardless of --json position without creating context state',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const before = fileSnapshot(sandbox.root);
+
+        for (const args of [
+          ['--json', 'name'],
+          ['name', '--json'],
+        ]) {
+          const result = await runCli(sandbox, args);
+          expect(result.status).toBe(1);
+          expectError(result, 'USAGE_ERROR');
+          expect(fileSnapshot(sandbox.root)).toEqual(before);
+        }
+      })
+  );
+
+  it(
+    'reports malformed configuration before initialization and preserves the file',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        mkdirSync(sandbox.globalDir, { recursive: true });
+        writeFileSync(sandbox.globalConfig, '{ malformed\n');
+        const before = fileSnapshot(sandbox.root);
+
+        const result = await runCli(sandbox, ['list', '--json']);
+
+        expect(result.status).toBe(1);
+        expectError(result, 'CONFIG_ERROR');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+        expect(existsSync(sandbox.database)).toBe(false);
+      })
+  );
+
+  it(
+    'preserves the missing explicit identity exit code and JSON error envelope',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const result = await runCli(sandbox, ['role', 'show', '--identity', 'missing', '--json']);
+
+        expect(result.status).toBe(3);
+        expectError(result, 'NAME_NOT_FOUND', "Identity 'missing' was not found.");
+        expect(existsSync(sandbox.database)).toBe(true);
+      })
+  );
+
+  it(
+    'maps an incompatible future schema to one role error without changing migration history',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        mkdirSync(sandbox.globalDir, { recursive: true });
+        const database = new Database(sandbox.database);
+        try {
+          database.exec(`
+            CREATE TABLE _migrations (
+              version INTEGER PRIMARY KEY,
+              name TEXT NOT NULL,
+              applied_at TEXT NOT NULL
+            );
+          `);
+          const insert = database.prepare(
+            'INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, ?)'
+          );
+          for (const migration of CURRENT_MIGRATIONS)
+            insert.run(migration.version, migration.name, '2026-01-01T00:00:00.000Z');
+          insert.run(5, 'future migration', '2026-01-01T00:00:00.000Z');
+        } finally {
+          database.close();
+        }
+        const before = readMigrationHistory(sandbox);
+
+        const result = await runCli(sandbox, ['role', 'show', '--identity', 'missing', '--json']);
+
+        expect(result.status).toBe(1);
+        const document = expectError(result, 'ROLE_ERROR');
+        expect((document.error as { message: string }).message).toContain(
+          'unsupported migration version'
+        );
+        expect(readMigrationHistory(sandbox)).toEqual(before);
+      })
+  );
+
+  it('pipes a large real role result as one complete JSON document', { timeout: 10_000 }, () =>
+    withSandbox(async (sandbox) => {
+      initializeDatabase(sandbox);
+      // Multibyte fixture data verifies that the real pipe preserves Unicode
+      // boundaries while transporting a large structured result.
+      const content = 'role-content-日本語-🚀-' + 'x'.repeat(48 * 1024);
+      const database = new Database(sandbox.database);
+      try {
+        database
+          .prepare(
+            'INSERT INTO identities (id, name, canonical_name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
+          )
+          .run(
+            'identity-large',
+            'LargeRole',
+            'largerole',
+            '2026-01-01T00:00:00.000Z',
+            '2026-01-01T00:00:00.000Z'
+          );
+        database
+          .prepare('INSERT INTO role_profiles (identity_id, content, updated_at) VALUES (?, ?, ?)')
+          .run('identity-large', content, '2026-01-01T00:00:00.000Z');
+      } finally {
+        database.close();
+      }
+
+      const result = await runCli(sandbox, ['role', 'show', '--identity', 'LargeRole', '--json']);
+
+      expect(result.status).toBe(0);
+      const document = parseWholeStdout(result) as {
+        identity: { name: string; canonicalName: string };
+        role: { content: string };
+      };
+      expect(result.stdout.length).toBeGreaterThan(32 * 1024);
+      expect(document.identity).toEqual({
+        id: 'identity-large',
+        name: 'LargeRole',
+        canonicalName: 'largerole',
+      });
+      expect(document.role.content).toBe(content);
+    })
+  );
+
+  it(
+    'returns an explicit JSON success document while config set and clear persist safely',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        writeFileSync(sandbox.localConfig, '{"keep":{"value":true}}\n');
+
+        const setResult = await runCli(sandbox, ['config', 'set', 'mode', 'polling', '--json']);
+        expectJsonSuccess(setResult, { ok: true });
+        expect(JSON.parse(readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+          keep: { value: true },
+          $config: { mode: 'polling' },
+        });
+
+        const clearResult = await runCli(sandbox, ['config', 'clear', 'mode', '--json']);
+        expectJsonSuccess(clearResult, { ok: true });
+        expect(JSON.parse(readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+          keep: { value: true },
+        });
+        expect(existsSync(sandbox.database)).toBe(false);
+      })
+  );
+
+  it('does not overwrite a preexisting local config when init fails', { timeout: 10_000 }, () =>
+    withSandbox(async (sandbox) => {
+      const original = '{"keep":"original"}\n';
+      writeFileSync(sandbox.localConfig, original);
+
+      const result = await runCli(sandbox, ['init', '--json']);
+
+      expect(result.status).toBe(1);
+      const document = parseWholeStdout(result);
+      expect(document.error).toMatchObject({ code: 'ERROR' });
+      expect((document.error as { message: string }).message).toContain('already exists');
+      expect(readFileSync(sandbox.localConfig, 'utf8')).toBe(original);
+      expect(existsSync(sandbox.database)).toBe(false);
+    })
+  );
+
+  it(
+    'rejects JSON mode for text-only help, version, completion, and learn commands',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const before = fileSnapshot(sandbox.root);
+        const commands = [
+          ['help', '--json'],
+          ['--json', '--help'],
+          ['--version', '--json'],
+          ['completion', 'bash', '--json'],
+          ['learn', '--json'],
+        ];
+
+        for (const args of commands) {
+          const result = await runCli(sandbox, args);
+          expect(result.status).toBe(1);
+          expectError(result, 'JSON_UNSUPPORTED');
+          expect(fileSnapshot(sandbox.root)).toEqual(before);
+        }
+      })
+  );
+
+  it('keeps human identity errors concise without a stack trace', { timeout: 10_000 }, () =>
+    withSandbox(async (sandbox) => {
+      const result = await runCli(sandbox, ['role', 'show', '--identity', 'missing']);
+
+      expect(result.status).toBe(3);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain("Identity 'missing' was not found.");
+      expect(result.stderr).not.toContain(' at ');
+      expect(result.stderr).not.toContain('Error:');
+    })
+  );
+});

--- a/src/cli-output.test.ts
+++ b/src/cli-output.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCliOutput, CliOutputSerializationError } from './cli-output.js';
+
+describe('CLI JSON output boundary', () => {
+  it('publishes at most one document and exposes duplicate writes', () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const output = createCliOutput(true);
+      output.setJson({ ok: true });
+      output.setJson({ second: true });
+
+      expect(output.hasDuplicateJson()).toBe(true);
+      output.replaceJson({ error: { code: 'INTERNAL_ERROR', message: 'duplicate' } });
+      output.flush();
+      output.flush();
+      expect(writeSpy).toHaveBeenCalledOnce();
+      expect(JSON.parse(String(writeSpy.mock.calls[0]?.[0]))).toEqual({
+        error: { code: 'INTERNAL_ERROR', message: 'duplicate' },
+      });
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it('does not publish an unserializable result', () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const output = createCliOutput(true);
+      output.setJson(1n);
+
+      expect(() => output.flush()).toThrow(CliOutputSerializationError);
+      expect(writeSpy).not.toHaveBeenCalled();
+      output.replaceJson({ error: { code: 'INTERNAL_ERROR', message: 'serialize failed' } });
+      output.flush();
+      expect(writeSpy).toHaveBeenCalledOnce();
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it.each(['undefined', 'circular'])('rejects %s before writing bytes', (kind) => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const output = createCliOutput(true);
+      if (kind === 'undefined') {
+        output.setJson(undefined);
+      } else {
+        const circular: { self?: unknown } = {};
+        circular.self = circular;
+        output.setJson(circular);
+      }
+
+      expect(() => output.flush()).toThrow(CliOutputSerializationError);
+      expect(writeSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it('does not retry a stdout write failure', () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => {
+      throw new Error('broken pipe');
+    });
+    try {
+      const output = createCliOutput(true);
+      output.setJson({ ok: true });
+      expect(() => output.flush()).toThrow('broken pipe');
+      expect(writeSpy).toHaveBeenCalledOnce();
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+});

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -1,0 +1,69 @@
+import { createUI } from './ui.js';
+import type { UI } from './types.js';
+
+export interface CliOutput {
+  readonly ui: UI;
+  readonly hasJson: () => boolean;
+  readonly hasError: () => boolean;
+  readonly hasDuplicateJson: () => boolean;
+  readonly setJson: (data: unknown) => void;
+  readonly replaceJson: (data: unknown) => void;
+  readonly flush: () => void;
+}
+
+export class CliOutputSerializationError extends Error {
+  constructor(cause: unknown) {
+    super('Could not serialize JSON output.', { cause });
+    this.name = 'CliOutputSerializationError';
+  }
+}
+
+/**
+ * Own process-boundary output so JSON is emitted once, after resource cleanup.
+ * Human output remains streamed through the established UI implementation.
+ */
+export function createCliOutput(jsonMode: boolean): CliOutput {
+  let jsonDocument: unknown;
+  let hasJson = false;
+  let duplicateJson = false;
+  let flushed = false;
+
+  const setJson = (data: unknown): void => {
+    if (hasJson) {
+      duplicateJson = true;
+      return;
+    }
+    jsonDocument = data;
+    hasJson = true;
+  };
+
+  const hasError = (): boolean => {
+    if (!jsonDocument || typeof jsonDocument !== 'object') return false;
+    return 'error' in jsonDocument;
+  };
+
+  return {
+    ui: createUI(jsonMode, { jsonSink: setJson }),
+    hasJson: () => hasJson,
+    hasError,
+    hasDuplicateJson: () => duplicateJson,
+    setJson,
+    replaceJson: (data: unknown) => {
+      jsonDocument = data;
+      hasJson = true;
+    },
+    flush: () => {
+      if (!jsonMode || !hasJson || flushed) return;
+      // Do not use process.exit: large JSON documents must be allowed to drain.
+      let serialized: string | undefined;
+      try {
+        serialized = JSON.stringify(jsonDocument, null, 2);
+      } catch (error) {
+        throw new CliOutputSerializationError(error);
+      }
+      if (serialized === undefined) throw new CliOutputSerializationError('undefined result');
+      process.stdout.write(`${serialized}\n`);
+      flushed = true;
+    },
+  };
+}

--- a/src/cli-runner.test.ts
+++ b/src/cli-runner.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Context, UI } from './types.js';
+import { ExitCodes } from './exits.js';
+
+function baseContext(): Context {
+  return {
+    argv: [],
+    flags: { json: true, verbose: false },
+    ui: {} as UI,
+    config: {} as Context['config'],
+    tmux: {} as Context['tmux'],
+    paths: {} as Context['paths'],
+    identityService: {} as Context['identityService'],
+    requestService: {} as Context['requestService'],
+    exit: (() => {
+      throw new Error('unconfigured exit');
+    }) as Context['exit'],
+    dispose: vi.fn(),
+  };
+}
+
+async function loadRunner(
+  options: {
+    dispatch?: (ctx: Context) => Promise<void> | void;
+    startup?: (ctx: Context) => Promise<void> | void;
+    dispose?: () => void;
+  } = {}
+) {
+  vi.resetModules();
+  const createContext = vi.fn((contextOptions: { ui: UI; exit: Context['exit'] }) => {
+    const ctx = baseContext();
+    ctx.ui = contextOptions.ui;
+    ctx.exit = contextOptions.exit;
+    ctx.dispose = options.dispose ?? ctx.dispose;
+    return ctx;
+  });
+  vi.doMock('./context.js', () => ({ ExitCodes, createContext }));
+  vi.doMock('./cli/application.js', () => ({
+    dispatchCommand: vi.fn((ctx: Context) => options.dispatch?.(ctx)),
+  }));
+  vi.doMock('./update-check.js', () => ({
+    runStartupChecks: vi.fn((ctx: Context) => options.startup?.(ctx)),
+  }));
+
+  return { ...(await import('./cli-runner.js')), createContext };
+}
+
+function captureStdout(): { chunks: string[]; restore: () => void } {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  return { chunks, restore: () => spy.mockRestore() };
+}
+
+function document(chunks: string[]): Record<string, unknown> {
+  return JSON.parse(chunks.join('')) as Record<string, unknown>;
+}
+
+describe('CLI runner lifecycle', () => {
+  afterEach(() => {
+    vi.doUnmock('./context.js');
+    vi.doUnmock('./cli/application.js');
+    vi.doUnmock('./update-check.js');
+    vi.restoreAllMocks();
+  });
+
+  it('reports parse errors without creating a Context', async () => {
+    const output = captureStdout();
+    try {
+      const { runCli, createContext } = await loadRunner();
+      await expect(runCli(['--json', 'name'])).resolves.toBe(1);
+      expect(document(output.chunks)).toMatchObject({ error: { code: 'USAGE_ERROR' } });
+      expect(createContext).not.toHaveBeenCalled();
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('disposes once when startup fails and emits an internal error', async () => {
+    const output = captureStdout();
+    let outputAtDisposal: string[] | undefined;
+    const dispose = vi.fn(() => {
+      outputAtDisposal = [...output.chunks];
+    });
+    try {
+      const { runCli } = await loadRunner({
+        dispose,
+        startup: () => {
+          throw new Error('startup failed');
+        },
+      });
+      await expect(runCli(['role', 'show', '--json'])).resolves.toBe(1);
+      expect(dispose).toHaveBeenCalledOnce();
+      expect(outputAtDisposal).toEqual([]);
+      expect(output.chunks).toHaveLength(1);
+      expect(document(output.chunks)).toEqual({
+        error: { code: 'INTERNAL_ERROR', message: 'startup failed' },
+      });
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('preserves a primary failure when cleanup also fails', async () => {
+    const output = captureStdout();
+    try {
+      const { runCli } = await loadRunner({
+        dispose: () => {
+          throw new Error('cleanup failed');
+        },
+        dispatch: () => {
+          throw new Error('primary failed');
+        },
+      });
+      await expect(runCli(['role', 'show', '--json'])).resolves.toBe(1);
+      expect(document(output.chunks)).toEqual({
+        error: { code: 'INTERNAL_ERROR', message: 'primary failed' },
+      });
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('replaces pending success with cleanup failure and effects warning', async () => {
+    const output = captureStdout();
+    try {
+      const { runCli } = await loadRunner({
+        dispose: () => {
+          throw new Error('close failed');
+        },
+        dispatch: (ctx) => {
+          ctx.ui.json({ result: 'pending' });
+        },
+      });
+      await expect(runCli(['role', 'show', '--json'])).resolves.toBe(1);
+      expect(document(output.chunks)).toEqual({
+        error: {
+          code: 'CLEANUP_ERROR',
+          message: 'Cleanup failed; command effects may already have occurred: close failed',
+        },
+      });
+    } finally {
+      output.restore();
+    }
+  });
+
+  it.each([undefined, 0, 5])('rejects duplicate results with exit %s', async (status) => {
+    const output = captureStdout();
+    try {
+      const { runCli } = await loadRunner({
+        dispatch: (ctx) => {
+          ctx.ui.json({ result: 'first' });
+          ctx.ui.json({ result: 'second' });
+          if (status !== undefined) ctx.exit(status);
+        },
+      });
+      await expect(runCli(['role', 'show', '--json'])).resolves.toBe(1);
+      expect(document(output.chunks)).toEqual({
+        error: { code: 'INTERNAL_ERROR', message: 'Command emitted more than one JSON result.' },
+      });
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('does not promote an arbitrary native error code into the public contract', async () => {
+    const output = captureStdout();
+    try {
+      const { runCli } = await loadRunner({
+        dispatch: () => {
+          throw Object.assign(new Error('native operation failed'), { code: 'ENOENT' });
+        },
+      });
+      expect(await runCli(['role', 'show', '--json'])).toBe(1);
+      expect(document(output.chunks)).toEqual({
+        error: { code: 'INTERNAL_ERROR', message: 'native operation failed' },
+      });
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('does not retry a potentially partial stdout write at the runner boundary', async () => {
+    const failure = new Error('output pipe failed');
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => {
+      throw failure;
+    });
+    const dispose = vi.fn();
+    try {
+      const { runCli } = await loadRunner({ dispose });
+      await expect(runCli(['role', 'show', '--json'])).rejects.toBe(failure);
+      expect(dispose).toHaveBeenCalledOnce();
+      expect(write).toHaveBeenCalledOnce();
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it('does not return success JSON after a nonzero exit', async () => {
+    const output = captureStdout();
+    try {
+      const { runCli } = await loadRunner({
+        dispatch: (ctx) => {
+          ctx.ui.json({ ok: true });
+          ctx.exit(5);
+        },
+      });
+      await expect(runCli(['role', 'show', '--json'])).resolves.toBe(5);
+      expect(document(output.chunks)).toEqual({
+        error: { code: 'ERROR', message: 'Command failed.' },
+      });
+    } finally {
+      output.restore();
+    }
+  });
+
+  it.each(['undefined', 'circular', 'bigint'])(
+    'maps %s serialization failures to one internal error document',
+    async (kind) => {
+      const output = captureStdout();
+      try {
+        const { runCli } = await loadRunner({
+          dispatch: (ctx) => {
+            let value: unknown;
+            if (kind === 'undefined') value = undefined;
+            else if (kind === 'bigint') value = 1n;
+            else {
+              const circular: { self?: unknown } = {};
+              circular.self = circular;
+              value = circular;
+            }
+            ctx.ui.json(value);
+          },
+        });
+        await expect(runCli(['role', 'show', '--json'])).resolves.toBe(1);
+        expect(document(output.chunks)).toEqual({
+          error: { code: 'INTERNAL_ERROR', message: 'Could not serialize JSON output.' },
+        });
+      } finally {
+        output.restore();
+      }
+    }
+  );
+
+  it.each([
+    [3, 'PANE_NOT_FOUND'],
+    [4, 'TIMEOUT'],
+    [5, 'CONFLICT'],
+  ] as const)(
+    'preserves emitted error details for exit %s when cleanup fails',
+    async (status, code) => {
+      const output = captureStdout();
+      try {
+        const { runCli } = await loadRunner({
+          dispose: () => {
+            throw new Error('cleanup failed');
+          },
+          dispatch: (ctx) => {
+            ctx.ui.json({
+              error: {
+                code,
+                message: 'request failed',
+                stage: 'submit',
+                suggestion: 'retry later',
+              },
+            });
+            ctx.exit(status);
+          },
+        });
+        await expect(runCli(['role', 'show', '--json'])).resolves.toBe(status);
+        expect(document(output.chunks)).toEqual({
+          error: {
+            code,
+            message: 'request failed',
+            stage: 'submit',
+            suggestion: 'retry later',
+          },
+        });
+      } finally {
+        output.restore();
+      }
+    }
+  );
+
+  it.each([
+    ['team', 'list', '--json'],
+    ['list', '--team', 'legacy', '--json'],
+    ['talk', 'Alpha', 'message', '--json', '--team', 'legacy'],
+  ])('rejects unsupported team routing with one JSON error: %s', async (...argv) => {
+    const output = captureStdout();
+    try {
+      const { runCli, createContext } = await loadRunner();
+      await expect(runCli(argv)).resolves.toBe(1);
+      expect(document(output.chunks)).toEqual({
+        error: {
+          code: 'UNSUPPORTED_TEAM',
+          message: 'Team-scoped commands and --team are not supported in tmt v5.',
+        },
+      });
+      expect(createContext).not.toHaveBeenCalled();
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('rejects JSON text-only commands before Context creation', async () => {
+    const output = captureStdout();
+    try {
+      const { runCli, createContext } = await loadRunner();
+      await expect(runCli(['--json', 'help'])).resolves.toBe(1);
+      expect(document(output.chunks)).toMatchObject({ error: { code: 'JSON_UNSUPPORTED' } });
+      expect(createContext).not.toHaveBeenCalled();
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('emits an explicit success document when a command has no result', async () => {
+    const output = captureStdout();
+    try {
+      const { runCli } = await loadRunner();
+      await expect(runCli(['role', 'show', '--json'])).resolves.toBe(0);
+      expect(document(output.chunks)).toEqual({ ok: true });
+    } finally {
+      output.restore();
+    }
+  });
+});

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -1,0 +1,244 @@
+import { ConfigParseError } from './config.js';
+import { createContext, ExitCodes } from './context.js';
+import { cmdHelp, type HelpConfig } from './commands/help.js';
+import { cmdCompletion } from './commands/completion.js';
+import { UNSUPPORTED_TEAM_MESSAGE } from './commands/unsupported-team.js';
+import { runStartupChecks } from './update-check.js';
+import { CliParseError, parseArgs, type ParsedArgs, type ParsedInvocation } from './cli/parser.js';
+import { dispatchCommand } from './cli/application.js';
+import type { Context, Flags } from './types.js';
+import { CliOutputSerializationError, createCliOutput, type CliOutput } from './cli-output.js';
+import { loadConfig, resolvePaths } from './config.js';
+
+export class CliExit extends Error {
+  readonly code: number;
+
+  constructor(code: number) {
+    super(`exit(${code})`);
+    this.name = 'CliExit';
+    this.code = code;
+  }
+}
+
+const JSON_UNSUPPORTED_MESSAGE =
+  'This command only supports human-readable output and cannot be used with --json.';
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function publicError(error: unknown): { code: string; message: string } {
+  if (error instanceof ConfigParseError) {
+    return { code: 'CONFIG_ERROR', message: error.message };
+  }
+  return { code: 'INTERNAL_ERROR', message: errorMessage(error) };
+}
+
+function writeJsonError(output: CliOutput, error: { code: string; message: string }): void {
+  output.replaceJson({ error });
+}
+
+function writeHumanError(output: CliOutput, message: string): void {
+  output.ui.error(message);
+}
+
+function flushJson(output: CliOutput, status: number, verbose: boolean, debug?: boolean): number {
+  try {
+    output.flush();
+    return status;
+  } catch (error) {
+    if (!(error instanceof CliOutputSerializationError)) throw error;
+    output.replaceJson({
+      error: {
+        code: 'INTERNAL_ERROR',
+        message: 'Could not serialize JSON output.',
+      },
+    });
+    if (verbose || debug) console.error('[DEBUG] JSON serialization failure:', error);
+    try {
+      output.flush();
+    } catch {
+      // A failed stdout write is outside the structured-output guarantee.
+    }
+    return ExitCodes.ERROR;
+  }
+}
+
+function textOnly(kind: ParsedInvocation['kind']): boolean {
+  return kind === 'help' || kind === 'version' || kind === 'completion' || kind === 'learn';
+}
+
+function unsupportedJson(output: CliOutput, flags: Flags): number {
+  writeJsonError(output, { code: 'JSON_UNSUPPORTED', message: JSON_UNSUPPORTED_MESSAGE });
+  return flushJson(output, ExitCodes.ERROR, flags.verbose, flags.debug);
+}
+
+function parseFailure(error: unknown): number {
+  const parseError = error instanceof CliParseError ? error : new Error(errorMessage(error));
+  const flags: Flags =
+    error instanceof CliParseError ? error.flags : { json: false, verbose: false };
+  const output = createCliOutput(flags.json);
+  if (flags.json) {
+    writeJsonError(output, { code: 'USAGE_ERROR', message: parseError.message });
+  } else {
+    writeHumanError(output, parseError.message);
+  }
+  return flushJson(output, ExitCodes.ERROR, flags.verbose, flags.debug);
+}
+
+function helpConfig(showIntro: boolean): HelpConfig {
+  try {
+    const config = loadConfig(resolvePaths());
+    return { mode: config.mode, timeout: config.defaults.timeout, showIntro };
+  } catch {
+    return { showIntro };
+  }
+}
+
+function ensureFailureDocument(output: CliOutput, code: number): void {
+  if (output.hasError()) return;
+  writeJsonError(output, {
+    code: code === ExitCodes.TIMEOUT ? 'TIMEOUT' : 'ERROR',
+    message: code === ExitCodes.TIMEOUT ? 'Command timed out.' : 'Command failed.',
+  });
+}
+
+async function runContextCommand(
+  parsed: ParsedArgs,
+  argv: readonly string[],
+  output: CliOutput
+): Promise<number> {
+  const { invocation, flags, metadata } = parsed;
+  const command = metadata.commandPath[0] ?? invocation.kind;
+  let ctx: Context | undefined;
+  let status: number = ExitCodes.SUCCESS;
+  try {
+    ctx = createContext({
+      argv: [...argv],
+      flags,
+      capability: metadata.capability,
+      ui: output.ui,
+      exit: (code: number): never => {
+        throw new CliExit(code);
+      },
+    });
+
+    const tmuxRequired = new Set([
+      'talk',
+      'send',
+      'check',
+      'read',
+      'this',
+      'name',
+      'add',
+      'whoami',
+      'unbind',
+    ]);
+    if (!process.env.TMUX && tmuxRequired.has(command)) {
+      ctx.ui.warn('Not running inside tmux. Some features may not work.');
+    }
+
+    await runStartupChecks(ctx, command);
+    await dispatchCommand(ctx, parsed);
+  } catch (error) {
+    if (error instanceof CliExit) {
+      status = error.code;
+      if (status !== ExitCodes.SUCCESS) ensureFailureDocument(output, status);
+    } else {
+      status = ExitCodes.ERROR;
+      const detail = publicError(error);
+      if (flags.json) writeJsonError(output, detail);
+      else writeHumanError(output, detail.message);
+      if (flags.verbose || flags.debug) console.error('[DEBUG] CLI failure:', error);
+    }
+  }
+
+  try {
+    ctx?.dispose?.();
+  } catch (error) {
+    if (status === ExitCodes.SUCCESS) {
+      status = ExitCodes.ERROR;
+      const detail = {
+        code: 'CLEANUP_ERROR',
+        message: `Cleanup failed; command effects may already have occurred: ${errorMessage(error)}`,
+      };
+      if (flags.json) writeJsonError(output, detail);
+      else writeHumanError(output, detail.message);
+    } else if (flags.verbose || flags.debug) {
+      console.error('[DEBUG] CLI cleanup failure:', error);
+    }
+  }
+
+  if (flags.json) {
+    if (output.hasDuplicateJson()) {
+      status = ExitCodes.ERROR;
+      writeJsonError(output, {
+        code: 'INTERNAL_ERROR',
+        message: 'Command emitted more than one JSON result.',
+      });
+    }
+    if (status === ExitCodes.SUCCESS && !output.hasJson()) output.setJson({ ok: true });
+    if (status !== ExitCodes.SUCCESS) ensureFailureDocument(output, status);
+    status = flushJson(output, status, flags.verbose, flags.debug);
+  }
+  return status;
+}
+
+/** Run one CLI invocation and return its meaningful process status. */
+export async function runCli(argv: readonly string[]): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(argv);
+  } catch (error) {
+    return parseFailure(error);
+  }
+
+  const { invocation, flags, metadata } = parsed;
+  const output = createCliOutput(flags.json);
+  const command = metadata.commandPath[0] ?? invocation.kind;
+
+  if (command === 'team' || metadata.unsupportedTeam) {
+    if (flags.json) {
+      writeJsonError(output, { code: 'UNSUPPORTED_TEAM', message: UNSUPPORTED_TEAM_MESSAGE });
+      return flushJson(output, ExitCodes.UNSUPPORTED_TEAM, flags.verbose, flags.debug);
+    } else {
+      writeHumanError(output, UNSUPPORTED_TEAM_MESSAGE);
+    }
+    return ExitCodes.UNSUPPORTED_TEAM;
+  }
+
+  if (flags.json && textOnly(invocation.kind)) return unsupportedJson(output, flags);
+
+  if (invocation.kind === 'help') {
+    try {
+      cmdHelp(helpConfig(invocation.showIntro));
+      return ExitCodes.SUCCESS;
+    } catch (error) {
+      writeHumanError(output, errorMessage(error));
+      return ExitCodes.ERROR;
+    }
+  }
+
+  if (invocation.kind === 'version') {
+    try {
+      const { VERSION } = await import('./version.js');
+      console.log(VERSION);
+      return ExitCodes.SUCCESS;
+    } catch (error) {
+      writeHumanError(output, errorMessage(error));
+      return ExitCodes.ERROR;
+    }
+  }
+
+  if (invocation.kind === 'completion') {
+    try {
+      cmdCompletion(invocation.shell);
+      return ExitCodes.SUCCESS;
+    } catch (error) {
+      writeHumanError(output, errorMessage(error));
+      return ExitCodes.ERROR;
+    }
+  }
+
+  return runContextCommand(parsed, argv, output);
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -83,14 +83,11 @@ function makeStubContext(): Context {
 }
 
 describe('cli', () => {
-  const originalArgv = process.argv;
-
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
   afterEach(() => {
-    process.argv = originalArgv;
     vi.restoreAllMocks();
   });
 
@@ -100,37 +97,22 @@ describe('cli', () => {
     ['--team=value', ['node', 'cli', 'list', '--team=legacy']],
   ])('rejects %s before creating command context', async (_label, argv) => {
     vi.resetModules();
-    process.argv = argv;
-    const ctx = makeStubContext();
-    const createContext = vi.fn(() => ctx);
-    const jsonSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new Error(`exit(${code})`);
-    }) as any);
+    const createContext = vi.fn(() => makeStubContext());
     vi.doMock('./context.js', () => ({
       createContext,
       ExitCodes: { SUCCESS: 0, ERROR: 1, UNSUPPORTED_TEAM: 1 },
     }));
-    vi.doMock('./ui.js', () => ({
-      createUI: () => ({
-        info: vi.fn(),
-        success: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        table: vi.fn(),
-        json: vi.fn(),
-      }),
-    }));
-
-    await expect(import('./cli.js')).rejects.toThrow('exit(1)');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(argv.slice(2))).toBe(1);
     expect(createContext).not.toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    jsonSpy.mockRestore();
+    expect(errorSpy).toHaveBeenCalledWith(
+      '✗ Team-scoped commands and --team are not supported in tmt v5.'
+    );
   });
 
   it('prints completion for bash', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'completion', 'bash'];
 
     vi.doMock('./context.js', () => ({
       createContext: () => makeStubContext(),
@@ -142,67 +124,49 @@ describe('cli', () => {
       },
     }));
 
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await import('./cli.js');
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['completion', 'bash'])).toBe(0);
     expect(logSpy).toHaveBeenCalledWith('completion:bash');
-    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it('errors on invalid time format', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'talk', 'codex', 'hi', '--delay', 'abc'];
-    const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new Error(`exit(${code})`);
-    }) as any);
-
-    await expect(import('./cli.js')).rejects.toThrow('exit(1)');
-    expect(ctx.ui.error).toHaveBeenCalledWith(
-      'Invalid time format: abc. Use number (seconds) or number with ms/s suffix.'
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['talk', 'codex', 'hi', '--delay', 'abc'])).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '✗ Invalid time format: abc. Use number (seconds) or number with ms/s suffix.'
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it('reports an unknown command through a no-resource context', async () => {
+  it('reports an unknown command without creating a Context', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'nope'];
-
-    const ctx = makeStubContext();
-    const createContext = vi.fn(() => ctx);
+    const createContext = vi.fn(() => makeStubContext());
     vi.doMock('./context.js', () => ({
       createContext,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
 
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-    await import('./cli.js');
-    expect(ctx.ui.error).toHaveBeenCalledWith(expect.stringContaining('Unknown command'));
-    expect(createContext).toHaveBeenCalledWith(expect.objectContaining({ capability: 'none' }));
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['nope'])).toBe(1);
+    expect(createContext).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown command'));
   });
 
   it('handles --version by printing VERSION', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', '--version'];
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
 
-    await import('./cli.js');
-    // allow the dynamic import to resolve
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['--version'])).toBe(0);
     expect(logSpy).toHaveBeenCalled();
-    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('routes learn command and does not exit', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'learn'];
 
     const ctx = makeStubContext();
     const learnSpy = vi.fn();
@@ -211,16 +175,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/learn.js', () => ({ cmdLearn: learnSpy }));
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['learn'])).toBe(0);
     expect(learnSpy).toHaveBeenCalled();
-    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('prints JSON error when --json and a command throws', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'role', 'show', '--json']; // will throw in our mocked cmdRole
+    // The mocked command throws through the shared runner boundary.
 
     const ctx = makeStubContext();
     ctx.flags.json = true;
@@ -234,20 +196,16 @@ describe('cli', () => {
       },
     }));
 
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    // allow the run().catch handler to run
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(errSpy).toHaveBeenCalledWith(JSON.stringify({ error: 'boom' }));
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['role', 'show', '--json'])).toBe(1);
+    expect(JSON.parse(String(writeSpy.mock.calls[0]?.[0]))).toEqual({
+      error: { code: 'INTERNAL_ERROR', message: 'boom' },
+    });
   });
 
   it('routes install command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'install', 'claude'];
 
     const ctx = makeStubContext();
     const installSpy = vi.fn();
@@ -256,19 +214,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/install.js', () => ({ cmdInstall: installSpy }));
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    // allow async to resolve
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['install', 'claude'])).toBe(0);
 
     expect(installSpy).toHaveBeenCalledWith(ctx, 'claude');
-    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('routes preamble command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'preamble', 'show'];
 
     const ctx = makeStubContext();
     const preambleSpy = vi.fn();
@@ -277,22 +230,18 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/preamble.js', () => ({ cmdPreamble: preambleSpy }));
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['preamble', 'show'])).toBe(0);
 
     expect(preambleSpy).toHaveBeenCalledWith(ctx, {
       kind: 'preamble',
       operation: 'show',
       agent: undefined,
     });
-    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('routes this command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'this', 'myagent'];
 
     const ctx = makeStubContext();
     const thisSpy = vi.fn();
@@ -301,18 +250,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/this.js', () => ({ cmdThis: thisSpy }));
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['this', 'myagent'])).toBe(0);
 
     expect(thisSpy).toHaveBeenCalledWith(ctx, 'myagent');
-    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('routes name command as a current-pane identity binding', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'name', 'backend'];
 
     const ctx = makeStubContext();
     const nameSpy = vi.fn();
@@ -321,91 +266,78 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/name.js', () => ({ cmdName: nameSpy }));
-    vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['name', 'backend'])).toBe(0);
 
     expect(nameSpy).toHaveBeenCalledWith(ctx, 'backend');
   });
 
   it('errors when name command has missing or extra arguments', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'name', 'backend', 'main:1.2', 'extra'];
+    const argv = ['name', 'backend', 'main:1.2', 'extra'];
 
     const ctx = makeStubContext();
-    const exitSpy = vi.fn();
-    ctx.exit = exitSpy as any;
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/name.js', () => ({ cmdName: vi.fn() }));
 
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team name <global-name>');
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(argv)).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team name <global-name>');
   });
 
   it('errors when name command has no name', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'name'];
+    const argv = ['name'];
     const ctx = makeStubContext();
-    const exitSpy = vi.fn();
-    ctx.exit = exitSpy as any;
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/name.js', () => ({ cmdName: vi.fn() }));
-    await import('./cli.js');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team name <global-name>');
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(argv)).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team name <global-name>');
   });
 
   it('errors when this command is missing name', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'this'];
+    const argv = ['this'];
 
     const ctx = makeStubContext();
-    const exitSpy = vi.fn();
-    ctx.exit = exitSpy as any;
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/this.js', () => ({ cmdThis: vi.fn() }));
 
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team this <global-name>');
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(argv)).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team this <global-name>');
   });
 
   it('errors when this command has an extra argument', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'this', 'backend', 'extra'];
+    const argv = ['this', 'backend', 'extra'];
     const ctx = makeStubContext();
-    const exitSpy = vi.fn();
-    ctx.exit = exitSpy as any;
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/this.js', () => ({ cmdThis: vi.fn() }));
-    await import('./cli.js');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team this <global-name>');
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(argv)).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team this <global-name>');
   });
 
   it('routes whoami without arguments', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'whoami'];
     const ctx = makeStubContext();
     const whoamiSpy = vi.fn();
     vi.doMock('./context.js', () => ({
@@ -413,14 +345,13 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/whoami.js', () => ({ cmdWhoami: whoamiSpy }));
-    await import('./cli.js');
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['whoami'])).toBe(0);
     expect(whoamiSpy).toHaveBeenCalledWith(ctx);
   });
 
   it('routes unbind without arguments', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'unbind'];
     const ctx = makeStubContext();
     const unbindSpy = vi.fn();
     vi.doMock('./context.js', () => ({
@@ -428,17 +359,15 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/unbind.js', () => ({ cmdUnbind: unbindSpy }));
-    await import('./cli.js');
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['unbind'])).toBe(0);
     expect(unbindSpy).toHaveBeenCalledWith(ctx);
   });
 
   it.each(['whoami', 'unbind'])('rejects arguments for %s', async (command) => {
     vi.resetModules();
-    process.argv = ['node', 'cli', command, 'extra'];
+    const argv = [command, 'extra'];
     const ctx = makeStubContext();
-    const exitSpy = vi.fn();
-    ctx.exit = exitSpy as any;
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
@@ -446,15 +375,14 @@ describe('cli', () => {
     vi.doMock(`./commands/${command}.js`, () => ({
       [command === 'whoami' ? 'cmdWhoami' : 'cmdUnbind']: vi.fn(),
     }));
-    await import('./cli.js');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(ctx.ui.error).toHaveBeenCalledWith(`Usage: tmux-team ${command}`);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(argv)).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(`✗ Usage: tmux-team ${command}`);
   });
 
   it('routes init command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'init'];
 
     const ctx = makeStubContext();
     const initSpy = vi.fn();
@@ -463,16 +391,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/init.js', () => ({ cmdInit: initSpy }));
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['init'])).toBe(0);
 
     expect(initSpy).toHaveBeenCalledWith(ctx);
   });
 
   it('routes list command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'list'];
 
     const ctx = makeStubContext();
     const listSpy = vi.fn();
@@ -481,16 +407,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/list.js', () => ({ cmdList: listSpy }));
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['list'])).toBe(0);
 
     expect(listSpy).toHaveBeenCalledWith(ctx);
   });
 
   it('routes ls alias to list command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'ls'];
 
     const ctx = makeStubContext();
     const listSpy = vi.fn();
@@ -499,16 +423,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/list.js', () => ({ cmdList: listSpy }));
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['ls'])).toBe(0);
 
     expect(listSpy).toHaveBeenCalledWith(ctx);
   });
 
   it('routes add command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'add', '1.0', 'myagent'];
 
     const ctx = makeStubContext();
     const addSpy = vi.fn();
@@ -517,9 +439,8 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/add.js', () => ({ cmdAdd: addSpy }));
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['add', '1.0', 'myagent'])).toBe(0);
 
     expect(addSpy).toHaveBeenCalledWith(ctx, '1.0', 'myagent');
   });
@@ -529,24 +450,21 @@ describe('cli', () => {
     ['extra', ['node', 'cli', 'add', '1.0', 'backend', 'remark']],
   ])('rejects add command with %s arguments', async (_case, argv) => {
     vi.resetModules();
-    process.argv = argv;
+    const commandArgs = argv.slice(2);
     const ctx = makeStubContext();
-    const exitSpy = vi.fn();
-    ctx.exit = exitSpy as any;
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/add.js', () => ({ cmdAdd: vi.fn() }));
-    await import('./cli.js');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(ctx.ui.error).toHaveBeenCalledWith('Usage: tmux-team add <pane-target> <global-name>');
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(commandArgs)).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team add <pane-target> <global-name>');
   });
 
   it('routes config command', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'config', 'show'];
 
     const ctx = makeStubContext();
     const configSpy = vi.fn();
@@ -555,22 +473,18 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/config.js', () => ({ cmdConfig: configSpy }));
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['config', 'show'])).toBe(0);
 
     expect(configSpy).toHaveBeenCalledWith(ctx, {
       kind: 'config',
       operation: 'show',
       global: false,
     });
-    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('parses --timeout flag with seconds', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'talk', 'claude', 'hi', '--timeout', '30'];
 
     const ctx = makeStubContext();
     const talkSpy = vi.fn();
@@ -582,17 +496,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/talk.js', () => ({ cmdTalk: talkSpy }));
-    vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['talk', 'claude', 'hi', '--timeout', '30'])).toBe(0);
 
     expect(ctx.flags.timeout).toBe(30);
   });
 
   it('parses --timeout flag with ms suffix', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'talk', 'claude', 'hi', '--timeout', '500ms'];
 
     const ctx = makeStubContext();
     const talkSpy = vi.fn();
@@ -604,17 +515,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/talk.js', () => ({ cmdTalk: talkSpy }));
-    vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['talk', 'claude', 'hi', '--timeout', '500ms'])).toBe(0);
 
     expect(ctx.flags.timeout).toBe(0.5);
   });
 
   it('parses --lines flag', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'talk', 'claude', 'hi', '--wait', '--lines', '50'];
 
     const ctx = makeStubContext();
     const talkSpy = vi.fn();
@@ -626,17 +534,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/talk.js', () => ({ cmdTalk: talkSpy }));
-    vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['talk', 'claude', 'hi', '--wait', '--lines', '50'])).toBe(0);
 
     expect(ctx.flags.lines).toBe(50);
   });
 
   it('parses --no-preamble flag', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'talk', 'claude', 'hi', '--no-preamble'];
 
     const ctx = makeStubContext();
     const talkSpy = vi.fn();
@@ -648,17 +553,14 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/talk.js', () => ({ cmdTalk: talkSpy }));
-    vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['talk', 'claude', 'hi', '--no-preamble'])).toBe(0);
 
     expect(ctx.flags.noPreamble).toBe(true);
   });
 
   it('routes check command with lines argument', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'check', 'claude', '50'];
 
     const ctx = makeStubContext();
     const checkSpy = vi.fn();
@@ -667,65 +569,54 @@ describe('cli', () => {
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
     vi.doMock('./commands/check.js', () => ({ cmdCheck: checkSpy }));
-    vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['check', 'claude', '50'])).toBe(0);
 
     expect(checkSpy).toHaveBeenCalledWith(ctx, 'claude', 50);
   });
 
   it('errors on talk with missing arguments', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'talk', 'claude']; // missing message
+    const argv = ['talk', 'claude']; // missing message
 
     const ctx = makeStubContext();
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(ctx.ui.error).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(argv)).toBe(1);
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it('errors on add with missing arguments', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'add', 'claude']; // missing pane
+    const argv = ['add', 'claude']; // missing pane
 
     const ctx = makeStubContext();
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(ctx.ui.error).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(argv)).toBe(1);
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it('errors on check with missing arguments', async () => {
     vi.resetModules();
-    process.argv = ['node', 'cli', 'check']; // missing target
+    const argv = ['check']; // missing target
 
     const ctx = makeStubContext();
     vi.doMock('./context.js', () => ({
       createContext: () => ctx,
       ExitCodes: { SUCCESS: 0, ERROR: 1 },
     }));
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
-
-    await import('./cli.js');
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(ctx.ui.error).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(argv)).toBe(1);
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,130 +1,18 @@
 #!/usr/bin/env tsx
-// ─────────────────────────────────────────────────────────────
-// tmux-team CLI entry point
-// ─────────────────────────────────────────────────────────────
 
-import { createContext, ExitCodes } from './context.js';
+import { runCli } from './cli-runner.js';
 
-// Commands
-import { cmdHelp, HelpConfig } from './commands/help.js';
-import { loadConfig, resolvePaths } from './config.js';
-import { createUI } from './ui.js';
-import { cmdCompletion } from './commands/completion.js';
-import { UNSUPPORTED_TEAM_MESSAGE } from './commands/unsupported-team.js';
-import { runStartupChecks } from './update-check.js';
-import { CliParseError, parseArgs } from './cli/parser.js';
-import { dispatchCommand } from './cli/application.js';
-
-// ─────────────────────────────────────────────────────────────
-// Main
-// ─────────────────────────────────────────────────────────────
-
-function main(): void {
-  const argv = process.argv.slice(2);
-  let parsed;
-  try {
-    parsed = parseArgs(argv);
-  } catch (error) {
-    const parseError = error instanceof CliParseError ? error : new Error(String(error));
-    const flags = error instanceof CliParseError ? error.flags : { json: false, verbose: false };
-    // Parse failures use the normal UI contract without loading config or tmux.
-    const parseContext = createContext({ argv, flags, capability: 'none' });
-    parseContext.ui.error(parseError.message);
-    try {
-      parseContext.exit(ExitCodes.ERROR);
-    } catch {
-      // A test double or embedder may model the non-returning exit by throwing.
-      process.exit(ExitCodes.ERROR);
+export function main(): void {
+  void runCli(process.argv.slice(2)).then(
+    (code) => {
+      // Let stdout/stderr drain before Node exits, including large JSON results.
+      process.exitCode = code;
+    },
+    (error: unknown) => {
+      process.exitCode = 1;
+      console.error(error instanceof Error ? error.message : String(error));
     }
-    return;
-  }
-  const { invocation, flags, metadata } = parsed;
-  const command = metadata.commandPath[0] ?? invocation.kind;
-
-  // Reject both `team` and either spelling of `--team` before command routing
-  // or configuration loading can interpret them as a scope.
-  if (command === 'team' || metadata.unsupportedTeam) {
-    const ui = createUI(flags.json);
-    const error = {
-      code: 'UNSUPPORTED_TEAM',
-      message: UNSUPPORTED_TEAM_MESSAGE,
-    };
-    if (flags.json) ui.json({ error });
-    else ui.error(error.message);
-    process.exit(ExitCodes.UNSUPPORTED_TEAM);
-    return;
-  }
-
-  // Help - load config to show current mode/timeout
-  if (invocation.kind === 'help') {
-    // Show intro highlight when running just `tmux-team` with no args
-    const showIntro = invocation.showIntro;
-    try {
-      const paths = resolvePaths();
-      const config = loadConfig(paths);
-      const helpConfig: HelpConfig = {
-        mode: config.mode,
-        timeout: config.defaults.timeout,
-        showIntro,
-      };
-      cmdHelp(helpConfig);
-    } catch {
-      // Fallback if config can't be loaded
-      cmdHelp({ showIntro });
-    }
-    process.exit(ExitCodes.SUCCESS);
-    return;
-  }
-
-  if (invocation.kind === 'version') {
-    import('./version.js').then((m) => console.log(m.VERSION));
-    return;
-  }
-
-  // Completion doesn't need context
-  if (invocation.kind === 'completion') {
-    cmdCompletion(invocation.shell);
-    process.exit(ExitCodes.SUCCESS);
-    return;
-  }
-
-  // Create context for all other commands
-  const ctx = createContext({ argv, flags, capability: metadata.capability });
-
-  // Warn if not in tmux for commands that require it
-  const TMUX_REQUIRED_COMMANDS = [
-    'talk',
-    'send',
-    'check',
-    'read',
-    'this',
-    'name',
-    'add',
-    'whoami',
-    'unbind',
-  ];
-  if (!process.env.TMUX && TMUX_REQUIRED_COMMANDS.includes(command)) {
-    ctx.ui.warn('Not running inside tmux. Some features may not work.');
-  }
-
-  const run = async (): Promise<void> => {
-    await runStartupChecks(ctx, command ?? 'help');
-    await dispatchCommand(ctx, parsed);
-  };
-
-  run()
-    .catch((err) => {
-      if (!flags.json) {
-        console.error(err);
-      } else {
-        console.error(JSON.stringify({ error: String(err?.message ?? err) }));
-      }
-      // Dispose before process.exit; Node does not guarantee finally blocks
-      // will run after an explicit exit in embedding and test environments.
-      ctx.dispose?.();
-      process.exit(ExitCodes.ERROR);
-    })
-    .finally(() => ctx.dispose?.());
+  );
 }
 
 main();

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -1105,7 +1105,67 @@ describe('cmdTalk - --wait mode', () => {
     expect(ui.jsonOutput).toHaveLength(1);
     const output = ui.jsonOutput[0] as Record<string, unknown>;
     expect(output.status).toBe('timeout');
-    expect(output.error).toContain('Timed out');
+    expect(output.error).toEqual({
+      code: 'TIMEOUT',
+      message: expect.stringContaining('Timed out'),
+    });
+  });
+
+  it('wakes a long poll on SIGINT, releases once, and cleans up wait resources', async () => {
+    vi.useFakeTimers();
+    const tmux = createMockTmux();
+    const ui = createMockUI();
+    const paths = createTestPaths(testDir);
+    const base = requestFixture(paths.databaseFile).service;
+    const releaseWait = vi.fn(base.releaseWait);
+    const requestService: RequestService = { ...base, releaseWait };
+    const listenerCount = process.listenerCount('SIGINT');
+    const ctx = createContext({
+      tmux,
+      ui,
+      paths,
+      requestService,
+      flags: { wait: true, timeout: 30 },
+      config: {
+        defaults: {
+          timeout: 30,
+          pollInterval: 60,
+          captureLines: 100,
+          maxCaptureLines: 2000,
+          preambleEvery: 3,
+          pasteEnterDelayMs: 500,
+        },
+      },
+    });
+
+    let pending: Promise<void> | undefined;
+    try {
+      pending = cmdTalk(ctx, 'claude', 'Hello');
+      await Promise.resolve();
+
+      expect(tmux.sends).toHaveLength(1);
+      expect(process.listenerCount('SIGINT')).toBe(listenerCount + 1);
+      process.emit('SIGINT');
+
+      await expect(pending).rejects.toMatchObject({ exitCode: ExitCodes.ERROR });
+      expect(releaseWait).toHaveBeenCalledOnce();
+      expect(requestService.listAttempts()).toHaveLength(1);
+      expect(requestService.listAttempts()[0]).toMatchObject({
+        status: 'sent',
+        waitActive: false,
+      });
+      expect(ui.errors).toEqual(['Interrupted.']);
+      expect(process.listenerCount('SIGINT')).toBe(listenerCount);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      // Keep a failed setup assertion from leaving the command suspended on its
+      // intentionally long fake poll timer or retaining the process listener.
+      if (pending && process.listenerCount('SIGINT') > listenerCount) {
+        process.emit('SIGINT');
+        await pending.catch(() => undefined);
+      }
+      vi.useRealTimers();
+    }
   });
 
   it('isolates response using end marker in scrollback', async () => {

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -23,6 +23,11 @@ function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+type PollWait = {
+  readonly timer: ReturnType<typeof setTimeout>;
+  readonly wake: () => void;
+};
+
 function failSend(ctx: Context, pane: string, error: unknown): never {
   if (error instanceof TmuxDeliveryError) {
     const detail = {
@@ -541,11 +546,31 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
   let lastOutput = '';
   let lastOutputChangeAt = Date.now();
 
+  let interrupted = false;
+  let pollWait: PollWait | undefined;
   const onSigint = (): void => {
+    interrupted = true;
+    pollWait?.wake();
+  };
+
+  const waitForPoll = (delayMs: number): Promise<void> =>
+    new Promise((resolve) => {
+      let timer: ReturnType<typeof setTimeout>;
+      const finish = (): void => {
+        if (!pollWait || pollWait.timer !== timer) return;
+        pollWait = undefined;
+        clearTimeout(timer);
+        resolve();
+      };
+      timer = setTimeout(finish, delayMs);
+      pollWait = { timer, wake: finish };
+    });
+
+  const handleInterrupt = (): never => {
     releaseWait(true);
     if (!flags.json) process.stdout.write('\n');
     ui.error('Interrupted.');
-    exit(ExitCodes.ERROR);
+    return exit(ExitCodes.ERROR);
   };
 
   process.once('SIGINT', onSigint);
@@ -570,6 +595,8 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
     settle('sent', true);
 
     while (true) {
+      if (interrupted) handleInterrupt();
+
       const elapsedSeconds = (Date.now() - startedAt) / 1000;
       if (elapsedSeconds >= timeoutSeconds) {
         // Capture partial response on timeout
@@ -597,7 +624,10 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
             pane,
             ...(identity && { identity }),
             status: 'timeout',
-            error: `Timed out waiting for ${agentName} after ${Math.floor(timeoutSeconds)}s`,
+            error: {
+              code: 'TIMEOUT',
+              message: `Timed out waiting for ${agentName} after ${Math.floor(timeoutSeconds)}s`,
+            },
             requestId,
             nonce: waitNonce,
             endMarker: waitEndMarker,
@@ -630,7 +660,8 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
         }
       }
 
-      await sleepMs(pollIntervalSeconds * 1000);
+      await waitForPoll(pollIntervalSeconds * 1000);
+      if (interrupted) handleInterrupt();
 
       let output = '';
       try {

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -141,6 +141,33 @@ describe('createContext', () => {
     expect(exitSpy).toHaveBeenCalledWith(2);
   });
 
+  it('uses injected output and exit ownership without terminating the process', async () => {
+    vi.resetModules();
+    const ui: UI = {
+      info: vi.fn(),
+      success: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      table: vi.fn(),
+      json: vi.fn(),
+    };
+    const injectedExit = vi.fn((code: number): never => {
+      throw new Error(`injected exit(${code})`);
+    });
+    const { createContext } = await import('./context.js');
+    const ctx = createContext({
+      argv: [],
+      flags: { json: false, verbose: false },
+      capability: 'none',
+      ui,
+      exit: injectedExit,
+    });
+
+    expect(ctx.ui).toBe(ui);
+    expect(() => ctx.exit(7)).toThrow('injected exit(7)');
+    expect(injectedExit).toHaveBeenCalledWith(7);
+  });
+
   it('does not construct tmux for a no-resource capability', async () => {
     vi.resetModules();
     const createTmux = vi.fn(() => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,7 @@
 // Context object - passed to all commands
 // ─────────────────────────────────────────────────────────────
 
-import type { Context, Flags } from './types.js';
+import type { Context, Flags, UI } from './types.js';
 import { resolvePaths, loadConfig } from './config.js';
 import { createUI } from './ui.js';
 import { createTmux } from './tmux.js';
@@ -17,6 +17,9 @@ export interface CreateContextOptions {
   argv: string[];
   flags: Flags;
   cwd?: string;
+  /** Allows the process runner to own output buffering and termination. */
+  ui?: UI;
+  exit?: (code: number) => never;
   /** Declares the resources a command may need; tmux and config are lazy. */
   capability?: 'none' | 'storage' | 'tmux';
 }
@@ -25,7 +28,7 @@ export function createContext(options: CreateContextOptions): Context {
   const { argv, flags, cwd = process.cwd() } = options;
 
   const paths = resolvePaths(cwd);
-  const ui = createUI(flags.json);
+  const ui = options.ui ?? createUI(flags.json);
   const capability = options.capability ?? 'tmux';
   let tmux: Context['tmux'] | undefined;
   let config: Context['config'] | undefined;
@@ -113,6 +116,7 @@ export function createContext(options: CreateContextOptions): Context {
     paths,
     dispose,
     exit(code: number): never {
+      if (options.exit) return options.exit(code);
       dispose();
       process.exit(code);
     },

--- a/src/ui.test.ts
+++ b/src/ui.test.ts
@@ -53,7 +53,10 @@ describe('ui', () => {
     expect(logSpy).not.toHaveBeenCalled();
 
     ui.error('boom');
-    expect(errSpy).toHaveBeenCalledWith(JSON.stringify({ error: 'boom' }));
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({ error: { code: 'ERROR', message: 'boom' } }, null, 2)
+    );
 
     ui.json({ ok: true });
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ ok: true }, null, 2));

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -4,6 +4,11 @@
 
 import type { UI } from './types.js';
 
+export interface UIOptions {
+  /** Receive JSON documents instead of writing them immediately. */
+  readonly jsonSink?: (data: unknown) => void;
+}
+
 const isTTY = process.stdout.isTTY;
 
 // Strip ANSI escape codes for accurate length calculation
@@ -19,7 +24,7 @@ export const colors = {
   dim: (s: string) => (isTTY ? `\x1b[2m${s}\x1b[0m` : s),
 };
 
-export function createUI(jsonMode: boolean): UI {
+export function createUI(jsonMode: boolean, options: UIOptions = {}): UI {
   if (jsonMode) {
     // In JSON mode, suppress all human-friendly output
     return {
@@ -27,11 +32,14 @@ export function createUI(jsonMode: boolean): UI {
       success: () => {},
       warn: () => {},
       error: (msg: string) => {
-        console.error(JSON.stringify({ error: msg }));
+        const data = { error: { code: 'ERROR', message: msg } };
+        if (options.jsonSink) options.jsonSink(data);
+        else console.log(JSON.stringify(data, null, 2));
       },
       table: () => {},
       json: (data: unknown) => {
-        console.log(JSON.stringify(data, null, 2));
+        if (options.jsonSink) options.jsonSink(data);
+        else console.log(JSON.stringify(data, null, 2));
       },
     };
   }

--- a/test/e2e/cli-errors.e2e.test.ts
+++ b/test/e2e/cli-errors.e2e.test.ts
@@ -1,0 +1,147 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type CliResult } from './harness.js';
+import { requestAttempts } from './request-state-oracle.js';
+
+interface ErrorResult {
+  error: { code: string; message: string; stage?: string };
+}
+
+function expectError(result: CliResult, exitCode: number, code: string): ErrorResult {
+  expect(result.code).toBe(exitCode);
+  expect(result.stderr).toBe('');
+  // Parse the entire stream: an extra document or progress line must fail.
+  const output = JSON.parse(result.stdout) as ErrorResult;
+  expect(output.error).toMatchObject({ code, message: expect.any(String) });
+  expect(output.error.message.length).toBeGreaterThan(0);
+  return output;
+}
+
+describe.sequential('single JSON command error boundary', () => {
+  it('preserves missing target and binding conflict exits without extra output', async () => {
+    await withE2EFixture(async (fixture) => {
+      expectError(await fixture.runJsonCli(['check', 'missing']), 3, 'NAME_NOT_FOUND');
+      expectError(await fixture.runJsonCli(['whoami'], { outsideTmux: true }), 3, 'PANE_NOT_FOUND');
+      expect((await fixture.runJsonCli(['name', 'Receiver'])).code).toBe(0);
+      expectError(await fixture.runJsonCli(['name', 'Other']), 5, 'PANE_ALREADY_BOUND');
+      const current = await fixture.runJsonCli<{ name: string }>(['whoami']);
+      expect(current.json?.name).toBe('Receiver');
+      expect(fixture.events().filter((event) => event.event === 'request')).toEqual([]);
+    });
+  });
+
+  it('reports busy storage once and recovers without changing the role', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect((await fixture.runJsonCli(['name', 'Receiver'])).code).toBe(0);
+      expect(
+        (await fixture.runJsonCli(['role', 'set', 'Keep this role', '--identity', 'Receiver'])).code
+      ).toBe(0);
+      const database = new Database(path.join(fixture.globalDir, 'tmux-team.db'));
+      try {
+        database.exec('BEGIN IMMEDIATE');
+        const request = fixture.runCliProcess([
+          '--json',
+          'role',
+          'set',
+          'Must not replace',
+          '--identity',
+          'Receiver',
+        ]);
+        let completed = false;
+        void request.result.then(() => {
+          completed = true;
+        });
+        // Existing repository initialization retries 20 times after the first
+        // attempt; each SQLite open can wait 5 s. Exercise actual exhaustion,
+        // not lock release that would turn this failure scenario into success.
+        // Retry-policy redesign is separate from the CLI output boundary.
+        await fixture.waitFor(() => completed, 115_000, 'storage retry exhaustion');
+        const failed = await request.result;
+        expectError(failed, 1, 'ROLE_ERROR');
+        expect(database.prepare('SELECT content FROM role_profiles').get()).toEqual({
+          content: 'Keep this role',
+        });
+      } finally {
+        if (database.inTransaction) database.exec('ROLLBACK');
+        database.close();
+      }
+      const recovered = await fixture.runJsonCli<{ role: { content: string } }>([
+        'role',
+        'show',
+        '--identity',
+        'Receiver',
+      ]);
+      expect(recovered.code).toBe(0);
+      expect(recovered.json?.role.content).toBe('Keep this role');
+    });
+  }, 125_000);
+
+  it('reports a real capture failure once and releases only its sent waiter', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        expect((await fixture.runJsonCli(['name', 'Receiver'])).code).toBe(0);
+        const request = fixture.runCliProcess([
+          '--json',
+          'talk',
+          'Receiver',
+          'capture failure request',
+          '--wait',
+          '--timeout',
+          '20',
+        ]);
+        const event = await fixture.waitForEvent(
+          (item) => item.event === 'silent' && item.message === 'capture failure request',
+          5_000
+        );
+        await fixture.waitFor(() => requestAttempts(fixture)[0]?.status === 'sent');
+        fixture.tmux(['kill-pane', '-t', fixture.pane]);
+        expectError(await request.result, 1, 'ERROR');
+        expect(requestAttempts(fixture)).toHaveLength(1);
+        expect(requestAttempts(fixture)[0]).toMatchObject({
+          nonce: event.nonce,
+          status: 'sent',
+          wait_active: 0,
+        });
+      },
+      { mode: 'silent' }
+    );
+  });
+
+  it('wakes a long poll on SIGINT and drains exactly one JSON error', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        fs.writeFileSync(
+          path.join(fixture.globalDir, 'config.json'),
+          JSON.stringify({ defaults: { pollInterval: 60 } })
+        );
+        expect((await fixture.runJsonCli(['name', 'Receiver'])).code).toBe(0);
+        const request = fixture.runCliProcess([
+          '--json',
+          'talk',
+          'Receiver',
+          'interrupt long poll',
+          '--wait',
+          '--timeout',
+          '120',
+        ]);
+        const event = await fixture.waitForEvent(
+          (item) => item.event === 'silent' && item.message === 'interrupt long poll',
+          5_000
+        );
+        await fixture.waitFor(() => requestAttempts(fixture)[0]?.status === 'sent');
+        request.kill('SIGINT');
+        const result = await request.result;
+        expectError(result, 1, 'ERROR');
+        expect(requestAttempts(fixture)).toHaveLength(1);
+        expect(requestAttempts(fixture)[0]).toMatchObject({
+          nonce: event.nonce,
+          status: 'sent',
+          wait_active: 0,
+        });
+      },
+      { mode: 'silent' }
+    );
+  }, 12_000);
+});

--- a/test/e2e/request-state.e2e.test.ts
+++ b/test/e2e/request-state.e2e.test.ts
@@ -80,8 +80,20 @@ describe.sequential('transactional live request bookkeeping', () => {
         const timedOut = await first.result;
         expect(timedOut).toMatchObject({
           code: 4,
-          json: { status: 'timeout', nonce: firstEvent.nonce },
+          json: {
+            status: 'timeout',
+            nonce: firstEvent.nonce,
+            error: { code: 'TIMEOUT', message: expect.stringContaining('Timed out') },
+          },
         });
+        expect(timedOut.stderr).toBe('');
+        const timeoutOutput = JSON.parse(timedOut.stdout);
+        expect(timeoutOutput).toMatchObject({
+          requestId: before.find((row) => row.nonce === firstEvent.nonce)?.request_id,
+          pane: fixture.pane,
+          endMarker: `RESPONSE-END-${firstEvent.nonce}`,
+        });
+        expect(timeoutOutput).toHaveProperty('partialResponse');
         const afterFirst = attempts(fixture);
         expect(afterFirst.find((row) => row.nonce === firstEvent.nonce)).toMatchObject({
           wait_active: 0,

--- a/test/e2e/retired-commands.e2e.test.ts
+++ b/test/e2e/retired-commands.e2e.test.ts
@@ -71,9 +71,10 @@ function expectUnknownCommandHuman(result: { code: number; stdout: string; stder
 
 function expectUnknownCommandJson(result: { code: number; stdout: string; stderr: string }): void {
   expect(result.code).toBe(1);
-  expect(result.stdout).toBe('');
-  expect(() => JSON.parse(result.stderr)).not.toThrow();
-  expect(JSON.parse(result.stderr)).toEqual({ error: expect.stringMatching(/unknown command/i) });
+  expect(result.stderr).toBe('');
+  expect(JSON.parse(result.stdout)).toEqual({
+    error: { code: 'USAGE_ERROR', message: expect.stringMatching(/unknown command/i) },
+  });
 }
 
 function expectRetiredNamesAndFlagsAbsent(output: string, shell?: 'bash' | 'zsh'): void {


### PR DESCRIPTION
## Scope

- Issue: [TMT-26](https://linear.app/tigerpig-dev/issue/TMT-26/unify-cli-json-errors-and-catch-initialization-failures-through-one)
- Establish one invocation-owned JSON result and cleanup boundary, including initialization and command failures.
- Preserve command-specific error details and exit statuses. Keep storage, delivery, and response-extraction semantics unchanged.
- No dependencies, versions, daemon, inbox, memory, release publishing, or v4 changes.

## Architecture and review

- `cli-runner.ts` owns the invocation lifecycle; `cli-output.ts` buffers JSON until Context disposal. The executable sets `process.exitCode` and lets pipes drain. Existing parser, dispatcher, UI, Context, request service, and Docker fixtures are reused.
- Expected command failures retain their nested error details and exit statuses. Parser errors now use stdout `USAGE_ERROR`; unexpected failures use `INTERNAL_ERROR`; silent JSON successes use `{ok:true}`. A cleanup failure after success returns `CLEANUP_ERROR` with an effects warning, not a rollback claim.
- Alpha migration: timeout `error` changes from a string to `{code:"TIMEOUT",message}`; exit 4 and all existing correlation/partial-response fields remain. Help/version/completion/learn reject JSON explicitly. Team rejection retains precedence.
- SIGINT only wakes the awaited talk poll. Waiter release and typed exit occur in the command flow, preserving finalization.
- Primary reviewer: Codex, with every changed file and relevant callers/tests personally inspected. Reviewed commit: `6983f13bf15383fe20fa37cdde0abf149f55bfa8`.
- Review corrections: removed duplicated error-code mapping; corrected team rejection precedence exposed by real Docker tests; retained and migrated all existing routing/parser cases; added actual no-Context assertions, disposal-order evidence, whole-stream Unicode checks, duplicate/serialization cases, and runner-level no-retry coverage for output failures.
- Gemini supplementary read-only review via tmt (`7de2`, completion confirmed) found no additional issues. Earlier cleanup-warning feedback was accepted; install-output leakage and pre-send SIGINT claims were rejected after inspecting their actual guards/registration order. Gemini did not execute verification.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact local commands and results are recorded below.
- [x] CI checked on this exact commit before authorized merge.

Commands and results:

- `pnpm check`: passed TypeScript, Oxlint, source/E2E formatting, and maintained-document checks.
- `pnpm test:run`: 503 tests passed in the complete unit/subprocess suite and coverage gate; local statements 94.34%, branches 86.63%.
- `pnpm test:e2e`: two sequential complete post-fix runs passed 58/58 each (354.16 s and 354.70 s), before the first push.
- `pnpm pack --pack-destination /private/tmp/tmt26-pack.F8ZONQ` and `node scripts/verify-packed-native-install.mjs --package-tarball /private/tmp/tmt26-pack.F8ZONQ/tmux-team-5.0.0-alpha.1.tgz --expected-arch arm64`: passed on darwin/arm64, with a clean installation and bundled native prebuild.
- Updated skill frontmatter validators, changed Markdown formatting, and `git diff --check`: passed.
- [CI run 33969389723](https://github.com/wkh237/tmux-team/actions/runs/33969389723): all 10 checks passed on reviewed head `6983f13bf15383fe20fa37cdde0abf149f55bfa8` in one run. This includes quality, 503 tests with coverage, real Docker E2E, all six native package targets, and the aggregate native gate. Branch protection reported CLEAN; no bypass.

New real Docker cases verify missing-target/conflict errors without side effects, held SQLite writer-lock exhaustion followed by recovery with unchanged role content, actual pane capture failure with waiter release, and SIGINT waking a 60-second poll promptly. Existing timeout tests now validate the complete JSON stream and retained correlation fields.

Known latency is explicit: repository initialization already retries up to 21 opens with a 5-second SQLite busy timeout. The held-lock test intentionally waits for approximately 105-second exhaustion rather than releasing the lock to turn failure into success. The cumulative retry policy is recorded on TMT-18 as deferred work; this PR does not redesign it. Runtime boot failures before application loading and unwritable output streams remain outside the one-document guarantee.

## Project lifecycle

- `ARCHITECTURE.md`, README, and all four shipped usage variants describe the implemented contract and alpha timeout migration.
- Linear contains accepted scope, audit/review dispositions, local evidence, and the deferred retry-latency finding.
- Branch: `codex/tmt-26-cli-errors`; dedicated worktree: `/Users/benhsieh/dev/tmt-26-cli-errors`.
- Merged as `885c858473a7df4259213490bd48f3bfec49d4b0`; the merged tree exactly matches the reviewed head. Main is synchronized and clean; v4 remains at its maintenance anchor.
- The completed issue worktree was verified clean and fully pushed, then removed and metadata pruned after Linear synchronization. Only the main checkout remains. The pushed issue branch is retained for traceability, and Gemini was notified of the new review location.
- Required protection remains Code quality, Unit tests, Docker E2E, and Native package matrix. No CI-debugging pushes or protection bypass.
