### PR TITLE
TMT-38: Add bounded durable reply and result commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,8 +80,9 @@ a matching end marker is not proof of a complete, isolated response body.
 `check` is a diagnostic pane snapshot, not correlated response retrieval.
 The [request/response decision document](REQUEST-RESPONSE.md) records TMT-35's
 source evidence, capability limits and staged proposal. The shared request service
-now stores and retrieves immutable final bodies, but has no public reply command
-or live caller integration yet. Marker behavior and CLI grammar remain unchanged.
+now stores and retrieves immutable final bodies. Storage-only `reply` and `result`
+adapters expose that service; live `talk` integration is not implemented yet.
+Marker-based `talk` behavior remains unchanged.
 Keep this distinction
 and the document's verification status current as those slices are delivered.
 
@@ -155,7 +156,7 @@ and one exact valid Unicode body, bounded to 1,048,576 UTF-8 bytes. It accepts o
 live pane. `getResponse` returns the original body and association, not a capture.
 Empty bodies, whitespace, BOM, NUL, CR/LF and marker-like text are preserved.
 Role/preamble normalization is not applied; only the Unicode predicate is shared.
-Input adapters such as file/stdin decoding remain TMT-37 work.
+The reply adapter decodes bounded file/stdin input before invoking this service.
 
 The same immediate transaction validates the fence and inserts the final plus its
 attempt's `responseSubmittedAtMs` marker. Retained identical retries return the
@@ -179,6 +180,40 @@ Typed response errors distinguish invalid/oversized input, unknown request, wron
 attempt/recipient, ineligible state, expiry and conflict. Rejections preserve
 attempts, cadence and replies. No cancellation, listener, remote authorization,
 provider-specific state machine or alternate database is introduced.
+
+### Explicit reply and result adapters
+
+`reply <request-id> --receipt <receipt> (--file <path> | --stdin)` submits one
+complete final. `result <request-id>` reads a retained final without waiting.
+Both select storage-only Context capabilities: no live caller, pane reconciliation
+or tmux construction is required. Neither infers a request from a pane or name.
+The existing `talk` command does not generate receipts yet; TMT-39 owns that
+cutover. These adapters alone do not fix marker-based response extraction.
+
+The receipt is a versioned, bounded, canonical base64url JSON envelope containing
+the explicit request, attempt and complete recorded endpoint. It is correlation,
+not authentication against another process running as the same OS user. The
+adapter validates its shape and positional request match; the shared service
+validates the recorded fence and transition in its existing transaction. Routine
+acknowledgements, result output and errors do not include the receipt or endpoint.
+
+File input follows symlinks to regular files, using nonblocking open, descriptor
+type validation and a cap-plus-one bounded read with guaranteed closure. It is
+explicit user-selected input, not a filesystem confinement boundary. Reply and
+role input share bounded file decoding, not feature limits or normalization.
+Stdin requires explicit `--stdin`, rejects a TTY, and completes only on EOF within
+five seconds and the 1 MiB body cap. Failure removes input listeners/timers and
+does not submit a partial body. Fatal UTF-8 decoding preserves BOM and exact text.
+No storage transaction spans either input path.
+
+Submission returns `status: submitted`, request ID, byte count and the original
+submission timestamp, including on an identical retry. Result JSON returns
+`status: completed` with exact `response`, byte count and timestamp. Human output
+is formatted; exact-text consumers use JSON. Missing retained bodies return
+`RESPONSE_NOT_AVAILABLE`/`status: unavailable` (exit 3), covering pending, unknown
+and expired results without inventing distinctions the service cannot establish.
+Submission conflicts use exit 5; stdin deadline uses exit 4. Neither timeout nor
+unavailable output cancels recipient work or changes service retention.
 
 ## Caller context
 
@@ -326,6 +361,8 @@ unwritable output streams are outside the one-document guarantee.
 | [src/tmux.ts](src/tmux.ts)                                                                                                                                                 | External tmux commands, snapshots, opaque metadata preservation and paste/capture. No workspace registry adapter.                                                       |
 | [src/tmux-message.ts](src/tmux-message.ts), [src/message-delivery.ts](src/message-delivery.ts)                                                                             | Stageful protected input and shared submission policy; narrow delivery uncertainty contract consumed by commands without importing the tmux implementation.             |
 | [src/role-content.ts](src/role-content.ts)                                                                                                                                 | Bounded role file reading/UTF-8 decoding; pure role and preamble normalization share `domain/text-content.ts`.                                                          |
+| [src/bounded-utf8-file.ts](src/bounded-utf8-file.ts), [src/response-content.ts](src/response-content.ts)                                                                   | Shared bounded regular-file decoding and response-specific EOF/deadline input. Feature adapters retain their own limits and error mappings.                             |
+| [src/reply-receipt.ts](src/reply-receipt.ts), [src/commands/reply.ts](src/commands/reply.ts), [src/commands/result.ts](src/commands/result.ts)                             | Versioned local correlation codec and storage-only CLI adapters over the existing request service. No SQL, endpoint discovery or completion policy duplication.         |
 | [src/preamble-service.ts](src/preamble-service.ts)                                                                                                                         | Explicit durable-name preamble CRUD/list and its narrow repository contract. Context composes the existing SQLite connection.                                           |
 | [src/config.ts](src/config.ts)                                                                                                                                             | Path/settings resolution. Legacy registration fields and request JSON are not runtime authorities.                                                                      |
 | [src/request-service.ts](src/request-service.ts), [src/storage/request-repository.ts](src/storage/request-repository.ts), [src/domain/response.ts](src/domain/response.ts) | Application-owned request/cadence/final-response policy, composed SQL adapter and exact-body validation. Context owns the shared connection.                            |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,6 +103,12 @@ submission/retention boundaries, plus independent processes for writer races.
 They do not imply the live CLI already consumes durable replies; TMT-37 owns that
 integration and its exact-body Docker/mock-agent acceptance scenarios.
 
+Reply adapter verification additionally exercises the real CLI in an isolated
+home and SQLite database, including file/stdin decoding, exact result text,
+idempotent retry across invocations and rejection without partial finalization.
+Input tests cover EOF, byte/deadline limits and listener/descriptor cleanup.
+These storage-only checks do not substitute for TMT-39's live tmux cutover tests.
+
 `docs:format:check` covers the architecture, policy, conventions, development
 guide, repository skills and PR template. It uses `.gitignore` as its ignore
 file because the legacy `.prettierignore` excludes Markdown. For other changed

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ once-daily cached update check, while local drift checks work without network.
 - `tmt role show|set|clear` manages an optional durable profile for an identity,
   including identities that are currently offline.
 - Multiline messages preserve real line breaks when delivered.
+- `tmt reply` submits a complete result with a supplied receipt, and `tmt result`
+  retrieves the exact retained body without tmux capture.
 - Skills can be installed and refreshed with `tmt install` and `tmt upgrade`.
 
 ## Quick Start
@@ -114,23 +116,25 @@ tmux display-message -p '#{pane_id}'
 
 ## Commands
 
-| Command                                      | Description                                                 |
-| -------------------------------------------- | ----------------------------------------------------------- |
-| `install [claude\|codex\|gemini\|all]`       | Install or repair agent integrations                        |
-| `upgrade`                                    | Upgrade tmux-team; managed skill links update automatically |
-| `name <global-name>`                         | Bind the current pane to a global identity                  |
-| `this <global-name>`                         | Exact supported alias for `name`                            |
-| `add <pane-target> <global-name>`            | Bind an explicit pane to a global identity                  |
-| `whoami`                                     | Show the current pane's global identity, if any             |
-| `unbind`                                     | Remove the current pane's global identity                   |
-| `role show [--identity <name>]`              | Read an identity's optional role profile                    |
-| `role set <profile> [--identity <name>]`     | Replace an identity's role profile                          |
-| `role set --file <path> [--identity <name>]` | Replace a profile from a UTF-8 file                         |
-| `role clear [--identity <name>]`             | Remove only the role profile                                |
-| `talk <target> "msg"`                        | Send a message to a global name or pane target              |
-| `check <target> [lines]`                     | Read output from a global name or pane target               |
-| `list [target]`                              | List active identities, or one target's pane status         |
-| `learn`                                      | Show the educational guide                                  |
+| Command                                                           | Description                                                 |
+| ----------------------------------------------------------------- | ----------------------------------------------------------- |
+| `install [claude\|codex\|gemini\|all]`                            | Install or repair agent integrations                        |
+| `upgrade`                                                         | Upgrade tmux-team; managed skill links update automatically |
+| `name <global-name>`                                              | Bind the current pane to a global identity                  |
+| `this <global-name>`                                              | Exact supported alias for `name`                            |
+| `add <pane-target> <global-name>`                                 | Bind an explicit pane to a global identity                  |
+| `whoami`                                                          | Show the current pane's global identity, if any             |
+| `unbind`                                                          | Remove the current pane's global identity                   |
+| `role show [--identity <name>]`                                   | Read an identity's optional role profile                    |
+| `role set <profile> [--identity <name>]`                          | Replace an identity's role profile                          |
+| `role set --file <path> [--identity <name>]`                      | Replace a profile from a UTF-8 file                         |
+| `role clear [--identity <name>]`                                  | Remove only the role profile                                |
+| `talk <target> "msg"`                                             | Send a message to a global name or pane target              |
+| `check <target> [lines]`                                          | Read output from a global name or pane target               |
+| `reply <request-id> --receipt <receipt> (--file <path>\|--stdin)` | Submit a complete result                                    |
+| `result <request-id>`                                             | Retrieve a retained result or report it unavailable         |
+| `list [target]`                                                   | List active identities, or one target's pane status         |
+| `learn`                                                           | Show the educational guide                                  |
 
 `list` also has the `ls` alias. With no target it shows all active global
 identities. With a target it resolves a global name or direct pane target and
@@ -142,6 +146,51 @@ shows that pane's status. `talk` and `check` use the same target resolution.
 - `--lines <number>` - Lines to capture from a response (default: 100)
 - `--wait` - Wait for a response before returning
 - `--delay <seconds>` - Delay before sending
+
+### Durable replies and results
+
+TMT-38 adds storage-only result adapters that work without tmux and can accept a
+late reply after a pane closes:
+
+```bash
+tmt reply <request-id> --receipt <receipt> --file response.md
+tmt reply <request-id> --receipt <receipt> --stdin < response.md
+tmt result <request-id>
+tmt result <request-id> --json
+```
+
+Use exactly one input source. The receipt must be supplied by TMT; do not
+manufacture one, look up the latest request, or infer a current pane. In this
+slice, `talk` still uses marker-based terminal capture and does not generate
+receipts; receipt generation and durable completion belong to TMT-39. There is
+no `--detach` or default durable-wait behavior yet.
+
+Reply input preserves the complete valid UTF-8 body, including empty or
+whitespace text, BOM, NUL, CR/LF, Unicode, and marker-like text, up to 1 MiB.
+File input must be a regular UTF-8 file; stdin is EOF-driven and bounded by a
+five-second input deadline. A successful reply means the result was delivered,
+not that the requested task succeeded. Agents should show a brief truthful
+summary only after a successful submission; the summary is not a completion
+signal.
+
+Retrying the identical body for the same request and attempt is idempotent and
+keeps the original `submittedAtMs`. A different body is a conflict; the
+stored response and timestamp remain unchanged.
+
+The receipt is local correlation, not remote authentication. Accepted bodies
+are retained for seven days from submission; identical retry is safe only
+while retained with the same receipt and body, not indefinitely. A missing
+result does not cancel the work. Surface failed submission without a success
+summary, and do not resubmit if final summarization fails after acceptance.
+
+With `--json`, reply success is `{status:"submitted",requestId,bodyBytes,submittedAtMs}`;
+result success is `{status:"completed",requestId,response,bodyBytes,submittedAtMs}`.
+Unavailable JSON is
+`{status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}`.
+If no retained body is available—pending, unknown, or expired—result returns
+`RESPONSE_NOT_AVAILABLE` (exit 3). Input errors are typed and exit 1,
+`RESPONSE_INPUT_TIMEOUT` exits 4, and service conflicts use exit 5. Do not
+expect receipts, endpoints, or raw bodies in a reply acknowledgement.
 
 Run `tmt help` for all commands and options.
 

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -2,8 +2,9 @@
 
 Status: historical research based on `cecaec7` (2026-09-05), with the accepted
 direction and TMT-36 service contract maintained below. The shared final-response
-service is implemented; live CLI integration is still TMT-37 work. No provider
-integration, daemon, inbox, memory feature, or new CLI syntax is supplied here.
+service and explicit reply/result adapters are implemented; the default live
+`talk` cutover remains TMT-39 under TMT-37. No provider integration, daemon,
+inbox or memory feature is supplied here.
 
 ## Accepted direction (2026-09-05; CLI integration not yet shipped)
 
@@ -11,8 +12,9 @@ The [accepted design](https://linear.app/tigerpig-dev/document/accepted-design-d
 supersedes the earlier opt-in proposal below. TMT-36 adds immutable full replies
 to the existing request service; TMT-37 changes the CLI to wait for a durable
 reply by default, with bounded `--timeout` and explicit `--detach`, retiring
-`--wait` and the polling/wait mode switch. These are proposals, not installed
-commands. Terminal capture and `check` remain diagnostics, never authoritative
+`--wait` and the polling/wait mode switch. The default-wait change remains a
+proposal, not installed behavior. Explicit `reply`/`result` adapters are described
+below. Terminal capture and `check` must not be treated as authoritative durable
 completion or full-body retrieval.
 
 A cooperating agent first successfully submits its complete final body, then
@@ -63,7 +65,43 @@ Typed response errors distinguish invalid/oversized input, unknown request, wron
 attempt, wrong recipient, ineligible state, expiry and conflicting content.
 Rejected submissions preserve attempts, cadence and responses. Storage failures
 remain storage failures. No cancellation operation, retry routing policy or new
-CLI command is introduced by this service contract.
+CLI command is introduced by this service contract itself.
+
+### TMT-38 explicit CLI adapters
+
+TMT-37 is split into TMT-38 (bounded submission/retrieval) and TMT-39 (default
+durable `talk`, obsolete-mode removal and the exact-body Docker cutover).
+TMT-38 adds:
+
+```text
+tmt reply <request-id> --receipt <receipt> (--file <path> | --stdin) [--json]
+tmt result <request-id> [--json]
+```
+
+The receipt is an explicit version-1 base64url envelope of request ID, attempt ID
+and the complete six-field endpoint. Its encoded length is at most 8192 characters.
+It is not authentication. The recipient must use the supplied receipt, not infer
+the latest request from a pane. Current `talk` does not supply one yet; TMT-39
+owns generation and delivery. No receipt is included in routine result/ack output.
+
+Files must resolve to regular files; symlinks are followed, and descriptors are
+closed after bounded reads. Explicit stdin requires EOF within five seconds.
+Both reject malformed UTF-8 and bodies beyond 1,048,576 bytes before submission,
+preserving empty text, BOM, NUL, CR/LF and whitespace without normalization.
+
+Reply success returns `status: submitted`, `requestId`, `bodyBytes` and
+`submittedAtMs`. Identical retries preserve the timestamp; different bodies
+cannot overwrite a final. Result success returns `status: completed`, `requestId`,
+exact `response`, `bodyBytes` and `submittedAtMs`. JSON is the exact-text interface;
+human output adds formatting. A missing retained result is `status: unavailable`
+with `RESPONSE_NOT_AVAILABLE` (exit 3), not a claim that a request is unknown,
+cancelled or completed. Input deadline uses exit 4; conflicting final uses exit 5.
+
+Storage-only commands work after pane closure and waiter exit. They reuse the
+service and its retention, not another reply store. Agent guidance requires a
+truthful short user summary only after successful submission. Submission means
+the result was delivered, not that the requested task succeeded. Summary failure
+does not undo or justify repeating an accepted final.
 
 TMT-24 implementation update: transport now prevents replay after an input
 stage may have acted, preserves the same `!` protection on fallback, reports

--- a/plugins/tmux-team/commands/learn.md
+++ b/plugins/tmux-team/commands/learn.md
@@ -83,6 +83,38 @@ tmt check <target>
 tmt check <target> 200
 ```
 
+## Durable result replies
+
+When TMT supplies an exact receipt, submit a complete response without tmux:
+
+```bash
+tmt reply <request-id> --receipt <receipt> --file response.md
+tmt reply <request-id> --receipt <receipt> --stdin < response.md
+tmt result <request-id> --json
+```
+
+Use exactly one input source and never manufacture a receipt, select the latest
+request, or infer a pane. `talk` is still marker-based in this release and
+does not generate receipts; TMT-39 owns receipt generation and durable
+completion. There is no `--detach` behavior yet. Submission confirms result
+delivery, not task success; summarize only after a successful submission.
+
+An identical retry keeps the original submission timestamp; a different body
+is a conflict and cannot replace the stored response.
+
+The receipt is local correlation, not remote authentication. Accepted bodies
+are retained for seven days from submission; identical retry is safe only
+while retained with the same receipt and body, not indefinitely. A missing
+result does not cancel the work. Surface failed submission without a success
+summary, and do not resubmit if final summarization fails after acceptance.
+
+Bodies are exact valid UTF-8 up to 1 MiB, including empty, whitespace, BOM,
+NUL, CR/LF, Unicode, and marker-like text. Stdin is EOF-driven with a
+five-second deadline. `result` reports `RESPONSE_NOT_AVAILABLE` (exit 3) for
+pending, unknown, or expired bodies; input errors exit 1, timeout exits 4,
+and conflicts exit 5. JSON unavailable output is
+`{status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}`.
+
 ## Best Practices
 
 1. Use `--wait` for synchronous request/response; use `check` after timeout

--- a/plugins/tmux-team/commands/team.md
+++ b/plugins/tmux-team/commands/team.md
@@ -15,21 +15,57 @@ Based on what the user wants, use the tmux-team CLI to coordinate with other age
 
 To send a message to a global identity or direct pane target and wait for a
 response:
-  tmt talk <target> "<message>" --wait
+tmt talk <target> "<message>" --wait
 
 To see available agents:
-  tmt list
-  tmt name <global-name>
-  tmt this <global-name>
-  tmt add <pane-target> <global-name>
-  tmt whoami
-  tmt unbind
+tmt list
+tmt name <global-name>
+tmt this <global-name>
+tmt add <pane-target> <global-name>
+tmt whoami
+tmt unbind
 
 Identities are global across working directories. `list`, `talk`, and `check`
 accept either a global name or a direct pane target (`%pane_id`, `window.pane`,
 or `session:window.pane`). The name `all` is an ordinary identity, not a
 special destination. The `add` order is pane target first, then global name;
 the old name-first order is rejected with a usage error.
+
+## Durable result replies
+
+When TMT gives you a receipt, submit the complete response through the
+storage-only result adapter:
+
+```bash
+tmt reply <request-id> --receipt <receipt> --file response.md
+tmt reply <request-id> --receipt <receipt> --stdin < response.md
+tmt result <request-id> --json
+```
+
+Use exactly one input source. Use the supplied receipt; never manufacture one,
+look up the latest request, or infer a current pane. `talk` remains
+marker-based in this release and does not generate receipts; receipt
+generation and durable completion are staged for TMT-39. There is no
+`--detach` behavior yet. A successful submission confirms delivery of the
+body, not success of the requested task, so give a truthful summary only
+after submission.
+
+An identical retry for the same request and attempt keeps the original
+submission timestamp. A different body is a conflict and cannot replace the
+stored response.
+
+The receipt is local correlation, not remote authentication. Accepted bodies
+are retained for seven days from submission; identical retry is safe only
+while retained with the same receipt and body, not indefinitely. A missing
+result does not cancel the work. Surface failed submission without a success
+summary, and do not resubmit if final summarization fails after acceptance.
+
+The body is exact valid UTF-8 up to 1 MiB, including empty, whitespace, BOM,
+NUL, CR/LF, Unicode, and marker-like text. Stdin is EOF-driven with a five-
+second input deadline. `result` reports `RESPONSE_NOT_AVAILABLE` (exit 3) for
+pending, unknown, or expired bodies; input errors exit 1, input timeout exits
+4, and conflicts exit 5. JSON unavailable output is
+`{status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}`.
 
 ## Examples
 
@@ -46,14 +82,14 @@ You run: tmt talk codex "Please review the refactor before I continue." --wait
 
 For long responses, increase timeout and lines captured:
 
-  tmt talk <target> "<message>" --wait --timeout 300 --lines 200
+tmt talk <target> "<message>" --wait --timeout 300 --lines 200
 
 ## If --wait Times Out
 
 Use the check command to retrieve the response with an optional line count:
 
-  tmt check <target>
-  tmt check <target> 200
+tmt check <target>
+tmt check <target> 200
 
 ## Important
 

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -50,6 +50,48 @@ retrying. Existing delivery-uncertainty guidance still applies.
 `--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
 also rejects JSON mode because it streams installer output.
 
+## Durable replies and results (TMT-38)
+
+When TMT supplies an exact receipt, submit the complete result through the
+storage-only adapters:
+
+```bash
+tmt reply <request-id> --receipt <receipt> --file response.md
+tmt reply <request-id> --receipt <receipt> --stdin < response.md
+tmt result <request-id> --json
+```
+
+Use exactly one input source. Never manufacture a receipt, select the latest
+request, or infer a current pane. `talk` remains marker-based terminal
+capture in this release and does not generate receipts; TMT-39 owns receipt
+generation and durable completion. There is no `--detach` behavior yet.
+
+Reply input is one exact valid UTF-8 body up to 1 MiB, preserving empty,
+whitespace, BOM, NUL, CR/LF, Unicode, and marker-like text. Stdin is
+EOF-driven with a five-second input deadline. Successful submission means the
+result was delivered, not that the task succeeded; show a brief truthful
+summary only after submission, never as completion evidence.
+
+An identical retry for the same request and attempt keeps the original
+`submittedAtMs`; a different body is a conflict and cannot replace the stored
+response.
+
+The receipt is local correlation, not remote authentication. Accepted bodies
+are retained for seven days from submission; an identical retry is safe only
+while that body is retained and with the same receipt and body, not
+indefinitely. A missing result does not cancel the work. Surface a failed
+submission without a success summary; if final summarization fails after
+acceptance, do not resubmit.
+
+With `--json`, reply success is `{status:"submitted",requestId,bodyBytes,submittedAtMs}`
+and result success is `{status:"completed",requestId,response,bodyBytes,submittedAtMs}`.
+Unavailable JSON is
+`{status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}`.
+`result` reports `RESPONSE_NOT_AVAILABLE` (exit 3) for pending, unknown, or
+expired bodies. Input errors exit 1, input timeout is `RESPONSE_INPUT_TIMEOUT`
+(exit 4), and conflicts exit 5. Receipts, endpoints, and raw bodies are not
+echoed in acknowledgements.
+
 ## Identity preambles
 
 Preambles are separate from role profiles and belong to existing durable global

--- a/skills/README.md
+++ b/skills/README.md
@@ -72,6 +72,42 @@ The `add` order is pane target first, then global name. Older name-first
 examples are rejected with a usage error. `all` is an ordinary identity name,
 not a special destination.
 
+## Durable replies and results
+
+When TMT supplies an exact receipt, an agent can submit a complete result
+without tmux:
+
+```bash
+tmt reply <request-id> --receipt <receipt> --file response.md
+tmt reply <request-id> --receipt <receipt> --stdin < response.md
+tmt result <request-id> --json
+```
+
+Use exactly one input source and the receipt supplied by TMT. Do not invent a
+receipt, guess the latest request, or infer a pane. In this release, `talk`
+still uses marker-based terminal capture and does not generate receipts;
+TMT-39 owns receipt generation and durable completion. There is no `--detach`
+or default durable-wait behavior yet. A successful submission means the
+result was delivered, not that the task succeeded; summarize only afterward.
+
+An identical retry for the same request and attempt keeps the original
+submission timestamp. A different body is a conflict and cannot replace the
+stored response.
+
+The receipt is local correlation, not remote authentication. Accepted bodies
+are retained for seven days from submission; identical retry is safe only
+while retained with the same receipt and body, not indefinitely. A missing
+result does not cancel the work. Surface failed submission without a success
+summary, and do not resubmit if final summarization fails after acceptance.
+
+Reply bodies are exact valid UTF-8 up to 1 MiB, including empty or whitespace
+text, BOM, NUL, CR/LF, Unicode, and marker-like content. Stdin is EOF-driven
+with a five-second input deadline. Result reports `RESPONSE_NOT_AVAILABLE`
+(exit 3) when the body is pending, unknown, or expired; input errors exit 1,
+input timeout exits 4, and conflicts exit 5.
+With `--json`, unavailable output is
+`{status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}`.
+
 tmux-team is CLI-only: each invocation exits after its operation and no daemon
 or background service is required.
 

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -47,6 +47,48 @@ retrying. Existing delivery-uncertainty guidance still applies.
 `--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
 also rejects JSON mode because it streams installer output.
 
+## Durable replies and results (TMT-38)
+
+When TMT supplies an exact receipt, submit the complete result through the
+storage-only adapters:
+
+```bash
+tmt reply <request-id> --receipt <receipt> --file response.md
+tmt reply <request-id> --receipt <receipt> --stdin < response.md
+tmt result <request-id> --json
+```
+
+Use exactly one input source. Never manufacture a receipt, select the latest
+request, or infer a current pane. `talk` remains marker-based terminal
+capture in this release and does not generate receipts; TMT-39 owns receipt
+generation and durable completion. There is no `--detach` behavior yet.
+
+Reply input is one exact valid UTF-8 body up to 1 MiB, preserving empty,
+whitespace, BOM, NUL, CR/LF, Unicode, and marker-like text. Stdin is
+EOF-driven with a five-second input deadline. Successful submission means the
+result was delivered, not that the task succeeded; show a brief truthful
+summary only after submission, never as completion evidence.
+
+An identical retry for the same request and attempt keeps the original
+`submittedAtMs`; a different body is a conflict and cannot replace the stored
+response.
+
+The receipt is local correlation, not remote authentication. Accepted bodies
+are retained for seven days from submission; an identical retry is safe only
+while that body is retained and with the same receipt and body, not
+indefinitely. A missing result does not cancel the work. Surface a failed
+submission without a success summary; if final summarization fails after
+acceptance, do not resubmit.
+
+With `--json`, reply success is `{status:"submitted",requestId,bodyBytes,submittedAtMs}`
+and result success is `{status:"completed",requestId,response,bodyBytes,submittedAtMs}`.
+Unavailable JSON is
+`{status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}`.
+`result` reports `RESPONSE_NOT_AVAILABLE` (exit 3) for pending, unknown, or
+expired bodies. Input errors exit 1, input timeout is `RESPONSE_INPUT_TIMEOUT`
+(exit 4), and conflicts exit 5. Receipts, endpoints, and raw bodies are not
+echoed in acknowledgements.
+
 ## Identity preambles
 
 Preambles are separate from role profiles and belong to existing durable global

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -47,6 +47,48 @@ retrying. Existing delivery-uncertainty guidance still applies.
 `--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
 also rejects JSON mode because it streams installer output.
 
+## Durable replies and results (TMT-38)
+
+When TMT supplies an exact receipt, submit the complete result through the
+storage-only adapters:
+
+```bash
+tmt reply <request-id> --receipt <receipt> --file response.md
+tmt reply <request-id> --receipt <receipt> --stdin < response.md
+tmt result <request-id> --json
+```
+
+Use exactly one input source. Never manufacture a receipt, select the latest
+request, or infer a current pane. `talk` remains marker-based terminal
+capture in this release and does not generate receipts; TMT-39 owns receipt
+generation and durable completion. There is no `--detach` behavior yet.
+
+Reply input is one exact valid UTF-8 body up to 1 MiB, preserving empty,
+whitespace, BOM, NUL, CR/LF, Unicode, and marker-like text. Stdin is
+EOF-driven with a five-second input deadline. Successful submission means the
+result was delivered, not that the task succeeded; show a brief truthful
+summary only after submission, never as completion evidence.
+
+An identical retry for the same request and attempt keeps the original
+`submittedAtMs`; a different body is a conflict and cannot replace the stored
+response.
+
+The receipt is local correlation, not remote authentication. Accepted bodies
+are retained for seven days from submission; an identical retry is safe only
+while that body is retained and with the same receipt and body, not
+indefinitely. A missing result does not cancel the work. Surface a failed
+submission without a success summary; if final summarization fails after
+acceptance, do not resubmit.
+
+With `--json`, reply success is `{status:"submitted",requestId,bodyBytes,submittedAtMs}`
+and result success is `{status:"completed",requestId,response,bodyBytes,submittedAtMs}`.
+Unavailable JSON is
+`{status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}`.
+`result` reports `RESPONSE_NOT_AVAILABLE` (exit 3) for pending, unknown, or
+expired bodies. Input errors exit 1, input timeout is `RESPONSE_INPUT_TIMEOUT`
+(exit 4), and conflicts exit 5. Receipts, endpoints, and raw bodies are not
+echoed in acknowledgements.
+
 ## Identity preambles
 
 Preambles are separate from role profiles and belong to existing durable global

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -43,6 +43,48 @@ retrying. Existing delivery-uncertainty guidance still applies.
 `--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
 also rejects JSON mode because it streams installer output.
 
+## Durable replies and results (TMT-38)
+
+When TMT supplies an exact receipt, submit the complete result through the
+storage-only adapters:
+
+```bash
+tmt reply <request-id> --receipt <receipt> --file response.md
+tmt reply <request-id> --receipt <receipt> --stdin < response.md
+tmt result <request-id> --json
+```
+
+Use exactly one input source. Never manufacture a receipt, select the latest
+request, or infer a current pane. `talk` remains marker-based terminal
+capture in this release and does not generate receipts; TMT-39 owns receipt
+generation and durable completion. There is no `--detach` behavior yet.
+
+Reply input is one exact valid UTF-8 body up to 1 MiB, preserving empty,
+whitespace, BOM, NUL, CR/LF, Unicode, and marker-like text. Stdin is
+EOF-driven with a five-second input deadline. Successful submission means the
+result was delivered, not that the task succeeded; show a brief truthful
+summary only after submission, never as completion evidence.
+
+An identical retry for the same request and attempt keeps the original
+`submittedAtMs`; a different body is a conflict and cannot replace the stored
+response.
+
+The receipt is local correlation, not remote authentication. Accepted bodies
+are retained for seven days from submission; an identical retry is safe only
+while that body is retained and with the same receipt and body, not
+indefinitely. A missing result does not cancel the work. Surface a failed
+submission without a success summary; if final summarization fails after
+acceptance, do not resubmit.
+
+With `--json`, reply success is `{status:"submitted",requestId,bodyBytes,submittedAtMs}`
+and result success is `{status:"completed",requestId,response,bodyBytes,submittedAtMs}`.
+Unavailable JSON is
+`{status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}`.
+`result` reports `RESPONSE_NOT_AVAILABLE` (exit 3) for pending, unknown, or
+expired bodies. Input errors exit 1, input timeout is `RESPONSE_INPUT_TIMEOUT`
+(exit 4), and conflicts exit 5. Receipts, endpoints, and raw bodies are not
+echoed in acknowledgements.
+
 ## Identity preambles
 
 Preambles are separate from role profiles and belong to existing durable global

--- a/src/bounded-utf8-file.ts
+++ b/src/bounded-utf8-file.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import { TextDecoder } from 'node:util';
+
+export type BoundedFileReadErrorKind = 'file' | 'non_regular' | 'too_large' | 'invalid';
+
+export class BoundedFileReadError extends Error {
+  constructor(
+    public readonly kind: BoundedFileReadErrorKind,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = 'BoundedFileReadError';
+  }
+}
+
+/** Read a regular file with a byte bound and strict, non-normalizing UTF-8 decoding. */
+export function readBoundedUtf8File(filePath: string, maxBytes: number): string {
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+  } catch (error) {
+    throw new BoundedFileReadError('file', 'Could not read bounded content file.', {
+      cause: error,
+    });
+  }
+  let failure: BoundedFileReadError | undefined;
+  let decoded: string | undefined;
+  let closeError: unknown;
+  try {
+    const stat = fs.fstatSync(descriptor);
+    if (!stat.isFile()) {
+      throw new BoundedFileReadError(
+        'non_regular',
+        'Bounded content input must be a regular file.'
+      );
+    }
+    const buffer = Buffer.alloc(maxBytes + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const count = fs.readSync(descriptor, buffer, offset, buffer.length - offset, null);
+      if (count === 0) break;
+      offset += count;
+    }
+    if (offset > maxBytes) {
+      throw new BoundedFileReadError('too_large', 'Bounded content input is too large.');
+    }
+    try {
+      decoded = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(
+        buffer.subarray(0, offset)
+      );
+    } catch (error) {
+      throw new BoundedFileReadError('invalid', 'Bounded content input is not valid UTF-8.', {
+        cause: error,
+      });
+    }
+  } catch (error) {
+    failure =
+      error instanceof BoundedFileReadError
+        ? error
+        : new BoundedFileReadError('file', 'Could not read bounded content file.', {
+            cause: error,
+          });
+  } finally {
+    try {
+      fs.closeSync(descriptor);
+    } catch (error) {
+      closeError = error;
+    }
+  }
+  if (failure) throw failure;
+  if (closeError) {
+    throw new BoundedFileReadError('file', 'Could not close bounded content file.', {
+      cause: closeError,
+    });
+  }
+  return decoded!;
+}

--- a/src/cli-contract.test.ts
+++ b/src/cli-contract.test.ts
@@ -1,206 +1,26 @@
-import { spawn } from 'node:child_process';
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
-  readdirSync,
-  rmSync,
+  realpathSync,
   writeFileSync,
 } from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
+import { getSkillConfigs } from './commands/install.js';
 import { CURRENT_MIGRATIONS } from './storage/migrations.js';
-import { openStorageWithMigrations } from './storage/sqlite-adapter.js';
-
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const binPath = path.join(repoRoot, 'bin', 'tmux-team');
-const maxSubprocessOutputBytes = 1024 * 1024;
-
-interface Sandbox {
-  readonly root: string;
-  readonly cwd: string;
-  readonly home: string;
-  readonly xdgConfigHome: string;
-  readonly globalDir: string;
-  readonly globalConfig: string;
-  readonly database: string;
-  readonly localConfig: string;
-  readonly env: NodeJS.ProcessEnv;
-}
-
-interface CliResult {
-  readonly status: number | null;
-  readonly signal: NodeJS.Signals | null;
-  readonly stdout: string;
-  readonly stderr: string;
-}
-
-type JsonDocument = Record<string, unknown>;
-
-function createSandbox(): Sandbox {
-  const root = mkdtempSync(path.join(os.tmpdir(), 'tmux-team-cli-contract-'));
-  try {
-    const cwd = path.join(root, 'cwd');
-    const home = path.join(root, 'home');
-    const xdgConfigHome = path.join(root, 'xdg');
-    mkdirSync(cwd);
-    mkdirSync(home);
-
-    const globalDir = path.join(xdgConfigHome, 'tmux-team');
-    return {
-      root,
-      cwd,
-      home,
-      xdgConfigHome,
-      globalDir,
-      globalConfig: path.join(globalDir, 'config.json'),
-      database: path.join(globalDir, 'tmux-team.db'),
-      localConfig: path.join(cwd, 'tmux-team.json'),
-      env: {
-        ...process.env,
-        HOME: home,
-        XDG_CONFIG_HOME: xdgConfigHome,
-        // The contract suite removes inherited tmux/config overrides before each
-        // child starts, so it never depends on the developer's session.
-      },
-    };
-  } catch (error) {
-    rmSync(root, { recursive: true, force: true });
-    throw error;
-  }
-}
-
-function runCli(sandbox: Sandbox, args: readonly string[]): Promise<CliResult> {
-  for (const key of ['TMUX', 'TMUX_PANE', 'TMUX_TEAM_HOME']) delete sandbox.env[key];
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [binPath, ...args], {
-      cwd: sandbox.cwd,
-      env: sandbox.env,
-      detached: true,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      windowsHide: true,
-    });
-    // Decode at the stream boundary so a multibyte UTF-8 character split
-    // across OS chunks cannot be corrupted by per-buffer toString() calls.
-    child.stdout.setEncoding('utf8');
-    child.stderr.setEncoding('utf8');
-    let stdout = '';
-    let stderr = '';
-    let timedOut = false;
-    let outputLimitExceeded = false;
-    const killProcessGroup = (): void => {
-      if (child.pid === undefined) return;
-      try {
-        process.kill(-child.pid, 'SIGKILL');
-      } catch {
-        child.kill('SIGKILL');
-      }
-    };
-    const timer = setTimeout(() => {
-      timedOut = true;
-      // The wrapper launches the TypeScript child; kill the process group so a
-      // timeout cannot leave that descendant running after the test exits.
-      killProcessGroup();
-    }, 5_000);
-    const readOutput =
-      (stream: 'stdout' | 'stderr') =>
-      (chunk: Buffer | string): void => {
-        const text = chunk.toString();
-        const nextBytes =
-          Buffer.byteLength(text) + Buffer.byteLength(stdout) + Buffer.byteLength(stderr);
-        if (nextBytes > maxSubprocessOutputBytes) {
-          outputLimitExceeded = true;
-          killProcessGroup();
-          return;
-        }
-        if (stream === 'stdout') stdout += text;
-        else stderr += text;
-      };
-    child.stdout.on('data', readOutput('stdout'));
-    child.stderr.on('data', readOutput('stderr'));
-    child.on('error', (error) => {
-      clearTimeout(timer);
-      if (outputLimitExceeded) {
-        reject(
-          new Error(`CLI subprocess exceeded the ${maxSubprocessOutputBytes}-byte output bound.`)
-        );
-      } else reject(error);
-    });
-    child.on('close', (status, signal) => {
-      clearTimeout(timer);
-      if (outputLimitExceeded) {
-        reject(
-          new Error(`CLI subprocess exceeded the ${maxSubprocessOutputBytes}-byte output bound.`)
-        );
-      } else if (timedOut) {
-        reject(new Error('CLI subprocess exceeded the 5 second test bound.'));
-        return;
-      }
-      resolve({ status, signal, stdout, stderr });
-    });
-  });
-}
-
-function parseWholeStdout(result: CliResult): JsonDocument {
-  expect(result.signal).toBeNull();
-  expect(result.stderr).toBe('');
-  expect(result.stdout.trim()).not.toBe('');
-  // Parse the complete stream. Parsing only the final line would allow human
-  // output or a second JSON document to leak into JSON mode unnoticed.
-  const document = JSON.parse(result.stdout) as unknown;
-  expect(document).toBeTypeOf('object');
-  expect(document).not.toBeNull();
-  return document as JsonDocument;
-}
-
-function expectError(result: CliResult, code: string, message?: string): JsonDocument {
-  const document = parseWholeStdout(result);
-  expect(document.error).toMatchObject({ code });
-  expect(document.error).toHaveProperty('message', expect.any(String));
-  expect((document.error as { message: string }).message.length).toBeGreaterThan(0);
-  if (message !== undefined) expect((document.error as { message: string }).message).toBe(message);
-  return document;
-}
-
-function expectJsonSuccess(result: CliResult, value: JsonDocument): void {
-  expect(result.status).toBe(0);
-  expect(parseWholeStdout(result)).toEqual(value);
-}
-
-function fileSnapshot(root: string): Record<string, string> {
-  const snapshot: Record<string, string> = {};
-  const visit = (current: string): void => {
-    for (const entry of readdirSync(current, { withFileTypes: true })) {
-      const entryPath = path.join(current, entry.name);
-      if (entry.isDirectory()) visit(entryPath);
-      else snapshot[path.relative(root, entryPath)] = readFileSync(entryPath, 'utf8');
-    }
-  };
-  visit(root);
-  return snapshot;
-}
-
-async function withSandbox<T>(callback: (sandbox: Sandbox) => T | Promise<T>): Promise<T> {
-  const sandbox = createSandbox();
-  try {
-    return await callback(sandbox);
-  } finally {
-    rmSync(sandbox.root, { recursive: true, force: true });
-  }
-}
-
-function initializeDatabase(sandbox: Sandbox): void {
-  let storage: ReturnType<typeof openStorageWithMigrations> | undefined;
-  try {
-    storage = openStorageWithMigrations(sandbox.database, CURRENT_MIGRATIONS);
-  } finally {
-    storage?.close();
-  }
-}
+import {
+  expectError,
+  expectJsonSuccess,
+  fileSnapshot,
+  initializeDatabase,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+} from './test-support/cli-process.js';
+import type { Sandbox } from './test-support/cli-process.js';
 
 function readMigrationHistory(sandbox: Sandbox): Array<{ version: number; name: string }> {
   const database = new Database(sandbox.database, { readonly: true });
@@ -214,6 +34,32 @@ function readMigrationHistory(sandbox: Sandbox): Array<{ version: number; name: 
 }
 
 describe('real CLI process contract', () => {
+  it(
+    'installs all skill integrations into isolated HOME with shipped source bytes',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const result = await runCli(sandbox, ['install', 'all', '--json']);
+        expect(result.status).toBe(0);
+        const document = parseWholeStdout(result) as {
+          installed: Array<{ agent: string; target: string }>;
+        };
+        expect(document.installed.map((item) => item.agent)).toEqual(['claude', 'codex', 'gemini']);
+
+        const configs = getSkillConfigs();
+        const claudeTarget = path.join(sandbox.home, '.claude', 'commands', 'team.md');
+        const universalTarget = path.join(sandbox.home, '.agents', 'skills', 'tmux-team');
+        expect(lstatSync(claudeTarget).isSymbolicLink()).toBe(true);
+        expect(lstatSync(universalTarget).isSymbolicLink()).toBe(true);
+        expect(realpathSync(claudeTarget)).toBe(realpathSync(configs.claude.source));
+        expect(realpathSync(universalTarget)).toBe(realpathSync(configs.codex.source));
+        expect(readFileSync(claudeTarget)).toEqual(readFileSync(configs.claude.source));
+        expect(readFileSync(path.join(universalTarget, 'SKILL.md'))).toEqual(
+          readFileSync(path.join(configs.codex.source, 'SKILL.md'))
+        );
+      })
+  );
+
   it(
     'reports JSON parse errors regardless of --json position without creating context state',
     { timeout: 10_000 },

--- a/src/cli/application.test.ts
+++ b/src/cli/application.test.ts
@@ -17,6 +17,8 @@ const handlers = {
   cmdWhoami: vi.fn(),
   cmdUnbind: vi.fn(),
   cmdRole: vi.fn(),
+  cmdReply: vi.fn(),
+  cmdResult: vi.fn(),
 };
 
 vi.mock('../commands/init.js', () => ({ cmdInit: handlers.cmdInit }));
@@ -34,6 +36,8 @@ vi.mock('../commands/upgrade.js', () => ({ cmdUpgrade: handlers.cmdUpgrade }));
 vi.mock('../commands/whoami.js', () => ({ cmdWhoami: handlers.cmdWhoami }));
 vi.mock('../commands/unbind.js', () => ({ cmdUnbind: handlers.cmdUnbind }));
 vi.mock('../commands/role.js', () => ({ cmdRole: handlers.cmdRole }));
+vi.mock('../commands/reply.js', () => ({ cmdReply: handlers.cmdReply }));
+vi.mock('../commands/result.js', () => ({ cmdResult: handlers.cmdResult }));
 
 const { dispatchCommand } = await import('./application.js');
 const parsed = (invocation: any) => ({
@@ -63,6 +67,8 @@ describe('application dispatcher', () => {
       ['config', { operation: 'show', global: false }],
       ['preamble', { operation: 'show' }],
       ['role', { operation: 'show' }],
+      ['reply', { requestId: 'request-1', receipt: 'receipt', file: '/tmp/reply.txt' }],
+      ['result', { requestId: 'request-1' }],
       ['install', { target: 'codex' }],
       ['upgrade', {}],
       ['learn', {}],
@@ -83,6 +89,14 @@ describe('application dispatcher', () => {
     expect(handlers.cmdRole).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({ operation: 'show' })
+    );
+    expect(handlers.cmdReply).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ kind: 'reply', requestId: 'request-1', file: '/tmp/reply.txt' })
+    );
+    expect(handlers.cmdResult).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ kind: 'result', requestId: 'request-1' })
     );
   });
 

--- a/src/cli/application.ts
+++ b/src/cli/application.ts
@@ -14,6 +14,8 @@ import { cmdUpgrade } from '../commands/upgrade.js';
 import { cmdWhoami } from '../commands/whoami.js';
 import { cmdUnbind } from '../commands/unbind.js';
 import { cmdRole } from '../commands/role.js';
+import { cmdReply } from '../commands/reply.js';
+import { cmdResult } from '../commands/result.js';
 import type { ParsedArgs, ParsedInvocation } from './parser.js';
 
 function assertNever(value: never): never {
@@ -51,6 +53,10 @@ export async function dispatchCommand(ctx: Context, parsed: ParsedArgs): Promise
       return cmdPreamble(ctx, request);
     case 'role':
       return cmdRole(ctx, request);
+    case 'reply':
+      return cmdReply(ctx, request);
+    case 'result':
+      return cmdResult(ctx, request);
     case 'install':
       return cmdInstall(ctx, request.target);
     case 'completion':

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import { CliParseError, parseArgs } from './parser.js';
+import { encodeReplyReceipt } from '../reply-receipt.js';
+
+const receipt = encodeReplyReceipt({
+  version: 1,
+  requestId: 'request-1',
+  attemptId: 'attempt-1',
+  endpoint: {
+    serverId: 'server-1',
+    socketPath: '/tmp/tmt.sock',
+    serverPid: 1234,
+    serverStartTime: 'start',
+    paneId: '%1',
+    panePid: 5678,
+  },
+});
 
 describe('declarative CLI parser', () => {
   it('parses global options independently of command position', () => {
@@ -251,5 +266,49 @@ describe('declarative CLI parser', () => {
       CliParseError
     );
     expect(() => parseArgs(['role', 'set', 'a', 'b'])).toThrow(CliParseError);
+  });
+
+  it('parses storage-only reply/result commands with explicit input and no tmux capability', () => {
+    expect(
+      parseArgs(['reply', 'request-1', '--receipt', receipt, '--file', '/tmp/reply.txt', '--json'])
+    ).toEqual(
+      expect.objectContaining({
+        invocation: {
+          kind: 'reply',
+          requestId: 'request-1',
+          receipt,
+          file: '/tmp/reply.txt',
+        },
+        metadata: expect.objectContaining({ capability: 'storage', commandPath: ['reply'] }),
+      })
+    );
+    expect(parseArgs(['reply', 'request-1', '--receipt', receipt, '--stdin']).invocation).toEqual({
+      kind: 'reply',
+      requestId: 'request-1',
+      receipt,
+      stdin: true,
+    });
+    expect(parseArgs(['result', 'request-1', '--json'])).toMatchObject({
+      invocation: { kind: 'result', requestId: 'request-1' },
+      metadata: expect.objectContaining({ capability: 'storage', commandPath: ['result'] }),
+    });
+  });
+
+  it('rejects reply input ambiguity, missing receipt, invalid IDs, and result input flags', () => {
+    const invalid = [
+      ['reply', 'request-1', '--receipt', receipt],
+      ['reply', 'request-1', '--receipt', receipt, '--file', '/tmp/reply', '--stdin'],
+      ['reply', 'request-1', '--receipt', receipt, '--wait', '--stdin'],
+      ['reply', 'request-1', '--receipt', receipt, '--team', 'legacy', '--stdin'],
+      ['--wait', 'reply', 'request-1', '--receipt', receipt, '--stdin'],
+      ['reply', 'request-1', '--receipt', receipt, '--stdin', '--no-preamble'],
+      ['--timeout', '5s', 'result', 'request-1'],
+      ['result', 'request-1', '--no-preamble'],
+      ['result', 'request-1', '--file', '/tmp/reply'],
+      ['result', 'request-1', '--stdin'],
+      ['reply', '', '--receipt', receipt, '--stdin'],
+      ['reply', 'x'.repeat(257), '--receipt', receipt, '--stdin'],
+    ];
+    for (const args of invalid) expect(() => parseArgs(args)).toThrow(CliParseError);
   });
 });

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -2,7 +2,8 @@ import { Command, CommanderError } from 'commander';
 import { isPaneTarget } from '../domain/names.js';
 import type { Flags } from '../types.js';
 import type { IdentitySelector } from '../identity-context.js';
-import type { RoleRequest } from './requests.js';
+import type { ReplyRequest, ResultRequest, RoleRequest } from './requests.js';
+import { validateReplyRequestId } from '../reply-receipt.js';
 export type { IdentitySelector } from '../identity-context.js';
 
 export type ParsedInvocation =
@@ -29,6 +30,8 @@ export type ParsedInvocation =
       readonly agent?: string;
       readonly preamble?: string;
     }
+  | ReplyRequest
+  | ResultRequest
   | RoleRequest;
 
 export interface ParsedMetadata {
@@ -158,6 +161,8 @@ function capabilityFor(invocation: ParsedInvocation): ParsedMetadata['capability
     case 'install':
       return 'storage';
     case 'preamble':
+    case 'reply':
+    case 'result':
       return 'storage';
     case 'role':
       // Keep context creation storage-only. Implicit current-pane resolution
@@ -226,6 +231,34 @@ function setupProgram(capture: Capture): Command {
   const leaf = <T extends Command>(command: T): T => {
     commonOptions(command);
     return command;
+  };
+  const storageOnly = <T extends Command>(command: T): T => {
+    command.option('--json');
+    return command;
+  };
+  const optionWasProvided = (command: Command, name: string): boolean => {
+    let current: Command | null = command;
+    while (current) {
+      if (current.getOptionValueSource(name) === 'cli') return true;
+      current = current.parent;
+    }
+    return false;
+  };
+  const rejectIrrelevantStorageOptions = (command: Command, kind: 'reply' | 'result'): void => {
+    const allowed = new Set(kind === 'reply' ? ['json', 'receipt', 'file', 'stdin'] : ['json']);
+    const seen = new Set<string>();
+    let current: Command | null = command;
+    while (current) {
+      for (const option of current.options) {
+        const name = option.attributeName();
+        if (seen.has(name)) continue;
+        seen.add(name);
+        if (!allowed.has(name) && optionWasProvided(command, name)) {
+          throw new CliParseError(`Unknown option '${option.long ?? option.flags}' for ${kind}.`);
+        }
+      }
+      current = current.parent;
+    }
   };
 
   program.action(() => action(program, { kind: 'help', showIntro: true }));
@@ -372,6 +405,45 @@ function setupProgram(capture: Capture): Command {
       operation: 'clear',
       ...(options.identity !== undefined && { selector: selector(options.identity, true) }),
     });
+  });
+  const reply = storageOnly(program.command('reply').argument('<request-id>'))
+    .requiredOption('--receipt <receipt>')
+    .option('--file <path>')
+    .option('--stdin');
+  reply.action(function (requestId: string) {
+    rejectIrrelevantStorageOptions(this, 'reply');
+    try {
+      validateReplyRequestId(requestId);
+    } catch (error) {
+      throw new CliParseError(error instanceof Error ? error.message : 'Invalid request ID.');
+    }
+    const options = commandOptions(this) as CommandOptions & {
+      receipt?: string;
+      stdin?: boolean;
+    };
+    const hasFile = options.file !== undefined;
+    const hasStdin = options.stdin === true;
+    if (hasFile === hasStdin || options.receipt === undefined) {
+      throw new CliParseError(
+        'Usage: tmux-team reply <request-id> --receipt <receipt> (--file <path> | --stdin) [--json]'
+      );
+    }
+    action(this, {
+      kind: 'reply',
+      requestId,
+      receipt: options.receipt,
+      ...(hasFile ? { file: options.file! } : { stdin: true }),
+    });
+  });
+  const result = storageOnly(program.command('result').argument('<request-id>'));
+  result.action(function (requestId: string) {
+    rejectIrrelevantStorageOptions(this, 'result');
+    try {
+      validateReplyRequestId(requestId);
+    } catch (error) {
+      throw new CliParseError(error instanceof Error ? error.message : 'Invalid request ID.');
+    }
+    action(this, { kind: 'result', requestId });
   });
   const install = leaf(program.command('install').argument('[agent]'));
   install.action(function (agent?: string) {

--- a/src/cli/requests.ts
+++ b/src/cli/requests.ts
@@ -9,3 +9,17 @@ export type RoleRequest = {
   | { readonly operation: 'set'; readonly content: string; readonly file?: never }
   | { readonly operation: 'set'; readonly file: string; readonly content?: never }
 );
+
+export type ReplyRequest = {
+  readonly kind: 'reply';
+  readonly requestId: string;
+  readonly receipt: string;
+} & (
+  | { readonly file: string; readonly stdin?: never }
+  | { readonly file?: never; readonly stdin: true }
+);
+
+export type ResultRequest = {
+  readonly kind: 'result';
+  readonly requestId: string;
+};

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -12,6 +12,8 @@ _tmux-team() {
   commands=(
     'talk:Send message to an agent'
     'check:Capture output from agent pane'
+    'reply:Submit a complete result with a receipt'
+    'result:Retrieve a retained result'
     'list:List active identities or pane status'
     'add:Add a new agent'
     'name:Bind the current pane identity'
@@ -43,6 +45,12 @@ _tmux-team() {
           _describe -t agents 'agents' agents
         fi
         ;;
+      reply)
+        compadd -- "--receipt" "--file" "--stdin" "--json"
+        ;;
+      result)
+        compadd -- "--json"
+        ;;
       completion)
         compadd "zsh" "bash"
         ;;
@@ -57,6 +65,12 @@ _tmux-team() {
     case \${words[2]} in
       talk)
         compadd -- "--delay" "--wait" "--timeout"
+        ;;
+      reply)
+        compadd -- "--receipt" "--file" "--stdin" "--json"
+        ;;
+      result)
+        compadd -- "--json"
         ;;
       role)
         compadd -- "--identity"
@@ -74,7 +88,7 @@ const bashCompletion = `_tmux_team() {
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
-  commands="talk check list add init completion help name this whoami unbind install upgrade config preamble role learn"
+  commands="talk check reply result list add init completion help name this whoami unbind install upgrade config preamble role learn"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "\${commands}" -- \${cur}) )
@@ -83,6 +97,12 @@ const bashCompletion = `_tmux_team() {
       talk|check)
         agents=$(tmux-team list --json 2>/dev/null | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>{try{const j=JSON.parse(s); console.log((j.identities||[]).map(a=>a.name).join(" "))}catch{}})')
         COMPREPLY=( $(compgen -W "\${agents}" -- \${cur}) )
+        ;;
+      reply)
+        COMPREPLY=( $(compgen -W "--receipt --file --stdin --json" -- \${cur}) )
+        ;;
+      result)
+        COMPREPLY=( $(compgen -W "--json" -- \${cur}) )
         ;;
       completion)
         COMPREPLY=( $(compgen -W "zsh bash" -- \${cur}) )
@@ -98,6 +118,12 @@ const bashCompletion = `_tmux_team() {
     case "\${COMP_WORDS[1]}" in
       talk)
         COMPREPLY=( $(compgen -W "--delay --wait --timeout" -- \${cur}) )
+        ;;
+      reply)
+        COMPREPLY=( $(compgen -W "--receipt --file --stdin --json" -- \${cur}) )
+        ;;
+      result)
+        COMPREPLY=( $(compgen -W "--json" -- \${cur}) )
         ;;
       role)
         if [[ "\${COMP_WORDS[2]}" == "set" ]]; then

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -47,6 +47,8 @@ ${colors.yellow('USAGE')}
 ${colors.yellow('COMMANDS')}
   ${colors.green('talk')} <target> <message>     Send message to an identity or pane
   ${colors.green('check')} <target> [lines]      Capture output from agent's pane
+  ${colors.green('reply')} <request-id>         Submit a complete result with a receipt
+  ${colors.green('result')} <request-id>        Retrieve a retained result
   ${colors.green('list')} [target]                List active identities or pane status
   ${colors.green('add')} <pane-target> <global-name> Bind an explicit pane identity
   ${colors.green('this')} <global-name>       Bind the current pane (alias of name)
@@ -87,6 +89,25 @@ ${colors.yellow('TALK OPTIONS')}
   ${colors.green('--lines')} <number>            Lines to capture (default: 100)
   ${colors.green('--no-preamble')}               Skip agent preamble for this message
   ${colors.green('--debug')}                     Show debug output
+
+${colors.yellow('REPLY / RESULT')}
+  tmt reply <request-id> --receipt <receipt> (--file <path> | --stdin) [--json]
+  tmt result <request-id> [--json]
+  Use exactly one input source and the receipt supplied by TMT. Do not invent a
+  receipt, select the latest request, or infer a current pane. In this release,
+  talk remains marker-based and does not generate receipts; TMT-39 owns receipt
+  generation and durable completion. There is no --detach behavior yet.
+  Bodies are exact valid UTF-8 up to 1 MiB; stdin is EOF-driven with a 5s
+  deadline. Submission means result delivery, not task success. Summarize only
+  after successful submission. Result unavailable (pending, unknown, expired)
+  uses RESPONSE_NOT_AVAILABLE (exit 3); input errors exit 1, input timeout
+  uses RESPONSE_INPUT_TIMEOUT (exit 4), and conflicts exit 5. Identical retries
+  keep the original submittedAtMs; conflicting bodies cannot replace results.
+  JSON unavailable is {status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}.
+  Receipts are local correlation, not remote authentication. Bodies are
+  retained seven days; retry only with the same receipt/body while retained.
+  Missing results do not cancel work. Surface failed submission without a
+  success summary, and never resubmit after accepted delivery.
 
 ${colors.yellow('EXAMPLES')}${
     isWaitMode

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -27,6 +27,32 @@ ${colors.yellow('ESSENTIAL COMMANDS')}
   ${colors.green('tmux-team check')} <target> [lines]  Read pane output
   ${colors.green('tmux-team talk')} <target> --wait    Send and wait for response
 
+${colors.yellow('DURABLE REPLIES AND RESULTS')}
+
+  When TMT supplies an exact receipt, submit a complete response without tmux:
+  ${colors.cyan('tmt reply <request-id> --receipt <receipt> --file response.md')}
+  ${colors.cyan('tmt reply <request-id> --receipt <receipt> --stdin < response.md')}
+  ${colors.cyan('tmt result <request-id> --json')}
+
+  Use exactly one input source and never manufacture a receipt, select the
+  latest request, or infer a pane. talk remains marker-based in this release
+  and does not generate receipts; TMT-39 owns receipt generation and durable
+  completion. There is no --detach behavior yet. Submission confirms result
+  delivery, not task success; summarize only after successful submission.
+
+  Bodies preserve exact valid UTF-8 up to 1 MiB, including empty, whitespace,
+  BOM, NUL, CR/LF, Unicode, and marker-like text. Stdin is EOF-driven with a
+  five-second deadline. result reports RESPONSE_NOT_AVAILABLE (exit 3) for
+  pending, unknown, or expired bodies; input errors exit 1, timeout exits 4,
+  and conflicts exit 5. JSON unavailable output is
+  {status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}.
+  Identical retries keep the original submission timestamp; conflicting bodies
+  cannot replace stored results.
+  Receipts are local correlation, not remote authentication. Bodies are
+  retained seven days; retry only with the same receipt/body while retained.
+  Missing results do not cancel work. Surface failed submission without a
+  success summary, and never resubmit after accepted delivery.
+
 ${colors.yellow('RECOMMENDED: WAIT MODE (--wait)')}
 
   The ${colors.green('--wait')} flag is recommended for better token utilization:

--- a/src/commands/reply-result.test.ts
+++ b/src/commands/reply-result.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Context, UI } from '../types.js';
+import type { RequestService } from '../request-service.js';
+import { ResponseError } from '../domain/response.js';
+import { encodeReplyReceipt } from '../reply-receipt.js';
+import { cmdReply } from './reply.js';
+import { cmdResult } from './result.js';
+
+const endpoint = {
+  serverId: 'server-1',
+  socketPath: '/tmp/tmt.sock',
+  serverPid: 1234,
+  serverStartTime: 'start',
+  paneId: '%1',
+  panePid: 5678,
+} as const;
+
+const tempFiles: string[] = [];
+
+afterEach(() => {
+  for (const file of tempFiles.splice(0)) fs.rmSync(file, { force: true });
+});
+
+function createContext(
+  requestService: Partial<RequestService>,
+  json = true
+): Context & { output: unknown[] } {
+  const output: unknown[] = [];
+  const ui: UI = {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    table: vi.fn(),
+    json: (value: unknown) => output.push(value),
+  };
+  return {
+    output,
+    argv: [],
+    flags: { json, verbose: false },
+    ui,
+    config: {} as Context['config'],
+    tmux: {} as Context['tmux'],
+    identityService: {} as Context['identityService'],
+    requestService: requestService as RequestService,
+    paths: {} as Context['paths'],
+    exit: ((code: number) => {
+      throw Object.assign(new Error(`exit(${code})`), { exitCode: code });
+    }) as Context['exit'],
+  };
+}
+
+describe('reply and result command adapters', () => {
+  it('keeps unavailable human errors on the error channel and hides unexpected error details', () => {
+    const missing = createContext({ getResponse: () => undefined }, false);
+    expect(() => cmdResult(missing, { kind: 'result', requestId: 'missing' })).toThrow('exit(3)');
+    expect(missing.ui.info).not.toHaveBeenCalled();
+    expect(missing.ui.error).toHaveBeenCalledWith(
+      "Response for request 'missing' is not available."
+    );
+    const failed = createContext({
+      getResponse: () => {
+        throw new Error('private endpoint details');
+      },
+    });
+    expect(() => cmdResult(failed, { kind: 'result', requestId: 'request' })).toThrow('exit(1)');
+    expect(failed.output).toEqual([
+      { error: { code: 'RESPONSE_ERROR', message: 'Could not retrieve response.' } },
+    ]);
+  });
+
+  it('reads the complete file and emits only the submitted acknowledgement fields', async () => {
+    const file = path.join(os.tmpdir(), `tmt-reply-${process.pid}-${Date.now()}.txt`);
+    tempFiles.push(file);
+    const body = '\ufefffirst\r\n\u0000日本語\n';
+    fs.writeFileSync(file, Buffer.from(body, 'utf8'));
+    const requestId = 'request-1';
+    const receipt = encodeReplyReceipt({
+      version: 1,
+      requestId,
+      attemptId: 'attempt-1',
+      endpoint,
+    });
+    const submitResponse = vi.fn(() => ({
+      requestId,
+      attemptId: 'attempt-1',
+      endpoint,
+      body,
+      bodyBytes: Buffer.byteLength(body),
+      submittedAtMs: 99,
+    }));
+    const ctx = createContext({ submitResponse });
+
+    await cmdReply(ctx, { kind: 'reply', requestId, receipt, file });
+
+    expect(submitResponse).toHaveBeenCalledWith({
+      requestId,
+      attemptId: 'attempt-1',
+      endpoint,
+      body,
+    });
+    expect(ctx.output).toEqual([
+      { status: 'submitted', requestId, bodyBytes: Buffer.byteLength(body), submittedAtMs: 99 },
+    ]);
+    expect(JSON.stringify(ctx.output)).not.toContain(receipt);
+    expect(JSON.stringify(ctx.output)).not.toContain(endpoint.socketPath);
+  });
+
+  it('maps receipt and service errors without opening storage for invalid input', async () => {
+    const submitResponse = vi.fn();
+    const ctx = createContext({ submitResponse });
+    const invalid = path.join(os.tmpdir(), `tmt-invalid-${process.pid}-${Date.now()}.txt`);
+    tempFiles.push(invalid);
+    fs.writeFileSync(invalid, 'should not be read');
+
+    await expect(
+      cmdReply(ctx, {
+        kind: 'reply',
+        requestId: 'request-1',
+        receipt: 'not-a-receipt',
+        file: invalid,
+      })
+    ).rejects.toMatchObject({ exitCode: 1 });
+    expect(submitResponse).not.toHaveBeenCalled();
+    expect(ctx.output).toEqual([
+      { error: { code: 'RESPONSE_RECEIPT_INVALID', message: expect.any(String) } },
+    ]);
+    expect(JSON.stringify(ctx.output)).not.toContain('not-a-receipt');
+  });
+
+  it('maps a final conflict to exit 5 and does not expose the attempted body', async () => {
+    const file = path.join(os.tmpdir(), `tmt-conflict-${process.pid}-${Date.now()}.txt`);
+    tempFiles.push(file);
+    fs.writeFileSync(file, 'different body');
+    const requestId = 'request-1';
+    const receipt = encodeReplyReceipt({ version: 1, requestId, attemptId: 'attempt-1', endpoint });
+    const submitResponse = vi.fn(() => {
+      throw new ResponseError('RESPONSE_CONFLICT', 'different final response');
+    });
+    const ctx = createContext({ submitResponse });
+
+    await expect(cmdReply(ctx, { kind: 'reply', requestId, receipt, file })).rejects.toMatchObject({
+      exitCode: 5,
+    });
+    expect(ctx.output).toEqual([
+      { error: { code: 'RESPONSE_CONFLICT', message: 'different final response' } },
+    ]);
+    expect(JSON.stringify(ctx.output)).not.toContain('different body');
+  });
+
+  it('returns an exact completed result without receipt or endpoint fields', () => {
+    const response = {
+      requestId: 'request-1',
+      attemptId: 'attempt-1',
+      endpoint,
+      body: '\ufeffbody\r\n日本語\u0000',
+      bodyBytes: Buffer.byteLength('\ufeffbody\r\n日本語\u0000'),
+      submittedAtMs: 123,
+    };
+    const ctx = createContext({ getResponse: vi.fn(() => response) });
+
+    cmdResult(ctx, { kind: 'result', requestId: response.requestId });
+
+    expect(ctx.output).toEqual([
+      {
+        status: 'completed',
+        requestId: response.requestId,
+        response: response.body,
+        bodyBytes: response.bodyBytes,
+        submittedAtMs: response.submittedAtMs,
+      },
+    ]);
+    expect(JSON.stringify(ctx.output)).not.toContain(response.attemptId);
+    expect(JSON.stringify(ctx.output)).not.toContain(endpoint.socketPath);
+  });
+
+  it('uses one unavailable result for pending, unknown, and expired bodies', () => {
+    for (const requestId of ['pending', 'unknown', 'expired']) {
+      const ctx = createContext({ getResponse: vi.fn(() => undefined) });
+      expect(() => cmdResult(ctx, { kind: 'result', requestId })).toThrow(/exit\(3\)/);
+      expect(ctx.output).toEqual([
+        {
+          status: 'unavailable',
+          requestId,
+          error: {
+            code: 'RESPONSE_NOT_AVAILABLE',
+            message: `Response for request '${requestId}' is not available.`,
+          },
+        },
+      ]);
+    }
+  });
+});

--- a/src/commands/reply.ts
+++ b/src/commands/reply.ts
@@ -1,0 +1,66 @@
+import type { Context } from '../types.js';
+import { ExitCodes } from '../exits.js';
+import { ResponseError } from '../domain/response.js';
+import { decodeReplyReceipt, ReplyReceiptError } from '../reply-receipt.js';
+import { readResponseFile, readResponseStdin, ResponseInputError } from '../response-content.js';
+import type { ReplyRequest } from '../cli/requests.js';
+
+function errorCode(error: unknown): string {
+  if (
+    error instanceof ResponseError ||
+    error instanceof ResponseInputError ||
+    error instanceof ReplyReceiptError
+  ) {
+    return error.code;
+  }
+  return 'RESPONSE_ERROR';
+}
+
+function exitCode(code: string): number {
+  if (code === 'RESPONSE_REQUEST_NOT_FOUND') return ExitCodes.NAME_NOT_FOUND;
+  if (code === 'RESPONSE_CONFLICT') return ExitCodes.CONFLICT;
+  if (code === 'RESPONSE_INPUT_TIMEOUT') return ExitCodes.TIMEOUT;
+  return ExitCodes.ERROR;
+}
+
+function fail(ctx: Context, error: unknown): never {
+  const code = errorCode(error);
+  const message =
+    error instanceof ResponseError ||
+    error instanceof ResponseInputError ||
+    error instanceof ReplyReceiptError
+      ? error.message
+      : 'Could not submit response.';
+  if (ctx.flags.json) ctx.ui.json({ error: { code, message } });
+  else ctx.ui.error(message);
+  return ctx.exit(exitCode(code));
+}
+
+/** Read the selected body completely before opening durable request storage. */
+export async function cmdReply(ctx: Context, request: ReplyRequest): Promise<void> {
+  let record;
+  try {
+    const receipt = decodeReplyReceipt(request.receipt, request.requestId);
+    const body =
+      request.file !== undefined ? readResponseFile(request.file) : await readResponseStdin();
+    record = ctx.requestService.submitResponse({
+      requestId: request.requestId,
+      attemptId: receipt.attemptId,
+      endpoint: receipt.endpoint,
+      body,
+    });
+  } catch (error) {
+    fail(ctx, error);
+  }
+  const result = {
+    status: 'submitted' as const,
+    requestId: request.requestId,
+    bodyBytes: record.bodyBytes,
+    submittedAtMs: record.submittedAtMs,
+  };
+  if (ctx.flags.json) ctx.ui.json(result);
+  else
+    ctx.ui.success(
+      `Submitted response for request '${request.requestId}' (${record.bodyBytes} bytes).`
+    );
+}

--- a/src/commands/result.ts
+++ b/src/commands/result.ts
@@ -1,0 +1,45 @@
+import type { Context } from '../types.js';
+import { ExitCodes } from '../exits.js';
+import { ResponseError } from '../domain/response.js';
+import type { ResultRequest } from '../cli/requests.js';
+
+function fail(ctx: Context, error: unknown): never {
+  const code = error instanceof ResponseError ? error.code : 'RESPONSE_ERROR';
+  const message = error instanceof ResponseError ? error.message : 'Could not retrieve response.';
+  if (ctx.flags.json) ctx.ui.json({ error: { code, message } });
+  else ctx.ui.error(message);
+  const status = code === 'RESPONSE_REQUEST_NOT_FOUND' ? ExitCodes.NAME_NOT_FOUND : ExitCodes.ERROR;
+  return ctx.exit(status);
+}
+
+/** Retrieve only an already-retained final response; absence is intentionally undifferentiated. */
+export function cmdResult(ctx: Context, request: ResultRequest): void {
+  let record;
+  try {
+    record = ctx.requestService.getResponse(request.requestId);
+  } catch (error) {
+    fail(ctx, error);
+  }
+  if (!record) {
+    const result = {
+      status: 'unavailable' as const,
+      requestId: request.requestId,
+      error: {
+        code: 'RESPONSE_NOT_AVAILABLE',
+        message: `Response for request '${request.requestId}' is not available.`,
+      },
+    };
+    if (ctx.flags.json) ctx.ui.json(result);
+    else ctx.ui.error(result.error.message);
+    ctx.exit(ExitCodes.NAME_NOT_FOUND);
+  }
+  const result = {
+    status: 'completed' as const,
+    requestId: request.requestId,
+    response: record.body,
+    bodyBytes: record.bodyBytes,
+    submittedAtMs: record.submittedAtMs,
+  };
+  if (ctx.flags.json) ctx.ui.json(result);
+  else ctx.ui.info(`Response for request '${request.requestId}':\n${record.body}`);
+}

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -1981,7 +1981,10 @@ describe('cmdTalk - request state lifecycle', () => {
     await cmdTalk(secondCtx, 'claude', 'Second');
 
     expect(secondTmux.sends[0]?.message).toContain('[SYSTEM: Be brief]');
-    expect(requestService.listAttempts()[1]).toMatchObject({
+    expect(beginSend).toHaveBeenCalledTimes(2);
+    // Attempts created in the same millisecond sort by UUID, not invocation order.
+    const secondAttemptId = beginSend.mock.calls[1]![0];
+    expect(requestService.getAttempt(secondAttemptId)).toMatchObject({
       status: 'sent',
       injectPreamble: true,
       cadenceReserved: true,

--- a/src/reply-cli-contract.test.ts
+++ b/src/reply-cli-contract.test.ts
@@ -1,0 +1,551 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequestService } from './request-service.js';
+import { encodeReplyReceipt } from './reply-receipt.js';
+import { MAX_RESPONSE_BYTES } from './domain/response.js';
+import { openIdentityRepository } from './storage/identity-repository.js';
+import {
+  expectError,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+  type Sandbox,
+} from './test-support/cli-process.js';
+
+const endpoint = {
+  serverId: 'server-1',
+  socketPath: '/tmp/tmt.sock',
+  serverPid: 1234,
+  serverStartTime: 'start',
+  paneId: '%1',
+  panePid: 5678,
+} as const;
+
+interface SeededReply {
+  readonly requestId: string;
+  readonly attemptId: string;
+  readonly receipt: string;
+}
+
+interface SeedOptions {
+  readonly wait?: boolean;
+  readonly releaseWait?: boolean;
+  readonly settle?: boolean;
+  readonly expired?: boolean;
+  readonly preparedAtMs?: number;
+  readonly reservePreamble?: boolean;
+}
+
+function seedAttempt(sandbox: Sandbox, requestId: string, options: SeedOptions = {}): SeededReply {
+  const repository = openIdentityRepository(sandbox.database);
+  try {
+    const identityName = `identity-${requestId}`;
+    const identity = options.reservePreamble
+      ? repository.createIdentity(identityName, identityName)
+      : undefined;
+    const now =
+      options.preparedAtMs ?? (options.expired ? Date.now() - 2 * 60 * 60 * 1000 : Date.now());
+    const service = createRequestService({ repository, now: () => now });
+    const prepared = service.prepare({
+      requestId,
+      endpoint,
+      wait: options.wait ?? false,
+      expiresAtMs: options.expired ? now + 1 : now + 60 * 60 * 1000,
+      ...(identity && { preamble: { identityId: identity.id, every: 3 } }),
+    });
+    if (options.settle !== false) {
+      service.beginSend(prepared.attemptId);
+      service.settle(prepared.attemptId, 'sent');
+      if (options.releaseWait) service.releaseWait(prepared.attemptId);
+    }
+    return {
+      requestId,
+      attemptId: prepared.attemptId,
+      receipt: encodeReplyReceipt({
+        version: 1,
+        requestId,
+        attemptId: prepared.attemptId,
+        endpoint,
+      }),
+    };
+  } finally {
+    repository.close();
+  }
+}
+
+function stateSnapshot(sandbox: Sandbox, requestId: string): unknown {
+  const database = new Database(sandbox.database, { readonly: true });
+  try {
+    return {
+      attempt: database
+        .prepare('SELECT * FROM request_attempts WHERE request_id = ?')
+        .get(requestId),
+      response: database
+        .prepare('SELECT * FROM request_responses WHERE request_id = ?')
+        .get(requestId),
+      cadence: database.prepare('SELECT * FROM preamble_counters ORDER BY identity_id').all(),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function temporaryFile(sandbox: Sandbox, name: string, bytes: string | Uint8Array): string {
+  const file = path.join(sandbox.root, name);
+  fs.writeFileSync(file, bytes);
+  return file;
+}
+
+describe('real reply/result CLI process contract', () => {
+  it(
+    'submits the exact file body and retrieves the exact result after process restart',
+    { timeout: 15_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-exact', { reservePreamble: true });
+        const body = '\ufefffirst\r\n\u0000日本語 😀\r\nRESPONSE-END-fake\n';
+        const file = temporaryFile(sandbox, 'exact.txt', Buffer.from(body, 'utf8'));
+        try {
+          const submitted = await runCli(
+            sandbox,
+            ['reply', seeded.requestId, '--receipt', seeded.receipt, '--file', file, '--json'],
+            { outputLimitBytes: 2 * 1024 * 1024 }
+          );
+          expect(submitted.status).toBe(0);
+          expect(parseWholeStdout(submitted)).toMatchObject({
+            status: 'submitted',
+            requestId: seeded.requestId,
+            bodyBytes: Buffer.byteLength(body),
+            submittedAtMs: expect.any(Number),
+          });
+          expect(submitted.stdout).not.toContain(seeded.receipt);
+          expect(submitted.stdout).not.toContain(endpoint.socketPath);
+
+          const result = await runCli(sandbox, ['result', seeded.requestId, '--json']);
+          expect(result.status).toBe(0);
+          expect(parseWholeStdout(result)).toEqual({
+            status: 'completed',
+            requestId: seeded.requestId,
+            response: body,
+            bodyBytes: Buffer.byteLength(body),
+            submittedAtMs: (parseWholeStdout(submitted) as { submittedAtMs: number }).submittedAtMs,
+          });
+          expect(result.stdout).not.toContain(seeded.receipt);
+          expect(result.stdout).not.toContain(endpoint.socketPath);
+        } finally {
+          fs.rmSync(file, { force: true });
+        }
+      })
+  );
+
+  it(
+    'keeps identical retries idempotent and conflicting replies unchanged',
+    { timeout: 15_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-idempotent', { reservePreamble: true });
+        const original = temporaryFile(sandbox, 'original.txt', 'original\r\n日本語');
+        const conflict = temporaryFile(sandbox, 'conflict.txt', 'different');
+        try {
+          const first = await runCli(sandbox, [
+            'reply',
+            seeded.requestId,
+            '--receipt',
+            seeded.receipt,
+            '--file',
+            original,
+            '--json',
+          ]);
+          expect(first.status).toBe(0);
+          const firstDocument = parseWholeStdout(first) as { submittedAtMs: number };
+          expect(firstDocument).toMatchObject({ status: 'submitted', requestId: seeded.requestId });
+          const second = await runCli(sandbox, [
+            'reply',
+            seeded.requestId,
+            '--receipt',
+            seeded.receipt,
+            '--file',
+            original,
+            '--json',
+          ]);
+          expect(second.status).toBe(0);
+          expect(parseWholeStdout(second)).toMatchObject({
+            submittedAtMs: firstDocument.submittedAtMs,
+          });
+          const beforeConflict = stateSnapshot(sandbox, seeded.requestId);
+
+          const rejected = await runCli(sandbox, [
+            'reply',
+            seeded.requestId,
+            '--receipt',
+            seeded.receipt,
+            '--file',
+            conflict,
+            '--json',
+          ]);
+          expect(rejected.status).toBe(5);
+          expectError(rejected, 'RESPONSE_CONFLICT');
+          expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(beforeConflict);
+          const result = await runCli(sandbox, ['result', seeded.requestId, '--json']);
+          expect(parseWholeStdout(result)).toMatchObject({
+            status: 'completed',
+            response: 'original\r\n日本語',
+            submittedAtMs: firstDocument.submittedAtMs,
+          });
+        } finally {
+          fs.rmSync(original, { force: true });
+          fs.rmSync(conflict, { force: true });
+        }
+      })
+  );
+
+  it(
+    'accepts an exact 1 MiB stdin body and returns it without truncation',
+    { timeout: 20_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-exact-stdin', { reservePreamble: true });
+        const body = 'a'.repeat(MAX_RESPONSE_BYTES);
+        const submitted = await runCli(
+          sandbox,
+          ['reply', seeded.requestId, '--receipt', seeded.receipt, '--stdin', '--json'],
+          { stdin: Buffer.from(body, 'utf8'), outputLimitBytes: 3 * 1024 * 1024 }
+        );
+        expect(submitted.status).toBe(0);
+        expect(parseWholeStdout(submitted)).toMatchObject({
+          status: 'submitted',
+          requestId: seeded.requestId,
+          bodyBytes: MAX_RESPONSE_BYTES,
+        });
+        const result = await runCli(sandbox, ['result', seeded.requestId, '--json'], {
+          outputLimitBytes: 3 * 1024 * 1024,
+        });
+        const document = parseWholeStdout(result) as {
+          status: string;
+          response: string;
+          bodyBytes: number;
+        };
+        expect(document.status).toBe('completed');
+        expect(document.bodyBytes).toBe(MAX_RESPONSE_BYTES);
+        expect(document.response).toBe(body);
+      })
+  );
+
+  it(
+    'rejects malformed and oversized files without changing durable request state',
+    { timeout: 15_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-invalid-file', { reservePreamble: true });
+        const before = stateSnapshot(sandbox, seeded.requestId);
+        const invalidReceipt = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          'not-a-receipt',
+          '--file',
+          path.join(sandbox.root, 'missing.txt'),
+          '--json',
+        ]);
+        expect(invalidReceipt.status).toBe(1);
+        expectError(invalidReceipt, 'RESPONSE_RECEIPT_INVALID');
+        expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+
+        const malformed = temporaryFile(sandbox, 'malformed.txt', Buffer.from([0xc3, 0x28]));
+        const oversized = temporaryFile(
+          sandbox,
+          'oversized.txt',
+          Buffer.concat([Buffer.alloc(1024 * 1024, 0x61), Buffer.from('x')])
+        );
+        try {
+          const invalid = await runCli(sandbox, [
+            'reply',
+            seeded.requestId,
+            '--receipt',
+            seeded.receipt,
+            '--file',
+            malformed,
+            '--json',
+          ]);
+          expect(invalid.status).toBe(1);
+          expectError(invalid, 'RESPONSE_INPUT_INVALID');
+          expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+
+          const tooLarge = await runCli(sandbox, [
+            'reply',
+            seeded.requestId,
+            '--receipt',
+            seeded.receipt,
+            '--file',
+            oversized,
+            '--json',
+          ]);
+          expect(tooLarge.status).toBe(1);
+          expectError(tooLarge, 'RESPONSE_INPUT_TOO_LARGE');
+          expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+        } finally {
+          fs.rmSync(malformed, { force: true });
+          fs.rmSync(oversized, { force: true });
+        }
+      })
+  );
+
+  it(
+    'checks every recorded endpoint fence and rejects wrong request/attempt receipts',
+    { timeout: 20_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-fences', { reservePreamble: true });
+        const empty = temporaryFile(sandbox, 'empty-fence.txt', '');
+        const before = stateSnapshot(sandbox, seeded.requestId);
+        const mismatchedRequest = encodeReplyReceipt({
+          version: 1,
+          requestId: 'other-request',
+          attemptId: seeded.attemptId,
+          endpoint,
+        });
+        const requestResult = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          mismatchedRequest,
+          '--file',
+          empty,
+          '--json',
+        ]);
+        expect(requestResult.status).toBe(1);
+        expectError(requestResult, 'RESPONSE_RECEIPT_MISMATCH');
+        expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+
+        const mismatchedAttempt = encodeReplyReceipt({
+          version: 1,
+          requestId: seeded.requestId,
+          attemptId: 'other-attempt',
+          endpoint,
+        });
+        const attemptResult = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          mismatchedAttempt,
+          '--file',
+          empty,
+          '--json',
+        ]);
+        expect(attemptResult.status).toBe(1);
+        expectError(attemptResult, 'RESPONSE_ATTEMPT_MISMATCH');
+        expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+
+        const fields = [
+          ['serverId', { serverId: 'other-server' }],
+          ['socketPath', { socketPath: '/tmp/other.sock' }],
+          ['serverPid', { serverPid: 1235 }],
+          ['serverStartTime', { serverStartTime: 'other-start' }],
+          ['paneId', { paneId: '%2' }],
+          ['panePid', { panePid: 5679 }],
+        ] as const;
+        for (const [field, change] of fields) {
+          const wrongEndpoint = encodeReplyReceipt({
+            version: 1,
+            requestId: seeded.requestId,
+            attemptId: seeded.attemptId,
+            endpoint: { ...endpoint, ...change },
+          });
+          const result = await runCli(sandbox, [
+            'reply',
+            seeded.requestId,
+            '--receipt',
+            wrongEndpoint,
+            '--file',
+            empty,
+            '--json',
+          ]);
+          expect(result.status, field).toBe(1);
+          expectError(result, 'RESPONSE_RECIPIENT_MISMATCH');
+          expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+        }
+      })
+  );
+
+  it(
+    'rejects malformed and oversized stdin at EOF while preserving state',
+    { timeout: 15_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-invalid-stdin', { reservePreamble: true });
+        const before = stateSnapshot(sandbox, seeded.requestId);
+        for (const [name, input, code] of [
+          ['malformed', Buffer.from([0xc3, 0x28]), 'RESPONSE_INPUT_INVALID'],
+          [
+            'oversized',
+            Buffer.concat([Buffer.alloc(1024 * 1024, 0x61), Buffer.from('x')]),
+            'RESPONSE_INPUT_TOO_LARGE',
+          ],
+        ] as const) {
+          const result = await runCli(
+            sandbox,
+            ['reply', seeded.requestId, '--receipt', seeded.receipt, '--stdin', '--json'],
+            { stdin: input, outputLimitBytes: 2 * 1024 * 1024 }
+          );
+          expect(result.status, name).toBe(1);
+          expectError(result, code);
+          expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+        }
+      })
+  );
+
+  it('returns one unavailable result without tmux for unknown requests', { timeout: 10_000 }, () =>
+    withSandbox(async (sandbox) => {
+      const result = await runCli(sandbox, ['result', 'unknown-request', '--json']);
+      expect(result.status).toBe(3);
+      expect(result.stderr).toBe('');
+      expectError(result, 'RESPONSE_NOT_AVAILABLE');
+    })
+  );
+
+  it(
+    'returns unavailable for real pending and expired attempts, and rejects an unknown valid receipt',
+    { timeout: 20_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const pending = seedAttempt(sandbox, 'request-pending', {
+          settle: false,
+          reservePreamble: true,
+        });
+        const expired = seedAttempt(sandbox, 'request-expired', {
+          settle: false,
+          expired: true,
+          reservePreamble: true,
+        });
+        for (const requestId of [pending.requestId, expired.requestId]) {
+          const result = await runCli(sandbox, ['result', requestId, '--json']);
+          expect(result.status).toBe(3);
+          expectError(result, 'RESPONSE_NOT_AVAILABLE');
+        }
+
+        const unknownId = 'request-unknown-valid-receipt';
+        const unknownReceipt = encodeReplyReceipt({
+          version: 1,
+          requestId: unknownId,
+          attemptId: 'attempt-unknown',
+          endpoint,
+        });
+        const empty = temporaryFile(sandbox, 'empty-unknown.txt', '');
+        const reply = await runCli(sandbox, [
+          'reply',
+          unknownId,
+          '--receipt',
+          unknownReceipt,
+          '--file',
+          empty,
+          '--json',
+        ]);
+        expect(reply.status).toBe(3);
+        expectError(reply, 'RESPONSE_REQUEST_NOT_FOUND');
+        expect(reply.stdout).not.toContain(unknownReceipt);
+      })
+  );
+
+  it(
+    'hides an actually expired retained body and rejects resurrection through the public reply command',
+    { timeout: 15_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const preparedAtMs = Date.now() - 8 * 24 * 60 * 60 * 1000;
+        const seeded = seedAttempt(sandbox, 'request-expired-body', {
+          preparedAtMs,
+          reservePreamble: true,
+        });
+        const repository = openIdentityRepository(sandbox.database);
+        try {
+          const service = createRequestService({ repository, now: () => preparedAtMs + 1 });
+          service.submitResponse({
+            requestId: seeded.requestId,
+            attemptId: seeded.attemptId,
+            endpoint,
+            body: 'retained but expired',
+          });
+        } finally {
+          repository.close();
+        }
+        const before = stateSnapshot(sandbox, seeded.requestId);
+        const result = await runCli(sandbox, ['result', seeded.requestId, '--json']);
+        expect(result.status).toBe(3);
+        expectError(result, 'RESPONSE_NOT_AVAILABLE');
+        expect(result.stdout).not.toContain('retained but expired');
+        const retry = await runCli(
+          sandbox,
+          ['reply', seeded.requestId, '--receipt', seeded.receipt, '--stdin', '--json'],
+          { stdin: Buffer.from('retained but expired') }
+        );
+        expect(retry.status).toBe(1);
+        expectError(retry, 'RESPONSE_EXPIRED');
+        expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+      })
+  );
+
+  it(
+    'accepts a late reply after waiter release without a live tmux pane',
+    { timeout: 15_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-late', {
+          wait: true,
+          releaseWait: true,
+          reservePreamble: true,
+        });
+        const empty = temporaryFile(sandbox, 'empty-late.txt', '');
+        const reply = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          seeded.receipt,
+          '--file',
+          empty,
+          '--json',
+        ]);
+        expect(reply.status).toBe(0);
+        expect(parseWholeStdout(reply)).toMatchObject({ status: 'submitted', bodyBytes: 0 });
+        const result = await runCli(sandbox, ['result', seeded.requestId, '--json']);
+        expect(parseWholeStdout(result)).toMatchObject({
+          status: 'completed',
+          response: '',
+          bodyBytes: 0,
+        });
+      })
+  );
+
+  it(
+    'rejects malformed positional IDs before touching an existing request',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-valid', { reservePreamble: true });
+        const before = stateSnapshot(sandbox, seeded.requestId);
+        const result = await runCli(sandbox, ['result', 'x'.repeat(257), '--json']);
+        expect(result.status).toBe(1);
+        expectError(result, 'USAGE_ERROR');
+        expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+      })
+  );
+
+  it(
+    'maps an open stdin past the five-second input deadline and leaves state untouched',
+    { timeout: 15_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-stdin-timeout', { reservePreamble: true });
+        const before = stateSnapshot(sandbox, seeded.requestId);
+        const result = await runCli(
+          sandbox,
+          ['reply', seeded.requestId, '--receipt', seeded.receipt, '--stdin', '--json'],
+          { stdin: Buffer.from('partial'), closeStdin: false, deadlineMs: 8_000 }
+        );
+        expect(result.status).toBe(4);
+        expectError(result, 'RESPONSE_INPUT_TIMEOUT');
+        expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+      })
+  );
+});

--- a/src/reply-receipt.test.ts
+++ b/src/reply-receipt.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_REPLY_RECEIPT_LENGTH,
+  ReplyReceiptError,
+  decodeReplyReceipt,
+  encodeReplyReceipt,
+  type ReplyReceipt,
+} from './reply-receipt.js';
+
+const endpoint = {
+  serverId: 'server-1',
+  socketPath: '/tmp/tmt-test.sock',
+  serverPid: 1234,
+  serverStartTime: '2026-09-06T00:00:00.000Z',
+  paneId: '%17',
+  panePid: 5678,
+} as const;
+
+const receipt: ReplyReceipt = {
+  version: 1,
+  requestId: 'request-α',
+  attemptId: 'attempt-1',
+  endpoint,
+};
+
+function expectReceiptError(action: () => unknown, code: ReplyReceiptError['code']): void {
+  try {
+    action();
+    expect.fail('expected receipt validation to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ReplyReceiptError);
+    expect((error as ReplyReceiptError).code).toBe(code);
+  }
+}
+
+describe('reply receipt codec', () => {
+  it('round-trips a canonical unpadded base64url envelope with the exact fence', () => {
+    const encoded = encodeReplyReceipt(receipt);
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(encoded).not.toContain('=');
+    expect(decodeReplyReceipt(encoded)).toEqual(receipt);
+    expect(decodeReplyReceipt(encoded, receipt.requestId)).toEqual(receipt);
+    expect(encodeReplyReceipt(decodeReplyReceipt(encoded))).toBe(encoded);
+  });
+
+  it('accepts valid JSON key reordering while rejecting non-zero base64 trailing bits', () => {
+    const reorderedJson = JSON.stringify({
+      endpoint,
+      attemptId: receipt.attemptId,
+      version: receipt.version,
+      requestId: receipt.requestId,
+    });
+    const reordered = Buffer.from(reorderedJson, 'utf8').toString('base64url');
+    expect(decodeReplyReceipt(reordered)).toEqual(receipt);
+
+    const canonical = encodeReplyReceipt(receipt);
+    const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+    const lastIndex = alphabet.indexOf(canonical.at(-1)!);
+    const ignoredBits = canonical.length % 4 === 2 ? 4 : canonical.length % 4 === 3 ? 2 : 0;
+    expect(ignoredBits).toBeGreaterThan(0);
+    const changedIndex =
+      (lastIndex & ~((1 << ignoredBits) - 1)) | ((lastIndex + 1) & ((1 << ignoredBits) - 1));
+    const nonCanonical = `${canonical.slice(0, -1)}${alphabet[changedIndex]}`;
+    expectReceiptError(() => decodeReplyReceipt(nonCanonical), 'RESPONSE_RECEIPT_INVALID');
+  });
+
+  it('rejects a positional request mismatch before service submission', () => {
+    const encoded = encodeReplyReceipt(receipt);
+    expectReceiptError(
+      () => decodeReplyReceipt(encoded, 'different-request'),
+      'RESPONSE_RECEIPT_MISMATCH'
+    );
+  });
+
+  it.each([
+    '',
+    'not-base64!',
+    'eyJ2ZXJzaW9uIjoxfQ==',
+    Buffer.from([0xff, 0xfe]).toString('base64url'),
+  ])('rejects malformed, padded, or non-UTF-8 receipt %j', (encoded) => {
+    expectReceiptError(() => decodeReplyReceipt(encoded), 'RESPONSE_RECEIPT_INVALID');
+  });
+
+  it.each([
+    { version: 2 },
+    { extra: true },
+    { requestId: '' },
+    { attemptId: '' },
+    { endpoint: { ...endpoint, paneId: '17' } },
+    { endpoint: { ...endpoint, panePid: 0 } },
+    { endpoint: { ...endpoint, serverPid: Number.MAX_SAFE_INTEGER + 1 } },
+    { endpoint: { ...endpoint, serverId: '\ud800' } },
+  ])('rejects an envelope violating the exact versioned fence shape', (change) => {
+    const value = { ...receipt, ...change, endpoint: { ...receipt.endpoint, ...change.endpoint } };
+    expectReceiptError(() => encodeReplyReceipt(value as ReplyReceipt), 'RESPONSE_RECEIPT_INVALID');
+  });
+
+  it('rejects decoded JSON envelopes with malformed top-level or endpoint shapes', () => {
+    const malformed = [
+      ['[]'],
+      [JSON.stringify({ ...receipt, endpoint: [] })],
+      [JSON.stringify({ ...receipt, endpoint: { ...endpoint, extra: true } })],
+    ];
+    for (const [value] of malformed) {
+      const encoded = Buffer.from(value, 'utf8').toString('base64url');
+      expectReceiptError(() => decodeReplyReceipt(encoded), 'RESPONSE_RECEIPT_INVALID');
+    }
+  });
+
+  it('rejects receipts whose encoded form exceeds the 8192-character bound', () => {
+    const oversized = {
+      ...receipt,
+      endpoint: {
+        ...endpoint,
+        serverId: 'x'.repeat(4096),
+        socketPath: 'y'.repeat(4096),
+      },
+    } as ReplyReceipt;
+    expect(() => encodeReplyReceipt(oversized)).toThrow(ReplyReceiptError);
+    try {
+      encodeReplyReceipt(oversized);
+    } catch (error) {
+      expect((error as ReplyReceiptError).code).toBe('RESPONSE_RECEIPT_INVALID');
+    }
+  });
+
+  it('enforces bounded request IDs while preserving valid Unicode bytes', () => {
+    expect(() => encodeReplyReceipt({ ...receipt, requestId: '😀'.repeat(65) })).toThrow(
+      ReplyReceiptError
+    );
+    expect(() => encodeReplyReceipt({ ...receipt, requestId: 'a'.repeat(257) })).toThrow(
+      ReplyReceiptError
+    );
+    expect(MAX_REPLY_RECEIPT_LENGTH).toBe(8192);
+  });
+});

--- a/src/reply-receipt.ts
+++ b/src/reply-receipt.ts
@@ -1,0 +1,153 @@
+import { TextDecoder } from 'node:util';
+import type { RequestEndpoint } from './request-service.js';
+import { hasLoneSurrogate } from './domain/text-content.js';
+
+export const MAX_REPLY_RECEIPT_LENGTH = 8192;
+const MAX_RECEIPT_STRING_BYTES = 4096;
+
+export interface ReplyReceipt {
+  readonly version: 1;
+  readonly requestId: string;
+  readonly attemptId: string;
+  readonly endpoint: RequestEndpoint;
+}
+
+export type ReplyReceiptErrorCode = 'RESPONSE_RECEIPT_INVALID' | 'RESPONSE_RECEIPT_MISMATCH';
+
+export class ReplyReceiptError extends Error {
+  constructor(
+    public readonly code: ReplyReceiptErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = 'ReplyReceiptError';
+  }
+}
+
+function invalid(message = 'Response receipt is invalid.', cause?: unknown): ReplyReceiptError {
+  return new ReplyReceiptError('RESPONSE_RECEIPT_INVALID', message, { cause });
+}
+
+function assertBoundedString(value: unknown, label: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    hasLoneSurrogate(value) ||
+    Buffer.byteLength(value, 'utf8') > MAX_RECEIPT_STRING_BYTES
+  ) {
+    throw invalid(`Response receipt ${label} is invalid.`);
+  }
+}
+
+function assertEndpoint(endpoint: unknown): asserts endpoint is RequestEndpoint {
+  if (!endpoint || typeof endpoint !== 'object' || Array.isArray(endpoint)) {
+    throw invalid('Response receipt endpoint is invalid.');
+  }
+  const value = endpoint as Record<string, unknown>;
+  const keys = Object.keys(value).sort();
+  if (
+    keys.join('\u0000') !==
+    ['paneId', 'panePid', 'serverId', 'serverPid', 'serverStartTime', 'socketPath'].join('\u0000')
+  ) {
+    throw invalid('Response receipt endpoint is invalid.');
+  }
+  assertBoundedString(value.serverId, 'serverId');
+  assertBoundedString(value.socketPath, 'socketPath');
+  assertBoundedString(value.serverStartTime, 'serverStartTime');
+  assertBoundedString(value.paneId, 'paneId');
+  if (!/^%\d+$/.test(value.paneId)) throw invalid('Response receipt paneId is invalid.');
+  if (!Number.isSafeInteger(value.serverPid) || (value.serverPid as number) <= 0) {
+    throw invalid('Response receipt serverPid is invalid.');
+  }
+  if (!Number.isSafeInteger(value.panePid) || (value.panePid as number) <= 0) {
+    throw invalid('Response receipt panePid is invalid.');
+  }
+}
+
+function validateReceipt(value: unknown): ReplyReceipt {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw invalid();
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (keys.join('\u0000') !== ['attemptId', 'endpoint', 'requestId', 'version'].join('\u0000')) {
+    throw invalid();
+  }
+  if (record.version !== 1) throw invalid('Response receipt version is invalid.');
+  assertBoundedString(record.requestId, 'requestId');
+  if (Buffer.byteLength(record.requestId, 'utf8') > 256) {
+    throw invalid('Response receipt requestId is invalid.');
+  }
+  assertBoundedString(record.attemptId, 'attemptId');
+  assertEndpoint(record.endpoint);
+  return {
+    version: 1,
+    requestId: record.requestId,
+    attemptId: record.attemptId,
+    endpoint: {
+      serverId: record.endpoint.serverId,
+      socketPath: record.endpoint.socketPath,
+      serverPid: record.endpoint.serverPid,
+      serverStartTime: record.endpoint.serverStartTime,
+      paneId: record.endpoint.paneId,
+      panePid: record.endpoint.panePid,
+    },
+  };
+}
+
+/** Encode a versioned, canonical, unpadded base64url correlation receipt. */
+export function encodeReplyReceipt(value: ReplyReceipt): string {
+  const receipt = validateReceipt(value);
+  const encoded = Buffer.from(JSON.stringify(receipt), 'utf8').toString('base64url');
+  if (encoded.length > MAX_REPLY_RECEIPT_LENGTH) {
+    throw invalid('Response receipt exceeds the maximum length.');
+  }
+  return encoded;
+}
+
+/** Decode and validate a receipt; positional request ID correlation is checked when supplied. */
+export function decodeReplyReceipt(encoded: string, requestId?: string): ReplyReceipt {
+  if (
+    typeof encoded !== 'string' ||
+    encoded.length === 0 ||
+    encoded.length > MAX_REPLY_RECEIPT_LENGTH ||
+    !/^[A-Za-z0-9_-]+$/.test(encoded)
+  ) {
+    throw invalid();
+  }
+  let decoded: string;
+  try {
+    decoded = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(
+      Buffer.from(encoded, 'base64url')
+    );
+  } catch (error) {
+    throw invalid('Response receipt is not valid UTF-8.', error);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch (error) {
+    throw invalid('Response receipt is not valid JSON.', error);
+  }
+  const receipt = validateReceipt(parsed);
+  if (Buffer.from(decoded, 'utf8').toString('base64url') !== encoded) {
+    throw invalid('Response receipt is not canonical.');
+  }
+  if (requestId !== undefined && receipt.requestId !== requestId) {
+    throw new ReplyReceiptError(
+      'RESPONSE_RECEIPT_MISMATCH',
+      'Response receipt does not match the requested ID.'
+    );
+  }
+  return receipt;
+}
+
+export function validateReplyRequestId(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0 || hasLoneSurrogate(value)) {
+    throw new Error('Request ID must be a non-empty string.');
+  }
+  if (Buffer.byteLength(value, 'utf8') > 256) {
+    throw new Error('Request ID must not exceed 256 UTF-8 bytes.');
+  }
+}

--- a/src/response-content.test.ts
+++ b/src/response-content.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { PassThrough, Readable } from 'node:stream';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { MAX_RESPONSE_BYTES } from './domain/response.js';
+import {
+  RESPONSE_INPUT_TIMEOUT_MS,
+  ResponseInputError,
+  readResponseFile,
+  readResponseStdin,
+} from './response-content.js';
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+function temporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-response-input-'));
+  directories.push(directory);
+  return directory;
+}
+
+function expectInputError(action: () => unknown, code: ResponseInputError['code']): void {
+  try {
+    action();
+    expect.fail('expected response input validation to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ResponseInputError);
+    expect((error as ResponseInputError).code).toBe(code);
+  }
+}
+
+describe('durable reply body input', () => {
+  it('preserves BOM, NUL, CRLF, Unicode, whitespace, and marker-like text byte-for-byte', () => {
+    const directory = temporaryDirectory();
+    const file = path.join(directory, 'reply.txt');
+    const body = '\ufefffirst\r\n\u0000日本語 😀\r\nRESPONSE-END-fake\n  ';
+    fs.writeFileSync(file, Buffer.from(body, 'utf8'));
+    expect(readResponseFile(file)).toBe(body);
+
+    const whitespace = path.join(directory, 'whitespace.txt');
+    fs.writeFileSync(whitespace, Buffer.from('\ufeff \r\n\t', 'utf8'));
+    expect(readResponseFile(whitespace)).toBe('\ufeff \r\n\t');
+  });
+
+  it('strictly rejects malformed UTF-8 and always closes the file descriptor', () => {
+    const directory = temporaryDirectory();
+    const file = path.join(directory, 'invalid.txt');
+    fs.writeFileSync(file, Buffer.from([0xc3, 0x28]));
+    const open = vi.spyOn(fs, 'openSync');
+    const close = vi.spyOn(fs, 'closeSync');
+    try {
+      expectInputError(() => readResponseFile(file), 'RESPONSE_INPUT_INVALID');
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(() => fs.fstatSync(open.mock.results[0]!.value as number)).toThrow(/EBADF/);
+    } finally {
+      open.mockRestore();
+      close.mockRestore();
+    }
+  });
+
+  it('accepts exactly the byte limit and rejects cap-plus-one without partial decoding', () => {
+    const directory = temporaryDirectory();
+    const exact = path.join(directory, 'exact.txt');
+    const oversized = path.join(directory, 'oversized.txt');
+    fs.writeFileSync(exact, Buffer.alloc(MAX_RESPONSE_BYTES, 0x61));
+    fs.writeFileSync(
+      oversized,
+      Buffer.concat([Buffer.alloc(MAX_RESPONSE_BYTES, 0x61), Buffer.from('x')])
+    );
+    expect(Buffer.byteLength(readResponseFile(exact), 'utf8')).toBe(MAX_RESPONSE_BYTES);
+    expectInputError(() => readResponseFile(oversized), 'RESPONSE_INPUT_TOO_LARGE');
+  });
+
+  it('follows symlinks to regular files and rejects directories, devices, and FIFOs', () => {
+    const directory = temporaryDirectory();
+    const regular = path.join(directory, 'regular.txt');
+    const symlink = path.join(directory, 'link.txt');
+    fs.writeFileSync(regular, 'reply');
+    fs.symlinkSync(regular, symlink);
+    expect(readResponseFile(symlink)).toBe('reply');
+    expectInputError(
+      () => readResponseFile(path.join(directory, 'missing.txt')),
+      'RESPONSE_FILE_ERROR'
+    );
+    expectInputError(() => readResponseFile(directory), 'RESPONSE_FILE_ERROR');
+    expectInputError(() => readResponseFile('/dev/null'), 'RESPONSE_FILE_ERROR');
+
+    const fifo = path.join(directory, 'reply.fifo');
+    execFileSync('mkfifo', [fifo]);
+    expectInputError(() => readResponseFile(fifo), 'RESPONSE_FILE_ERROR');
+    const empty = path.join(directory, 'empty.txt');
+    fs.writeFileSync(empty, Buffer.alloc(0));
+    expect(readResponseFile(empty)).toBe('');
+  });
+
+  it('reads stdin until EOF and removes listeners while pausing the stream', async () => {
+    const input = new PassThrough();
+    const promise = readResponseStdin(input);
+    input.end(Buffer.from('\ufeffline\r\n日本語\u0000', 'utf8'));
+    await expect(promise).resolves.toBe('\ufeffline\r\n日本語\u0000');
+    expect(input.listenerCount('data')).toBe(0);
+    expect(input.listenerCount('end')).toBe(0);
+    expect(input.listenerCount('error')).toBe(0);
+    expect(input.isPaused()).toBe(true);
+  });
+
+  it('accepts the exact stdin byte limit across split multibyte chunks', async () => {
+    const input = new PassThrough();
+    const promise = readResponseStdin(input);
+    input.write(Buffer.alloc(MAX_RESPONSE_BYTES - 4, 0x61));
+    input.write(Buffer.from([0xf0]));
+    input.write(Buffer.from([0x9f, 0x98]));
+    input.end(Buffer.from([0x80]));
+    await expect(promise).resolves.toBe('a'.repeat(MAX_RESPONSE_BYTES - 4) + '😀');
+    expect(input.listenerCount('data')).toBe(0);
+  });
+
+  it('rejects malformed UTF-8, cap-plus-one, and stream errors without accepting partial input', async () => {
+    const malformed = new PassThrough();
+    const malformedResult = readResponseStdin(malformed);
+    malformed.end(Buffer.from([0xc3, 0x28]));
+    await expect(malformedResult).rejects.toMatchObject({ code: 'RESPONSE_INPUT_INVALID' });
+
+    const oversized = new PassThrough();
+    const oversizedResult = readResponseStdin(oversized);
+    oversized.end(Buffer.concat([Buffer.alloc(MAX_RESPONSE_BYTES, 0x61), Buffer.from('x')]));
+    await expect(oversizedResult).rejects.toMatchObject({ code: 'RESPONSE_INPUT_TOO_LARGE' });
+    expect(oversized.listenerCount('data')).toBe(0);
+    expect(oversized.listenerCount('end')).toBe(0);
+    expect(oversized.listenerCount('error')).toBe(0);
+
+    const errored = new PassThrough();
+    const erroredResult = readResponseStdin(errored);
+    errored.destroy(new Error('input broke'));
+    await expect(erroredResult).rejects.toMatchObject({ code: 'RESPONSE_INPUT_INVALID' });
+    expect(errored.listenerCount('data')).toBe(0);
+    expect(errored.listenerCount('close')).toBe(0);
+    expect(errored.listenerCount('end')).toBe(0);
+    expect(errored.listenerCount('error')).toBe(0);
+  });
+
+  it('rejects string/object stream chunks and a close before EOF', async () => {
+    const stringInput = new PassThrough();
+    stringInput.setEncoding('utf8');
+    const stringResult = readResponseStdin(stringInput);
+    stringInput.end('text');
+    await expect(stringResult).rejects.toMatchObject({ code: 'RESPONSE_INPUT_INVALID' });
+
+    const objectInput = new Readable({ objectMode: true, read() {} });
+    const objectResult = readResponseStdin(objectInput);
+    objectInput.push({ chunk: 'not bytes' });
+    await expect(objectResult).rejects.toMatchObject({ code: 'RESPONSE_INPUT_INVALID' });
+
+    const closed = new PassThrough();
+    const closedResult = readResponseStdin(closed);
+    closed.destroy();
+    await expect(closedResult).rejects.toMatchObject({ code: 'RESPONSE_INPUT_INVALID' });
+  });
+
+  it('accepts EOF before the deadline and leaves no timer-visible listeners', async () => {
+    const input = new PassThrough();
+    const result = readResponseStdin(input, 100);
+    setTimeout(() => input.end(Buffer.from('done')), 5);
+    await expect(result).resolves.toBe('done');
+    expect(input.listenerCount('data')).toBe(0);
+    expect(input.listenerCount('end')).toBe(0);
+    expect(input.listenerCount('error')).toBe(0);
+    expect(input.listenerCount('close')).toBe(0);
+  });
+
+  it('returns a typed deadline error and cleans up timer/listeners', async () => {
+    vi.useFakeTimers();
+    const input = new Readable({ read() {} });
+    const now = vi.spyOn(performance, 'now').mockReturnValueOnce(0).mockReturnValue(101);
+    try {
+      const result = readResponseStdin(input, 100);
+      expect(vi.getTimerCount()).toBe(1);
+      // EOF arrives after the monotonic deadline but before the timer callback;
+      // checking the clock in the EOF path prevents accepting late input.
+      input.emit('end');
+      await expect(result).rejects.toMatchObject({
+        code: 'RESPONSE_INPUT_TIMEOUT',
+        message: expect.any(String),
+      });
+      expect(vi.getTimerCount()).toBe(0);
+      expect(input.listenerCount('data')).toBe(0);
+      expect(input.listenerCount('end')).toBe(0);
+      expect(input.listenerCount('error')).toBe(0);
+      expect(input.isPaused()).toBe(true);
+    } finally {
+      now.mockRestore();
+      vi.useRealTimers();
+    }
+    expect(RESPONSE_INPUT_TIMEOUT_MS).toBe(5000);
+  });
+
+  it('rejects TTY stdin before installing listeners', async () => {
+    const input = new PassThrough();
+    Object.defineProperty(input, 'isTTY', { value: true });
+    await expect(readResponseStdin(input)).rejects.toMatchObject({
+      code: 'RESPONSE_INPUT_INVALID',
+    });
+    expect(input.listenerCount('data')).toBe(0);
+  });
+});

--- a/src/response-content.ts
+++ b/src/response-content.ts
@@ -1,0 +1,193 @@
+import { TextDecoder } from 'node:util';
+import type { Readable } from 'node:stream';
+import { BoundedFileReadError, readBoundedUtf8File } from './bounded-utf8-file.js';
+import { MAX_RESPONSE_BYTES } from './domain/response.js';
+
+export const RESPONSE_INPUT_TIMEOUT_MS = 5000;
+
+export type ResponseInputErrorCode =
+  | 'RESPONSE_INPUT_INVALID'
+  | 'RESPONSE_INPUT_TOO_LARGE'
+  | 'RESPONSE_INPUT_TIMEOUT'
+  | 'RESPONSE_FILE_ERROR';
+
+export class ResponseInputError extends Error {
+  constructor(
+    public readonly code: ResponseInputErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = 'ResponseInputError';
+  }
+}
+
+function decodeBody(bytes: Buffer): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
+  } catch (error) {
+    throw new ResponseInputError('RESPONSE_INPUT_INVALID', 'Response input is not valid UTF-8.', {
+      cause: error,
+    });
+  }
+}
+
+/** Read a complete bounded response from an explicitly selected regular file. */
+export function readResponseFile(filePath: string): string {
+  try {
+    return readBoundedUtf8File(filePath, MAX_RESPONSE_BYTES);
+  } catch (error) {
+    if (error instanceof BoundedFileReadError) {
+      if (error.kind === 'too_large') {
+        throw new ResponseInputError(
+          'RESPONSE_INPUT_TOO_LARGE',
+          `Response body must not exceed ${MAX_RESPONSE_BYTES} UTF-8 bytes.`,
+          { cause: error }
+        );
+      }
+      if (error.kind === 'invalid') {
+        throw new ResponseInputError(
+          'RESPONSE_INPUT_INVALID',
+          'Response input is not valid UTF-8.',
+          { cause: error }
+        );
+      }
+      throw new ResponseInputError('RESPONSE_FILE_ERROR', 'Could not read response input file.', {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
+function pause(stream: Readable): void {
+  try {
+    stream.pause();
+  } catch {
+    // Cleanup must not replace the settled input result.
+  }
+}
+
+/** Read one complete EOF-delimited response from stdin with a hard deadline. */
+export function readResponseStdin(
+  input: Readable & { readonly isTTY?: boolean } = process.stdin,
+  timeoutMs = RESPONSE_INPUT_TIMEOUT_MS
+): Promise<string> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return Promise.reject(
+      new ResponseInputError('RESPONSE_INPUT_INVALID', 'Response input timeout is invalid.')
+    );
+  }
+  if (input.isTTY) {
+    return Promise.reject(
+      new ResponseInputError('RESPONSE_INPUT_INVALID', 'Response input cannot be a TTY.')
+    );
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const deadline = performance.now() + timeoutMs;
+    const expired = (): boolean => performance.now() >= deadline;
+
+    const cleanup = (): void => {
+      if (timer !== undefined) clearTimeout(timer);
+      input.removeListener('data', onData);
+      input.removeListener('end', onEnd);
+      input.removeListener('error', onError);
+      input.removeListener('close', onClose);
+      pause(input);
+    };
+    const settle = (result: { value: string } | { error: Error }): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if ('error' in result) reject(result.error);
+      else resolve(result.value);
+    };
+    const onData = (chunk: unknown): void => {
+      if (expired()) {
+        settle({
+          error: new ResponseInputError(
+            'RESPONSE_INPUT_TIMEOUT',
+            'Timed out while reading response input.'
+          ),
+        });
+        return;
+      }
+      if (!Buffer.isBuffer(chunk) && !(chunk instanceof Uint8Array)) {
+        settle({
+          error: new ResponseInputError(
+            'RESPONSE_INPUT_INVALID',
+            'Response input must be binary data.'
+          ),
+        });
+        return;
+      }
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += bytes.byteLength;
+      if (totalBytes > MAX_RESPONSE_BYTES) {
+        settle({
+          error: new ResponseInputError(
+            'RESPONSE_INPUT_TOO_LARGE',
+            `Response body must not exceed ${MAX_RESPONSE_BYTES} UTF-8 bytes.`
+          ),
+        });
+        return;
+      }
+      chunks.push(bytes);
+    };
+    const onEnd = (): void => {
+      if (expired()) {
+        settle({
+          error: new ResponseInputError(
+            'RESPONSE_INPUT_TIMEOUT',
+            'Timed out while reading response input.'
+          ),
+        });
+        return;
+      }
+      try {
+        settle({ value: decodeBody(Buffer.concat(chunks, totalBytes)) });
+      } catch (error) {
+        settle({
+          error:
+            error instanceof Error
+              ? error
+              : new ResponseInputError('RESPONSE_INPUT_INVALID', 'Response input is invalid.'),
+        });
+      }
+    };
+    const onError = (error: Error): void => {
+      settle({
+        error: new ResponseInputError('RESPONSE_INPUT_INVALID', 'Could not read response input.', {
+          cause: error,
+        }),
+      });
+    };
+    const onClose = (): void => {
+      settle({
+        error: new ResponseInputError(
+          'RESPONSE_INPUT_INVALID',
+          'Response input closed before EOF.'
+        ),
+      });
+    };
+
+    input.on('data', onData);
+    input.once('end', onEnd);
+    input.once('error', onError);
+    input.once('close', onClose);
+    timer = setTimeout(() => {
+      settle({
+        error: new ResponseInputError(
+          'RESPONSE_INPUT_TIMEOUT',
+          'Timed out while reading response input.'
+        ),
+      });
+    }, timeoutMs);
+    input.resume();
+  });
+}

--- a/src/role-content.ts
+++ b/src/role-content.ts
@@ -1,6 +1,5 @@
-import fs from 'node:fs';
-import { TextDecoder } from 'node:util';
 import { MAX_ROLE_BYTES, RoleContentError } from './domain/role.js';
+import { BoundedFileReadError, readBoundedUtf8File } from './bounded-utf8-file.js';
 
 export type RoleFileErrorCode = 'ROLE_FILE_ERROR';
 
@@ -17,50 +16,32 @@ export class RoleFileError extends Error {
 
 /** Read one bounded regular file and reject malformed UTF-8 before normalization. */
 export function readRoleFile(filePath: string): string {
-  let descriptor: number;
   try {
-    descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
-  } catch (_error) {
-    throw new RoleFileError('ROLE_FILE_ERROR', `Could not read role file '${filePath}'.`, {
-      cause: _error,
-    });
-  }
-  try {
-    const stat = fs.fstatSync(descriptor);
-    if (!stat.isFile()) {
-      throw new RoleFileError('ROLE_FILE_ERROR', `Role file '${filePath}' must be a regular file.`);
-    }
-    const buffer = Buffer.alloc(MAX_ROLE_BYTES + 1);
-    let offset = 0;
-    while (offset < buffer.length) {
-      const count = fs.readSync(descriptor, buffer, offset, buffer.length - offset, null);
-      if (count === 0) break;
-      offset += count;
-    }
-    if (offset > MAX_ROLE_BYTES) {
-      throw new RoleContentError(
-        'ROLE_INPUT_TOO_LARGE',
-        'Role content must not exceed 65536 bytes.'
-      );
-    }
-    let decoded: string;
-    try {
-      decoded = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(
-        buffer.subarray(0, offset)
-      );
-    } catch {
-      throw new RoleContentError(
-        'ROLE_INPUT_INVALID',
-        `Role file '${filePath}' is not valid UTF-8.`
-      );
-    }
-    return decoded;
+    return readBoundedUtf8File(filePath, MAX_ROLE_BYTES);
   } catch (error) {
-    if (error instanceof RoleFileError || error instanceof RoleContentError) throw error;
-    throw new RoleFileError('ROLE_FILE_ERROR', `Could not read role file '${filePath}'.`, {
-      cause: error,
-    });
-  } finally {
-    fs.closeSync(descriptor);
+    if (error instanceof BoundedFileReadError) {
+      if (error.kind === 'too_large') {
+        throw new RoleContentError(
+          'ROLE_INPUT_TOO_LARGE',
+          'Role content must not exceed 65536 bytes.'
+        );
+      }
+      if (error.kind === 'invalid') {
+        throw new RoleContentError(
+          'ROLE_INPUT_INVALID',
+          `Role file '${filePath}' is not valid UTF-8.`
+        );
+      }
+      if (error.kind === 'non_regular') {
+        throw new RoleFileError(
+          'ROLE_FILE_ERROR',
+          `Role file '${filePath}' must be a regular file.`
+        );
+      }
+      throw new RoleFileError('ROLE_FILE_ERROR', `Could not read role file '${filePath}'.`, {
+        cause: error,
+      });
+    }
+    throw error;
   }
 }

--- a/src/test-support/cli-process.ts
+++ b/src/test-support/cli-process.ts
@@ -1,0 +1,214 @@
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect } from 'vitest';
+import { CURRENT_MIGRATIONS } from '../storage/migrations.js';
+import { openStorageWithMigrations } from '../storage/sqlite-adapter.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+export const binPath = path.join(repoRoot, 'bin', 'tmux-team');
+
+export interface Sandbox {
+  readonly root: string;
+  readonly cwd: string;
+  readonly home: string;
+  readonly xdgConfigHome: string;
+  readonly globalDir: string;
+  readonly globalConfig: string;
+  readonly database: string;
+  readonly localConfig: string;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+export interface CliResult {
+  readonly status: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface CliRunOptions {
+  /** Bytes to write to stdin before closing it; omitted means stdin is ignored. */
+  readonly stdin?: string | Uint8Array;
+  /** Keep stdin open after writing, for deadline and cleanup scenarios. */
+  readonly closeStdin?: boolean;
+  /** Combined stdout/stderr bound. Reply JSON can exceed the legacy 1 MiB bound. */
+  readonly outputLimitBytes?: number;
+  /** Hard process-group deadline, including startup and cleanup. */
+  readonly deadlineMs?: number;
+}
+
+export type JsonDocument = Record<string, unknown>;
+
+export function createSandbox(): Sandbox {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'tmux-team-cli-contract-'));
+  try {
+    const cwd = path.join(root, 'cwd');
+    const home = path.join(root, 'home');
+    const xdgConfigHome = path.join(root, 'xdg');
+    mkdirSync(cwd);
+    mkdirSync(home);
+
+    const globalDir = path.join(xdgConfigHome, 'tmux-team');
+    return {
+      root,
+      cwd,
+      home,
+      xdgConfigHome,
+      globalDir,
+      globalConfig: path.join(globalDir, 'config.json'),
+      database: path.join(globalDir, 'tmux-team.db'),
+      localConfig: path.join(cwd, 'tmux-team.json'),
+      env: {
+        ...process.env,
+        HOME: home,
+        XDG_CONFIG_HOME: xdgConfigHome,
+        CODEX_HOME: path.join(home, '.codex'),
+      },
+    };
+  } catch (error) {
+    rmSync(root, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export function runCli(
+  sandbox: Sandbox,
+  args: readonly string[],
+  options: CliRunOptions = {}
+): Promise<CliResult> {
+  for (const key of ['TMUX', 'TMUX_PANE', 'TMUX_TEAM_HOME']) delete sandbox.env[key];
+  const outputLimitBytes = options.outputLimitBytes ?? 1024 * 1024;
+  const deadlineMs = options.deadlineMs ?? 5_000;
+  const hasStdin = options.stdin !== undefined;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [binPath, ...args], {
+      cwd: sandbox.cwd,
+      env: sandbox.env,
+      detached: true,
+      stdio: [hasStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    // Decode at the stream boundary so a multibyte UTF-8 character split
+    // across OS chunks cannot be corrupted by per-buffer toString() calls.
+    const stdoutStream = child.stdout;
+    const stderrStream = child.stderr;
+    if (!stdoutStream || !stderrStream) throw new Error('CLI subprocess output pipes unavailable.');
+    stdoutStream.setEncoding('utf8');
+    stderrStream.setEncoding('utf8');
+    let stdout = '';
+    let stderr = '';
+    let outputBytes = 0;
+    let timedOut = false;
+    let outputLimitExceeded = false;
+    const killProcessGroup = (): void => {
+      if (child.pid === undefined) return;
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        child.kill('SIGKILL');
+      }
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // The wrapper launches the TypeScript child; kill the process group so a
+      // timeout cannot leave that descendant running after the test exits.
+      killProcessGroup();
+    }, deadlineMs);
+    const readOutput =
+      (stream: 'stdout' | 'stderr') =>
+      (chunk: Buffer | string): void => {
+        const text = chunk.toString();
+        outputBytes += Buffer.byteLength(text);
+        if (outputBytes > outputLimitBytes) {
+          outputLimitExceeded = true;
+          killProcessGroup();
+          return;
+        }
+        if (stream === 'stdout') stdout += text;
+        else stderr += text;
+      };
+    stdoutStream.on('data', readOutput('stdout'));
+    stderrStream.on('data', readOutput('stderr'));
+    if (child.stdin) child.stdin.on('error', () => undefined);
+    if (hasStdin && child.stdin) {
+      if (options.closeStdin === false) child.stdin.write(options.stdin);
+      else child.stdin.end(options.stdin);
+    }
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      if (outputLimitExceeded) {
+        reject(new Error(`CLI subprocess exceeded the ${outputLimitBytes}-byte output bound.`));
+      } else reject(error);
+    });
+    child.on('close', (status, signal) => {
+      clearTimeout(timer);
+      if (outputLimitExceeded) {
+        reject(new Error(`CLI subprocess exceeded the ${outputLimitBytes}-byte output bound.`));
+      } else if (timedOut) {
+        reject(new Error(`CLI subprocess exceeded the ${deadlineMs} millisecond test bound.`));
+      } else {
+        resolve({ status, signal, stdout, stderr });
+      }
+    });
+  });
+}
+
+export function parseWholeStdout(result: CliResult): JsonDocument {
+  expect(result.signal).toBeNull();
+  expect(result.stderr).toBe('');
+  expect(result.stdout.trim()).not.toBe('');
+  // Parse the complete stream. Parsing only the final line would allow human
+  // output or a second JSON document to leak into JSON mode unnoticed.
+  const document = JSON.parse(result.stdout) as unknown;
+  expect(document).toBeTypeOf('object');
+  expect(document).not.toBeNull();
+  return document as JsonDocument;
+}
+
+export function expectError(result: CliResult, code: string, message?: string): JsonDocument {
+  const document = parseWholeStdout(result);
+  expect(document.error).toMatchObject({ code });
+  expect(document.error).toHaveProperty('message', expect.any(String));
+  expect((document.error as { message: string }).message.length).toBeGreaterThan(0);
+  if (message !== undefined) expect((document.error as { message: string }).message).toBe(message);
+  return document;
+}
+
+export function expectJsonSuccess(result: CliResult, value: JsonDocument): void {
+  expect(result.status).toBe(0);
+  expect(parseWholeStdout(result)).toEqual(value);
+}
+
+export function fileSnapshot(root: string): Record<string, string> {
+  const snapshot: Record<string, string> = {};
+  const visit = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) visit(entryPath);
+      else snapshot[path.relative(root, entryPath)] = readFileSync(entryPath, 'utf8');
+    }
+  };
+  visit(root);
+  return snapshot;
+}
+
+export async function withSandbox<T>(callback: (sandbox: Sandbox) => T | Promise<T>): Promise<T> {
+  const sandbox = createSandbox();
+  try {
+    return await callback(sandbox);
+  } finally {
+    rmSync(sandbox.root, { recursive: true, force: true });
+  }
+}
+
+export function initializeDatabase(sandbox: Sandbox): void {
+  let storage: ReturnType<typeof openStorageWithMigrations> | undefined;
+  try {
+    storage = openStorageWithMigrations(sandbox.database, CURRENT_MIGRATIONS);
+  } finally {
+    storage?.close();
+  }
+}


### PR DESCRIPTION
## Scope

- Issue: [TMT-38](https://linear.app/tigerpig-dev/issue/TMT-38/expose-bounded-durable-reply-submission-and-result-retrieval), first child of TMT-37.
- Add storage-only `reply <request-id> --receipt <receipt> (--file <path> | --stdin)` and `result <request-id>` adapters over the existing immutable response service.
- Deliver a bounded versioned correlation receipt, exact UTF-8 input, typed output/errors, and updated user-installed skills/help/completions.
- Default `talk` behavior is deliberately unchanged. TMT-39 owns receipt generation, durable waiting, and terminal-mode retirement. No daemon, inbox, schema change, dependency change, version bump, or publishing.

## Architecture and review

- Primary reviewer: Codex. Reviewed commit: `7c8b72ea34edd1d021f23c5bb1e511bbcc1a8850`.
- Personally reviewed all changed files, relevant parser/Context/service callers, input lifecycle, output contract, real-process test isolation, and distributed guidance. Luna performed the mandatory read-only pattern audit and bounded implementation; Gemini supplemented implementation review through TMT.
- Reuse: existing request service/endpoint types and transactional fences; role and reply adapters share a neutral bounded regular-file reader, not role normalization. Existing real-CLI test infrastructure is extracted once into test support.
- Corrections from primary review: preserve BOM, avoid duplicate JSON exit handling, reject irrelevant flags through Commander provenance rather than raw token scanning, restrict public error forwarding, test exact multibyte input and expired stored finals, and replace an existing same-millisecond request-order assumption with exact attempt correlation.
- Receipts are correlation, not authentication. Bodies preserve empty/whitespace/BOM/NUL/CRLF/Unicode/marker text up to 1 MiB. Stdin has a 5-second EOF deadline. Identical retained retries preserve the timestamp; conflicts never overwrite. Unavailable means no retained body, not cancellation or inferred status.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge: Code quality, Unit tests, Docker E2E, Native package matrix, and all six native targets passed on `7c8b72ea34edd1d021f23c5bb1e511bbcc1a8850` (run 33978831216).

- `pnpm check`: passed type checks, lint, formatting, and documented quality gates.
- `pnpm test:run`: 574 tests / 46 files passed; 94.42% statements and 86.96% branches, unchanged 90% / 85% gates.
- `pnpm test:e2e`: two local Docker runs each passed 58 tests / 14 files; the second ran the final production/test snapshot (352 seconds), with cleanup succeeding.
- Negative control: deliberately stripping BOM made the exact-body test fail; restored code and reran the full checks/tests successfully.
- `pnpm pack` followed by `node scripts/verify-packed-native-install.mjs --package-tarball <artifact> --expected-arch arm64 --expected-libc none`: clean darwin/arm64 packed native installation passed.
- Real CLI tests cover file/stdin limits and malformed input, request/attempt/endpoint fences, retry/conflict across invocations, pending/expired/unknown results, late and empty replies, state preservation, and isolated installed skill source bytes.
- Explicit Prettier checks for distributed Markdown and all three distributable skill validators passed.

## Project lifecycle

- Updated ARCHITECTURE.md, REQUEST-RESPONSE.md, DEVELOPMENT.md, README, all relevant installed skill/plugin mirrors, help, learn, and completion.
- Linear records bounded scope, design/audit decisions, review findings, verification evidence, and intentionally deferred TMT-39 work. TMT-37 stays open until both children are delivered.
- Branch: `codex/tmt-38-reply-cli`; dedicated worktree: `/Users/benhsieh/dev/tmt-38-reply-cli`. Cleanup only after authorized merge, recorded handoff, and clean/pushed verification.
