### PR TITLE
feat: replace terminal completion with durable replies (TMT-39)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,13 +48,13 @@ Unbind, pane death and rebind do not erase it. Binding failures never delete
 committed identities, regardless of whether they have a preamble or profile.
 
 Talk composes preambles once through a shared delivery-preparation path before
-existing wait marker framing and transport protection. A verified bound direct
+durable reply instructions and transport protection. A verified bound direct
 pane uses the same identity preamble as a name; unnamed panes use none. Storage
 lookup failure stops preparation rather than silently omitting the prefix.
 The `[SYSTEM: ...]` prefix is ordinary delivered text, not an authenticated
 provider system-message channel.
 
-Existing mode/every settings remain. Eligible attempts reserve identity-ID-keyed
+Existing preambleMode/preambleEvery settings remain. Eligible attempts reserve identity-ID-keyed
 SQLite cadence at effective counts 1, 1+N, ...; disabled/no-content/N=0 paths
 do not advance it. Set, clear and rebind do not reset cadence. No old JSON
 counter import or deletion occurs, so this cutover begins a fresh cadence.
@@ -73,24 +73,21 @@ There is no automatic preamble migration, role conversion or user-file deletion.
 These are invariants to protect. Known delivery
 gaps below remain limitations, not guarantees supplied by this document.
 
-## Request/response research boundary
+## Durable request/response boundary
 
-Current `talk --wait` completion and body extraction rely on terminal capture;
-a matching end marker is not proof of a complete, isolated response body.
-`check` is a diagnostic pane snapshot, not correlated response retrieval.
-The [request/response decision document](REQUEST-RESPONSE.md) records TMT-35's
-source evidence, capability limits and staged proposal. The shared request service
-now stores and retrieves immutable final bodies. Storage-only `reply` and `result`
-adapters expose that service; live `talk` integration is not implemented yet.
-Marker-based `talk` behavior remains unchanged.
-Keep this distinction
-and the document's verification status current as those slices are delivered.
+`talk` waits for an immutable final response through the existing request service
+by default. `--detach` sends the same receipt instruction but returns without
+observing completion. `reply` submits a complete body; `result` retrieves it.
+No terminal marker, capture, debounce, provider cleanup, idle state, summary or
+process exit determines completion. `check` remains a diagnostic pane snapshot.
+Cooperation is required: a recipient that never calls reply has no durable final.
 
-The accepted proposal now targets durable completion by default, timeout/detach,
-and a short human summary after successful final submission. TMT-36 owns the
-shared final-response service; TMT-37 owns the CLI cutover and shipped guidance.
-This supersedes the earlier opt-in proposal, not the current runtime contract.
-MCP/remote connectivity remains a separate future project.
+The [request/response decision document](REQUEST-RESPONSE.md) retains the historical
+research and current contracts. TMT-36 supplies the service, TMT-38 the bounded
+adapters, and TMT-39 the live cutover under TMT-37. Installed agent instructions
+require complete submission before a short truthful user summary. Delivery of a
+reply is not success of the requested task. Inbox, daemon, MCP/remote connectivity
+and memory remain outside this implementation.
 
 ## Message delivery and uncertainty
 
@@ -130,7 +127,8 @@ server ID, socket, server PID/start time, pane ID and pane PID. An endpoint is
 not a display name or `%pane_id` alone. Multiple waits on the same endpoint
 retain independent rows; the overlap warning is advisory and `--force` only
 suppresses that warning. This is bookkeeping isolation, not transport
-serialization or proof that terminal-captured responses cannot interleave.
+serialization or exactly-once agent processing. Finals are matched by request,
+attempt and full endpoint rather than by shared terminal output.
 
 Preparation and marking `sending` commit in separate short transactions before
 the external effect; no request transaction spans tmux, capture or polling.
@@ -187,8 +185,11 @@ provider-specific state machine or alternate database is introduced.
 complete final. `result <request-id>` reads a retained final without waiting.
 Both select storage-only Context capabilities: no live caller, pane reconciliation
 or tmux construction is required. Neither infers a request from a pane or name.
-The existing `talk` command does not generate receipts yet; TMT-39 owns that
-cutover. These adapters alone do not fix marker-based response extraction.
+`talk` generates the exact receipt after preparation and sends it inside the
+single recipient instruction frame, for both default waiting and detach. The
+frame bounds request instructions, not terminal output or result extraction.
+An instruction/encoding failure before beginSend settles definitely_failed and
+releases its waiter, refunding cadence through the existing service.
 
 The receipt is a versioned, bounded, canonical base64url JSON envelope containing
 the explicit request, attempt and complete recorded endpoint. It is correlation,
@@ -214,6 +215,31 @@ is formatted; exact-text consumers use JSON. Missing retained bodies return
 and expired results without inventing distinctions the service cannot establish.
 Submission conflicts use exit 5; stdin deadline uses exit 4. Neither timeout nor
 unavailable output cancels recipient work or changes service retention.
+
+## Talk observer and retired settings
+
+The parser rejects retired `--wait`, talk `--lines`, and explicit
+`--timeout`/`--detach` combinations before Context effects. `send` follows the
+same talk semantics. Runtime timing validation precedes preamble/request mutation:
+timeout is finite, positive and at most 24 hours; poll interval is finite and
+positive. Default timeout remains 180 seconds unless configured. Pre-send delay
+and configured paste-enter delay must be finite, non-negative and no greater
+than 2,147,483,647 milliseconds, avoiding timer overflow that could send early.
+
+The monotonic deadline starts immediately before beginSend/transport, after
+pre-send delay, preparation and receipt construction. It is checked before and
+after each synchronous getResponse read; equality or a read crossing the bound
+returns timeout, with no final read afterward. Sleeps are clamped to remaining
+time. Transport/Enter elapsed time counts, but synchronous transport cannot be
+cancelled mid-operation by this logical observer deadline. A retained late
+response remains available through result. No transaction spans polling.
+
+Wait/polling mode and extraction-only maxCaptureLines are absent from runtime
+types, defaults and resolved output. Raw stored values remain opaque and are
+not automatically rewritten. Explicit local `config clear mode` may remove
+that key; config set mode and global clear remain unsupported. captureLines
+still controls check diagnostics. Historical migrations/nonce columns stay
+unchanged; new talk attempts do not create a nonce.
 
 ## Caller context
 
@@ -331,11 +357,13 @@ use `USAGE_ERROR` without constructing Context; configuration parsing uses
 stderr when requested. Successful commands without a detailed result emit
 `{ok:true}`. A cleanup failure replaces a pending success with `CLEANUP_ERROR`
 and an effects warning, but cannot replace an existing primary failure/status.
-This is output consistency, not rollback of command effects.
+Failure replacement preserves only bounded data-property requestId/target/pane
+correlation from the pending document, never its response, receipt, endpoint or
+arbitrary fields. This is output consistency, not rollback of command effects.
 
-The alpha timeout envelope intentionally changes only its `error` string to
-`{code: "TIMEOUT", message}`. Exit 4, status, correlation/target fields and
-nullable partial response remain. SIGINT only signals and wakes the talk poll;
+Talk timeout uses `{code: "TIMEOUT", message}`, exit 4 and request/target/pane
+correlation, without partialResponse, nonce, endMarker or truncated. SIGINT
+only signals and wakes the talk poll;
 the awaited command flow releases its waiter and exits through the runner.
 It must not throw exit control flow across an event callback. Neither timeout
 nor interruption cancels recipient work or alters recorded delivery certainty.
@@ -369,6 +397,13 @@ unwritable output streams are outside the one-document guarantee.
 | [src/ui.ts](src/ui.ts), [src/exits.ts](src/exits.ts)                                                                                                                       | Presentation helpers and exit-code registry; do not invent conflicting mappings.                                                                                        |
 | [src/commands/install.ts](src/commands/install.ts), [src/update-check.ts](src/update-check.ts), [skills/](skills/), [plugins/](plugins/)                                   | User-facing integrations, instructions and updates. These differ from repository developer skills in `.agents/skills/`.                                                 |
 | [test/e2e/](test/e2e/), [scripts/](scripts/), [.github/workflows/ci.yml](.github/workflows/ci.yml)                                                                         | Docker fixtures/scenarios, orchestration/pack verification and CI. Unit tests are colocated with source; concurrency workers currently also live in `src/`.             |
+
+`src/commands/talk.ts` owns the bounded observer and existing request lifecycle
+composition. `src/talk-instruction.ts` owns recipient guidance only, using the
+shared response byte limit; it does not parse or infer terminal completion.
+The test mock independently recognizes the documented request instruction frame
+and invokes the public reply CLI, rather than importing a production response
+store or completing requests through a test-only endpoint.
 
 ## Dependency and module design rules
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -51,7 +51,9 @@ Use the [development skill](.agents/skills/tmt-dev/SKILL.md) to apply them.
   Direct file writes are not atomic or concurrency-safe. Follow the state owner's
   transaction/recovery contract, not an "atomic-like" write.
 - Message framing and adaptation belong to shared delivery implementation.
-  Current waits use `RESPONSE-END-<nonce>`; do not invent a second marker.
+  Talk completion comes only from the shared durable request service. Generated
+  request-instruction framing is not a terminal-output completion boundary.
+  Never add capture/idle/marker fallbacks or provider-specific result cleanup.
   The `!` policy protects coding-agent shell/bash mode, not TTY cosmetics.
   Consult ARCHITECTURE's message delivery and uncertainty contract before
   changing payload/fallback behavior.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,14 +100,25 @@ Test-support infrastructure is excluded from production coverage, like worker
 fixtures; this does not exclude the request service, domain rules or SQL adapter.
 Final-response tests use real temporary SQLite and an injected clock for exact
 submission/retention boundaries, plus independent processes for writer races.
-They do not imply the live CLI already consumes durable replies; TMT-37 owns that
-integration and its exact-body Docker/mock-agent acceptance scenarios.
+The live CLI consumes this same service; Docker/mock-agent scenarios verify
+request correlation and exact-body retrieval across the real CLI/tmux boundary.
 
 Reply adapter verification additionally exercises the real CLI in an isolated
 home and SQLite database, including file/stdin decoding, exact result text,
 idempotent retry across invocations and rejection without partial finalization.
 Input tests cover EOF, byte/deadline limits and listener/descriptor cleanup.
-These storage-only checks do not substitute for TMT-39's live tmux cutover tests.
+These storage-only checks do not substitute for live tmux cutover tests. The
+mock agent invokes the public reply CLI and logs request/submission/summary
+events; the virtualized-body test compares the exact complete response against
+an independent oracle even when terminal capture has only its tail. State
+oracles verify independent request IDs, immutable finals and waiter cleanup.
+Monotonic observer tests cover transport/read overruns and deadline equality;
+terminal markers or idle output must not produce completion.
+Reply-order scenarios release per-request gates after observing causal events,
+not elapsed sleeps. Fixture teardown stops producers before discovering active
+reply child groups, and verifies group absence even after a mock is forcibly
+killed. A stopped public reply child makes that cleanup regression observable
+instead of relying on EOF to let the child exit naturally.
 
 `docs:format:check` covers the architecture, policy, conventions, development
 guide, repository skills and PR template. It uses `.gitignore` as its ignore

--- a/README.md
+++ b/README.md
@@ -142,15 +142,19 @@ shows that pane's status. `talk` and `check` use the same target resolution.
 
 **Options for `talk`:**
 
-- `--timeout <seconds>` - Max wait time (default: 180s)
-- `--lines <number>` - Lines to capture from a response (default: 100)
-- `--wait` - Wait for a response before returning
+- `--timeout <time>` - Bound default durable waiting (default: 180s; positive, at most 24h)
+- `--detach` - Return a request ID after sending; mutually exclusive with explicit timeout
 - `--delay <seconds>` - Delay before sending
+
+`--wait` is retired. `--lines` belongs to diagnostic `check`, not `talk`.
+Time accepts seconds or ms/s suffixes. Stored mode and maxCaptureLines values
+are inert and preserved; `config clear mode` removes only the obsolete local key.
 
 ### Durable replies and results
 
-TMT-38 adds storage-only result adapters that work without tmux and can accept a
-late reply after a pane closes:
+Talk waits for a complete durable final by default. It sends an exact request
+ID/receipt to the recipient, who must submit a reply. The storage-only result
+adapters work without tmux and can accept a late reply after a pane closes:
 
 ```bash
 tmt reply <request-id> --receipt <receipt> --file response.md
@@ -160,10 +164,25 @@ tmt result <request-id> --json
 ```
 
 Use exactly one input source. The receipt must be supplied by TMT; do not
-manufacture one, look up the latest request, or infer a current pane. In this
-slice, `talk` still uses marker-based terminal capture and does not generate
-receipts; receipt generation and durable completion belong to TMT-39. There is
-no `--detach` or default durable-wait behavior yet.
+manufacture one, look up the latest request, or infer a current pane. Detached
+requests receive the same instructions. No reply means no durable final:
+terminal markers, idle output, summaries and process exit cannot complete talk.
+This is local storage access, not an inbox, listener or remote transport.
+
+```bash
+tmt talk reviewer "Review this patch" --timeout 300 --json
+tmt talk reviewer "Run the agreed tests" --detach --json
+tmt result <request-id> --json
+```
+
+Detach returns `{status:"sent",requestId,target,pane,identity?}`, not task success.
+Completed talk returns that correlation with `status:"completed"`, exact
+`response`, `bodyBytes` and `submittedAtMs`, matching result retrieval.
+The observer clock begins immediately before send after preparation/delay;
+transport/Enter time counts, but cannot be cancelled mid-operation. Equality
+with the deadline, or a response read crossing it, yields timeout; no final
+post-deadline read occurs. Late results remain retrievable. Do not resend
+merely because a caller timed out or was interrupted.
 
 Reply input preserves the complete valid UTF-8 body, including empty or
 whitespace text, BOM, NUL, CR/LF, Unicode, and marker-like text, up to 1 MiB.
@@ -255,15 +274,15 @@ tmt config set pasteEnterDelayMs 500
 
 Once paste or literal input may have reached a pane, TMT does not automatically
 replay it. A failed input/submission stage returns `DELIVERY_UNCERTAIN` (exit 1)
-in both wait and non-wait modes, with `error.stage` in JSON. Inspect the pane
+for both default wait and detach, with request ID and `error.stage` in JSON. Inspect the pane
 before deciding whether to retry; absent visible output does not prove that no
 work started. Successful submission does not promise exactly-once processing.
 Each transport/capture subprocess is bounded independently of the configured
 Enter delay and response wait timeout.
 
-Response waits still use best-effort terminal extraction: a completion marker
-does not guarantee a full body under virtual scrolling. `check` is a diagnostic
-snapshot, not durable response retrieval. See the
+Response waits retrieve exact durable bodies without terminal extraction or
+provider-specific cleanup. `check` is a diagnostic snapshot, not durable result
+retrieval. Same-pane input serialization is not guaranteed. See the
 [channel research and implementation plan](REQUEST-RESPONSE.md).
 
 ## Local SQLite storage
@@ -399,20 +418,20 @@ Each `talk` attempt records its own ID and complete tmux server/pane instance
 in SQLite, including direct unnamed panes. Concurrent waiters never replace
 one another's rows; an overlap warning is advisory, and `--force` only suppresses
 the warning. Cleanup affects only its own attempt. Transactions end before
-transport and capture, so a waiting agent does not hold the database writer lock.
+transport and polling, so a waiting agent does not hold the database writer lock.
 
 An attempt is prepared before transmission and marked sending immediately
 before invoking it. A crash after sending starts is uncertain, never permission
 to retry. Timeout or interruption releases the waiter, not the recipient's
 work. Expired prepared attempts can refund their reservations; expired sending
 attempts remain consumed as uncertain. Attempt metadata is pruned opportunistically
-after terminal retention; cadence totals persist. No prompt or response body is
-stored by this bookkeeping feature.
+after terminal retention; cadence totals persist. Prompts are not stored;
+complete final responses are stored separately by the shared request service.
 
 `REQUEST_STATE_ERROR` (exit 1) reports a bookkeeping failure. When delivery may
 already have occurred, inspect the pane before retrying; a failed state write
-does not mean the message was not sent. The existing terminal-marker response
-and truncation limitations remain unchanged.
+does not mean the message was not sent. Preserve its request ID to inspect
+the retained result; do not infer that retrying is safe.
 
 Old preambles in JSON or workspace metadata are ignored, not automatically
 imported or deleted. Reapply desired text using `preamble set`. A preamble lookup
@@ -433,11 +452,12 @@ the command boundary. `CLEANUP_ERROR` after successful work does not roll back
 its effects; inspect state before retrying. A cleanup failure alongside an
 existing command failure preserves that primary error and status.
 
-This v5 alpha intentionally changes the timeout `error` field from a string to
-`{ "code": "TIMEOUT", "message": "..." }`. The existing `status`, target,
-pane, identity when present, request ID, nonce, end marker and nullable
-`partialResponse` remain. Read `error.message` instead of treating `error` as
-text. Timeout and Ctrl+C release the waiter, not recipient work.
+Talk timeout returns `status:"timeout"`, request ID, target/pane correlation and
+`error:{code:"TIMEOUT",message:"..."}` (exit 4), without partialResponse,
+nonce, endMarker or truncated. Timeout and Ctrl+C release the waiter, not
+recipient work. Use `tmt result <request-id> --json` later. Failure replacement
+after a pending result preserves bounded request ID/target/pane inspection
+fields, not its raw response or receipt.
 
 `help`, `version`, `completion`, and `learn` remain text-only; combining them
 with `--json` returns `JSON_UNSUPPORTED` before output or effects. `upgrade`

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -2,18 +2,18 @@
 
 Status: historical research based on `cecaec7` (2026-09-05), with the accepted
 direction and TMT-36 service contract maintained below. The shared final-response
-service and explicit reply/result adapters are implemented; the default live
-`talk` cutover remains TMT-39 under TMT-37. No provider integration, daemon,
+service, explicit reply/result adapters and default durable `talk` are implemented
+through TMT-36/38/39 under TMT-37. No provider integration, daemon,
 inbox or memory feature is supplied here.
 
-## Accepted direction (2026-09-05; CLI integration not yet shipped)
+## Accepted direction and implemented CLI contract
 
 The [accepted design](https://linear.app/tigerpig-dev/document/accepted-design-durable-replies-automatic-completion-and-human-21745047ee15)
 supersedes the earlier opt-in proposal below. TMT-36 adds immutable full replies
 to the existing request service; TMT-37 changes the CLI to wait for a durable
 reply by default, with bounded `--timeout` and explicit `--detach`, retiring
-`--wait` and the polling/wait mode switch. The default-wait change remains a
-proposal, not installed behavior. Explicit `reply`/`result` adapters are described
+`--wait` and the polling/wait mode switch. The default-wait change is implemented
+by TMT-39. Explicit `reply`/`result` adapters are described
 below. Terminal capture and `check` must not be treated as authoritative durable
 completion or full-body retrieval.
 
@@ -81,8 +81,8 @@ tmt result <request-id> [--json]
 The receipt is an explicit version-1 base64url envelope of request ID, attempt ID
 and the complete six-field endpoint. Its encoded length is at most 8192 characters.
 It is not authentication. The recipient must use the supplied receipt, not infer
-the latest request from a pane. Current `talk` does not supply one yet; TMT-39
-owns generation and delivery. No receipt is included in routine result/ack output.
+the latest request from a pane. `talk` supplies it in the recipient instruction,
+including detached requests. No receipt is included in routine result/ack output.
 
 Files must resolve to regular files; symlinks are followed, and descriptors are
 closed after bounded reads. Explicit stdin requires EOF within five seconds.
@@ -103,6 +103,44 @@ truthful short user summary only after successful submission. Submission means
 the result was delivered, not that the requested task succeeded. Summary failure
 does not undo or justify repeating an accepted final.
 
+### TMT-39 live durable completion
+
+`talk <target> <message> [--timeout <time> | --detach] [--json]` waits for the
+shared service's complete final by default. It no longer captures or cleans
+terminal output to determine completion. `send` follows the same semantics.
+The recipient must cooperate by invoking reply; idle output, fake markers,
+process exit and human summaries do not complete a request.
+
+Timeout defaults to 180 seconds unless configured, accepts finite positive
+seconds or ms/s suffixes, and is bounded to 24 hours. Explicit timeout and
+detach are mutually exclusive. The monotonic deadline starts immediately before
+beginSend/transport, after delay/preparation/receipt encoding. Checks before and
+after each synchronous response read treat equality or crossing as timeout;
+there is no final post-deadline read. Poll sleeps are bounded by remaining time.
+Synchronous transport/Enter time counts, but cannot be cancelled mid-operation.
+Timeout/interruption only releases the observer; late results remain retrievable.
+
+Detached JSON is `{status:"sent",requestId,target,pane,identity?}`. Completed
+talk returns `status:"completed"`, the same correlation and exact `response`,
+`bodyBytes`, `submittedAtMs`. Timeout uses `status:"timeout"`, request/target/pane
+correlation and `error:{code:"TIMEOUT",message}` (exit 4), without partialResponse,
+nonce, endMarker or truncated. Delivery/state uncertainty remains nonzero and
+retains inspection correlation, never automatic resend. Failure during receipt
+construction before beginSend refunds a proven-unsent reservation.
+
+`--wait` is rejected with migration guidance; talk rejects `--lines` while check
+retains it. Stored mode/maxCaptureLines values are inert, not automatically
+rewritten; explicit local `config clear mode` deletes only that obsolete key.
+Historical migrations/nonce columns stay unchanged; new attempts omit nonce.
+
+The Docker peer submits through the real public reply CLI, logs causal
+request/submitted/summary or failure events, and retains a full-body oracle.
+Virtualized output exposes only its tail; acceptance requires exact complete
+talk/result equality, not a missing-interior characterization. Same-pane input
+serialization, exactly-once processing, inbox and remote authentication are
+still outside scope. User-installed skills teach full submission first, then
+a truthful work/tests/blockers summary; failed submission is never success.
+
 TMT-24 implementation update: transport now prevents replay after an input
 stage may have acted, preserves the same `!` protection on fallback, reports
 `DELIVERY_UNCERTAIN`, and bounds argv-based capture. The current implementation
@@ -111,7 +149,7 @@ longer present. At that baseline, request/response storage, instruction-boundary
 extraction and structured final-body delivery remained unresolved. See ARCHITECTURE.md for the
 maintained shipped transport boundary.
 
-## Current implementation map
+## Historical implementation map (research baseline, not current runtime)
 
 TMT-25 implementation update: request/attempt bookkeeping and identity cadence
 now share the existing SQLite connection through an application service.
@@ -120,8 +158,8 @@ cleanup, and short transactions outside tmux effects. Cadence uses reservations,
 not an exact ordering of successful concurrent sends. Old JSON state is ignored
 and preserved. The map and matrix below remain the historical research baseline;
 see ARCHITECTURE.md for the maintained shipped state. Final-body
-storage is implemented by TMT-36; TMT-37 live structured reply integration is
-still not shipped.
+storage is implemented by TMT-36; TMT-38/39 now implement TMT-37's live durable
+reply integration. The following marker/JSON-state descriptions are historical.
 
 `cmdTalk` resolves one target, then either sends and returns (`talk` without
 `--wait`) or creates a request ID, random nonce, and
@@ -261,9 +299,9 @@ provider integration test was run.
 - [Gemini headless CLI](https://geminicli.com/docs/cli/headless/): headless operation can provide response JSON or message chunks plus a result. TMT should consume a bounded final result, not invent a second chunk protocol.
 - [tmux manual](https://raw.githubusercontent.com/tmux/tmux/master/tmux.1): capture reads pane screen/history, while pipe-pane receives program output. A pane supports one pipe command at a time. Neither supplies semantic request ownership; neither can recover text never rendered or emitted. Correlation alone also cannot restore missing text.
 
-## User-observable contract: current versus proposal
+## Historical user-observable contract: research baseline versus proposal
 
-Current behavior is observable as `status: sent` for non-wait sends,
+At the research baseline, behavior was observable as `status: sent` for non-wait sends,
 `status: completed` with `requestId`, `nonce`, `endMarker`, and `response` for
 marker-detected waits, and `status: timeout` with optional `partialResponse`.
 Human output also prints a response extracted from the pane.
@@ -278,9 +316,9 @@ this document does not commit to them.
 
 ## Verification matrix
 
-### Research diagnostic, not a delivered channel
+### Historical research diagnostic, now replaced by full-body acceptance
 
-`test/e2e/response-integrity.e2e.test.ts` exercises the real CLI against the
+Before TMT-39, `test/e2e/response-integrity.e2e.test.ts` exercised the real CLI against the
 existing private-server fixture in `virtualized` mock mode. The mock constructs
 a full 202-line plain-text body, renders only its last three lines and the
 completion marker, then records the full body in its causal event. The scenario
@@ -314,8 +352,8 @@ Implementation work should add deterministic tests for:
 - durable state preservation after failed finalization and cleanup after
   success, timeout, cancellation, and thrown errors.
 
-The E2E cases should assert JSON fields plus causal mock-agent events keyed by
-nonce and PID, not terminal echo alone. Use barriers and bounded polling rather
+The E2E cases now assert JSON fields plus causal mock-agent events keyed by
+request ID and PID, not terminal echo alone. Use barriers and bounded polling rather
 than fixed sleeps, and run the Docker suite twice when lifecycle/cleanup code
 changes. Provider-source adapters should use recorded fixtures and remain
 network-free; no actual provider integration result is claimed here.

--- a/plugins/tmux-team/commands/learn.md
+++ b/plugins/tmux-team/commands/learn.md
@@ -15,7 +15,8 @@ Each agent runs in its own tmux pane. When you want to talk to another agent:
 
 1. Your message is pasted via a tmux buffer
 2. tmux-team waits briefly, then sends Enter to submit
-3. You read their response by capturing their pane output
+3. The recipient submits its complete final through `tmt reply`
+4. Talk returns that retained body; `check` is a diagnostic snapshot only
 
 ## Essential Commands
 
@@ -24,7 +25,7 @@ Each agent runs in its own tmux pane. When you want to talk to another agent:
 tmt list
 
 # Send and wait for response (recommended); use a name or pane target
-tmt talk <target> "<message>" --wait
+tmt talk <target> "<message>" --json
 
 # Inspect output by name or pane target
 tmt check <target> 100
@@ -35,20 +36,20 @@ tmt check <target> 100
 ### Quick question to another agent
 
 ```bash
-tmt talk codex "What's the status of the authentication refactor?" --wait
+tmt talk codex "What's the status of the authentication refactor?" --json
 # Response is returned directly
 ```
 
-### Delegate a task with longer timeout and more output
+### Delegate a task with a longer timeout
 
 ```bash
-tmt talk codex "Please implement the login form. Reply when done." --wait --timeout 300 --lines 200
+tmt talk codex "Please implement the login form. Reply when done." --timeout 300 --json
 ```
 
 ### Address a named identity
 
 ```bash
-tmt talk codex "Sync: PR #123 was merged, please pull latest" --wait
+tmt talk codex "Sync: PR #123 was merged, please pull latest" --json
 ```
 
 The name `all` is an ordinary identity, not a special destination. To address
@@ -71,17 +72,24 @@ tmt config set pasteEnterDelayMs 500
 
 To find your pane ID, run: tmux display-message -p '#{pane_id}'
 
-## If --wait Times Out
+## Waiting and retrieving results
 
-If the agent takes longer than expected, --wait will timeout. Use the check command to retrieve the response later:
+Talk waits for a durable final by default, with 180 seconds unless configured.
+Use positive seconds or ms/s suffixes, at most 24 hours, for `--timeout`.
+Use `--detach` instead of explicit timeout to return a request ID after sending.
+On timeout, preserve that ID and retrieve the result later:
 
 ```bash
-# Check for response after timeout (default 100 lines)
-tmt check <target>
-
-# Check with more lines for long responses
-tmt check <target> 200
+tmt result <request-id> --json
+tmt check <target> 200  # diagnostics only
 ```
+
+`--wait` is retired; `--lines` belongs to check, not talk. Stored mode settings
+are inert; `config clear mode` removes only that local obsolete key. Timeout
+or interruption never cancels work or makes a resend safe. Transport/Enter
+time counts after preparation/delay but cannot be interrupted mid-operation.
+Markers, idle output and summaries never complete a request without a reply.
+Same-pane input serialization and exactly-once processing are not guaranteed.
 
 ## Durable result replies
 
@@ -93,10 +101,9 @@ tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
 
-Use exactly one input source and never manufacture a receipt, select the latest
-request, or infer a pane. `talk` is still marker-based in this release and
-does not generate receipts; TMT-39 owns receipt generation and durable
-completion. There is no `--detach` behavior yet. Submission confirms result
+Use exactly one input source and the exact request ID/receipt from the received
+talk instruction, including detached requests. Never manufacture a receipt,
+select the latest request, or infer a pane. Submission confirms result
 delivery, not task success; summarize only after a successful submission.
 
 An identical retry keeps the original submission timestamp; a different body
@@ -117,11 +124,11 @@ and conflicts exit 5. JSON unavailable output is
 
 ## Best Practices
 
-1. Use `--wait` for synchronous request/response; use `check` after timeout
+1. Submit the full reply before giving a brief truthful work/tests/blockers summary
 2. **Be explicit** - Tell the other agent exactly what you need and how to respond
 3. **Set timeout appropriately** - Use --timeout 300 for complex tasks
-4. **Use --lines for long responses** - Default is 100 lines, increase for verbose output
-5. **If timeout occurs** - Use "tmux-team check <target> [lines]" to retrieve the response
+4. **Use result for complete output** - Never reconstruct results from terminal capture
+5. **If timeout occurs** - Use `tmt result <request-id> --json`; do not automatically resend
 6. **Use stable pane IDs in scripts** - `tmt add` resolves window-style targets to `%pane_id`
 
 ## Your Next Step

--- a/plugins/tmux-team/commands/team.md
+++ b/plugins/tmux-team/commands/team.md
@@ -15,7 +15,7 @@ Based on what the user wants, use the tmux-team CLI to coordinate with other age
 
 To send a message to a global identity or direct pane target and wait for a
 response:
-tmt talk <target> "<message>" --wait
+tmt talk <target> "<message>" --json
 
 To see available agents:
 tmt list
@@ -42,11 +42,9 @@ tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
 
-Use exactly one input source. Use the supplied receipt; never manufacture one,
-look up the latest request, or infer a current pane. `talk` remains
-marker-based in this release and does not generate receipts; receipt
-generation and durable completion are staged for TMT-39. There is no
-`--detach` behavior yet. A successful submission confirms delivery of the
+Use exactly one input source and the request ID/receipt supplied by `talk`,
+including detached requests. Never manufacture a receipt, look up the latest
+request, or infer a current pane. A successful submission confirms delivery of the
 body, not success of the requested task, so give a truthful summary only
 after submission.
 
@@ -70,31 +68,43 @@ pending, unknown, or expired bodies; input errors exit 1, input timeout exits
 ## Examples
 
 User says: "tell codex to review the auth module"
-You run: tmt talk codex "Please review the auth module and share your findings" --wait
+You run: tmt talk codex "Please review the auth module and share your findings" --json
 
 User says: "ask gemini about the test coverage"
-You run: tmt talk gemini "What is the current test coverage status?" --wait
+You run: tmt talk gemini "What is the current test coverage status?" --json
 
 User says: "ask codex to review the refactor"
-You run: tmt talk codex "Please review the refactor before I continue." --wait
+You run: tmt talk codex "Please review the refactor before I continue." --json
 
 ## Options
 
-For long responses, increase timeout and lines captured:
+Talk waits for a complete durable final by default (180 seconds unless configured).
+Timeout accepts positive seconds or ms/s suffixes, at most 24 hours. For longer work:
 
-tmt talk <target> "<message>" --wait --timeout 300 --lines 200
+tmt talk <target> "<message>" --timeout 300 --json
 
-## If --wait Times Out
+Use `--detach` instead of explicit timeout to return the request ID after sending.
+`--wait` is retired; `--lines` belongs to diagnostic `check`, not `talk`.
+Stored mode settings are inert; `config clear mode` removes only the local key.
 
-Use the check command to retrieve the response with an optional line count:
+## If talk times out
 
-tmt check <target>
-tmt check <target> 200
+Preserve the request ID and retrieve the final later:
+
+```bash
+tmt result <request-id> --json
+tmt check <target> 200  # diagnostics only, not full result retrieval
+```
+
+Timeout and interruption end only the observer, not recipient work. Transport/Enter
+time counts after preparation/delay, but synchronous transport cannot be cancelled
+mid-operation. No reply means no durable final; idle output, markers and summaries
+do not complete a request. Same-pane input serialization is not guaranteed.
 
 ## Important
 
-- Use `--wait` when the user asks for a synchronous answer; `check` can read a
-  response later after timeout.
+- Wait by default, or detach and use `result` later; do not automatically resend
+  on timeout, cleanup failure or `DELIVERY_UNCERTAIN` (exit 1).
 - Craft clear, specific messages for the other agent
 - Preserve multiline messages and do not send pane input without authorization
 - After receiving a response, summarize it for the user

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -27,10 +27,10 @@ with `tmt check <target>` and establish whether work started before deciding
 what to do next. Missing visible output is not proof that nothing executed.
 Successful submission also does not guarantee exactly-once agent processing.
 
-`--wait` still extracts a best-effort terminal response. A completion marker
-can coexist with cropped content; increasing `check` lines cannot recover text
-that the agent never rendered. No durable structured response channel is
-implied by this transport safety behavior.
+`talk` waits for the complete durable reply by default. It never treats terminal
+markers, idle output, a summary, or process exit as completion. A cooperating
+recipient must invoke `tmt reply`; otherwise there is no final result yet.
+`check` is only a diagnostic snapshot, not correlated result retrieval.
 
 ## JSON results and failures
 
@@ -39,18 +39,18 @@ With `--json`, parse the entire stdout as one JSON document. Errors contain
 Check the exit status too: missing targets use 3, timeout 4, and conflicts 5.
 Successful commands without a detailed result return `{ok:true}`.
 
-The v5 alpha timeout contract now uses
-`error: {code: "TIMEOUT", message: "..."}` instead of a string. It retains
-`status: "timeout"`, correlation fields and nullable `partialResponse`.
-Timeout and interruption do not cancel recipient work. A `CLEANUP_ERROR`
-after successful work does not mean its effects were undone; inspect before
-retrying. Existing delivery-uncertainty guidance still applies.
+Timeout returns `status: "timeout"`, `requestId`, target/pane correlation and
+`error: {code: "TIMEOUT", message: "..."}` (exit 4). There is no partial response,
+nonce, end marker or truncation flag. Use `tmt result <request-id> --json` later.
+Timeout and interruption end only the observer, never recipient work. A
+`CLEANUP_ERROR` does not undo effects; preserve the request ID and inspect before
+retrying. Missing visible output is not permission to resend.
 
 `help`, `version`, `completion` and `learn` are text-only and reject
 `--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
 also rejects JSON mode because it streams installer output.
 
-## Durable replies and results (TMT-38)
+## Durable replies and results
 
 When TMT supplies an exact receipt, submit the complete result through the
 storage-only adapters:
@@ -61,10 +61,11 @@ tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
 
-Use exactly one input source. Never manufacture a receipt, select the latest
-request, or infer a current pane. `talk` remains marker-based terminal
-capture in this release and does not generate receipts; TMT-39 owns receipt
-generation and durable completion. There is no `--detach` behavior yet.
+Use exactly one input source and the exact request ID/receipt supplied in the
+received `talk` instruction, including detached requests. Never manufacture a
+receipt, select the latest request, or infer a current pane. Both `reply` and
+`result` are storage-only and work without a live pane on this same local
+TMT database; this is not an inbox, listener, remote transport or authentication.
 
 Reply input is one exact valid UTF-8 body up to 1 MiB, preserving empty,
 whitespace, BOM, NUL, CR/LF, Unicode, and marker-like text. Stdin is
@@ -91,6 +92,34 @@ Unavailable JSON is
 expired bodies. Input errors exit 1, input timeout is `RESPONSE_INPUT_TIMEOUT`
 (exit 4), and conflicts exit 5. Receipts, endpoints, and raw bodies are not
 echoed in acknowledgements.
+
+## Calling an agent
+
+`tmt talk <target> "message" [--timeout <time> | --detach] [--json]` waits for
+one durable final by default. The default is 180 seconds unless
+`defaults.timeout` is configured. Time accepts positive seconds or `ms`/`s`
+suffixes, at most 24 hours. Do not combine explicit timeout with detach.
+Pre-send delay accepts zero or a positive finite value, up to 2,147,483,647 ms.
+`--wait` is retired and rejected; `--lines` applies to check, not talk.
+Stored wait/polling mode settings are inert; `config clear mode` removes
+only the explicit local obsolete key, without migrating other settings.
+
+```bash
+tmt talk reviewer "Review this patch" --timeout 300 --json
+tmt talk reviewer "Run the agreed tests" --detach --json
+tmt result <request-id> --json
+tmt check reviewer 200  # diagnostics only
+```
+
+Detached success is `{status:"sent",requestId,target,pane,identity?}`, not task
+completion. Completed talk adds the exact `response`, `bodyBytes` and
+`submittedAtMs` to request/target/pane correlation. Preserve that request ID.
+
+The observer clock starts immediately before send, after pre-send delay and
+preparation. Transport/Enter time counts; synchronous transport cannot be
+cancelled mid-operation. A response read at or crossing the deadline is not
+accepted by that observer; it may still be retrieved with result afterward.
+Do not resend simply because a caller timed out or was interrupted.
 
 ## Identity preambles
 
@@ -123,7 +152,8 @@ Concurrent waits retain separate request records and remain advisory, not a
 single-flight lock. Timeout or interruption ends only that waiter; it does not
 cancel the recipient or undo sent cadence. `REQUEST_STATE_ERROR` (exit 1) can
 occur after possible delivery: follow its inspection guidance, never infer that
-retrying is safe. SQLite bookkeeping does not fix terminal response truncation.
+retrying is safe. Replies are correlated independently, but same-pane input
+serialization and exactly-once agent processing are not guaranteed.
 
 Old JSON/workspace-metadata preambles are ignored, not migrated or deleted.
 Reapply intended text explicitly with `preamble set`. Preamble changes persist
@@ -151,13 +181,13 @@ outside tmux, use explicit `add <pane-target> <global-name>`, `talk <target>`,
 does not bind or authenticate the caller.
 
 ```bash
-# Send and wait for response (recommended)
-tmt talk codex "your message" --wait
-tmt talk gemini "your message" --wait --timeout 120
+# Send and wait for the durable final response
+tmt talk codex "your message"
+tmt talk gemini "your message" --timeout 120
 
 # Send to an identity or direct pane target
-tmt talk codex "message" --wait
-tmt talk %12 "message" --wait
+tmt talk codex "message"
+tmt talk %12 "message"
 
 # List active identities, or inspect one pane
 tmt list
@@ -171,17 +201,17 @@ tmt unbind
 
 ## Workflow
 
-The `--wait` flag blocks until the agent responds, returning the response directly:
+Talk waits until the agent submits its complete final response:
 
 ```bash
-tmux-team talk codex "Review this authentication code" --wait
-# Response is returned directly - no need for a separate check command
+tmux-team talk codex "Review this authentication code" --json
+# On timeout, preserve the request ID and retrieve it with tmt result later.
 ```
 
 ## Tips
 
-- Use `--wait` when the user needs a response before continuing; use `check`
-  after a timeout or for polling.
+- Wait by default or use `--detach`; use `result` after a timeout and `check`
+  only for diagnostics.
 - `tmt name` binds a global identity; `tmt this` is its exact supported alias.
   `tmt whoami` inspects the current binding and `tmt unbind` removes it.
 - `tmt talk`, `tmt check`, and `tmt list` accept either a global name or a

--- a/skills/README.md
+++ b/skills/README.md
@@ -83,11 +83,9 @@ tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
 
-Use exactly one input source and the receipt supplied by TMT. Do not invent a
-receipt, guess the latest request, or infer a pane. In this release, `talk`
-still uses marker-based terminal capture and does not generate receipts;
-TMT-39 owns receipt generation and durable completion. There is no `--detach`
-or default durable-wait behavior yet. A successful submission means the
+Use exactly one input source and the request ID/receipt supplied by `talk`,
+including detached requests. Do not invent a receipt, guess the latest
+request, or infer a pane. A successful submission means the
 result was delivered, not that the task succeeded; summarize only afterward.
 
 An identical retry for the same request and attempt keeps the original
@@ -110,6 +108,16 @@ With `--json`, unavailable output is
 
 tmux-team is CLI-only: each invocation exits after its operation and no daemon
 or background service is required.
+
+Talk waits for a complete durable final by default, with a 180-second timeout
+unless `defaults.timeout` is configured. `--timeout` accepts positive seconds
+or ms/s suffixes, at most 24 hours. Use `--detach` instead of explicit timeout
+to return a request ID after sending; retrieve it with `result` later.
+Timeout/interruption never cancels work or permits automatic resend. Terminal
+markers, idle output and summaries are not completion signals; `check` is only
+diagnostic. Same-pane input serialization and exactly-once processing are not
+guaranteed. `--wait` is retired, `--lines` is for check, and stored mode values
+are inert. `config clear mode` removes only the obsolete local key.
 
 ## Claude Code
 
@@ -149,7 +157,7 @@ cp skills/codex/SKILL.md ~/.agents/skills/tmux-team/SKILL.md
 
 ```bash
 # Explicit invocation
-$tmt talk codex "Review this PR" --wait
+$tmt talk codex "Review this PR" --json
 
 # Implicit - Codex auto-selects when you mention other agents
 "Ask the codex agent to review the authentication code"

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -24,10 +24,10 @@ with `tmt check <target>` and establish whether work started before deciding
 what to do next. Missing visible output is not proof that nothing executed.
 Successful submission also does not guarantee exactly-once agent processing.
 
-`--wait` still extracts a best-effort terminal response. A completion marker
-can coexist with cropped content; increasing `check` lines cannot recover text
-that the agent never rendered. No durable structured response channel is
-implied by this transport safety behavior.
+`talk` waits for the complete durable reply by default. It never treats terminal
+markers, idle output, a summary, or process exit as completion. A cooperating
+recipient must invoke `tmt reply`; otherwise there is no final result yet.
+`check` is only a diagnostic snapshot, not correlated result retrieval.
 
 ## JSON results and failures
 
@@ -36,18 +36,18 @@ With `--json`, parse the entire stdout as one JSON document. Errors contain
 Check the exit status too: missing targets use 3, timeout 4, and conflicts 5.
 Successful commands without a detailed result return `{ok:true}`.
 
-The v5 alpha timeout contract now uses
-`error: {code: "TIMEOUT", message: "..."}` instead of a string. It retains
-`status: "timeout"`, correlation fields and nullable `partialResponse`.
-Timeout and interruption do not cancel recipient work. A `CLEANUP_ERROR`
-after successful work does not mean its effects were undone; inspect before
-retrying. Existing delivery-uncertainty guidance still applies.
+Timeout returns `status: "timeout"`, `requestId`, target/pane correlation and
+`error: {code: "TIMEOUT", message: "..."}` (exit 4). There is no partial response,
+nonce, end marker or truncation flag. Use `tmt result <request-id> --json` later.
+Timeout and interruption end only the observer, never recipient work. A
+`CLEANUP_ERROR` does not undo effects; preserve the request ID and inspect before
+retrying. Missing visible output is not permission to resend.
 
 `help`, `version`, `completion` and `learn` are text-only and reject
 `--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
 also rejects JSON mode because it streams installer output.
 
-## Durable replies and results (TMT-38)
+## Durable replies and results
 
 When TMT supplies an exact receipt, submit the complete result through the
 storage-only adapters:
@@ -58,10 +58,11 @@ tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
 
-Use exactly one input source. Never manufacture a receipt, select the latest
-request, or infer a current pane. `talk` remains marker-based terminal
-capture in this release and does not generate receipts; TMT-39 owns receipt
-generation and durable completion. There is no `--detach` behavior yet.
+Use exactly one input source and the exact request ID/receipt supplied in the
+received `talk` instruction, including detached requests. Never manufacture a
+receipt, select the latest request, or infer a current pane. Both `reply` and
+`result` are storage-only and work without a live pane on this same local
+TMT database; this is not an inbox, listener, remote transport or authentication.
 
 Reply input is one exact valid UTF-8 body up to 1 MiB, preserving empty,
 whitespace, BOM, NUL, CR/LF, Unicode, and marker-like text. Stdin is
@@ -88,6 +89,34 @@ Unavailable JSON is
 expired bodies. Input errors exit 1, input timeout is `RESPONSE_INPUT_TIMEOUT`
 (exit 4), and conflicts exit 5. Receipts, endpoints, and raw bodies are not
 echoed in acknowledgements.
+
+## Calling an agent
+
+`tmt talk <target> "message" [--timeout <time> | --detach] [--json]` waits for
+one durable final by default. The default is 180 seconds unless
+`defaults.timeout` is configured. Time accepts positive seconds or `ms`/`s`
+suffixes, at most 24 hours. Do not combine explicit timeout with detach.
+Pre-send delay accepts zero or a positive finite value, up to 2,147,483,647 ms.
+`--wait` is retired and rejected; `--lines` applies to check, not talk.
+Stored wait/polling mode settings are inert; `config clear mode` removes
+only the explicit local obsolete key, without migrating other settings.
+
+```bash
+tmt talk reviewer "Review this patch" --timeout 300 --json
+tmt talk reviewer "Run the agreed tests" --detach --json
+tmt result <request-id> --json
+tmt check reviewer 200  # diagnostics only
+```
+
+Detached success is `{status:"sent",requestId,target,pane,identity?}`, not task
+completion. Completed talk adds the exact `response`, `bodyBytes` and
+`submittedAtMs` to request/target/pane correlation. Preserve that request ID.
+
+The observer clock starts immediately before send, after pre-send delay and
+preparation. Transport/Enter time counts; synchronous transport cannot be
+cancelled mid-operation. A response read at or crossing the deadline is not
+accepted by that observer; it may still be retrieved with result afterward.
+Do not resend simply because a caller timed out or was interrupted.
 
 ## Identity preambles
 
@@ -120,7 +149,8 @@ Concurrent waits retain separate request records and remain advisory, not a
 single-flight lock. Timeout or interruption ends only that waiter; it does not
 cancel the recipient or undo sent cadence. `REQUEST_STATE_ERROR` (exit 1) can
 occur after possible delivery: follow its inspection guidance, never infer that
-retrying is safe. SQLite bookkeeping does not fix terminal response truncation.
+retrying is safe. Replies are correlated independently, but same-pane input
+serialization and exactly-once agent processing are not guaranteed.
 
 Old JSON/workspace-metadata preambles are ignored, not migrated or deleted.
 Reapply intended text explicitly with `preamble set`. Preamble changes persist
@@ -157,9 +187,9 @@ tmt talk %12 "your message"
 tmt talk codex "message" --delay 5
 
 # Send and wait for response (blocks until agent replies)
-tmt talk codex "message" --wait --timeout 120
+tmt talk codex "message" --timeout 120
 
-# Read response (default: 100 lines); names and pane targets are both valid
+# Inspect diagnostic output; this is not full result retrieval
 tmt check codex
 tmt check %12 200
 
@@ -203,10 +233,10 @@ identity/profile. Do not delete old user files as a migration workaround.
 
 ## Workflow
 
-1. Send message: `tmt talk codex "Review this code" --wait`
-2. Wait 5-15 seconds (or use `--wait` flag)
-3. Read response: `tmux-team check codex`
-4. If response is cut off: `tmux-team check codex 200`
+1. Send and wait: `tmt talk codex "Review this code" --json`.
+2. Preserve the request ID, including on timeout, interruption or uncertainty.
+3. Retrieve the final later with `tmt result <request-id> --json`; use `check`
+   only for diagnostics, never to reconstruct the authoritative response.
 
 ## Notes
 
@@ -214,8 +244,7 @@ identity/profile. Do not delete old user files as a migration workaround.
   preserves multiline text.
 - Control the delay with `pasteEnterDelayMs` in config (default: 500)
 - Use `--delay` instead of sleep (safer for tool whitelists)
-- Use `--wait` for synchronous request-response patterns; use `check` after a
-  timeout or when polling.
+- Wait by default or use `--detach`; use `result` after a timeout.
 - Sending pane input is an external action requiring user authorization.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -24,10 +24,10 @@ with `tmt check <target>` and establish whether work started before deciding
 what to do next. Missing visible output is not proof that nothing executed.
 Successful submission also does not guarantee exactly-once agent processing.
 
-`--wait` still extracts a best-effort terminal response. A completion marker
-can coexist with cropped content; increasing `check` lines cannot recover text
-that the agent never rendered. No durable structured response channel is
-implied by this transport safety behavior.
+`talk` waits for the complete durable reply by default. It never treats terminal
+markers, idle output, a summary, or process exit as completion. A cooperating
+recipient must invoke `tmt reply`; otherwise there is no final result yet.
+`check` is only a diagnostic snapshot, not correlated result retrieval.
 
 ## JSON results and failures
 
@@ -36,18 +36,18 @@ With `--json`, parse the entire stdout as one JSON document. Errors contain
 Check the exit status too: missing targets use 3, timeout 4, and conflicts 5.
 Successful commands without a detailed result return `{ok:true}`.
 
-The v5 alpha timeout contract now uses
-`error: {code: "TIMEOUT", message: "..."}` instead of a string. It retains
-`status: "timeout"`, correlation fields and nullable `partialResponse`.
-Timeout and interruption do not cancel recipient work. A `CLEANUP_ERROR`
-after successful work does not mean its effects were undone; inspect before
-retrying. Existing delivery-uncertainty guidance still applies.
+Timeout returns `status: "timeout"`, `requestId`, target/pane correlation and
+`error: {code: "TIMEOUT", message: "..."}` (exit 4). There is no partial response,
+nonce, end marker or truncation flag. Use `tmt result <request-id> --json` later.
+Timeout and interruption end only the observer, never recipient work. A
+`CLEANUP_ERROR` does not undo effects; preserve the request ID and inspect before
+retrying. Missing visible output is not permission to resend.
 
 `help`, `version`, `completion` and `learn` are text-only and reject
 `--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
 also rejects JSON mode because it streams installer output.
 
-## Durable replies and results (TMT-38)
+## Durable replies and results
 
 When TMT supplies an exact receipt, submit the complete result through the
 storage-only adapters:
@@ -58,10 +58,11 @@ tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
 
-Use exactly one input source. Never manufacture a receipt, select the latest
-request, or infer a current pane. `talk` remains marker-based terminal
-capture in this release and does not generate receipts; TMT-39 owns receipt
-generation and durable completion. There is no `--detach` behavior yet.
+Use exactly one input source and the exact request ID/receipt supplied in the
+received `talk` instruction, including detached requests. Never manufacture a
+receipt, select the latest request, or infer a current pane. Both `reply` and
+`result` are storage-only and work without a live pane on this same local
+TMT database; this is not an inbox, listener, remote transport or authentication.
 
 Reply input is one exact valid UTF-8 body up to 1 MiB, preserving empty,
 whitespace, BOM, NUL, CR/LF, Unicode, and marker-like text. Stdin is
@@ -88,6 +89,34 @@ Unavailable JSON is
 expired bodies. Input errors exit 1, input timeout is `RESPONSE_INPUT_TIMEOUT`
 (exit 4), and conflicts exit 5. Receipts, endpoints, and raw bodies are not
 echoed in acknowledgements.
+
+## Calling an agent
+
+`tmt talk <target> "message" [--timeout <time> | --detach] [--json]` waits for
+one durable final by default. The default is 180 seconds unless
+`defaults.timeout` is configured. Time accepts positive seconds or `ms`/`s`
+suffixes, at most 24 hours. Do not combine explicit timeout with detach.
+Pre-send delay accepts zero or a positive finite value, up to 2,147,483,647 ms.
+`--wait` is retired and rejected; `--lines` applies to check, not talk.
+Stored wait/polling mode settings are inert; `config clear mode` removes
+only the explicit local obsolete key, without migrating other settings.
+
+```bash
+tmt talk reviewer "Review this patch" --timeout 300 --json
+tmt talk reviewer "Run the agreed tests" --detach --json
+tmt result <request-id> --json
+tmt check reviewer 200  # diagnostics only
+```
+
+Detached success is `{status:"sent",requestId,target,pane,identity?}`, not task
+completion. Completed talk adds the exact `response`, `bodyBytes` and
+`submittedAtMs` to request/target/pane correlation. Preserve that request ID.
+
+The observer clock starts immediately before send, after pre-send delay and
+preparation. Transport/Enter time counts; synchronous transport cannot be
+cancelled mid-operation. A response read at or crossing the deadline is not
+accepted by that observer; it may still be retrieved with result afterward.
+Do not resend simply because a caller timed out or was interrupted.
 
 ## Identity preambles
 
@@ -120,7 +149,8 @@ Concurrent waits retain separate request records and remain advisory, not a
 single-flight lock. Timeout or interruption ends only that waiter; it does not
 cancel the recipient or undo sent cadence. `REQUEST_STATE_ERROR` (exit 1) can
 occur after possible delivery: follow its inspection guidance, never infer that
-retrying is safe. SQLite bookkeeping does not fix terminal response truncation.
+retrying is safe. Replies are correlated independently, but same-pane input
+serialization and exactly-once agent processing are not guaranteed.
 
 Old JSON/workspace-metadata preambles are ignored, not migrated or deleted.
 Reapply intended text explicitly with `preamble set`. Preamble changes persist
@@ -157,9 +187,9 @@ tmt talk %12 "your message"
 tmt talk codex "message" --delay 5
 
 # Send and wait for response (blocks until agent replies)
-tmt talk codex "message" --wait --timeout 120
+tmt talk codex "message" --timeout 120
 
-# Read response (default: 100 lines); names and pane targets are both valid
+# Inspect diagnostic output; this is not full result retrieval
 tmt check codex
 tmt check %12 200
 
@@ -203,9 +233,10 @@ identity/profile. Do not delete old user files as a migration workaround.
 
 ## Workflow
 
-1. Send and wait: `tmt talk codex "Review this code" --wait`
-2. If the request times out, read the pane later with `tmt check codex`.
-3. If the response is cut off, increase the capture with `tmt check codex 200`.
+1. Send and wait: `tmt talk codex "Review this code" --json`.
+2. Preserve the request ID, including on timeout, interruption or uncertainty.
+3. Retrieve the final later with `tmt result <request-id> --json`; use `check`
+   only for diagnostics, never to reconstruct the authoritative response.
 
 ## Notes
 
@@ -213,8 +244,7 @@ identity/profile. Do not delete old user files as a migration workaround.
   messages preserve their line breaks.
 - Control the delay with `pasteEnterDelayMs` in config (default: 500)
 - Use `--delay` instead of sleep (safer for tool whitelists)
-- Use `--wait` for synchronous request-response patterns; use `check` after a
-  timeout or when polling.
+- Wait by default or use `--detach`; use `result` after a timeout.
 - Sending text or commands to another pane is an external action. Do it only
   with user authorization; do not send secrets or unrelated commands.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -20,10 +20,10 @@ with `tmt check <target>` and establish whether work started before deciding
 what to do next. Missing visible output is not proof that nothing executed.
 Successful submission also does not guarantee exactly-once agent processing.
 
-`--wait` still extracts a best-effort terminal response. A completion marker
-can coexist with cropped content; increasing `check` lines cannot recover text
-that the agent never rendered. No durable structured response channel is
-implied by this transport safety behavior.
+`talk` waits for the complete durable reply by default. It never treats terminal
+markers, idle output, a summary, or process exit as completion. A cooperating
+recipient must invoke `tmt reply`; otherwise there is no final result yet.
+`check` is only a diagnostic snapshot, not correlated result retrieval.
 
 ## JSON results and failures
 
@@ -32,18 +32,18 @@ With `--json`, parse the entire stdout as one JSON document. Errors contain
 Check the exit status too: missing targets use 3, timeout 4, and conflicts 5.
 Successful commands without a detailed result return `{ok:true}`.
 
-The v5 alpha timeout contract now uses
-`error: {code: "TIMEOUT", message: "..."}` instead of a string. It retains
-`status: "timeout"`, correlation fields and nullable `partialResponse`.
-Timeout and interruption do not cancel recipient work. A `CLEANUP_ERROR`
-after successful work does not mean its effects were undone; inspect before
-retrying. Existing delivery-uncertainty guidance still applies.
+Timeout returns `status: "timeout"`, `requestId`, target/pane correlation and
+`error: {code: "TIMEOUT", message: "..."}` (exit 4). There is no partial response,
+nonce, end marker or truncation flag. Use `tmt result <request-id> --json` later.
+Timeout and interruption end only the observer, never recipient work. A
+`CLEANUP_ERROR` does not undo effects; preserve the request ID and inspect before
+retrying. Missing visible output is not permission to resend.
 
 `help`, `version`, `completion` and `learn` are text-only and reject
 `--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
 also rejects JSON mode because it streams installer output.
 
-## Durable replies and results (TMT-38)
+## Durable replies and results
 
 When TMT supplies an exact receipt, submit the complete result through the
 storage-only adapters:
@@ -54,10 +54,11 @@ tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
 
-Use exactly one input source. Never manufacture a receipt, select the latest
-request, or infer a current pane. `talk` remains marker-based terminal
-capture in this release and does not generate receipts; TMT-39 owns receipt
-generation and durable completion. There is no `--detach` behavior yet.
+Use exactly one input source and the exact request ID/receipt supplied in the
+received `talk` instruction, including detached requests. Never manufacture a
+receipt, select the latest request, or infer a current pane. Both `reply` and
+`result` are storage-only and work without a live pane on this same local
+TMT database; this is not an inbox, listener, remote transport or authentication.
 
 Reply input is one exact valid UTF-8 body up to 1 MiB, preserving empty,
 whitespace, BOM, NUL, CR/LF, Unicode, and marker-like text. Stdin is
@@ -84,6 +85,34 @@ Unavailable JSON is
 expired bodies. Input errors exit 1, input timeout is `RESPONSE_INPUT_TIMEOUT`
 (exit 4), and conflicts exit 5. Receipts, endpoints, and raw bodies are not
 echoed in acknowledgements.
+
+## Calling an agent
+
+`tmt talk <target> "message" [--timeout <time> | --detach] [--json]` waits for
+one durable final by default. The default is 180 seconds unless
+`defaults.timeout` is configured. Time accepts positive seconds or `ms`/`s`
+suffixes, at most 24 hours. Do not combine explicit timeout with detach.
+Pre-send delay accepts zero or a positive finite value, up to 2,147,483,647 ms.
+`--wait` is retired and rejected; `--lines` applies to check, not talk.
+Stored wait/polling mode settings are inert; `config clear mode` removes
+only the explicit local obsolete key, without migrating other settings.
+
+```bash
+tmt talk reviewer "Review this patch" --timeout 300 --json
+tmt talk reviewer "Run the agreed tests" --detach --json
+tmt result <request-id> --json
+tmt check reviewer 200  # diagnostics only
+```
+
+Detached success is `{status:"sent",requestId,target,pane,identity?}`, not task
+completion. Completed talk adds the exact `response`, `bodyBytes` and
+`submittedAtMs` to request/target/pane correlation. Preserve that request ID.
+
+The observer clock starts immediately before send, after pre-send delay and
+preparation. Transport/Enter time counts; synchronous transport cannot be
+cancelled mid-operation. A response read at or crossing the deadline is not
+accepted by that observer; it may still be retrieved with result afterward.
+Do not resend simply because a caller timed out or was interrupted.
 
 ## Identity preambles
 
@@ -116,7 +145,8 @@ Concurrent waits retain separate request records and remain advisory, not a
 single-flight lock. Timeout or interruption ends only that waiter; it does not
 cancel the recipient or undo sent cadence. `REQUEST_STATE_ERROR` (exit 1) can
 occur after possible delivery: follow its inspection guidance, never infer that
-retrying is safe. SQLite bookkeeping does not fix terminal response truncation.
+retrying is safe. Replies are correlated independently, but same-pane input
+serialization and exactly-once agent processing are not guaranteed.
 
 Old JSON/workspace-metadata preambles are ignored, not migrated or deleted.
 Reapply intended text explicitly with `preamble set`. Preamble changes persist
@@ -190,7 +220,7 @@ identity/profile. Do not delete old user files as a migration workaround.
 `talk` sends text to another pane and can cause external input there. Only use
 it when the user has requested that communication or the surrounding task
 clearly authorizes it; do not infer permission for unrelated changes. Use
-`--wait` to wait for a response, `--timeout <seconds>` to bound the wait, and
-`--delay <seconds>` to delay sending.
+`--timeout <time>` to bound the default wait, `--detach` to return a request ID
+after sending, and `--delay <seconds>` to delay sending.
 
 Install integrations with `tmt install` (auto-detects supported agents) or `tmt install all --force` to refresh managed links. Upgrade the CLI with `tmt upgrade`; managed links automatically use the updated bundled skill. Run install when an integration is missing or has drifted.

--- a/src/cli-contract.test.ts
+++ b/src/cli-contract.test.ts
@@ -195,14 +195,17 @@ describe('real CLI process contract', () => {
   );
 
   it(
-    'returns an explicit JSON success document while config set and clear persist safely',
+    'preserves opaque mode while allowing explicit local mode clear only',
     { timeout: 10_000 },
     () =>
       withSandbox(async (sandbox) => {
-        writeFileSync(sandbox.localConfig, '{"keep":{"value":true}}\n');
+        writeFileSync(
+          sandbox.localConfig,
+          '{"keep":{"value":true},"$config":{"mode":"polling"}}\n'
+        );
 
         const setResult = await runCli(sandbox, ['config', 'set', 'mode', 'polling', '--json']);
-        expectJsonSuccess(setResult, { ok: true });
+        expect(setResult.status).toBe(1);
         expect(JSON.parse(readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
           keep: { value: true },
           $config: { mode: 'polling' },

--- a/src/cli-output.test.ts
+++ b/src/cli-output.test.ts
@@ -2,6 +2,78 @@ import { describe, expect, it, vi } from 'vitest';
 import { createCliOutput, CliOutputSerializationError } from './cli-output.js';
 
 describe('CLI JSON output boundary', () => {
+  it('preserves only bounded correlation when replacing a pending result with failure', () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const output = createCliOutput(true);
+      const getter = vi.fn(() => {
+        throw new Error('must not evaluate');
+      });
+      const pending = {
+        status: 'completed',
+        requestId: 'req-one',
+        target: 'Alice',
+        pane: '%14',
+        response: 'private full body',
+        receipt: 'private receipt',
+        endpoint: { secret: true },
+      };
+      Object.defineProperty(pending, 'unused', { get: getter });
+      output.setJson(pending);
+      output.replaceFailure({ code: 'CLEANUP_ERROR', message: 'Inspect the request.' });
+      output.flush();
+      expect(write).toHaveBeenCalledOnce();
+      expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toEqual({
+        requestId: 'req-one',
+        target: 'Alice',
+        pane: '%14',
+        error: { code: 'CLEANUP_ERROR', message: 'Inspect the request.' },
+      });
+      expect(getter).not.toHaveBeenCalled();
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it.each([
+    { requestId: 'x'.repeat(257), target: 'Alice', pane: '%14' },
+    { requestId: 12, target: 'Alice', pane: '%14' },
+    Object.defineProperty({}, 'requestId', {
+      get() {
+        throw new Error('unexpected getter');
+      },
+    }),
+  ])('does not promote invalid correlation fields from an arbitrary result', (pending) => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const output = createCliOutput(true);
+      output.setJson(pending);
+      output.replaceFailure({ code: 'ERROR', message: 'failed' });
+      output.flush();
+      expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toEqual({
+        error: { code: 'ERROR', message: 'failed' },
+      });
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it('omits invalid target/pane fields without losing a valid request ID', () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const output = createCliOutput(true);
+      output.setJson({ requestId: 'req-one', target: 'x'.repeat(257), pane: '10.3' });
+      output.replaceFailure({ code: 'ERROR', message: 'failed' });
+      output.flush();
+      expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toEqual({
+        requestId: 'req-one',
+        error: { code: 'ERROR', message: 'failed' },
+      });
+    } finally {
+      write.mockRestore();
+    }
+  });
+
   it('publishes at most one document and exposes duplicate writes', () => {
     const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     try {

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -8,6 +8,8 @@ export interface CliOutput {
   readonly hasDuplicateJson: () => boolean;
   readonly setJson: (data: unknown) => void;
   readonly replaceJson: (data: unknown) => void;
+  /** Replace a pending result without losing bounded request inspection fields. */
+  readonly replaceFailure: (error: { code: string; message: string }) => void;
   readonly flush: () => void;
 }
 
@@ -16,6 +18,23 @@ export class CliOutputSerializationError extends Error {
     super('Could not serialize JSON output.', { cause });
     this.name = 'CliOutputSerializationError';
   }
+}
+
+function requestCorrelation(document: unknown): Record<string, string> {
+  if (!document || typeof document !== 'object' || Array.isArray(document)) return {};
+  // Read data properties only: failure reporting must not evaluate arbitrary getters.
+  const field = (key: string): unknown => Object.getOwnPropertyDescriptor(document, key)?.value;
+  const requestId = field('requestId');
+  if (typeof requestId !== 'string' || requestId.length === 0 || Buffer.byteLength(requestId) > 256)
+    return {};
+  const correlation: Record<string, string> = { requestId };
+  const target = field('target');
+  const pane = field('pane');
+  if (typeof target === 'string' && target.length > 0 && Buffer.byteLength(target) <= 256)
+    correlation.target = target;
+  if (typeof pane === 'string' && pane.length <= 256 && /^%\d+$/.test(pane))
+    correlation.pane = pane;
+  return correlation;
 }
 
 /**
@@ -50,6 +69,10 @@ export function createCliOutput(jsonMode: boolean): CliOutput {
     setJson,
     replaceJson: (data: unknown) => {
       jsonDocument = data;
+      hasJson = true;
+    },
+    replaceFailure: (error) => {
+      jsonDocument = { ...requestCorrelation(jsonDocument), error };
       hasJson = true;
     },
     flush: () => {

--- a/src/cli-runner.test.ts
+++ b/src/cli-runner.test.ts
@@ -165,6 +165,120 @@ describe('CLI runner lifecycle', () => {
     }
   });
 
+  it.each(['sent', 'completed'])(
+    'preserves %s request correlation when disposal fails',
+    async (status) => {
+      const output = captureStdout();
+      try {
+        const { runCli } = await loadRunner({
+          dispatch: (ctx) =>
+            ctx.ui.json({
+              status,
+              requestId: 'req-inspect',
+              target: 'Alice',
+              pane: '%14',
+              response: 'complete private body',
+              receipt: 'private',
+              endpoint: { secret: true },
+            }),
+          dispose: () => {
+            throw new Error('close failed');
+          },
+        });
+        expect(await runCli(['talk', 'Alice', 'work', '--json'])).toBe(1);
+        expect(output.chunks).toHaveLength(1);
+        expect(document(output.chunks)).toEqual({
+          requestId: 'req-inspect',
+          target: 'Alice',
+          pane: '%14',
+          error: {
+            code: 'CLEANUP_ERROR',
+            message: 'Cleanup failed; command effects may already have occurred: close failed',
+          },
+        });
+      } finally {
+        output.restore();
+      }
+    }
+  );
+
+  it('keeps timeout correlation and its primary status when disposal also fails', async () => {
+    const output = captureStdout();
+    const timeout = {
+      status: 'timeout',
+      requestId: 'req-late',
+      target: 'Alice',
+      pane: '%14',
+      error: { code: 'TIMEOUT', message: 'Use tmt result req-late to inspect later.' },
+    };
+    try {
+      const { runCli } = await loadRunner({
+        dispatch: (ctx) => {
+          ctx.ui.json(timeout);
+          ctx.exit(4);
+        },
+        dispose: () => {
+          throw new Error('close failed');
+        },
+      });
+      expect(await runCli(['talk', 'Alice', 'work', '--json'])).toBe(4);
+      expect(output.chunks).toHaveLength(1);
+      expect(document(output.chunks)).toEqual(timeout);
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('keeps request inspection fields when serializing a pending response fails', async () => {
+    const output = captureStdout();
+    try {
+      const { runCli } = await loadRunner({
+        dispatch: (ctx) =>
+          ctx.ui.json({
+            status: 'completed',
+            requestId: 'req-inspect',
+            target: 'Alice',
+            pane: '%14',
+            response: 1n,
+            receipt: 'do not expose',
+          }),
+      });
+      expect(await runCli(['talk', 'Alice', 'work', '--json'])).toBe(1);
+      expect(output.chunks).toHaveLength(1);
+      expect(document(output.chunks)).toEqual({
+        requestId: 'req-inspect',
+        target: 'Alice',
+        pane: '%14',
+        error: { code: 'INTERNAL_ERROR', message: 'Could not serialize JSON output.' },
+      });
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('does not erase already-streamed human request guidance on cleanup failure', async () => {
+    const events: string[] = [];
+    const info = vi.spyOn(console, 'log').mockImplementation((value) => events.push(String(value)));
+    const error = vi
+      .spyOn(console, 'error')
+      .mockImplementation((value) => events.push(String(value)));
+    try {
+      const { runCli } = await loadRunner({
+        dispatch: (ctx) => ctx.ui.info('Request req-inspect. Use tmt result req-inspect.'),
+        dispose: () => {
+          throw new Error('close failed');
+        },
+      });
+      expect(await runCli(['role', 'show'])).toBe(1);
+      expect(events).toHaveLength(2);
+      expect(events[0]).toContain('tmt result req-inspect');
+      expect(events[1]).toContain('Cleanup failed; command effects may already have occurred');
+    } finally {
+      info.mockRestore();
+      error.mockRestore();
+    }
+  });
+
   it('does not promote an arbitrary native error code into the public contract', async () => {
     const output = captureStdout();
     try {

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -35,7 +35,7 @@ function publicError(error: unknown): { code: string; message: string } {
 }
 
 function writeJsonError(output: CliOutput, error: { code: string; message: string }): void {
-  output.replaceJson({ error });
+  output.replaceFailure(error);
 }
 
 function writeHumanError(output: CliOutput, message: string): void {
@@ -48,11 +48,9 @@ function flushJson(output: CliOutput, status: number, verbose: boolean, debug?: 
     return status;
   } catch (error) {
     if (!(error instanceof CliOutputSerializationError)) throw error;
-    output.replaceJson({
-      error: {
-        code: 'INTERNAL_ERROR',
-        message: 'Could not serialize JSON output.',
-      },
+    output.replaceFailure({
+      code: 'INTERNAL_ERROR',
+      message: 'Could not serialize JSON output.',
     });
     if (verbose || debug) console.error('[DEBUG] JSON serialization failure:', error);
     try {
@@ -89,7 +87,7 @@ function parseFailure(error: unknown): number {
 function helpConfig(showIntro: boolean): HelpConfig {
   try {
     const config = loadConfig(resolvePaths());
-    return { mode: config.mode, timeout: config.defaults.timeout, showIntro };
+    return { timeout: config.defaults.timeout, showIntro };
   } catch {
     return { showIntro };
   }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -44,13 +44,11 @@ function makeStubContext(): Context {
       json: vi.fn(),
     },
     config: {
-      mode: 'polling',
       preambleMode: 'always',
       defaults: {
         timeout: 180,
         pollInterval: 1,
         captureLines: 100,
-        maxCaptureLines: 2000,
         preambleEvery: 3,
         pasteEnterDelayMs: 500,
       },
@@ -527,7 +525,7 @@ describe('cli', () => {
     expect(ctx.flags.timeout).toBe(0.5);
   });
 
-  it('parses --lines flag', async () => {
+  it('parses --detach flag', async () => {
     vi.resetModules();
 
     const ctx = makeStubContext();
@@ -541,9 +539,23 @@ describe('cli', () => {
     }));
     vi.doMock('./commands/talk.js', () => ({ cmdTalk: talkSpy }));
     const { runCli } = await import('./cli-runner.js');
-    expect(await runCli(['talk', 'claude', 'hi', '--wait', '--lines', '50'])).toBe(0);
+    expect(await runCli(['talk', 'claude', 'hi', '--detach'])).toBe(0);
 
-    expect(ctx.flags.lines).toBe(50);
+    expect(ctx.flags.detach).toBe(true);
+  });
+
+  it('rejects talk --lines before creating command context', async () => {
+    vi.resetModules();
+    const contextFactory = vi.fn(() => makeStubContext());
+    vi.doMock('./context.js', () => ({
+      createContext: contextFactory,
+      ExitCodes: { SUCCESS: 0, ERROR: 1 },
+    }));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runCli } = await import('./cli-runner.js');
+    expect(await runCli(['talk', 'claude', 'hi', '--lines', '50'])).toBe(1);
+    expect(contextFactory).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it('parses --no-preamble flag', async () => {

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -18,8 +18,8 @@ const receipt = encodeReplyReceipt({
 
 describe('declarative CLI parser', () => {
   it('parses global options independently of command position', () => {
-    const parsed = parseArgs(['talk', 'claude', 'hello', '--timeout', '500ms', '--wait']);
-    expect(parsed.flags).toMatchObject({ timeout: 0.5, wait: true });
+    const parsed = parseArgs(['talk', 'claude', 'hello', '--timeout', '500ms']);
+    expect(parsed.flags).toMatchObject({ timeout: 0.5 });
     expect(parsed.invocation).toMatchObject({
       kind: 'talk',
       target: { value: 'claude', kind: 'identity' },
@@ -70,6 +70,35 @@ describe('declarative CLI parser', () => {
     });
   });
 
+  it('parses detach and rejects retired wait/lines options before effects', () => {
+    expect(parseArgs(['talk', 'claude', 'hello', '--detach']).flags).toMatchObject({
+      detach: true,
+    });
+    expect(() => parseArgs(['talk', 'claude', 'hello', '--wait'])).toThrow(CliParseError);
+    expect(() => parseArgs(['talk', 'claude', 'hello', '--lines', '10'])).toThrow(CliParseError);
+    expect(() => parseArgs(['check', 'claude', '--lines', '10'])).not.toThrow();
+  });
+
+  it('applies no-preamble regardless of whether it appears before or after talk', () => {
+    expect(parseArgs(['--no-preamble', 'talk', 'claude', 'hello']).flags.noPreamble).toBe(true);
+    expect(parseArgs(['talk', 'claude', 'hello', '--no-preamble']).flags.noPreamble).toBe(true);
+  });
+
+  it.each([
+    ['0', 'zero'],
+    ['-1', 'negative'],
+    ['NaN', 'non-finite'],
+    ['86400.001s', 'over the 24-hour maximum'],
+  ])('rejects %s timeout (%s)', (value) => {
+    expect(() => parseArgs(['talk', 'claude', 'hello', '--timeout', value])).toThrow(CliParseError);
+  });
+
+  it('rejects detach together with an explicit timeout', () => {
+    expect(() => parseArgs(['talk', 'claude', 'hello', '--detach', '--timeout', '1s'])).toThrow(
+      CliParseError
+    );
+  });
+
   it('classifies existing positional targets without introducing future selector syntax', () => {
     expect(parseArgs(['list', 'all']).invocation).toMatchObject({
       target: { value: 'all', kind: 'identity' },
@@ -112,6 +141,7 @@ describe('declarative CLI parser', () => {
       key: 'mode',
       global: false,
     });
+    expect(() => parseArgs(['config', 'clear', 'mode', '--global'])).toThrow(CliParseError);
     expect(parseArgs(['install', 'codex']).invocation).toEqual({
       kind: 'install',
       target: 'codex',
@@ -220,11 +250,9 @@ describe('declarative CLI parser', () => {
       '/tmp/tmt.json',
       '--delay',
       '250ms',
-      '--wait',
       '--timeout',
       '3s',
-      '--lines',
-      '12',
+      '--detach',
       '--team',
       'legacy',
       'list',
@@ -236,9 +264,8 @@ describe('declarative CLI parser', () => {
       force: true,
       config: '/tmp/tmt.json',
       delay: 0.25,
-      wait: true,
       timeout: 3,
-      lines: 12,
+      detach: true,
     });
     expect(parsed.metadata).toMatchObject({ unsupportedTeam: true, commandPath: ['list'] });
   });

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -65,6 +65,7 @@ interface CommonOptions {
   config?: string;
   delay?: string;
   wait?: boolean;
+  detach?: boolean;
   timeout?: string;
   lines?: string;
   noPreamble?: boolean;
@@ -91,7 +92,12 @@ function parseTime(value: string): number {
     throw new CliParseError(
       `Invalid time format: ${value}. Use number (seconds) or number with ms/s suffix.`
     );
-  return match[2]?.toLowerCase() === 'ms' ? parseFloat(match[1]) / 1000 : parseFloat(match[1]);
+  const seconds =
+    match[2]?.toLowerCase() === 'ms' ? parseFloat(match[1]) / 1000 : parseFloat(match[1]);
+  if (!Number.isFinite(seconds)) {
+    throw new CliParseError(`Invalid time format: ${value}. The value must be finite.`);
+  }
+  return seconds;
 }
 
 function parseLines(value: string): number {
@@ -109,7 +115,7 @@ function flagsFrom(options: CommonOptions, argv: readonly string[] = []): Flags 
   if (options.force) flags.force = true;
   if (options.config !== undefined) flags.config = options.config;
   if (options.delay !== undefined) flags.delay = parseTime(options.delay);
-  if (options.wait) flags.wait = true;
+  if (options.detach) flags.detach = true;
   if (options.timeout !== undefined) flags.timeout = parseTime(options.timeout);
   if (options.lines !== undefined) {
     if (!/^\d+$/.test(options.lines))
@@ -189,6 +195,7 @@ function commonOptions(command: Command): Command {
     .option('--config <path>')
     .option('--delay <time>')
     .option('--wait')
+    .option('--detach')
     .option('--timeout <time>')
     .option('--lines <count>')
     .option('--no-preamble')
@@ -217,6 +224,41 @@ function setupProgram(capture: Capture): Command {
   program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
 
   const action = (command: Command, invocation: ParsedInvocation): void => {
+    const commandName = command.name();
+    if (optionWasProvided(command, 'wait')) {
+      throw new CliParseError(
+        'The --wait option is retired. talk waits for a durable reply by default; use --timeout or --detach.'
+      );
+    }
+    if ((commandName === 'talk' || commandName === 'send') && optionWasProvided(command, 'lines')) {
+      throw new CliParseError(
+        'The --lines option is only supported by check/read; talk retrieves the complete durable response.'
+      );
+    }
+    if (commandName === 'talk' || commandName === 'send') {
+      const options = commandOptions(command);
+      if (options.detach && optionWasProvided(command, 'timeout')) {
+        throw new CliParseError('Use either --timeout or --detach, not both.');
+      }
+      if (optionWasProvided(command, 'timeout') && options.timeout !== undefined) {
+        const timeoutSeconds = parseTime(options.timeout);
+        if (
+          !Number.isFinite(timeoutSeconds) ||
+          timeoutSeconds <= 0 ||
+          timeoutSeconds > 24 * 60 * 60
+        ) {
+          throw new CliParseError(
+            'Talk timeout must be finite, positive, and no greater than 24 hours.'
+          );
+        }
+      }
+      if (optionWasProvided(command, 'delay') && options.delay !== undefined) {
+        const delaySeconds = parseTime(options.delay);
+        if (delaySeconds * 1000 > 2_147_483_647) {
+          throw new CliParseError('Talk delay exceeds the supported timer limit.');
+        }
+      }
+    }
     capture.invocation = invocation;
     capture.command = command;
     const path: string[] = [];

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -96,13 +96,11 @@ function createCtx(
     databaseFile: path.join(testDir, 'tmux-team.db'),
   };
   const baseConfig: ResolvedConfig = {
-    mode: 'polling',
     preambleMode: 'always',
     defaults: {
       timeout: 180,
       pollInterval: 1,
       captureLines: 100,
-      maxCaptureLines: 2000,
       preambleEvery: 3,
       pasteEnterDelayMs: 500,
     },
@@ -500,20 +498,26 @@ describe('basic commands', () => {
     const ctx = createCtx(testDir);
     fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({}, null, 2));
 
-    cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'wait', global: false }));
+    fs.writeFileSync(
+      ctx.paths.localConfig,
+      JSON.stringify({ $config: { mode: 'wait', preambleMode: 'disabled' } }, null, 2)
+    );
+    cmdConfig(ctx, configRequest('show'));
     const saved = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved.$config.mode).toBe('wait');
 
     cmdConfig(ctx, configRequest('clear', { key: 'mode', global: false }));
     const saved2 = JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf-8'));
     expect(saved2.$config?.mode).toBeUndefined();
+    expect(saved2.$config?.preambleMode).toBe('disabled');
   });
 
-  it('cmdConfig set supports --global', () => {
+  it('cmdConfig rejects obsolete global mode writes', () => {
     const ctx = createCtx(testDir);
-    cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'wait', global: true }));
-    const saved = JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf-8'));
-    expect(saved.mode).toBe('wait');
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'wait', global: true }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(fs.existsSync(ctx.paths.globalConfig)).toBe(false);
   });
 
   it('cmdConfig set errors when not enough args', () => {
@@ -558,7 +562,7 @@ describe('basic commands', () => {
       cmdConfig(ctx, configRequest('clear', { key: 'invalidkey', global: false }))
     ).toThrow(`exit(${ExitCodes.ERROR})`);
     expect(ctx.ui.error).toHaveBeenCalledWith(
-      'Invalid key: invalidkey. Valid keys: mode, preambleMode, preambleEvery, pasteEnterDelayMs'
+      'Invalid key: invalidkey. Valid keys: preambleMode, preambleEvery, pasteEnterDelayMs'
     );
   });
 
@@ -585,8 +589,8 @@ describe('basic commands', () => {
 
   it('cmdHelp/cmdLearn print output', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    cmdHelp({ mode: 'polling', showIntro: true });
-    cmdHelp({ mode: 'wait', timeout: 10 });
+    cmdHelp({ showIntro: true });
+    cmdHelp({ timeout: 10 });
     cmdLearn();
     const output = logSpy.mock.calls.join('\n');
     expect(output).toContain('add <pane-target> <global-name>');

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -64,7 +64,7 @@ _tmux-team() {
   elif (( CURRENT == 4 )); then
     case \${words[2]} in
       talk)
-        compadd -- "--delay" "--wait" "--timeout"
+        compadd -- "--delay" "--detach" "--timeout"
         ;;
       reply)
         compadd -- "--receipt" "--file" "--stdin" "--json"
@@ -117,7 +117,7 @@ const bashCompletion = `_tmux_team() {
   elif [[ \${COMP_CWORD} -eq 3 ]]; then
     case "\${COMP_WORDS[1]}" in
       talk)
-        COMPREPLY=( $(compgen -W "--delay --wait --timeout" -- \${cur}) )
+        COMPREPLY=( $(compgen -W "--delay --detach --timeout" -- \${cur}) )
         ;;
       reply)
         COMPREPLY=( $(compgen -W "--receipt --file --stdin --json" -- \${cur}) )

--- a/src/commands/config-command.test.ts
+++ b/src/commands/config-command.test.ts
@@ -38,13 +38,11 @@ function createCtx(
     databaseFile: path.join(testDir, 'global', 'tmux-team.db'),
   };
   const config: ResolvedConfig = {
-    mode: 'polling',
     preambleMode: 'always',
     defaults: {
       timeout: 180,
       pollInterval: 1,
       captureLines: 100,
-      maxCaptureLines: 2000,
       preambleEvery: 3,
       pasteEnterDelayMs: 500,
     },
@@ -136,11 +134,36 @@ describe('cmdConfig', () => {
     expect(saved2.$config).toBeUndefined();
   });
 
+  it('preserves an opaque local mode key during unrelated settings writes', () => {
+    const ctx = createCtx(testDir);
+    fs.writeFileSync(
+      ctx.paths.localConfig,
+      JSON.stringify({ keep: { value: true }, $config: { mode: 'wait' } })
+    );
+    cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value: '5', global: false }));
+    expect(JSON.parse(fs.readFileSync(ctx.paths.localConfig, 'utf8'))).toEqual({
+      keep: { value: true },
+      $config: { mode: 'wait', preambleEvery: 5 },
+    });
+  });
+
   it('sets global settings with -g', () => {
     const ctx = createCtx(testDir);
     cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value: '5', global: true }));
     const saved = JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf-8'));
     expect(saved.defaults.preambleEvery).toBe(5);
+  });
+
+  it('preserves an opaque global mode key during unrelated settings writes', () => {
+    const ctx = createCtx(testDir);
+    fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
+    fs.writeFileSync(ctx.paths.globalConfig, JSON.stringify({ mode: 'wait', keep: true }));
+    cmdConfig(ctx, configRequest('set', { key: 'preambleMode', value: 'disabled', global: true }));
+    expect(JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf8'))).toEqual({
+      mode: 'wait',
+      keep: true,
+      preambleMode: 'disabled',
+    });
   });
 
   it('shows local source when local config has settings', () => {
@@ -154,7 +177,7 @@ describe('cmdConfig', () => {
     );
     cmdConfig(ctx, configRequest('show'));
     const out = (ctx.ui as any).jsonCalls[0] as any;
-    expect(out.sources.mode).toBe('local');
+    expect(out.resolved).not.toHaveProperty('mode');
     expect(out.sources.preambleMode).toBe('local');
     expect(out.sources.preambleEvery).toBe('local');
   });
@@ -173,7 +196,6 @@ describe('cmdConfig', () => {
     );
     cmdConfig(ctx, configRequest('show'));
     const out = (ctx.ui as any).jsonCalls[0] as any;
-    expect(out.sources.mode).toBe('global');
     expect(out.sources.preambleMode).toBe('global');
     expect(out.sources.preambleEvery).toBe('global');
   });
@@ -182,14 +204,16 @@ describe('cmdConfig', () => {
     const ctx = createCtx(testDir, { json: true });
     cmdConfig(ctx, configRequest('show'));
     const out = (ctx.ui as any).jsonCalls[0] as any;
-    expect(out.sources.mode).toBe('default');
     expect(out.sources.preambleMode).toBe('default');
     expect(out.sources.preambleEvery).toBe('default');
   });
 
   it('shows sources in table mode with local settings', () => {
     const ctx = createCtx(testDir);
-    fs.writeFileSync(ctx.paths.localConfig, JSON.stringify({ $config: { mode: 'wait' } }));
+    fs.writeFileSync(
+      ctx.paths.localConfig,
+      JSON.stringify({ $config: { preambleMode: 'disabled' } })
+    );
     cmdConfig(ctx, configRequest('show'));
     expect(ctx.ui.table).toHaveBeenCalled();
     // The table call should include (local) source
@@ -200,19 +224,18 @@ describe('cmdConfig', () => {
   it('shows sources in table mode with global settings', () => {
     const ctx = createCtx(testDir);
     fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
-    fs.writeFileSync(ctx.paths.globalConfig, JSON.stringify({ mode: 'wait' }));
+    fs.writeFileSync(ctx.paths.globalConfig, JSON.stringify({ preambleMode: 'disabled' }));
     cmdConfig(ctx, configRequest('show'));
     expect(ctx.ui.table).toHaveBeenCalled();
     const tableCall = (ctx.ui.table as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(tableCall[1].some((row: string[]) => row[2]?.includes('global'))).toBe(true);
   });
 
-  it('sets global mode and preambleMode', () => {
+  it('rejects obsolete mode writes, including global writes', () => {
     const ctx = createCtx(testDir);
-    cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'wait', global: true }));
-    cmdConfig(ctx, configRequest('set', { key: 'preambleMode', value: 'disabled', global: true }));
-    const saved = JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf-8'));
-    expect(saved.mode).toBe('wait');
-    expect(saved.preambleMode).toBe('disabled');
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'wait', global: true }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(fs.existsSync(ctx.paths.globalConfig)).toBe(false);
   });
 });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -13,7 +13,7 @@ import {
   clearLocalSettings,
 } from '../config.js';
 
-type EnumConfigKey = 'mode' | 'preambleMode';
+type EnumConfigKey = 'preambleMode';
 type NumericConfigKey = 'preambleEvery' | 'pasteEnterDelayMs';
 type ConfigKey = EnumConfigKey | NumericConfigKey;
 
@@ -25,12 +25,11 @@ export interface ConfigRequest {
   readonly global: boolean;
 }
 
-const ENUM_KEYS: EnumConfigKey[] = ['mode', 'preambleMode'];
+const ENUM_KEYS: EnumConfigKey[] = ['preambleMode'];
 const NUMERIC_KEYS: NumericConfigKey[] = ['preambleEvery', 'pasteEnterDelayMs'];
 const VALID_KEYS: ConfigKey[] = [...ENUM_KEYS, ...NUMERIC_KEYS];
 
 const VALID_VALUES: Record<EnumConfigKey, string[]> = {
-  mode: ['polling', 'wait'],
   preambleMode: ['always', 'disabled'],
 };
 
@@ -61,14 +60,12 @@ function showConfig(ctx: Context): void {
   if (ctx.flags.json) {
     ctx.ui.json({
       resolved: {
-        mode: ctx.config.mode,
         preambleMode: ctx.config.preambleMode,
         preambleEvery: ctx.config.defaults.preambleEvery,
         pasteEnterDelayMs: ctx.config.defaults.pasteEnterDelayMs,
         defaults: ctx.config.defaults,
       },
       sources: {
-        mode: localSettings?.mode ? 'local' : globalConfig.mode ? 'global' : 'default',
         preambleMode: localSettings?.preambleMode
           ? 'local'
           : globalConfig.preambleMode
@@ -96,7 +93,6 @@ function showConfig(ctx: Context): void {
   }
 
   // Determine sources
-  const modeSource = localSettings?.mode ? '(local)' : globalConfig.mode ? '(global)' : '(default)';
   const preambleSource = localSettings?.preambleMode
     ? '(local)'
     : globalConfig.preambleMode
@@ -119,7 +115,6 @@ function showConfig(ctx: Context): void {
   ctx.ui.table(
     ['Key', 'Value', 'Source'],
     [
-      ['mode', ctx.config.mode, modeSource],
       ['preambleMode', ctx.config.preambleMode, preambleSource],
       ['preambleEvery', String(ctx.config.defaults.preambleEvery), preambleEverySource],
       ['pasteEnterDelayMs', String(ctx.config.defaults.pasteEnterDelayMs), pasteEnterDelaySource],
@@ -167,9 +162,7 @@ function setConfig(ctx: Context, key: string, value: string, global: boolean): v
   if (global) {
     // Set in global config
     const globalConfig = loadGlobalConfig(ctx.paths);
-    if (key === 'mode') {
-      globalConfig.mode = value as 'polling' | 'wait';
-    } else if (key === 'preambleMode') {
+    if (key === 'preambleMode') {
       globalConfig.preambleMode = value as 'always' | 'disabled';
     } else if (key === 'preambleEvery') {
       if (!globalConfig.defaults) {
@@ -177,7 +170,6 @@ function setConfig(ctx: Context, key: string, value: string, global: boolean): v
           timeout: 180,
           pollInterval: 1,
           captureLines: 100,
-          maxCaptureLines: 2000,
           preambleEvery: parseInt(value, 10),
           pasteEnterDelayMs: 500,
         };
@@ -190,7 +182,6 @@ function setConfig(ctx: Context, key: string, value: string, global: boolean): v
           timeout: 180,
           pollInterval: 1,
           captureLines: 100,
-          maxCaptureLines: 2000,
           preambleEvery: 3,
           pasteEnterDelayMs: parseInt(value, 10),
         };
@@ -202,9 +193,7 @@ function setConfig(ctx: Context, key: string, value: string, global: boolean): v
     ctx.ui.success(`Set ${key}=${value} in global config`);
   } else {
     // Set in local config
-    if (key === 'mode') {
-      updateLocalSettings(ctx.paths, { mode: value as 'polling' | 'wait' });
-    } else if (key === 'preambleMode') {
+    if (key === 'preambleMode') {
       updateLocalSettings(ctx.paths, { preambleMode: value as 'always' | 'disabled' });
     } else if (key === 'preambleEvery') {
       updateLocalSettings(ctx.paths, { preambleEvery: parseInt(value, 10) });
@@ -220,7 +209,10 @@ function setConfig(ctx: Context, key: string, value: string, global: boolean): v
  */
 function clearConfig(ctx: Context, key?: string): void {
   if (key) {
-    if (!isValidKey(key)) {
+    // mode is an obsolete local-only key. It may be explicitly removed, but
+    // it is not part of the runtime or config set/show surface anymore.
+    const isObsoleteMode = key === 'mode';
+    if (!isObsoleteMode && !isValidKey(key)) {
       ctx.ui.error(`Invalid key: ${key}. Valid keys: ${VALID_KEYS.join(', ')}`);
       ctx.exit(ExitCodes.ERROR);
     }
@@ -228,7 +220,7 @@ function clearConfig(ctx: Context, key?: string): void {
     // Clear specific key from local settings
     const localConfigFile = loadLocalConfigFile(ctx.paths);
     if (localConfigFile.$config) {
-      delete localConfigFile.$config[key];
+      delete (localConfigFile.$config as unknown as Record<string, unknown>)[key];
       // Remove $config if empty
       if (Object.keys(localConfigFile.$config).length === 0) {
         delete localConfigFile.$config;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -6,15 +6,12 @@ import { colors } from '../ui.js';
 import { VERSION } from '../version.js';
 
 export interface HelpConfig {
-  mode?: 'polling' | 'wait';
   timeout?: number;
   showIntro?: boolean;
 }
 
 export function cmdHelp(config?: HelpConfig): void {
-  const mode = config?.mode ?? 'wait';
   const timeout = config?.timeout ?? 180;
-  const isWaitMode = mode === 'wait';
 
   // Show intro highlight when running just `tmux-team` with no args
   if (config?.showIntro) {
@@ -25,21 +22,12 @@ ${colors.cyan('│')}  ${colors.dim('tmt is a shorthand alias for tmux-team')}  
 ${colors.cyan('└─────────────────────────────────────────────────────────────┘')}`);
   }
 
-  // Mode indicator with clear explanation
-  const modeInfo = isWaitMode
-    ? `${colors.yellow('CURRENT MODE')}: ${colors.green('wait')} (timeout: ${timeout}s) ${colors.green('✓ recommended')}
-  ${colors.dim('→ talk commands will BLOCK until agent responds or timeout')}
-  ${colors.dim('→ Response is returned directly, no need to use check command')}`
-    : `${colors.yellow('CURRENT MODE')}: ${colors.cyan('polling')}
-  ${colors.dim('→ talk commands send and return immediately')}
-  ${colors.dim('→ Use check command to read agent response')}
-  ${colors.dim('→')} ${colors.yellow('TIP')}: ${colors.dim('Use --wait or set mode to wait for better token utilization')}`;
-
   console.log(`
 ${colors.cyan('tmux-team')} v${VERSION} - AI agent collaboration in tmux
 ${colors.dim('Alias: tmt')}
 
-${modeInfo}
+Talk waits for a complete durable reply (timeout: ${timeout}s).
+Use --detach to return after sending; use result <request-id> to retrieve later.
 
 ${colors.yellow('USAGE')}
   tmt <command> [arguments]
@@ -84,19 +72,18 @@ ${colors.yellow('CALLER CONTEXT')}
 
 ${colors.yellow('TALK OPTIONS')}
   ${colors.green('--delay')} <seconds>           Wait before sending
-  ${colors.green('--wait')}                      Force wait mode (block until response)
-  ${colors.green('--timeout')} <seconds>         Max wait time (current: ${timeout}s)
-  ${colors.green('--lines')} <number>            Lines to capture (default: 100)
+  ${colors.green('--timeout')} <time>            Observer bound (current: ${timeout}s; positive, at most 24h)
+  ${colors.green('--detach')}                    Return request ID after sending; no explicit --timeout
   ${colors.green('--no-preamble')}               Skip agent preamble for this message
   ${colors.green('--debug')}                     Show debug output
 
 ${colors.yellow('REPLY / RESULT')}
   tmt reply <request-id> --receipt <receipt> (--file <path> | --stdin) [--json]
   tmt result <request-id> [--json]
-  Use exactly one input source and the receipt supplied by TMT. Do not invent a
-  receipt, select the latest request, or infer a current pane. In this release,
-  talk remains marker-based and does not generate receipts; TMT-39 owns receipt
-  generation and durable completion. There is no --detach behavior yet.
+  Use exactly one input source and the request ID/receipt from the talk instruction.
+  Do not invent a receipt, select the latest request, or infer a current pane.
+  A recipient must submit a final; markers, idle output and summaries do not complete talk.
+  Reply/result work without tmux on the same local database; check is diagnostic only.
   Bodies are exact valid UTF-8 up to 1 MiB; stdin is EOF-driven with a 5s
   deadline. Submission means result delivery, not task success. Summarize only
   after successful submission. Result unavailable (pending, unknown, expired)
@@ -109,17 +96,11 @@ ${colors.yellow('REPLY / RESULT')}
   Missing results do not cancel work. Surface failed submission without a
   success summary, and never resubmit after accepted delivery.
 
-${colors.yellow('EXAMPLES')}${
-    isWaitMode
-      ? `
-  ${colors.dim('# Wait mode: commands block until response')}
-  tmux-team talk codex "Review this PR"     ${colors.dim('← blocks, returns response')}
-  tmux-team talk %12 "Status update"       ${colors.dim('← waits for one pane')}`
-      : `
-  ${colors.dim('# Polling mode: send then check')}
-  tmux-team talk codex "Review this PR"     ${colors.dim('← sends immediately')}
-  tmux-team check codex                     ${colors.dim('← read response later')}`
-  }
+${colors.yellow('EXAMPLES')}
+  tmux-team talk codex "Review this PR" --timeout 300 --json
+  tmux-team talk %12 "Run the agreed tests" --detach --json
+  tmux-team result <request-id> --json
+  tmux-team check codex 200                ${colors.dim('← diagnostic snapshot only')}
   tmux-team list --json
   tmux-team list main:1.0
   tmux-team add 10.1 codex
@@ -132,10 +113,15 @@ ${colors.yellow('CONFIG')}
   Local:  ./tmux-team.json (settings override; other fields remain opaque)
   Global: ~/.config/tmux-team/config.json (settings)
 
-${colors.yellow('CHANGE MODE')}
-  tmux-team config set mode wait            ${colors.dim('Enable wait mode (local)')}
-  tmux-team config set mode polling         ${colors.dim('Enable polling mode (local)')}
+${colors.yellow('SETTINGS')}
   tmux-team config set preambleMode disabled ${colors.dim('Disable preambles (local)')}
   tmux-team config set preambleEvery 5      ${colors.dim('Inject preamble every 5 messages')}
+  --wait is retired; --lines is only for check, not talk.
+  Stored mode/maxCaptureLines settings are inert and preserved, not migrated.
+  config clear mode removes only the obsolete local mode key.
+  Timeout accepts seconds or ms/s suffixes and includes transport/Enter time,
+  after pre-send delay/preparation. It never cancels work or permits a resend.
+  Synchronous transport is not interrupted mid-operation by this observer bound.
+  Same-pane input serialization and exactly-once processing are not guaranteed.
 `);
 }

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -25,13 +25,11 @@ function createCtx(testDir: string, overrides?: Partial<{ flags: Partial<Flags> 
     databaseFile: path.join(testDir, 'tmux-team.db'),
   };
   const config: ResolvedConfig = {
-    mode: 'polling',
     preambleMode: 'always',
     defaults: {
       timeout: 180,
       pollInterval: 1,
       captureLines: 100,
-      maxCaptureLines: 2000,
       preambleEvery: 3,
       pasteEnterDelayMs: 500,
     },

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -214,7 +214,8 @@ function printNextSteps(ctx: Context, installed: InstallResult[]): void {
   console.log(
     `  ${colors.cyan('tmt add <pane-target> <global-name>')} or ${colors.cyan('tmt this <global-name>')}`
   );
-  console.log(`  ${colors.cyan('tmt talk <target> "message" --wait')}`);
+  console.log(`  ${colors.cyan('tmt talk <target> "message" --timeout 180')}`);
+  console.log(`  ${colors.cyan('tmt result <request-id> --json')} (after timeout or --detach)`);
 }
 
 export async function cmdInstall(ctx: Context, agent?: string): Promise<void> {

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -18,14 +18,16 @@ ${colors.yellow('CORE CONCEPT')}
   Each agent runs in its own tmux pane. When you talk to another agent:
   1. Your message is pasted via a tmux buffer
   2. tmux-team waits briefly, then sends Enter to submit
-  3. You read their response by capturing their pane output
+  3. The recipient submits its complete final through tmt reply
+  4. Talk returns that retained body; check is only a diagnostic pane snapshot
 
 ${colors.yellow('ESSENTIAL COMMANDS')}
 
   ${colors.green('tmux-team list')}                     List active identities
   ${colors.green('tmux-team talk')} <target> "<msg>"   Send a message
   ${colors.green('tmux-team check')} <target> [lines]  Read pane output
-  ${colors.green('tmux-team talk')} <target> --wait    Send and wait for response
+  ${colors.green('tmux-team talk')} <target> "<msg>" --detach  Send without waiting
+  ${colors.green('tmux-team result')} <request-id> --json      Retrieve a retained final
 
 ${colors.yellow('DURABLE REPLIES AND RESULTS')}
 
@@ -35,9 +37,8 @@ ${colors.yellow('DURABLE REPLIES AND RESULTS')}
   ${colors.cyan('tmt result <request-id> --json')}
 
   Use exactly one input source and never manufacture a receipt, select the
-  latest request, or infer a pane. talk remains marker-based in this release
-  and does not generate receipts; TMT-39 owns receipt generation and durable
-  completion. There is no --detach behavior yet. Submission confirms result
+  latest request, or infer a pane. talk supplies the exact request ID/receipt
+  for both default wait and detached requests. Submission confirms result
   delivery, not task success; summarize only after successful submission.
 
   Bodies preserve exact valid UTF-8 up to 1 MiB, including empty, whitespace,
@@ -53,28 +54,28 @@ ${colors.yellow('DURABLE REPLIES AND RESULTS')}
   Missing results do not cancel work. Surface failed submission without a
   success summary, and never resubmit after accepted delivery.
 
-${colors.yellow('RECOMMENDED: WAIT MODE (--wait)')}
+${colors.yellow('DEFAULT WAIT, TIMEOUT AND DETACH')}
 
-  The ${colors.green('--wait')} flag is recommended for better token utilization:
-
-  ${colors.dim('# Without --wait (polling mode):')}
-  tmux-team talk codex "Review this code"
-  ${colors.dim('# ... wait manually ...')}
-  tmux-team check codex                    ${colors.dim('← extra command')}
-
-  ${colors.dim('# With --wait:')}
-  tmux-team talk codex "Review this code" --wait
-  ${colors.dim('↳ Blocks until response, returns it directly')}
-
-  Enable by default: ${colors.cyan('tmux-team config set mode wait')}
+  Talk waits by default (180 seconds unless defaults.timeout is configured).
+  --timeout accepts positive seconds or ms/s suffixes, at most 24 hours.
+  Use --detach to return a request ID after sending; do not combine with --timeout.
+  --wait is retired; --lines belongs to check, not talk. Stored mode settings
+  are inert and preserved; config clear mode removes only the obsolete local key.
+  Timeout/interrupt ends the observer, not the task. Preserve the request ID
+  and use result later; never automatically resend. The clock includes send/Enter
+  time after preparation/delay, but cannot interrupt synchronous transport.
+  Markers, idle panes and summaries never complete a request without a reply.
+  Same-pane input serialization and exactly-once processing are not guaranteed.
 
 ${colors.yellow('PRACTICAL EXAMPLES')}
 
   ${colors.dim('# Quick question')}
-  tmux-team talk codex "What's the auth status?" --wait
+  tmux-team talk codex "What's the auth status?" --json
 
   ${colors.dim('# Delegate a task with timeout')}
-  tmux-team talk gemini "Implement login form" --wait --timeout 300
+  tmux-team talk gemini "Implement login form" --timeout 300 --json
+  tmux-team talk gemini "Run the agreed tests" --detach --json
+  tmux-team result <request-id> --json
 
 ${colors.yellow('GLOBAL IDENTITIES')}
 
@@ -89,7 +90,7 @@ ${colors.yellow('GLOBAL IDENTITIES')}
 
 ${colors.yellow('BEST PRACTICES')}
 
-  1. ${colors.green('Use --wait for correlated completion')} - captured response text is best-effort
+  1. ${colors.green('Submit a full reply before summarizing')} - terminal text is not completion
   2. ${colors.green('Be explicit')} - tell agents exactly what you need
   3. ${colors.green('Set timeout appropriately')} - complex tasks need more time
   4. ${colors.green('Use stable pane IDs in scripts')} - avoid ambiguous locators

--- a/src/commands/name.test.ts
+++ b/src/commands/name.test.ts
@@ -45,13 +45,11 @@ function context(json = false): Context {
       json: vi.fn(),
     },
     config: {
-      mode: 'polling',
       preambleMode: 'always',
       defaults: {
         timeout: 1,
         pollInterval: 1,
         captureLines: 1,
-        maxCaptureLines: 1,
         preambleEvery: 1,
         pasteEnterDelayMs: 0,
       },

--- a/src/commands/preamble.test.ts
+++ b/src/commands/preamble.test.ts
@@ -45,13 +45,11 @@ function createContext(service: PreambleService, flags: Partial<Context['flags']
     flags: { json: false, verbose: false, ...flags },
     ui,
     config: {
-      mode: 'wait',
       preambleMode: 'always',
       defaults: {
         timeout: 180,
         pollInterval: 1,
         captureLines: 100,
-        maxCaptureLines: 2000,
         preambleEvery: 3,
         pasteEnterDelayMs: 500,
       },

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -1,104 +1,83 @@
-// ─────────────────────────────────────────────────────────────
-// Talk Command Tests - --delay, --wait, preambles, nonce detection
-// ─────────────────────────────────────────────────────────────
-
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
-import type { Context, Tmux, UI, Paths, ResolvedConfig, Flags } from '../types.js';
-import type { RequestService, RequestSettlement } from '../request-service.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Context, Flags, Paths, ResolvedConfig, Tmux, UI } from '../types.js';
+import type {
+  RequestEndpoint,
+  RequestService,
+  RequestAttemptRecord,
+  RequestSettlement,
+} from '../request-service.js';
 import { createRequestService } from '../request-service.js';
 import { openIdentityRepository, type IdentityRepository } from '../storage/identity-repository.js';
 import { ExitCodes } from '../exits.js';
 import { TmuxDeliveryError } from '../message-delivery.js';
+import { decodeReplyReceipt } from '../reply-receipt.js';
 import { cmdTalk } from './talk.js';
 
-// ─────────────────────────────────────────────────────────────
-// Constants
-// ─────────────────────────────────────────────────────────────
+const ENDPOINT = {
+  serverId: 'server-test',
+  socketPath: '/tmp/tmt-test',
+  serverPid: 123,
+  serverStartTime: 'test-start',
+  paneId: '%1',
+  panePid: 456,
+} as const;
 
-// Regex to extract nonce from instruction (new format: "where xxxx = <nonce>")
-const INSTRUCTION_NONCE_REGEX = /where xxxx = ([a-f0-9]+)/;
-
-// ─────────────────────────────────────────────────────────────
-// Test utilities
-// ─────────────────────────────────────────────────────────────
-
-function createMockTmux(): Tmux & {
-  sends: Array<{ pane: string; message: string }>;
-  captureReturn: string;
-} {
-  const mock = {
-    sends: [] as Array<{ pane: string; message: string }>,
-    captureReturn: '',
-    send(pane: string, message: string) {
-      mock.sends.push({ pane, message });
-    },
-    capture(_pane: string, _lines: number) {
-      return mock.captureReturn;
-    },
-    listPanes() {
-      return [];
-    },
-    getCurrentPaneId() {
-      return null;
-    },
-    resolvePaneTarget(target: string) {
-      return target;
-    },
-    setPaneTitle() {},
-    getEndpointSnapshot() {
-      return {
-        server: {
-          serverId: 'server-test',
-          socketPath: '/tmp/tmt-test',
-          serverPid: 123,
-          serverStartTime: 'test-start',
-        },
-        panes: ['1.0', '1.1', '1.2', '1.9', '%9'].map((id) => ({
-          id,
-          command: 'test-agent',
-          panePid: 456,
-          suggestedName: null,
-        })),
-      };
-    },
-  };
-  return mock;
+type SentMessage = { pane: string; message: string };
+interface MockTmux extends Tmux {
+  readonly sends: SentMessage[];
+  readonly captureCalls: number;
 }
-
 interface RequestFixture {
   readonly repository: IdentityRepository;
   readonly service: RequestService;
   readonly identityIds: ReadonlyMap<string, string>;
 }
+interface TestUI extends UI {
+  readonly errors: string[];
+  readonly warnings: string[];
+  readonly jsonOutput: unknown[];
+}
 
-const requestFixtures = new Map<string, RequestFixture>();
-const ownedTempDirs = new Set<string>();
+const fixtures = new Map<string, RequestFixture>();
+const temporaryDirectories = new Set<string>();
 
-function createOwnedTempDir(prefix: string): string {
+function temporaryDirectory(prefix: string): string {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-  ownedTempDirs.add(directory);
+  temporaryDirectories.add(directory);
   return directory;
 }
 
+function closeFixtures(): void {
+  for (const fixture of fixtures.values()) fixture.repository.close();
+  fixtures.clear();
+  for (const directory of temporaryDirectories)
+    fs.rmSync(directory, { recursive: true, force: true });
+  temporaryDirectories.clear();
+}
+afterEach(closeFixtures);
+
 function requestFixture(databaseFile: string): RequestFixture {
-  const existing = requestFixtures.get(databaseFile);
+  const existing = fixtures.get(databaseFile);
   if (existing) return existing;
   const repository = openIdentityRepository(databaseFile);
   try {
     const identityIds = new Map<string, string>();
     for (const name of ['claude', 'codex', 'gemini', 'all']) {
-      const existingIdentity = repository.findByCanonicalName(name);
-      identityIds.set(name, (existingIdentity ?? repository.createIdentity(name, name)).id);
+      const identity =
+        repository.findByCanonicalName(name) ?? repository.createIdentity(name, name);
+      identityIds.set(name, identity.id);
     }
     const fixture = {
       repository,
       service: createRequestService({ repository }),
       identityIds,
     };
-    requestFixtures.set(databaseFile, fixture);
+    fixtures.set(databaseFile, fixture);
     return fixture;
   } catch (error) {
     repository.close();
@@ -106,30 +85,21 @@ function requestFixture(databaseFile: string): RequestFixture {
   }
 }
 
-function closeRequestFixtures(): void {
-  for (const fixture of requestFixtures.values()) fixture.repository.close();
-  requestFixtures.clear();
-  for (const directory of ownedTempDirs) {
-    if (fs.existsSync(directory)) fs.rmSync(directory, { recursive: true, force: true });
-  }
-  ownedTempDirs.clear();
-}
-
-afterEach(closeRequestFixtures);
-
-function createMockUI(): UI & { errors: string[]; warnings: string[]; jsonOutput: unknown[] } {
-  const mock = {
-    errors: [] as string[],
-    warnings: [] as string[],
-    jsonOutput: [] as unknown[],
+function createUI(): TestUI {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const jsonOutput: unknown[] = [];
+  return {
+    errors,
+    warnings,
+    jsonOutput,
     info: vi.fn(),
     success: vi.fn(),
-    warn: (msg: string) => mock.warnings.push(msg),
-    error: (msg: string) => mock.errors.push(msg),
+    warn: (message: string) => warnings.push(message),
+    error: (message: string) => errors.push(message),
     table: vi.fn(),
-    json: (data: unknown) => mock.jsonOutput.push(data),
+    json: (value: unknown) => jsonOutput.push(value),
   };
-  return mock;
 }
 
 function activeIdentity(name: string, paneId: string) {
@@ -146,11 +116,11 @@ function activeIdentity(name: string, paneId: string) {
       identityId: `identity-${name}`,
       transport: 'tmux' as const,
       paneId,
-      serverId: 's',
-      socketPath: '/s',
-      serverPid: 1,
-      serverStartTime: 'now',
-      panePid: 1,
+      serverId: ENDPOINT.serverId,
+      socketPath: ENDPOINT.socketPath,
+      serverPid: ENDPOINT.serverPid,
+      serverStartTime: ENDPOINT.serverStartTime,
+      panePid: ENDPOINT.panePid,
       boundAt: 'now',
       lastVerifiedAt: 'now',
     },
@@ -158,82 +128,85 @@ function activeIdentity(name: string, paneId: string) {
   };
 }
 
-function createTestPaths(testDir: string): Paths {
+function createMockTmux(options: { readonly onSend?: (message: string) => void } = {}): MockTmux {
+  const sends: SentMessage[] = [];
+  let captureCalls = 0;
   return {
-    globalDir: testDir,
-    globalConfig: path.join(testDir, 'config.json'),
-    localConfig: path.join(testDir, 'tmux-team.json'),
-    stateFile: path.join(testDir, 'state.json'),
-    databaseFile: path.join(testDir, 'tmux-team.db'),
+    sends,
+    get captureCalls() {
+      return captureCalls;
+    },
+    send(pane, message) {
+      sends.push({ pane, message });
+      options.onSend?.(message);
+    },
+    capture() {
+      captureCalls += 1;
+      throw new Error('terminal capture is not a durable completion oracle');
+    },
+    listPanes: () => [],
+    getCurrentPaneId: () => null,
+    resolvePaneTarget: (target: string) => target,
+    setPaneTitle: () => undefined,
+    getEndpointSnapshot: () => ({
+      server: {
+        serverId: ENDPOINT.serverId,
+        socketPath: ENDPOINT.socketPath,
+        serverPid: ENDPOINT.serverPid,
+        serverStartTime: ENDPOINT.serverStartTime,
+      },
+      panes: [
+        { id: '%1', command: 'claude', panePid: ENDPOINT.panePid, suggestedName: 'claude' },
+        { id: '%2', command: 'codex', panePid: 457, suggestedName: 'codex' },
+        { id: '%3', command: 'gemini', panePid: 458, suggestedName: 'gemini' },
+        { id: '%9', command: 'test-agent', panePid: 459, suggestedName: null },
+      ],
+    }),
   };
 }
 
-function createDefaultConfig(): ResolvedConfig {
+function createPaths(root: string): Paths {
   return {
-    mode: 'polling',
+    globalDir: root,
+    globalConfig: path.join(root, 'config.json'),
+    localConfig: path.join(root, 'tmux-team.json'),
+    stateFile: path.join(root, 'state.json'),
+    databaseFile: path.join(root, 'tmux-team.db'),
+  };
+}
+
+function createConfig(overrides: Partial<ResolvedConfig['defaults']> = {}): ResolvedConfig {
+  return {
     preambleMode: 'always',
     defaults: {
-      timeout: 60,
-      pollInterval: 0.1, // Fast polling for tests
+      timeout: 180,
+      pollInterval: 0.001,
       captureLines: 100,
-      maxCaptureLines: 2000,
       preambleEvery: 3,
-      pasteEnterDelayMs: 500,
+      pasteEnterDelayMs: 0,
+      ...overrides,
     },
   };
 }
 
-function createMockPreambleService(content?: string): NonNullable<Context['preambleService']> {
-  const identities = new Map([
-    [
-      'claude',
+function createPreambleService(content = 'Be concise'): NonNullable<Context['preambleService']> {
+  const identities = new Map(
+    ['claude', 'codex', 'gemini', 'all'].map((name) => [
+      name,
       {
-        id: 'identity-claude',
-        name: 'claude',
-        canonicalName: 'claude',
+        id: `identity-${name}`,
+        name,
+        canonicalName: name,
         createdAt: 'now',
         updatedAt: 'now',
       },
-    ],
-    [
-      'codex',
-      {
-        id: 'identity-codex',
-        name: 'codex',
-        canonicalName: 'codex',
-        createdAt: 'now',
-        updatedAt: 'now',
-      },
-    ],
-    [
-      'gemini',
-      {
-        id: 'identity-gemini',
-        name: 'gemini',
-        canonicalName: 'gemini',
-        createdAt: 'now',
-        updatedAt: 'now',
-      },
-    ],
-    [
-      'all',
-      {
-        id: 'identity-all',
-        name: 'all',
-        canonicalName: 'all',
-        createdAt: 'now',
-        updatedAt: 'now',
-      },
-    ],
-  ]);
+    ])
+  );
   return {
     show: vi.fn((name: string) => {
       const identity = identities.get(name);
       if (!identity) throw new Error(`Unknown identity: ${name}`);
-      return {
-        identity,
-        preamble: content ? { content, updatedAt: 'now' } : null,
-      };
+      return { identity, preamble: content ? { content, updatedAt: 'now' } : null };
     }),
     set: vi.fn(),
     clear: vi.fn(),
@@ -242,1779 +215,879 @@ function createMockPreambleService(content?: string): NonNullable<Context['pream
 }
 
 function createContext(
+  root: string,
   overrides: Partial<{
     tmux: Tmux;
-    ui: UI;
-    config: Partial<Omit<ResolvedConfig, 'defaults'>> & {
-      defaults?: Partial<ResolvedConfig['defaults']>;
-    };
+    ui: TestUI;
+    config: ResolvedConfig;
     flags: Partial<Flags>;
-    paths: Paths;
     preambleService: NonNullable<Context['preambleService']>;
     requestService: RequestService;
-  }>
+    identities: string[];
+  }> = {}
 ): Context {
-  const exitError = new Error('exit called');
-  (exitError as Error & { exitCode?: number }).exitCode = 0;
-
-  const baseConfig = createDefaultConfig();
-  const config = {
-    ...baseConfig,
-    ...overrides.config,
-    defaults: {
-      ...baseConfig.defaults,
-      ...overrides.config?.defaults,
-    },
-  };
-  const flags: Flags = { json: false, verbose: false, ...overrides.flags };
-  const tmux = overrides.tmux || createMockTmux();
-  const paths = overrides.paths || createTestPaths(createOwnedTempDir('talk-default-'));
-  const requestFixtureValue = requestFixture(paths.databaseFile);
-  const sourcePreambleService = overrides.preambleService || createMockPreambleService();
+  const paths = createPaths(root);
+  const fixture = requestFixture(paths.databaseFile);
+  const sourcePreamble = overrides.preambleService ?? createPreambleService();
   const preambleService: NonNullable<Context['preambleService']> = {
-    ...sourcePreambleService,
+    ...sourcePreamble,
     show(name: string) {
-      const result = sourcePreambleService.show(name);
-      const identityId = requestFixtureValue.identityIds.get(name);
-      if (!identityId) return result;
-      return { ...result, identity: { ...result.identity, id: identityId } };
+      const result = sourcePreamble.show(name);
+      const identityId = fixture.identityIds.get(name);
+      return identityId ? { ...result, identity: { ...result.identity, id: identityId } } : result;
     },
-  };
-  const identityService = {
-    bindCurrent: vi.fn(),
-    bindPane: vi.fn(),
-    unbindCurrent: vi.fn(),
-    currentIdentity: vi.fn(),
-    activeIdentities: vi.fn(() =>
-      ['claude', 'codex', 'gemini'].map((name, index) => activeIdentity(name, `1.${index}`))
-    ),
-    resolveActive: vi.fn(),
-    reconcile: vi.fn(),
   };
   return {
     argv: [],
-    flags,
-    ui: overrides.ui || createMockUI(),
-    config,
-    tmux,
-    identityService,
+    flags: { json: true, verbose: false, ...overrides.flags } as Flags,
+    ui: overrides.ui ?? createUI(),
+    config: overrides.config ?? createConfig(),
+    tmux: overrides.tmux ?? createMockTmux(),
+    identityService: {
+      bindCurrent: vi.fn(),
+      bindPane: vi.fn(),
+      unbindCurrent: vi.fn(),
+      currentIdentity: vi.fn(),
+      activeIdentities: vi.fn(() =>
+        (overrides.identities ?? ['claude', 'codex', 'gemini']).map((name, index) =>
+          activeIdentity(name, `%${index + 1}`)
+        )
+      ),
+      resolveActive: vi.fn(),
+      reconcile: vi.fn(),
+    },
     preambleService,
-    requestService: overrides.requestService || requestFixtureValue.service,
+    requestService: overrides.requestService ?? fixture.service,
     paths,
-    exit: ((code: number) => {
-      const err = new Error(`exit(${code})`);
-      (err as Error & { exitCode: number }).exitCode = code;
-      throw err;
-    }) as (code: number) => never,
+    exit: ((code: number): never => {
+      throw Object.assign(new Error(`exit(${code})`), { exitCode: code });
+    }) as Context['exit'],
   };
 }
 
-// ─────────────────────────────────────────────────────────────
-// Tests
-// ─────────────────────────────────────────────────────────────
+function onlyAttempt(service: RequestService): RequestAttemptRecord {
+  const records = service.listAttempts();
+  if (records.length !== 1) throw new Error(`Expected one attempt, found ${records.length}.`);
+  return records[0]!;
+}
 
-describe('buildMessage (via cmdTalk)', () => {
-  let testDir: string;
+function attemptFromInstruction(service: RequestService, message: string): RequestAttemptRecord {
+  const requestId = message.match(/^request-id=([^\n]+)$/m)?.[1];
+  const encodedReceipt = message.match(/^receipt=([^\n]+)$/m)?.[1];
+  if (!requestId || !encodedReceipt) throw new Error('Durable receipt instruction is incomplete.');
+  const receipt = decodeReplyReceipt(encodedReceipt, requestId);
+  const attempt = service.getAttempt(receipt.attemptId);
+  if (!attempt) throw new Error(`Attempt '${receipt.attemptId}' was not persisted.`);
+  return attempt;
+}
 
-  beforeEach(() => {
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'talk-test-'));
+function endpointOf(attempt: RequestAttemptRecord): RequestEndpoint {
+  return {
+    serverId: attempt.serverId,
+    socketPath: attempt.socketPath,
+    serverPid: attempt.serverPid,
+    serverStartTime: attempt.serverStartTime,
+    paneId: attempt.paneId,
+    panePid: attempt.panePid,
+  };
+}
+
+function submitFor(service: RequestService, attempt: RequestAttemptRecord, body: string): void {
+  service.submitResponse({
+    requestId: attempt.requestId,
+    attemptId: attempt.attemptId,
+    endpoint: endpointOf(attempt),
+    body,
   });
+}
 
-  afterEach(() => {
-    closeRequestFixtures();
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-
-  it('returns original message when preambleMode is disabled', async () => {
-    const tmux = createMockTmux();
-    const ctx = createContext({
-      tmux,
-      paths: createTestPaths(testDir),
-      config: { preambleMode: 'disabled' },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    expect(tmux.sends).toHaveLength(1);
-    expect(tmux.sends[0].message).toBe('Hello');
-  });
-
-  it('returns original message when --no-preamble flag is set', async () => {
-    const tmux = createMockTmux();
-    const ctx = createContext({
-      tmux,
-      paths: createTestPaths(testDir),
-      flags: { noPreamble: true },
-      config: { preambleMode: 'always' },
-      preambleService: createMockPreambleService('Be brief'),
-    });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    expect(tmux.sends).toHaveLength(1);
-    expect(tmux.sends[0].message).toBe('Hello');
-  });
-
-  it('returns original message when agent has no preamble', async () => {
-    const tmux = createMockTmux();
-    const preambleService = createMockPreambleService();
-    const paths = createTestPaths(testDir);
-    const ctx = createContext({
-      tmux,
-      paths,
-      config: { preambleMode: 'always' },
-      preambleService,
-    });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    expect(tmux.sends).toHaveLength(1);
-    expect(tmux.sends[0].message).toBe('Hello');
-    expect(preambleService.show).toHaveBeenCalledWith('claude');
-    expect(fs.existsSync(paths.stateFile)).toBe(false);
-  });
-
-  it('prepends [SYSTEM: preamble] when preambleMode is always', async () => {
-    const tmux = createMockTmux();
-    const ctx = createContext({
-      tmux,
-      paths: createTestPaths(testDir),
-      config: {
-        preambleMode: 'always',
-      },
-      preambleService: createMockPreambleService('Be helpful and concise'),
-    });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    expect(tmux.sends).toHaveLength(1);
-    expect(tmux.sends[0].message).toContain('[SYSTEM: Be helpful and concise]');
-    expect(tmux.sends[0].message).toContain('Hello');
-  });
-
-  it('formats preamble as [SYSTEM: <preamble>]\\n\\n<message>', async () => {
-    const tmux = createMockTmux();
-    const ctx = createContext({
-      tmux,
-      paths: createTestPaths(testDir),
-      config: {
-        preambleMode: 'always',
-      },
-      preambleService: createMockPreambleService('Test preamble'),
-    });
-
-    await cmdTalk(ctx, 'claude', 'Test message');
-
-    expect(tmux.sends[0].message).toBe('[SYSTEM: Test preamble]\n\nTest message');
-  });
-
-  it('injects preamble based on preambleEvery config (every N messages)', async () => {
-    const paths = createTestPaths(testDir);
-    fs.mkdirSync(paths.globalDir, { recursive: true });
-
-    const config = {
-      preambleMode: 'always' as const,
-      defaults: {
-        timeout: 60,
-        pollInterval: 0.1,
-        captureLines: 100,
-        maxCaptureLines: 2000,
-        preambleEvery: 3,
-        pasteEnterDelayMs: 500,
-      },
+function stateSnapshot(root: string): {
+  attempts: unknown[];
+  responses: unknown[];
+  cadence: unknown[];
+} {
+  const database = new Database(createPaths(root).databaseFile, { readonly: true });
+  try {
+    return {
+      attempts: database.prepare('SELECT * FROM request_attempts ORDER BY attempt_id').all(),
+      responses: database.prepare('SELECT * FROM request_responses ORDER BY request_id').all(),
+      cadence: database.prepare('SELECT * FROM preamble_counters ORDER BY identity_id').all(),
     };
-
-    // Message 1: should include preamble (first message)
-    const tmux1 = createMockTmux();
-    await cmdTalk(
-      createContext({
-        tmux: tmux1,
-        paths,
-        config,
-        preambleService: createMockPreambleService('Be brief'),
-      }),
-      'claude',
-      'Hello 1'
-    );
-    expect(tmux1.sends[0].message).toContain('[SYSTEM: Be brief]');
-
-    // Message 2: should NOT include preamble
-    const tmux2 = createMockTmux();
-    await cmdTalk(
-      createContext({
-        tmux: tmux2,
-        paths,
-        config,
-        preambleService: createMockPreambleService('Be brief'),
-      }),
-      'claude',
-      'Hello 2'
-    );
-    expect(tmux2.sends[0].message).toBe('Hello 2');
-
-    // Message 3: should NOT include preamble
-    const tmux3 = createMockTmux();
-    await cmdTalk(
-      createContext({
-        tmux: tmux3,
-        paths,
-        config,
-        preambleService: createMockPreambleService('Be brief'),
-      }),
-      'claude',
-      'Hello 3'
-    );
-    expect(tmux3.sends[0].message).toBe('Hello 3');
-
-    // Message 4: should include preamble (4 - 1 = 3, divisible by 3)
-    const tmux4 = createMockTmux();
-    await cmdTalk(
-      createContext({
-        tmux: tmux4,
-        paths,
-        config,
-        preambleService: createMockPreambleService('Be brief'),
-      }),
-      'claude',
-      'Hello 4'
-    );
-    expect(tmux4.sends[0].message).toContain('[SYSTEM: Be brief]');
-  });
-
-  it('injects preamble every time when preambleEvery is 1', async () => {
-    const paths = createTestPaths(testDir);
-    fs.mkdirSync(paths.globalDir, { recursive: true });
-
-    const config = {
-      preambleMode: 'always' as const,
-      defaults: {
-        timeout: 60,
-        pollInterval: 0.1,
-        captureLines: 100,
-        maxCaptureLines: 2000,
-        preambleEvery: 1,
-        pasteEnterDelayMs: 500,
-      },
-    };
-
-    // All messages should include preamble
-    for (let i = 0; i < 3; i++) {
-      const tmux = createMockTmux();
-      await cmdTalk(
-        createContext({
-          tmux,
-          paths,
-          config,
-          preambleService: createMockPreambleService('Be brief'),
-        }),
-        'claude',
-        `Hello ${i}`
-      );
-      expect(tmux.sends[0].message).toContain('[SYSTEM: Be brief]');
-    }
-  });
-
-  it('never injects preamble when preambleEvery is 0', async () => {
-    const paths = createTestPaths(testDir);
-    fs.mkdirSync(paths.globalDir, { recursive: true });
-
-    const config = {
-      preambleMode: 'always' as const,
-      defaults: {
-        timeout: 60,
-        pollInterval: 0.1,
-        captureLines: 100,
-        maxCaptureLines: 2000,
-        preambleEvery: 0,
-        pasteEnterDelayMs: 500,
-      },
-    };
-
-    // No messages should include preamble
-    for (let i = 0; i < 3; i++) {
-      const tmux = createMockTmux();
-      await cmdTalk(
-        createContext({
-          tmux,
-          paths,
-          config,
-          preambleService: createMockPreambleService('Be brief'),
-        }),
-        'claude',
-        `Hello ${i}`
-      );
-      expect(tmux.sends[0].message).toBe(`Hello ${i}`);
-    }
-  });
-});
-
-describe('cmdTalk - basic send', () => {
-  it.each(['claude', '%9'])(
-    'does not send target %s without required identity wiring',
-    async (target) => {
-      for (const wait of [false, true]) {
-        const tmux = createMockTmux();
-        const legacyRead = vi.fn(() => [{ name: 'claude', canonicalName: 'claude', paneId: '%9' }]);
-        Object.assign(tmux, { listGlobalIdentities: legacyRead });
-        const ctx = createContext({ tmux, flags: { wait }, paths: createTestPaths(testDir) });
-        Object.defineProperty(ctx, 'identityService', { value: undefined });
-        await expect(cmdTalk(ctx, target, 'must not send')).rejects.toThrow(
-          'Identity service is required'
-        );
-        expect(legacyRead).not.toHaveBeenCalled();
-        expect(tmux.sends).toEqual([]);
-        expect(fs.existsSync(ctx.paths.stateFile)).toBe(false);
-      }
-    }
-  );
-  let testDir: string;
-  const originalEnv = { ...process.env };
-
-  beforeEach(() => {
-    // Disable pane detection in tests
-    delete process.env.TMUX;
-    delete process.env.TMT_AGENT_NAME;
-    delete process.env.TMUX_TEAM_ACTOR;
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'talk-test-'));
-  });
-
-  afterEach(() => {
-    closeRequestFixtures();
-    process.env = { ...originalEnv };
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-
-  it('sends message to specified agent pane', async () => {
-    const tmux = createMockTmux();
-    const ctx = createContext({ tmux, paths: createTestPaths(testDir) });
-
-    await cmdTalk(ctx, 'claude', 'Hello Claude');
-
-    expect(tmux.sends).toHaveLength(1);
-    expect(tmux.sends[0].pane).toBe('1.0');
-    expect(tmux.sends[0].message).toBe('Hello Claude');
-  });
-
-  it('treats all as an ordinary identity and reports it when inactive', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-    });
-
-    await expect(cmdTalk(ctx, 'all', 'Hello')).rejects.toThrow(`exit(${ExitCodes.NAME_NOT_FOUND})`);
-    expect(ui.jsonOutput).toEqual([]);
-    expect(ui.errors).toContain("Identity 'all' is not active.");
-  });
-
-  it('sends to a bound all identity as one pane', async () => {
-    const tmux = createMockTmux();
-    const ctx = createContext({
-      tmux,
-      paths: createTestPaths(testDir),
-    });
-    (ctx.identityService.activeIdentities as ReturnType<typeof vi.fn>).mockReturnValue([
-      {
-        ...activeIdentity('all', '1.9'),
-      },
-    ]);
-
-    await cmdTalk(ctx, 'all', 'Hello');
-
-    expect(tmux.sends).toHaveLength(1);
-    expect(tmux.sends[0].pane).toBe('1.9');
-  });
-
-  it('returns a structured error when tmux.send fails', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    tmux.send = () => {
-      throw new Error('tmux error');
-    };
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { json: true },
-    });
-
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(ui.jsonOutput).toEqual([
-      {
-        error: {
-          code: 'ERROR',
-          message: 'Failed to send to pane 1.0. Is tmux running?',
-          suggestion: 'Delivery may have occurred; inspect the target pane before retrying.',
-        },
-      },
-    ]);
-  });
-
-  it('returns one structured uncertainty envelope for a typed send failure', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    tmux.send = () => {
-      throw new TmuxDeliveryError('paste');
-    };
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { json: true },
-    });
-
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(ui.jsonOutput).toEqual([
-      {
-        error: {
-          code: 'DELIVERY_UNCERTAIN',
-          message: 'Message delivery is uncertain during paste.',
-          stage: 'paste',
-          suggestion: 'Inspect the target pane before retrying.',
-        },
-      },
-    ]);
-    expect(ui.jsonOutput).toHaveLength(1);
-  });
-
-  it('shows an actionable inspection hint for human uncertainty output', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    tmux.send = () => {
-      throw new TmuxDeliveryError('literal');
-    };
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-    });
-
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(ui.errors).toEqual([
-      'Message delivery is uncertain during literal. Inspect the target pane before retrying.',
-    ]);
-    expect(ui.jsonOutput).toEqual([]);
-  });
-
-  it.each([
-    ['non-wait', { wait: false }],
-    ['wait', { wait: true, timeout: 0.5 }],
-  ] as const)(
-    'fails named %s talk before transport when the preamble service is absent',
-    async (_mode, flags) => {
-      const tmux = createMockTmux();
-      const ui = createMockUI();
-      const ctx = createContext({
-        tmux,
-        ui,
-        paths: createTestPaths(testDir),
-        flags: { ...flags, json: true },
-      });
-      delete ctx.preambleService;
-
-      await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-      expect(tmux.sends).toHaveLength(0);
-      expect(ui.jsonOutput).toEqual([
-        { error: { code: 'PREAMBLE_ERROR', message: 'Preamble service is unavailable.' } },
-      ]);
-    }
-  );
-
-  it.each([
-    ['non-wait', { wait: false }],
-    ['wait', { wait: true, timeout: 0.5 }],
-  ] as const)('maps %s preamble lookup failures before transport', async (_mode, flags) => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    const paths = createTestPaths(testDir);
-    const preambleService = createMockPreambleService('Be brief');
-    preambleService.show = vi.fn(() => {
-      throw new Error('preamble database unavailable');
-    });
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths,
-      flags: { ...flags, json: true },
-      preambleService,
-    });
-
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(tmux.sends).toHaveLength(0);
-    expect(ui.jsonOutput).toEqual([
-      { error: { code: 'PREAMBLE_ERROR', message: 'preamble database unavailable' } },
-    ]);
-    expect(fs.existsSync(paths.stateFile)).toBe(false);
-  });
-
-  it.each([
-    ['disabled', { preambleMode: 'disabled' as const }],
-    ['zero cadence', { defaults: { preambleEvery: 0 } }],
-  ] as const)(
-    'does not require preamble service when %s disables lookup',
-    async (_mode, config) => {
-      const tmux = createMockTmux();
-      const ctx = createContext({ tmux, paths: createTestPaths(testDir), config });
-      delete ctx.preambleService;
-
-      await cmdTalk(ctx, 'claude', 'Hello');
-      expect(tmux.sends).toHaveLength(1);
-      expect(tmux.sends[0].message).toBe('Hello');
-    }
-  );
-
-  it('preserves exclamation marks for gemini agent', async () => {
-    const tmux = createMockTmux();
-    const ctx = createContext({ tmux, paths: createTestPaths(testDir) });
-
-    await cmdTalk(ctx, 'gemini', 'Hello! This is exciting!');
-
-    expect(tmux.sends).toHaveLength(1);
-    expect(tmux.sends[0].message).toBe('Hello! This is exciting!');
-  });
-
-  it('exits with error for unknown agent', async () => {
-    const ui = createMockUI();
-    const ctx = createContext({ ui, paths: createTestPaths(testDir) });
-
-    await expect(cmdTalk(ctx, 'unknown', 'Hello')).rejects.toThrow('exit(3)');
-
-    expect(ui.errors).toHaveLength(1);
-    expect(ui.errors[0]).toContain("Identity 'unknown' is not active.");
-  });
-
-  it('outputs JSON when --json flag is set', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { json: true },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    expect(ui.jsonOutput).toHaveLength(1);
-    expect(ui.jsonOutput[0]).toMatchObject({
-      target: 'claude',
-      pane: '1.0',
-      status: 'sent',
-    });
-  });
-});
-
-describe('cmdTalk - --delay flag', () => {
-  let testDir: string;
-
-  beforeEach(() => {
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'talk-test-'));
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    closeRequestFixtures();
-    vi.useRealTimers();
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-
-  it('waits specified seconds before sending', async () => {
-    const tmux = createMockTmux();
-    const ctx = createContext({
-      tmux,
-      paths: createTestPaths(testDir),
-      flags: { delay: 2 },
-    });
-
-    const promise = cmdTalk(ctx, 'claude', 'Hello');
-
-    // Before delay, no message sent
-    expect(tmux.sends).toHaveLength(0);
-
-    // Advance time
-    await vi.advanceTimersByTimeAsync(2000);
-    await promise;
-
-    expect(tmux.sends).toHaveLength(1);
-  });
-});
-
-describe('cmdTalk - --wait mode', () => {
-  let testDir: string;
-
-  beforeEach(() => {
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'talk-test-'));
-  });
-
-  afterEach(() => {
-    closeRequestFixtures();
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-
-  // Helper: generate mock capture output with proper marker structure
-  // New protocol: instruction shows format with placeholder "xxxx" then actual nonce
-  // Include the instruction line so extraction can anchor to it for clean output
-  function mockCompleteResponse(nonce: string, response: string): string {
-    const instruction = `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`;
-    const endMarker = `RESPONSE-END-${nonce}`;
-    // Simulate: scrollback, user message with instruction, agent response, marker
-    return `Some scrollback content\nUser message here\n\n${instruction}\n${response}\n${endMarker}`;
+  } finally {
+    database.close();
   }
+}
 
-  it.each([
-    [
-      'generic',
-      () => new Error('tmux error'),
-      {
-        code: 'ERROR',
-        message: 'Failed to send to pane 1.0. Is tmux running?',
-        suggestion: 'Delivery may have occurred; inspect the target pane before retrying.',
-      },
-    ],
-    [
-      'typed',
-      () => new TmuxDeliveryError('submit'),
-      {
-        code: 'DELIVERY_UNCERTAIN',
-        message: 'Message delivery is uncertain during submit.',
-        stage: 'submit',
-        suggestion: 'Inspect the target pane before retrying.',
-      },
-    ],
-  ] as const)(
-    'maps %s send failure once in wait mode and releases only its waiter',
-    async (_kind, makeError, expected) => {
-      const tmux = createMockTmux();
-      const ui = createMockUI();
-      tmux.send = () => {
-        throw makeError();
-      };
-      const paths = createTestPaths(testDir);
-      const requestService = requestFixture(paths.databaseFile).service;
-      const unrelated = requestService.prepare({
-        requestId: 'other-request',
-        nonce: 'other',
-        endpoint: {
-          serverId: 'server-test',
-          socketPath: '/tmp/tmt-test',
-          serverPid: 123,
-          serverStartTime: 'test-start',
-          paneId: '1.1',
-          panePid: 456,
+describe('cmdTalk durable completion', () => {
+  it('sends an exact receipt instruction and returns the durable body without capture', async () => {
+    const root = temporaryDirectory('tmt-talk-success-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const body = '\ufefffirst\r\n\u0000日本語 😀\r\nRESPONSE-END-fake\n  ';
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), body),
+    });
+    const ctx = createContext(root, { tmux });
+    await cmdTalk(ctx, 'claude', 'Hello!');
+    const attempt = onlyAttempt(fixture.service);
+    expect((ctx.ui as TestUI).jsonOutput).toEqual([
+      expect.objectContaining({
+        status: 'completed',
+        requestId: attempt.requestId,
+        response: body,
+        bodyBytes: Buffer.byteLength(body),
+        submittedAtMs: expect.any(Number),
+      }),
+    ]);
+    expect(tmux.captureCalls).toBe(0);
+    expect(tmux.sends[0]?.message).toContain(attempt.requestId);
+    expect(tmux.sends[0]?.message).toContain('tmt reply');
+    expect(tmux.sends[0]?.message).toContain('--receipt');
+    expect(tmux.sends[0]?.message).toContain('--file');
+    expect(tmux.sends[0]?.message).toContain('--stdin');
+    expect(tmux.sends[0]?.message).toContain('body-limit-bytes=1048576');
+    const receipt = tmux.sends[0]?.message.match(/^receipt=([^\n]+)$/m)?.[1];
+    expect(receipt).toBeTruthy();
+    expect(decodeReplyReceipt(receipt!, attempt.requestId)).toMatchObject({
+      version: 1,
+      requestId: attempt.requestId,
+      attemptId: attempt.attemptId,
+      endpoint: ENDPOINT,
+    });
+    expect(stateSnapshot(root).responses).toHaveLength(1);
+  });
+
+  it('supports detach by recording sent state without polling or result output', async () => {
+    const root = temporaryDirectory('tmt-talk-detach-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const tmux = createMockTmux();
+    const ctx = createContext(root, { tmux, flags: { detach: true } });
+    await cmdTalk(ctx, 'claude', 'Hello');
+    const attempt = onlyAttempt(fixture.service);
+    expect((ctx.ui as TestUI).jsonOutput).toEqual([
+      expect.objectContaining({
+        status: 'sent',
+        requestId: attempt.requestId,
+        target: 'claude',
+        pane: '%1',
+      }),
+    ]);
+    expect(tmux.captureCalls).toBe(0);
+    expect(stateSnapshot(root).responses).toEqual([]);
+    expect(attempt.status).toBe('sent');
+    expect(attempt.waitActive).toBe(false);
+  });
+
+  it('does not poll request results in detach mode', async () => {
+    const root = temporaryDirectory('tmt-talk-detach-no-poll-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const getResponse = vi.fn(() => undefined);
+    const service = { ...fixture.service, getResponse } as RequestService;
+    const ctx = createContext(root, {
+      requestService: service,
+      tmux: createMockTmux(),
+      flags: { detach: true },
+    });
+    await cmdTalk(ctx, 'claude', 'Hello');
+    expect(getResponse).not.toHaveBeenCalled();
+  });
+
+  it('warns about an overlapping waiter only for human output and suppresses it with force', async () => {
+    const root = temporaryDirectory('tmt-talk-overlap-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const existing = fixture.service.prepare({
+      requestId: 'existing-request',
+      endpoint: ENDPOINT,
+      wait: true,
+      expiresAtMs: Date.now() + 60 * 60 * 1000,
+    });
+    fixture.service.beginSend(existing.attemptId);
+
+    const warningUI = createUI();
+    const warningTmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'ok'),
+    });
+    const warningCtx = createContext(root, {
+      tmux: warningTmux,
+      ui: warningUI,
+      flags: { json: false },
+    });
+    await cmdTalk(warningCtx, 'claude', 'Hello');
+    expect(warningUI.warnings.join('\n')).toContain('existing-request');
+
+    const forceUI = createUI();
+    const forceTmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'ok'),
+    });
+    const forceCtx = createContext(root, {
+      tmux: forceTmux,
+      ui: forceUI,
+      flags: { json: false, force: true },
+    });
+    await cmdTalk(forceCtx, 'claude', 'Hello');
+    expect(forceUI.warnings).toEqual([]);
+  });
+
+  it('does not emit overlap warnings in JSON mode', async () => {
+    const root = temporaryDirectory('tmt-talk-overlap-json-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const existing = fixture.service.prepare({
+      requestId: 'existing-json-request',
+      endpoint: ENDPOINT,
+      wait: true,
+      expiresAtMs: Date.now() + 60 * 60 * 1000,
+    });
+    fixture.service.beginSend(existing.attemptId);
+    const ui = createUI();
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'ok'),
+    });
+    const ctx = createContext(root, { tmux, ui, flags: { json: true } });
+    await cmdTalk(ctx, 'claude', 'Hello');
+    expect(ui.warnings).toEqual([]);
+    expect(ui.jsonOutput).toHaveLength(1);
+  });
+
+  it('reports human detach and completion summaries through UI with request inspection guidance', async () => {
+    for (const detach of [true, false]) {
+      const root = temporaryDirectory(`tmt-talk-human-${detach ? 'detach' : 'completed'}-`);
+      const fixture = requestFixture(createPaths(root).databaseFile);
+      const ui = createUI();
+      const tmux = createMockTmux({
+        onSend: (message) => {
+          if (!detach)
+            submitFor(
+              fixture.service,
+              attemptFromInstruction(fixture.service, message),
+              'human result'
+            );
         },
-        wait: true,
-        expiresAtMs: Date.now() + 60_000,
       });
-      const ctx = createContext({
+      const ctx = createContext(root, {
         tmux,
         ui,
-        paths,
-        flags: { wait: true, json: true, timeout: 0.5 },
-        config: {
-          defaults: {
-            timeout: 0.5,
-            pollInterval: 0.01,
-            captureLines: 100,
-            maxCaptureLines: 2000,
-            preambleEvery: 3,
-            pasteEnterDelayMs: 500,
-          },
-        },
-        requestService,
+        flags: { json: false, ...(detach ? { detach: true } : {}) },
       });
-      ctx.exit = (code: number) => {
-        expect(code).toBe(ExitCodes.ERROR);
-        const attempts = requestService.listAttempts();
-        expect(
-          attempts.find((attempt) => attempt.requestId === unrelated.requestId)?.waitActive
-        ).toBe(true);
-        throw new Error(`exit(${code})`);
-      };
-
-      await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-      expect(ui.jsonOutput).toEqual([{ error: expected }]);
-      expect(ui.jsonOutput).toHaveLength(1);
-      const failed = requestService
-        .listAttempts()
-        .find((attempt) => attempt.requestId !== unrelated.requestId);
-      expect(failed?.status).toBe('uncertain');
-      expect(failed?.waitActive).toBe(false);
-    }
-  );
-
-  it('does not clear a newer pane request after an uncertain send', async () => {
-    const paths = createTestPaths(testDir);
-    const tmux = createMockTmux();
-    const requestService = requestFixture(paths.databaseFile).service;
-    let replacement: ReturnType<RequestService['prepare']> | undefined;
-    tmux.send = () => {
-      const attempt = requestService.listAttempts()[0];
-      expect(attempt?.requestId).not.toBe('newer-request');
-      replacement = requestService.prepare({
-        requestId: 'newer-request',
-        nonce: 'newer',
-        endpoint: {
-          serverId: 'server-test',
-          socketPath: '/tmp/tmt-test',
-          serverPid: 123,
-          serverStartTime: 'test-start',
-          paneId: '1.0',
-          panePid: 456,
-        },
-        wait: true,
-        expiresAtMs: Date.now() + 60_000,
-      });
-      throw new TmuxDeliveryError('paste');
-    };
-    const ctx = createContext({ tmux, paths, requestService, flags: { wait: true, json: true } });
-    ctx.exit = (code: number) => {
-      expect(code).toBe(ExitCodes.ERROR);
-      expect(replacement).toBeDefined();
-      expect(requestService.getAttempt(replacement!.attemptId)?.waitActive).toBe(true);
-      throw new Error(`exit(${code})`);
-    };
-
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(requestService.getAttempt(replacement!.attemptId)?.waitActive).toBe(true);
-  });
-
-  it('appends nonce instruction to message', async () => {
-    const tmux = createMockTmux();
-    // Set up capture to return the nonce marker immediately
-    let captureCount = 0;
-    tmux.capture = () => {
-      captureCount++;
-      if (captureCount === 1) return ''; // Baseline
-      // Extract nonce from instruction and return agent response with marker
-      const sent = tmux.sends[0]?.message || '';
-      const match = sent.match(INSTRUCTION_NONCE_REGEX);
-      return match ? mockCompleteResponse(match[1], 'Response here') : '';
-    };
-
-    const ctx = createContext({
-      tmux,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    expect(tmux.sends).toHaveLength(1);
-    // New protocol: instruction shows format with placeholder, then actual nonce
-    expect(tmux.sends[0].message).toContain('output exactly: RESPONSE-END-xxxx');
-    expect(tmux.sends[0].message).toContain('where xxxx =');
-    // Should NOT contain the literal marker format (marker appears only in agent response)
-    expect(tmux.sends[0].message).not.toMatch(/^RESPONSE-END-[a-f0-9]+$/m);
-  });
-
-  it('detects nonce marker and extracts response', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    let captureCount = 0;
-
-    tmux.capture = () => {
-      captureCount++;
-      if (captureCount === 1) return 'baseline content';
-      // Extract nonce from instruction and return agent response with marker
-      const sent = tmux.sends[0]?.message || '';
-      const match = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (match) {
-        return mockCompleteResponse(match[1], 'Agent response here');
-      }
-      return 'baseline content';
-    };
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    expect(ui.jsonOutput).toHaveLength(1);
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output.status).toBe('completed');
-    expect(output.response).toEqual(expect.stringContaining('Agent response here'));
-  });
-
-  it('returns timeout error with correct exit code', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    // Capture never returns the marker
-    tmux.capture = () => 'no marker here';
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.1 },
-      config: {
-        defaults: {
-          timeout: 0.1,
-          pollInterval: 0.02,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    try {
       await cmdTalk(ctx, 'claude', 'Hello');
-      expect.fail('Should have thrown');
-    } catch (err) {
-      const error = err as Error & { exitCode: number };
-      expect(error.exitCode).toBe(ExitCodes.TIMEOUT);
+      const requestId = onlyAttempt(fixture.service).requestId;
+      expect(ui.info).toHaveBeenCalledWith(expect.stringContaining(requestId));
+      expect(ui.info).toHaveBeenCalledWith(expect.stringContaining('result'));
     }
+  });
 
-    expect(ui.jsonOutput).toHaveLength(1);
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output.status).toBe('timeout');
-    expect(output.error).toEqual({
-      code: 'TIMEOUT',
-      message: expect.stringContaining('Timed out'),
+  it('reports a human timeout with request correlation and result inspection guidance', async () => {
+    const root = temporaryDirectory('tmt-talk-human-timeout-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const ui = createUI();
+    const ctx = createContext(root, {
+      tmux: createMockTmux(),
+      ui,
+      flags: { json: false, timeout: 0.01 },
+      config: createConfig({ pollInterval: 0.001 }),
+    });
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.TIMEOUT,
+    });
+    const requestId = onlyAttempt(fixture.service).requestId;
+    expect(ui.errors.join('\n')).toContain(requestId);
+    expect(ui.errors.join('\n')).toContain('result');
+  });
+
+  it('preserves preamble injection, cadence reservation, and target identity', async () => {
+    const root = temporaryDirectory('tmt-talk-preamble-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'ok'),
+    });
+    const ctx = createContext(root, { tmux });
+    await cmdTalk(ctx, 'claude', 'Hello');
+    expect(tmux.sends).toHaveLength(1);
+    expect(tmux.sends[0]?.pane).toBe('%1');
+    expect(tmux.sends[0]?.message).toContain('[SYSTEM: Be concise]');
+    const snapshot = stateSnapshot(root);
+    expect(snapshot.cadence).toHaveLength(1);
+    expect(snapshot.attempts[0]).toMatchObject({
+      pane_id: '%1',
+      cadence_reserved: 1,
+      wait_active: 0,
     });
   });
 
-  it('wakes a long poll on SIGINT, releases once, and cleans up wait resources', async () => {
-    vi.useFakeTimers();
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    const paths = createTestPaths(testDir);
-    const base = requestFixture(paths.databaseFile).service;
-    const releaseWait = vi.fn(base.releaseWait);
-    const requestService: RequestService = { ...base, releaseWait };
-    const listenerCount = process.listenerCount('SIGINT');
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths,
-      requestService,
-      flags: { wait: true, timeout: 30 },
-      config: {
-        defaults: {
-          timeout: 30,
-          pollInterval: 60,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
+  it.each([
+    { every: 1, expected: [true, true, true, true] },
+    { every: 3, expected: [true, false, false, true] },
+  ])('reserves repeated preambles at cadence N=$every', async ({ every, expected }) => {
+    const root = temporaryDirectory(`tmt-talk-cadence-${every}-`);
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'ok'),
+    });
+    for (let index = 0; index < expected.length; index += 1) {
+      const ctx = createContext(root, {
+        tmux,
+        config: createConfig({ preambleEvery: every }),
+      });
+      await cmdTalk(ctx, 'claude', `message-${index}`);
+      expect(tmux.sends[index]?.message.includes('[SYSTEM: Be concise]')).toBe(expected[index]);
+    }
+    const snapshot = stateSnapshot(root);
+    expect(snapshot.cadence).toHaveLength(1);
+    expect(snapshot.cadence[0]).toMatchObject({ reserved_count: expected.length });
+  });
+
+  it('normalizes identity names, injects for a bound direct pane, and skips unbound panes', async () => {
+    const namedRoot = temporaryDirectory('tmt-talk-case-name-');
+    const namedFixture = requestFixture(createPaths(namedRoot).databaseFile);
+    const namedPreamble = createPreambleService();
+    const namedTmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(
+          namedFixture.service,
+          attemptFromInstruction(namedFixture.service, message),
+          'ok'
+        ),
+    });
+    const namedCtx = createContext(namedRoot, {
+      tmux: namedTmux,
+      preambleService: namedPreamble,
+    });
+    await cmdTalk(namedCtx, 'Claude', 'Hello');
+    expect(namedPreamble.show).toHaveBeenCalledWith('claude');
+    expect(namedTmux.sends[0]?.message).toContain('[SYSTEM: Be concise]');
+
+    const boundRoot = temporaryDirectory('tmt-talk-bound-pane-');
+    const boundFixture = requestFixture(createPaths(boundRoot).databaseFile);
+    const boundPreamble = createPreambleService();
+    const boundTmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(
+          boundFixture.service,
+          attemptFromInstruction(boundFixture.service, message),
+          'ok'
+        ),
+    });
+    const boundCtx = createContext(boundRoot, {
+      tmux: boundTmux,
+      preambleService: boundPreamble,
+    });
+    await cmdTalk(boundCtx, '%1', 'Hello');
+    expect(boundPreamble.show).toHaveBeenCalledWith('claude');
+    expect(boundTmux.sends[0]?.message).toContain('[SYSTEM: Be concise]');
+
+    const unboundRoot = temporaryDirectory('tmt-talk-unbound-pane-');
+    const unboundFixture = requestFixture(createPaths(unboundRoot).databaseFile);
+    const unboundPreamble = createPreambleService();
+    const unboundTmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(
+          unboundFixture.service,
+          attemptFromInstruction(unboundFixture.service, message),
+          'ok'
+        ),
+    });
+    const unboundCtx = createContext(unboundRoot, {
+      tmux: unboundTmux,
+      preambleService: unboundPreamble,
+    });
+    await cmdTalk(unboundCtx, '%9', 'Hello');
+    expect(unboundPreamble.show).not.toHaveBeenCalled();
+    expect(unboundTmux.sends[0]?.message).not.toContain('[SYSTEM:');
+  });
+
+  it('does not look up or reserve a preamble when disabled, no-preamble is set, or cadence is zero', async () => {
+    for (const variant of [
+      { preambleMode: 'disabled' as const },
+      { flags: { noPreamble: true } },
+      { config: { preambleEvery: 0 } },
+    ]) {
+      const root = temporaryDirectory('tmt-talk-no-preamble-');
+      const fixture = requestFixture(createPaths(root).databaseFile);
+      const preambleService = createPreambleService();
+      const tmux = createMockTmux({
+        onSend: (message) =>
+          submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'ok'),
+      });
+      const ctx = createContext(root, {
+        tmux,
+        preambleService,
+        flags: variant.flags,
+        config: {
+          ...createConfig(variant.config),
+          ...(variant.preambleMode ? { preambleMode: variant.preambleMode } : {}),
         },
+      });
+      await cmdTalk(ctx, 'claude', 'Hello');
+      expect(preambleService.show).not.toHaveBeenCalled();
+      expect(stateSnapshot(root).cadence).toEqual([]);
+      expect(tmux.sends[0]?.message).toMatch(/^Hello\n\n\[TMT-DURABLE-REPLY v1 BEGIN\]/);
+    }
+  });
+
+  it('does not create cadence state when no-preamble delivery fails before transport', async () => {
+    const root = temporaryDirectory('tmt-talk-no-preamble-refund-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const service = {
+      ...fixture.service,
+      beginSend: vi.fn(() => {
+        throw new Error('begin send failed');
+      }),
+    } as RequestService;
+    const ctx = createContext(root, {
+      requestService: service,
+      flags: { noPreamble: true },
+      tmux: createMockTmux(),
+    });
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.ERROR,
+    });
+    expect(stateSnapshot(root).cadence).toEqual([]);
+    expect(stateSnapshot(root).responses).toEqual([]);
+  });
+
+  it('keeps literal exclamation source text at the command boundary', async () => {
+    const root = temporaryDirectory('tmt-talk-bang-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'ok'),
+    });
+    const ctx = createContext(root, { tmux, flags: { noPreamble: true } });
+    await cmdTalk(ctx, '%9', 'if (!ready) Hello!');
+    expect(tmux.sends[0]?.message).toContain('if (!ready) Hello!');
+  });
+
+  it('applies delay before transport and starts the observer deadline afterwards', async () => {
+    const root = temporaryDirectory('tmt-talk-delay-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const sleeps: number[] = [];
+    let clock = 1_000;
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(
+          fixture.service,
+          attemptFromInstruction(fixture.service, message),
+          'delayed result'
+        ),
+    });
+    const ctx = createContext(root, { tmux, flags: { delay: 2, timeout: 1 } });
+    await cmdTalk(ctx, 'claude', 'Hello', {
+      now: () => clock,
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+        clock += milliseconds;
       },
     });
+    expect(sleeps).toEqual([2_000]);
+    expect(tmux.sends).toHaveLength(1);
+    expect(onlyAttempt(fixture.service).status).toBe('sent');
+  });
 
-    let pending: Promise<void> | undefined;
+  it.each([
+    { name: 'zero timeout', flags: { timeout: 0 } },
+    { name: 'infinite timeout', flags: { timeout: Infinity } },
+    { name: 'negative delay', flags: { delay: -1 } },
+    { name: 'non-finite delay', flags: { delay: Number.NaN } },
+    { name: 'infinite delay', flags: { delay: Infinity } },
+    { name: 'zero poll interval', config: { pollInterval: 0 } },
+    { name: 'non-finite poll interval', config: { pollInterval: Number.NaN } },
+    { name: 'non-finite enter delay', config: { pasteEnterDelayMs: Number.NaN } },
+  ])('rejects invalid $name before send or request preparation', async ({ flags, config }) => {
+    const root = temporaryDirectory('tmt-talk-invalid-timing-');
+    requestFixture(createPaths(root).databaseFile);
+    const tmux = createMockTmux();
+    const ctx = createContext(root, {
+      tmux,
+      flags,
+      config: createConfig(config),
+    });
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.ERROR,
+    });
+    expect(tmux.sends).toEqual([]);
+    expect(stateSnapshot(root).attempts).toEqual([]);
+    expect(stateSnapshot(root).responses).toEqual([]);
+  });
+
+  it('refunds a definitely-unsent begin failure without sending or mutating state', async () => {
+    const root = temporaryDirectory('tmt-talk-refund-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const service = {
+      ...fixture.service,
+      beginSend: vi.fn(() => {
+        throw new Error('state write failed');
+      }),
+    } as RequestService;
+    const tmux = createMockTmux();
+    const ctx = createContext(root, { tmux, requestService: service });
+    const before = stateSnapshot(root);
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.ERROR,
+    });
+    expect(tmux.sends).toHaveLength(0);
+    expect(stateSnapshot(root).responses).toEqual(before.responses);
+    expect(stateSnapshot(root).cadence).toEqual([expect.objectContaining({ reserved_count: 0 })]);
+    expect((ctx.ui as TestUI).jsonOutput).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({ code: 'REQUEST_STATE_ERROR' }),
+      }),
+    ]);
+  });
+
+  it('records typed transport uncertainty, releases the waiter, and never replays', async () => {
+    const root = temporaryDirectory('tmt-talk-uncertain-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const tmux = createMockTmux();
+    tmux.send = vi.fn(() => {
+      throw new TmuxDeliveryError('paste');
+    });
+    const ctx = createContext(root, { tmux });
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.ERROR,
+    });
+    expect(tmux.send).toHaveBeenCalledTimes(1);
+    const attempt = onlyAttempt(fixture.service);
+    expect(attempt.status).toBe('uncertain');
+    expect(attempt.waitActive).toBe(false);
+    expect((ctx.ui as TestUI).jsonOutput).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({ code: 'DELIVERY_UNCERTAIN', stage: 'paste' }),
+      }),
+    ]);
+  });
+
+  it('returns a correlated timeout without capture fields and leaves the late result available', async () => {
+    const root = temporaryDirectory('tmt-talk-timeout-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const tmux = createMockTmux();
+    const ctx = createContext(root, {
+      tmux,
+      flags: { timeout: 0.01 },
+      config: createConfig({ pollInterval: 0.001 }),
+    });
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.TIMEOUT,
+    });
+    const timeout = (ctx.ui as TestUI).jsonOutput[0] as Record<string, unknown>;
+    expect(timeout).toMatchObject({
+      status: 'timeout',
+      requestId: expect.any(String),
+      error: { code: 'TIMEOUT' },
+    });
+    for (const forbidden of ['partialResponse', 'nonce', 'endMarker', 'truncated'])
+      expect(timeout).not.toHaveProperty(forbidden);
+    const attempt = onlyAttempt(fixture.service);
+    expect(attempt.waitActive).toBe(false);
+    expect(attempt.status).toBe('sent');
+    submitFor(fixture.service, attempt, 'late durable response');
+    expect(fixture.service.getResponse(attempt.requestId)?.body).toBe('late durable response');
+  });
+
+  it('interrupts only its waiter, emits a correlated error, and leaves no response', async () => {
+    vi.useFakeTimers();
+    const root = temporaryDirectory('tmt-talk-interrupt-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    let interrupted = false;
+    const ctx = createContext(root, {
+      tmux: createMockTmux(),
+      flags: { timeout: 1 },
+      config: createConfig({ pollInterval: 0.1 }),
+    });
+    const listenersBefore = process.listenerCount('SIGINT');
     try {
-      pending = cmdTalk(ctx, 'claude', 'Hello');
-      await Promise.resolve();
-
-      expect(tmux.sends).toHaveLength(1);
-      expect(process.listenerCount('SIGINT')).toBe(listenerCount + 1);
-      process.emit('SIGINT');
-
-      await expect(pending).rejects.toMatchObject({ exitCode: ExitCodes.ERROR });
-      expect(releaseWait).toHaveBeenCalledOnce();
-      expect(requestService.listAttempts()).toHaveLength(1);
-      expect(requestService.listAttempts()[0]).toMatchObject({
-        status: 'sent',
-        waitActive: false,
+      await expect(
+        cmdTalk(ctx, 'claude', 'Hello', {
+          now: () => 50_000,
+          sleep: async () => {
+            if (!interrupted) {
+              interrupted = true;
+              process.emit('SIGINT');
+            }
+          },
+        })
+      ).rejects.toMatchObject({ exitCode: ExitCodes.ERROR });
+      const output = (ctx.ui as TestUI).jsonOutput[0] as Record<string, unknown>;
+      const attempt = onlyAttempt(fixture.service);
+      expect(output).toMatchObject({
+        requestId: attempt.requestId,
+        error: { code: 'INTERRUPTED' },
       });
-      expect(ui.errors).toEqual(['Interrupted.']);
-      expect(process.listenerCount('SIGINT')).toBe(listenerCount);
+      expect(attempt.waitActive).toBe(false);
+      expect(fixture.service.getResponse(attempt.requestId)).toBeUndefined();
+      expect(process.listenerCount('SIGINT')).toBe(listenersBefore);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
-      // Keep a failed setup assertion from leaving the command suspended on its
-      // intentionally long fake poll timer or retaining the process listener.
-      if (pending && process.listenerCount('SIGINT') > listenerCount) {
-        process.emit('SIGINT');
-        await pending.catch(() => undefined);
-      }
       vi.useRealTimers();
     }
   });
 
-  it('isolates response using end marker in scrollback', async () => {
+  it('uses monotonic equality as a timeout boundary and never reads after the deadline', async () => {
+    const root = temporaryDirectory('tmt-talk-clock-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
     const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    const oldContent = 'Previous conversation\nOld content here';
-
-    tmux.capture = () => {
-      // Simulate scrollback with old content, then agent response with marker
-      const sent = tmux.sends[0]?.message || '';
-      const nonceMatch = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (nonceMatch) {
-        const endMarker = `RESPONSE-END-${nonceMatch[1]}`;
-        // Only ONE marker from agent
-        return `${oldContent}\nNew response content\n\n${endMarker}`;
-      }
-      return oldContent;
-    };
-
-    const ctx = createContext({
+    const getResponse = vi.fn(() => undefined);
+    const service = { ...fixture.service, getResponse } as RequestService;
+    let clock = 1_000;
+    const ctx = createContext(root, {
       tmux,
+      requestService: service,
+      flags: { timeout: 0.01 },
+      config: createConfig({ pollInterval: 0.001 }),
+    });
+    const promise = cmdTalk(ctx, 'claude', 'Hello', {
+      now: () => clock,
+      sleep: async () => {
+        clock = 1_010;
+      },
+    });
+    await expect(promise).rejects.toMatchObject({ exitCode: ExitCodes.TIMEOUT });
+    expect(getResponse).toHaveBeenCalledTimes(1);
+    expect(tmux.captureCalls).toBe(0);
+    expect(onlyAttempt(fixture.service).waitActive).toBe(false);
+  });
+
+  it('cleans the real pending poll timer and SIGINT listener, while retaining late replies', async () => {
+    vi.useFakeTimers();
+    const root = temporaryDirectory('tmt-talk-real-interrupt-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const ui = createUI();
+    const listenersBefore = process.listenerCount('SIGINT');
+    const ctx = createContext(root, {
+      tmux: createMockTmux(),
       ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
+      flags: { timeout: 60 },
+      config: createConfig({ pollInterval: 10 }),
     });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output.status).toBe('completed');
-    // Response should contain the actual response content
-    expect(output.response).toContain('New response content');
-  });
-
-  it('clears active request on completion', async () => {
-    const tmux = createMockTmux();
-    let captureCount = 0;
-
-    tmux.capture = () => {
-      captureCount++;
-      if (captureCount === 1) return '';
-      const sent = tmux.sends[0]?.message || '';
-      const match = sent.match(INSTRUCTION_NONCE_REGEX);
-      return match ? mockCompleteResponse(match[1], 'Done') : '';
-    };
-
-    const paths = createTestPaths(testDir);
-    const ctx = createContext({
-      tmux,
-      paths,
-      flags: { wait: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    // Check state file is cleaned up
-    if (fs.existsSync(paths.stateFile)) {
-      const state = JSON.parse(fs.readFileSync(paths.stateFile, 'utf-8'));
-      expect(state.requests.claude).toBeUndefined();
-    }
-  });
-
-  it('clears active request on timeout', async () => {
-    const tmux = createMockTmux();
-    tmux.capture = () => 'no marker';
-
-    const paths = createTestPaths(testDir);
-    const ctx = createContext({
-      tmux,
-      paths,
-      flags: { wait: true, timeout: 0.05 },
-      config: {
-        defaults: {
-          timeout: 0.05,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
     try {
-      await cmdTalk(ctx, 'claude', 'Hello');
-    } catch {
-      // Expected timeout
-    }
-
-    // Check state file is cleaned up
-    if (fs.existsSync(paths.stateFile)) {
-      const state = JSON.parse(fs.readFileSync(paths.stateFile, 'utf-8'));
-      expect(state.requests.claude).toBeUndefined();
-    }
-  });
-});
-
-describe('cmdTalk - errors and JSON output', () => {
-  it('errors when target agent is not found', async () => {
-    const ctx = createContext({});
-    await expect(cmdTalk(ctx, 'nope', 'hi')).rejects.toMatchObject({
-      exitCode: ExitCodes.PANE_NOT_FOUND,
-    });
-    expect((ctx.ui as any).errors.join('\n')).toContain("Identity 'nope' is not active.");
-  });
-
-  it('outputs JSON in non-wait mode', async () => {
-    const ctx = createContext({
-      flags: { json: true },
-    });
-    await cmdTalk(ctx, 'claude', 'hello');
-    const out = (ctx.ui as any).jsonOutput[0] as any;
-    expect(out).toMatchObject({ target: 'claude', pane: '1.0', status: 'sent' });
-  });
-});
-
-describe('cmdTalk - nonce collision handling', () => {
-  let testDir: string;
-
-  beforeEach(() => {
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'talk-test-'));
-  });
-
-  afterEach(() => {
-    closeRequestFixtures();
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
+      const pending = cmdTalk(ctx, 'claude', 'Hello');
+      await Promise.resolve();
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+      process.emit('SIGINT');
+      await expect(pending).rejects.toMatchObject({ exitCode: ExitCodes.ERROR });
+      expect(process.listenerCount('SIGINT')).toBe(listenersBefore);
+      expect(vi.getTimerCount()).toBe(0);
+      const attempt = onlyAttempt(fixture.service);
+      expect(attempt.waitActive).toBe(false);
+      submitFor(fixture.service, attempt, 'late after interrupt');
+      expect(fixture.service.getResponse(attempt.requestId)?.body).toBe('late after interrupt');
+    } finally {
+      vi.useRealTimers();
     }
   });
 
-  it('ignores old markers in scrollback that do not match current nonce', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    let captureCount = 0;
-    const oldEndMarker = 'RESPONSE-END-0000'; // Old marker from previous request
-
-    tmux.capture = () => {
-      captureCount++;
-      // Scrollback includes OLD markers from a previous request
-      if (captureCount === 1) {
-        return `Old question\nOld response\n${oldEndMarker}`;
-      }
-      // New capture still has old markers but agent hasn't responded yet
-      if (captureCount === 2) {
-        return `Old question\nOld response\n${oldEndMarker}`;
-      }
-      // Finally, new end marker appears from agent
-      const sent = tmux.sends[0]?.message || '';
-      const nonceMatch = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (nonceMatch) {
-        const newEndMarker = `RESPONSE-END-${nonceMatch[1]}`;
-        // Old markers in scrollback + new response + agent's end marker
-        return `Old question\nOld response\n${oldEndMarker}\nNew response\n\n${newEndMarker}`;
-      }
-      return `Old question\nOld response\n${oldEndMarker}`;
-    };
-
-    const ctx = createContext({
+  it('includes synchronous send time in the observer timeout budget', async () => {
+    const root = temporaryDirectory('tmt-talk-transport-overrun-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    let clock = 10_000;
+    const tmux = createMockTmux({ onSend: () => (clock += 20) });
+    const ctx = createContext(root, {
       tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
+      flags: { timeout: 0.01 },
+      config: createConfig({ pollInterval: 0.001 }),
     });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output.status).toBe('completed');
-    // The key behavior: old markers with different nonce don't trigger completion
-    // We waited for the NEW marker with correct nonce before completing
-    // Note: With new protocol, response includes N lines before marker (may include scrollback)
-    expect(output.response as string).toContain('New response');
-    // Verify we polled multiple times (waiting for correct marker, not triggered by old one)
-    expect(captureCount).toBeGreaterThan(2);
-  });
-});
-
-describe('cmdTalk - JSON output contract', () => {
-  let testDir: string;
-
-  beforeEach(() => {
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'talk-test-'));
+    await expect(
+      cmdTalk(ctx, 'claude', 'Hello', { now: () => clock, sleep: async () => undefined })
+    ).rejects.toMatchObject({ exitCode: ExitCodes.TIMEOUT });
+    expect(tmux.captureCalls).toBe(0);
+    expect(onlyAttempt(fixture.service).waitActive).toBe(false);
   });
 
-  afterEach(() => {
-    closeRequestFixtures();
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-
-  it('includes required fields in success response', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    tmux.capture = () => {
-      const sent = tmux.sends[0]?.message || '';
-      const nonceMatch = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (nonceMatch) {
-        return mockCompleteResponse(nonceMatch[1], 'Response');
-      }
-      return '';
-    };
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Hello');
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output).toHaveProperty('target', 'claude');
-    expect(output).toHaveProperty('pane', '1.0');
-    expect(output).toHaveProperty('status', 'completed');
-    expect(output).toHaveProperty('requestId');
-    expect(output).toHaveProperty('nonce');
-    expect(output).toHaveProperty('endMarker');
-    expect(output).toHaveProperty('response');
-  });
-
-  // Helper moved to describe scope for JSON output tests
-  // Include instruction line for proper extraction anchoring
-  function mockCompleteResponse(nonce: string, response: string): string {
-    const instruction = `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`;
-    const endMarker = `RESPONSE-END-${nonce}`;
-    return `Some scrollback\n${instruction}\n${response}\n${endMarker}`;
-  }
-
-  it('includes required fields in timeout response', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    tmux.capture = () => 'no marker';
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.05 },
-      config: {
-        defaults: {
-          timeout: 0.05,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    try {
-      await cmdTalk(ctx, 'claude', 'Hello');
-    } catch {
-      // Expected
-    }
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output).toHaveProperty('target', 'claude');
-    expect(output).toHaveProperty('pane', '1.0');
-    expect(output).toHaveProperty('status', 'timeout');
-    expect(output).toHaveProperty('error');
-    expect(output).toHaveProperty('requestId');
-    expect(output).toHaveProperty('nonce');
-    expect(output).toHaveProperty('endMarker');
-  });
-
-  it('captures partialResponse on timeout even when no marker visible', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    // Agent is writing but hasn't printed any marker yet
-    // New behavior: we capture the last N lines as partial response
-    tmux.capture = () => {
-      return `This is partial content\nStill writing...`;
-    };
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.05 },
-      config: {
-        defaults: {
-          timeout: 0.05,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    try {
-      await cmdTalk(ctx, 'claude', 'Hello');
-    } catch {
-      // Expected timeout
-    }
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output).toHaveProperty('status', 'timeout');
-    // Fallback: capture last N lines as partial response
-    expect(output.partialResponse).toContain('This is partial content');
-    expect(output.partialResponse).toContain('Still writing...');
-  });
-
-  it('returns scrollback as partialResponse when no instruction visible', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    // Capture shows scrollback but no instruction marker
-    // Fallback returns last N lines
-    tmux.capture = () => 'random scrollback content';
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.05 },
-      config: {
-        defaults: {
-          timeout: 0.05,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    try {
-      await cmdTalk(ctx, 'claude', 'Hello');
-    } catch {
-      // Expected timeout
-    }
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output).toHaveProperty('status', 'timeout');
-    // Fallback captures last N lines even without instruction visible
-    expect(output.partialResponse).toBe('random scrollback content');
-  });
-});
-
-// ─────────────────────────────────────────────────────────────
-// End Marker Tests - comprehensive coverage for the simplified marker system
-// ─────────────────────────────────────────────────────────────
-
-describe('cmdTalk - end marker detection', () => {
-  let testDir: string;
-
-  beforeEach(() => {
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'talk-test-'));
-  });
-
-  afterEach(() => {
-    closeRequestFixtures();
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-
-  // Helper: generate mock capture output with proper marker structure
-  // Include instruction line for proper extraction anchoring
-  function mockResponse(nonce: string, response: string): string {
-    const instruction = `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`;
-    const endMarker = `RESPONSE-END-${nonce}`;
-    return `Some scrollback\n${instruction}\n${response}\n${endMarker}`;
-  }
-
-  it('includes end marker instruction in sent message (not literal marker)', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    // Return complete response immediately
-    tmux.capture = () => {
-      const sent = tmux.sends[0]?.message || '';
-      // Extract nonce from instruction (looks for RESPONSE-END-xxxx pattern)
-      const nonceMatch = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (nonceMatch) {
-        return mockResponse(nonceMatch[1], 'Response');
-      }
-      return '';
-    };
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Test message');
-
-    const sent = tmux.sends[0].message;
-    // New protocol: instruction shows format with placeholder, then actual nonce
-    expect(sent).toContain('output exactly: RESPONSE-END-xxxx');
-    expect(sent).toContain('where xxxx =');
-    // Should NOT contain the literal marker format (marker appears only in agent response)
-    expect(sent).not.toMatch(/^RESPONSE-END-[a-f0-9]+$/m);
-  });
-
-  it('extracts response before end marker', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    tmux.capture = () => {
-      const sent = tmux.sends[0]?.message || '';
-      // Extract nonce from instruction
-      const nonceMatch = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (nonceMatch) {
-        const endMarker = `RESPONSE-END-${nonceMatch[1]}`;
-        // Simulate scrollback with old content, then agent's response with marker
-        return `Old garbage\nMore old stuff\nThis is the actual response\n\n${endMarker}\nContent after marker`;
-      }
-      return 'Old garbage\nMore old stuff';
-    };
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Test');
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output.status).toBe('completed');
-    expect(output.response).toContain('actual response');
-  });
-
-  it('handles multiline responses correctly', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    const multilineResponse = `Line 1 of response
-Line 2 of response
-Line 3 with special chars: <>&"'
-Line 4 final`;
-
-    tmux.capture = () => {
-      const sent = tmux.sends[0]?.message || '';
-      // Extract nonce from instruction
-      const nonceMatch = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (nonceMatch) {
-        return mockResponse(nonceMatch[1], multilineResponse);
-      }
-      return '';
-    };
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Test');
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output.response).toContain('Line 1 of response');
-    expect(output.response).toContain('Line 4 final');
-  });
-
-  it('handles empty response before marker', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    tmux.capture = () => {
-      const sent = tmux.sends[0]?.message || '';
-      // Extract nonce from instruction
-      const nonceMatch = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (nonceMatch) {
-        const endMarker = `RESPONSE-END-${nonceMatch[1]}`;
-        // Agent printed end marker immediately with no content before it
-        return `${endMarker}`;
-      }
-      return '';
-    };
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Test');
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output.status).toBe('completed');
-    expect(typeof output.response).toBe('string');
-  });
-
-  it('waits until marker appears (not triggered while agent is thinking)', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    let captureCount = 0;
-    tmux.capture = () => {
-      captureCount++;
-      const sent = tmux.sends[0]?.message || '';
-      // Extract nonce from instruction
-      const nonceMatch = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (nonceMatch) {
-        const endMarker = `RESPONSE-END-${nonceMatch[1]}`;
-        if (captureCount < 3) {
-          // No marker yet - agent is still thinking
-          return `Agent is still thinking...`;
-        }
-        // Finally, agent prints marker
-        return `Actual response\n${endMarker}`;
-      }
-      return '';
-    };
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 100,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Test');
-
-    // Should have polled multiple times before detecting completion
-    expect(captureCount).toBeGreaterThanOrEqual(3);
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output.status).toBe('completed');
-    expect(output.response).toContain('Actual response');
-  });
-
-  it('handles large scrollback with marker at end', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-
-    // Simulate 100+ lines of scrollback
-    const lotsOfContent = Array.from({ length: 150 }, (_, i) => `Line ${i}`).join('\n');
-
-    tmux.capture = () => {
-      const sent = tmux.sends[0]?.message || '';
-      // Extract nonce from instruction
-      const nonceMatch = sent.match(INSTRUCTION_NONCE_REGEX);
-      if (nonceMatch) {
-        const endMarker = `RESPONSE-END-${nonceMatch[1]}`;
-        // ONE marker only - from agent response
-        return `${lotsOfContent}\nThe actual response\n\n${endMarker}`;
-      }
-      return lotsOfContent;
-    };
-
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: createTestPaths(testDir),
-      flags: { wait: true, json: true, timeout: 0.5 },
-      config: {
-        defaults: {
-          timeout: 0.5,
-          pollInterval: 0.01,
-          captureLines: 200,
-          maxCaptureLines: 2000,
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-        },
-      },
-    });
-
-    await cmdTalk(ctx, 'claude', 'Test');
-
-    const output = ui.jsonOutput[0] as Record<string, unknown>;
-    expect(output.status).toBe('completed');
-    expect(output.response).toContain('actual response');
-  });
-});
-
-describe('cmdTalk - request state lifecycle', () => {
-  it('fails closed before transport when request preparation cannot persist', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    const stateDir = createOwnedTempDir('talk-state-test-');
-    const statePaths = createTestPaths(stateDir);
-    const requestService = requestFixture(statePaths.databaseFile).service;
-    requestService.prepare = vi.fn(() => {
-      throw new Error('database unavailable');
-    });
-    const ctx = createContext({
-      tmux,
-      ui,
-      requestService,
-      paths: statePaths,
-      flags: { json: true },
-    });
-
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(tmux.sends).toHaveLength(0);
-    expect(ui.jsonOutput).toEqual([
-      {
-        error: {
-          code: 'REQUEST_STATE_ERROR',
-          message:
-            'Request state could not be persisted before transport; no message was sent. Fix the request state database before retrying.',
-          suggestion: 'Fix the request state database before retrying.',
-        },
-      },
-    ]);
-  });
-
-  it('fails closed when the wait timing budget is not finite', async () => {
-    const tmux = createMockTmux();
-    const ui = createMockUI();
-    const stateDir = createOwnedTempDir('talk-state-test-');
-    const statePaths = createTestPaths(stateDir);
-    const ctx = createContext({
-      tmux,
-      ui,
-      paths: statePaths,
-      flags: { wait: true, json: true, timeout: Number.POSITIVE_INFINITY },
-    });
-
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(tmux.sends).toHaveLength(0);
-    expect(ui.jsonOutput[0]).toMatchObject({
-      error: expect.objectContaining({ code: 'REQUEST_STATE_ERROR' }),
-    });
-  });
-
-  it('records uncertainty and never replays after a possible transport failure', async () => {
-    const tmux = createMockTmux();
-    const stateDir = createOwnedTempDir('talk-state-test-');
-    const statePaths = createTestPaths(stateDir);
-    const requestService = requestFixture(statePaths.databaseFile).service;
-    let sendAttempts = 0;
-    tmux.send = () => {
-      sendAttempts += 1;
-      throw new Error('submit failed');
-    };
-    const ctx = createContext({
-      tmux,
-      requestService,
-      paths: statePaths,
-      flags: { json: true },
-    });
-
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(sendAttempts).toBe(1);
-    expect(requestService.listAttempts()).toHaveLength(1);
-    expect(requestService.listAttempts()[0]?.status).toBe('uncertain');
-  });
-
-  it('reports state uncertainty after transport and releases a waiter before exit', async () => {
-    const tmux = createMockTmux();
-    const stateDir = createOwnedTempDir('talk-state-test-');
-    const statePaths = createTestPaths(stateDir);
-    const base = requestFixture(statePaths.databaseFile).service;
-    const releaseWait = vi.fn(base.releaseWait);
+  it('correlates a settle failure after delivery without replaying the request', async () => {
+    const root = temporaryDirectory('tmt-talk-settle-failure-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
     const settle = vi.fn((attemptId: string, outcome: RequestSettlement) => {
-      if (outcome === 'sent') throw new Error('settle failed');
-      base.settle(attemptId, outcome);
+      if (outcome === 'sent') throw new Error('settle persistence failed after delivery');
+      return fixture.service.settle(attemptId, outcome);
     });
-    const requestService: RequestService = { ...base, releaseWait, settle };
-    const ui = createMockUI();
-    const ctx = createContext({
-      tmux,
-      ui,
-      requestService,
-      paths: statePaths,
-      flags: { wait: true, json: true },
+    const service = { ...fixture.service, settle } as RequestService;
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'delivered'),
     });
+    const ctx = createContext(root, { tmux, requestService: service });
 
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(tmux.sends).toHaveLength(1);
-    expect(releaseWait).toHaveBeenCalledOnce();
-    expect(ui.jsonOutput[0]).toMatchObject({
-      error: expect.objectContaining({ code: 'REQUEST_STATE_ERROR' }),
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.ERROR,
     });
-  });
-
-  it('refunds a begin-send failure and allows the next preamble reservation', async () => {
-    const stateDir = createOwnedTempDir('talk-state-test-');
-    const statePaths = createTestPaths(stateDir);
-    const base = requestFixture(statePaths.databaseFile).service;
-    let failBegin = true;
-    const beginSend = vi.fn((attemptId: string) => {
-      if (failBegin) {
-        failBegin = false;
-        throw new Error('begin failed');
-      }
-      base.beginSend(attemptId);
-    });
-    const requestService: RequestService = { ...base, beginSend };
-    const firstTmux = createMockTmux();
-    const firstCtx = createContext({
-      tmux: firstTmux,
-      requestService,
-      paths: statePaths,
-      preambleService: createMockPreambleService('Be brief'),
-      flags: { json: true },
-    });
-
-    await expect(cmdTalk(firstCtx, 'claude', 'First')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(firstTmux.sends).toHaveLength(0);
-    expect(requestService.listAttempts()[0]).toMatchObject({
-      status: 'definitely_failed',
-      cadenceReserved: false,
-      waitActive: false,
-    });
-
-    const secondTmux = createMockTmux();
-    const secondCtx = createContext({
-      tmux: secondTmux,
-      requestService,
-      paths: statePaths,
-      preambleService: createMockPreambleService('Be brief'),
-      flags: { json: true },
-    });
-    await cmdTalk(secondCtx, 'claude', 'Second');
-
-    expect(secondTmux.sends[0]?.message).toContain('[SYSTEM: Be brief]');
-    expect(beginSend).toHaveBeenCalledTimes(2);
-    // Attempts created in the same millisecond sort by UUID, not invocation order.
-    const secondAttemptId = beginSend.mock.calls[1]![0];
-    expect(requestService.getAttempt(secondAttemptId)).toMatchObject({
-      status: 'sent',
-      injectPreamble: true,
-      cadenceReserved: true,
-    });
-  });
-
-  it('releases a sent waiter when capture fails unexpectedly', async () => {
-    const stateDir = createOwnedTempDir('talk-state-test-');
-    const statePaths = createTestPaths(stateDir);
-    const base = requestFixture(statePaths.databaseFile).service;
-    const releaseWait = vi.fn(base.releaseWait);
-    const requestService: RequestService = { ...base, releaseWait };
-    const tmux = createMockTmux();
-    tmux.capture = () => {
-      throw new Error('capture failed');
+    const attempt = onlyAttempt(fixture.service);
+    const output = (ctx.ui as TestUI).jsonOutput[0] as {
+      requestId: string;
+      error: { code: string; suggestion: string };
     };
-    const ui = createMockUI();
-    const ctx = createContext({
+    expect(output).toMatchObject({
+      requestId: attempt.requestId,
+      error: {
+        code: 'REQUEST_STATE_ERROR',
+        suggestion: expect.stringContaining(attempt.requestId),
+      },
+    });
+    expect(tmux.sends).toHaveLength(1);
+    expect(fixture.service.getResponse(attempt.requestId)?.body).toBe('delivered');
+    expect(settle).toHaveBeenCalledWith(attempt.attemptId, 'sent');
+  });
+
+  it('correlates a response-read failure after delivery without replaying the request', async () => {
+    const root = temporaryDirectory('tmt-talk-read-failure-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const getResponse = vi.fn(() => {
+      throw new Error('response read failed after delivery');
+    });
+    const service = { ...fixture.service, getResponse } as RequestService;
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'delivered'),
+    });
+    const ctx = createContext(root, {
       tmux,
-      ui,
-      requestService,
-      paths: statePaths,
-      flags: { wait: true, json: true, timeout: 0.5 },
+      requestService: service,
+      config: createConfig({ pollInterval: 0.001 }),
     });
 
-    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
-    expect(releaseWait).toHaveBeenCalledOnce();
-    expect(requestService.listAttempts()[0]).toMatchObject({ status: 'sent', waitActive: false });
-    expect(ui.jsonOutput).toEqual([
-      { error: { code: 'ERROR', message: 'Failed to capture pane 1.0. Is tmux running?' } },
-    ]);
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.ERROR,
+    });
+    const attempt = onlyAttempt(fixture.service);
+    expect((ctx.ui as TestUI).jsonOutput[0]).toMatchObject({
+      requestId: attempt.requestId,
+      error: {
+        code: 'REQUEST_STATE_ERROR',
+        message: expect.stringContaining('read'),
+        suggestion: expect.stringContaining(attempt.requestId),
+      },
+    });
+    expect(tmux.sends).toHaveLength(1);
+    expect(getResponse).toHaveBeenCalledTimes(1);
+    expect(fixture.service.getResponse(attempt.requestId)?.body).toBe('delivered');
+  });
+
+  it('correlates waiter-release failure after delivery without replaying the request', async () => {
+    const root = temporaryDirectory('tmt-talk-release-failure-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const releaseWait = vi.fn(() => {
+      throw new Error('waiter release failed after delivery');
+    });
+    const service = { ...fixture.service, releaseWait } as RequestService;
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'delivered'),
+    });
+    const ctx = createContext(root, { tmux, requestService: service });
+
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.ERROR,
+    });
+    const attempt = onlyAttempt(fixture.service);
+    expect((ctx.ui as TestUI).jsonOutput[0]).toMatchObject({
+      requestId: attempt.requestId,
+      error: {
+        code: 'REQUEST_STATE_ERROR',
+        suggestion: expect.stringContaining(attempt.requestId),
+      },
+    });
+    expect(tmux.sends).toHaveLength(1);
+    expect(releaseWait).toHaveBeenCalledTimes(1);
+    expect(fixture.service.getResponse(attempt.requestId)?.body).toBe('delivered');
+  });
+
+  it('rejects a response read that crosses the deadline and performs no second read', async () => {
+    const root = temporaryDirectory('tmt-talk-read-overrun-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    let clock = 20_000;
+    const getResponse = vi.fn((requestId: string) => {
+      const response = fixture.service.getResponse(requestId);
+      clock += 20;
+      return response;
+    });
+    const service = { ...fixture.service, getResponse } as RequestService;
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'crossed'),
+    });
+    const ctx = createContext(root, {
+      tmux,
+      requestService: service,
+      flags: { timeout: 0.01 },
+      config: createConfig({ pollInterval: 0.001 }),
+    });
+    await expect(
+      cmdTalk(ctx, 'claude', 'Hello', {
+        now: () => clock,
+        sleep: async () => undefined,
+      })
+    ).rejects.toMatchObject({ exitCode: ExitCodes.TIMEOUT });
+    expect(getResponse).toHaveBeenCalledTimes(1);
+    expect(fixture.service.getResponse(onlyAttempt(fixture.service).requestId)?.body).toBe(
+      'crossed'
+    );
+  });
+
+  it('fails closed when request preparation cannot persist and does not send', async () => {
+    const root = temporaryDirectory('tmt-talk-receipt-failure-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const service = {
+      ...fixture.service,
+      prepare: vi.fn(() => {
+        throw new Error('receipt persistence failed');
+      }),
+    } as RequestService;
+    const tmux = createMockTmux();
+    const ctx = createContext(root, { tmux, requestService: service });
+    const before = stateSnapshot(root);
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.ERROR,
+    });
+    expect(tmux.sends).toHaveLength(0);
+    expect(stateSnapshot(root)).toEqual(before);
+  });
+
+  it('refunds the prepared cadence reservation when receipt construction fails', async () => {
+    const root = temporaryDirectory('tmt-talk-receipt-encode-failure-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const tmux = createMockTmux();
+    const requestId = 'x'.repeat(300) as ReturnType<typeof crypto.randomUUID>;
+    const uuid = vi.spyOn(crypto, 'randomUUID').mockReturnValue(requestId);
+    const ctx = createContext(root, { tmux });
+    try {
+      await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+        exitCode: ExitCodes.ERROR,
+      });
+      expect(tmux.sends).toHaveLength(0);
+      const attempt = onlyAttempt(fixture.service);
+      expect(attempt.status).toBe('definitely_failed');
+      expect(attempt.waitActive).toBe(false);
+      expect(stateSnapshot(root).responses).toEqual([]);
+      expect(stateSnapshot(root).cadence).toEqual([expect.objectContaining({ reserved_count: 0 })]);
+    } finally {
+      uuid.mockRestore();
+    }
+  });
+
+  it('releases only its waiter after an unexpected transport error', async () => {
+    const root = temporaryDirectory('tmt-talk-cleanup-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const prepared = fixture.service.prepare({
+      requestId: 'other-request',
+      endpoint: ENDPOINT,
+      wait: true,
+      expiresAtMs: Date.now() + 60 * 60 * 1000,
+    });
+    fixture.service.beginSend(prepared.attemptId);
+    const tmux = createMockTmux();
+    tmux.send = vi.fn(() => {
+      throw new Error('unexpected send failure');
+    });
+    const ctx = createContext(root, { tmux });
+    await expect(cmdTalk(ctx, 'claude', 'Hello')).rejects.toMatchObject({
+      exitCode: ExitCodes.ERROR,
+    });
+    expect(fixture.service.getAttempt(prepared.attemptId)?.waitActive).toBe(true);
+    const newAttempt = fixture.service
+      .listAttempts()
+      .find((attempt) => attempt.requestId !== 'other-request');
+    expect(newAttempt?.waitActive).toBe(false);
   });
 });

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -2,14 +2,15 @@
 // talk command - send a message to one resolved pane
 // ─────────────────────────────────────────────────────────────
 
-import type { Context } from '../types.js';
-import type { WaitResult } from '../types.js';
-import { ExitCodes } from '../exits.js';
-import { colors } from '../ui.js';
 import crypto from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import type { Context } from '../types.js';
+import { ExitCodes } from '../exits.js';
+import { encodeReplyReceipt, type ReplyReceipt } from '../reply-receipt.js';
 import {
   endpointFromSnapshot,
   type RequestPreparation,
+  type RequestResponseRecord,
   type RequestService,
 } from '../request-service.js';
 import { resolveTarget } from '../target-resolver.js';
@@ -18,35 +19,68 @@ import { IdentitySelectionError } from '../identity-context.js';
 import { PreambleContentError } from '../domain/preamble.js';
 import { identityAwareTmux } from '../identity-service.js';
 import { TmuxDeliveryError } from '../message-delivery.js';
+import { buildDurableReplyInstruction } from '../talk-instruction.js';
 
-function sleepMs(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+const MAX_OBSERVER_TIMEOUT_SECONDS = 24 * 60 * 60;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export interface TalkRuntime {
+  readonly now?: () => number;
+  readonly sleep?: (milliseconds: number) => Promise<void>;
 }
 
-type PollWait = {
-  readonly timer: ReturnType<typeof setTimeout>;
-  readonly wake: () => void;
-};
+interface TalkCorrelation {
+  readonly requestId: string;
+  readonly target: string;
+  readonly pane: string;
+  readonly identity?: { readonly name: string; readonly canonicalName: string };
+}
 
-function failSend(ctx: Context, pane: string, error: unknown): never {
-  if (error instanceof TmuxDeliveryError) {
-    const detail = {
-      code: error.code,
-      message: error.message,
-      stage: error.stage,
-      suggestion: 'Inspect the target pane before retrying.',
-    };
-    if (ctx.flags.json) ctx.ui.json({ error: detail });
-    else ctx.ui.error(`${detail.message} ${detail.suggestion}`);
-    return ctx.exit(ExitCodes.ERROR);
-  }
+function sleepMs(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
 
-  const detail = {
-    code: 'ERROR',
-    message: `Failed to send to pane ${pane}. Is tmux running?`,
-    suggestion: 'Delivery may have occurred; inspect the target pane before retrying.',
+function monotonicNow(): number {
+  return performance.now();
+}
+
+function makeRequestId(): string {
+  return `req_${crypto.randomUUID()}`;
+}
+
+function correlationDocument(correlation: TalkCorrelation): Record<string, unknown> {
+  return {
+    requestId: correlation.requestId,
+    target: correlation.target,
+    pane: correlation.pane,
+    ...(correlation.identity && { identity: correlation.identity }),
   };
-  if (ctx.flags.json) ctx.ui.json({ error: detail });
+}
+
+function inspectionGuidance(correlation: TalkCorrelation): string {
+  return `Inspect with 'tmt result ${correlation.requestId}' and 'tmt check ${correlation.target}' before deciding whether to retry.`;
+}
+
+function resultGuidance(correlation: TalkCorrelation): string {
+  return `Retrieve later with 'tmt result ${correlation.requestId}'.`;
+}
+
+function failSend(ctx: Context, correlation: TalkCorrelation, error: unknown): never {
+  const detail =
+    error instanceof TmuxDeliveryError
+      ? {
+          code: error.code,
+          message: error.message,
+          stage: error.stage,
+          suggestion: inspectionGuidance(correlation),
+        }
+      : {
+          code: 'DELIVERY_UNCERTAIN',
+          message: 'Message delivery is uncertain; inspect the target pane before retrying.',
+          stage: 'unknown',
+          suggestion: inspectionGuidance(correlation),
+        };
+  if (ctx.flags.json) ctx.ui.json({ ...correlationDocument(correlation), error: detail });
   else ctx.ui.error(`${detail.message} ${detail.suggestion}`);
   return ctx.exit(ExitCodes.ERROR);
 }
@@ -69,235 +103,47 @@ function failPreamble(ctx: Context, error: unknown): never {
   return ctx.exit(publicCode === 'NAME_NOT_FOUND' ? ExitCodes.NAME_NOT_FOUND : ExitCodes.ERROR);
 }
 
-function failRequestState(ctx: Context, possibleDelivery: boolean, cause?: unknown): never {
+function failRequestState(
+  ctx: Context,
+  correlation: TalkCorrelation,
+  possibleDelivery: boolean,
+  cause?: unknown,
+  operation: 'persist' | 'access' = 'persist'
+): never {
   const detail = {
     code: 'REQUEST_STATE_ERROR',
-    message: possibleDelivery
-      ? 'Request state could not be persisted after transport; delivery may have occurred. Do not retry until you inspect the target pane.'
-      : 'Request state could not be persisted before transport; no message was sent. Fix the request state database before retrying.',
+    message:
+      operation === 'access'
+        ? 'Request state could not be read after transport; delivery may have occurred.'
+        : possibleDelivery
+          ? 'Request state could not be persisted after transport; delivery may have occurred.'
+          : 'Request state could not be persisted before transport; no message was sent.',
     suggestion: possibleDelivery
-      ? 'Inspect the target pane before retrying.'
+      ? inspectionGuidance(correlation)
       : 'Fix the request state database before retrying.',
   };
-  if (ctx.flags.json) ctx.ui.json({ error: detail });
+  if (ctx.flags.json) ctx.ui.json({ ...correlationDocument(correlation), error: detail });
   else ctx.ui.error(`${detail.message} ${detail.suggestion}`);
-  if (cause && ctx.flags.debug) {
-    console.error('[DEBUG] Request state failure:', cause);
-  }
+  if (cause && ctx.flags.debug) console.error('[DEBUG] Request state failure:', cause);
   return ctx.exit(ExitCodes.ERROR);
 }
 
-/**
- * Clean Gemini CLI response by removing UI artifacts.
- */
-function cleanGeminiResponse(response: string): string {
-  return response
-    .split('\n')
-    .filter((line) => {
-      // Remove "Responding with..." status lines
-      if (/Responding with\s+\S+/.test(line)) return false;
-      // Remove empty lines with only whitespace/box chars
-      if (/^[\s█]*$/.test(line)) return false;
-      return true;
-    })
-    .map((line) => line.replace(/^[\s█]*✦?\s*/, '').replace(/[\s█]*$/, ''))
-    .join('\n')
-    .trim();
+function failPreparation(ctx: Context, correlation: TalkCorrelation): never {
+  const detail = {
+    code: 'ERROR',
+    message: 'Could not prepare durable response instructions.',
+  };
+  if (ctx.flags.json) ctx.ui.json({ ...correlationDocument(correlation), error: detail });
+  else ctx.ui.error(`${detail.message} Request: ${correlation.requestId}.`);
+  return ctx.exit(ExitCodes.ERROR);
 }
 
-function makeRequestId(): string {
-  return `req_${crypto.randomUUID()}`;
+function failTiming(ctx: Context, message: string): never {
+  if (ctx.flags.json) ctx.ui.json({ error: { code: 'CONFIG_ERROR', message } });
+  else ctx.ui.error(message);
+  return ctx.exit(ExitCodes.ERROR);
 }
 
-function makeNonce(): string {
-  return crypto.randomBytes(2).toString('hex');
-}
-
-function makeEndMarker(nonce: string): string {
-  return `RESPONSE-END-${nonce}`;
-}
-
-/**
- * Build a regex to match the end marker case-insensitively.
- * This handles agents that might print the marker in different case.
- * Also tolerates optional surrounding dashes for backwards compatibility.
- */
-function makeEndMarkerRegex(nonce: string): RegExp {
-  return new RegExp(`-{0,3}RESPONSE-END-${nonce}-{0,3}`, 'i');
-}
-
-/**
- * Build the end marker instruction showing the exact format with a placeholder.
- *
- * The instruction uses "xxxx" as a placeholder, so the literal marker with the
- * actual nonce can ONLY appear if the agent prints it. This avoids false-positive
- * detection when the instruction is still visible in scrollback.
- */
-function makeEndMarkerInstruction(nonce: string): string {
-  return `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`;
-}
-
-/**
- * Check if a line is the instruction line (not the actual marker).
- * The instruction line contains both the nonce AND instruction keywords.
- */
-function isInstructionLine(line: string, nonce: string): boolean {
-  const lowerLine = line.toLowerCase();
-  return (
-    lowerLine.includes(`response-end-${nonce.toLowerCase()}`) &&
-    (lowerLine.includes('output exactly') || lowerLine.includes('where xxxx'))
-  );
-}
-
-/**
- * Check if output contains an actual end marker (not just the instruction).
- * Returns true only if there's a line with the marker that isn't the instruction.
- */
-function hasActualEndMarker(output: string, nonce: string, endMarkerRegex: RegExp): boolean {
-  const lines = output.split('\n');
-  return lines.some((line) => endMarkerRegex.test(line) && !isInstructionLine(line, nonce));
-}
-
-function renderWaitLine(agent: string, elapsedSeconds: number): string {
-  const s = Math.max(0, Math.floor(elapsedSeconds));
-  return `⏳ Waiting for ${agent}... (${s}s)`;
-}
-
-/**
- * Extract partial response from output when end marker is not found.
- * Used to capture whatever the agent wrote before timeout.
- *
- * We look for the instruction line (contains instruction keywords like "output exactly")
- * and extract content after it. Falls back to last N lines if instruction not found.
- */
-function extractPartialResponse(
-  output: string,
-  endMarker: string,
-  maxLines: number
-): string | null {
-  const lines = output.split('\n');
-
-  // Extract nonce from endMarker (format: RESPONSE-END-xxxx)
-  // Use case-insensitive match to be flexible with nonce format changes
-  const nonceMatch = endMarker.match(/RESPONSE-END-([a-f0-9]+)/i);
-  if (!nonceMatch) return null;
-  const nonce = nonceMatch[1];
-
-  // Find the instruction line using consistent detection
-  const instructionLineIndex = lines.findIndex((line) => isInstructionLine(line, nonce));
-
-  let responseLines: string[];
-  if (instructionLineIndex !== -1) {
-    // Extract lines after instruction
-    responseLines = lines.slice(instructionLineIndex + 1);
-  } else {
-    // Fallback: just take the output (no instruction found in view)
-    responseLines = lines;
-  }
-
-  const limitedLines = responseLines.slice(-maxLines); // Take last N lines
-
-  const partial = limitedLines.join('\n').trim();
-  return partial || null;
-}
-// Expandable capture extraction
-// ─────────────────────────────────────────────────────────────
-
-interface ExtractResult {
-  response: string;
-  truncated: boolean;
-}
-
-/**
- * Extract response with expandable capture.
- *
- * When the instruction line is not found in the initial capture (response too long),
- * retry with progressively larger captures up to maxCaptureLines.
- */
-function extractWithExpandableCapture(
-  tmux: Context['tmux'],
-  pane: string,
-  nonce: string,
-  endMarkerRegex: RegExp,
-  initialCapture: string,
-  captureLines: number,
-  maxCaptureLines: number,
-  responseLines: number,
-  debug?: boolean
-): ExtractResult {
-  let output = initialCapture;
-  let currentCaptureLines = captureLines;
-  let truncated = false;
-
-  // Try extraction with progressively larger captures
-  while (true) {
-    const lines = output.split('\n');
-
-    // Find end marker line (case-insensitive, last occurrence, excluding instruction lines)
-    let endMarkerLineIndex = -1;
-    for (let i = lines.length - 1; i >= 0; i--) {
-      if (endMarkerRegex.test(lines[i]) && !isInstructionLine(lines[i], nonce)) {
-        endMarkerLineIndex = i;
-        break;
-      }
-    }
-
-    if (endMarkerLineIndex === -1) {
-      // No marker found - shouldn't happen if called correctly
-      return { response: '', truncated: true };
-    }
-
-    // Find instruction line using consistent detection
-    const instructionLineIndex = lines.findIndex((line) => isInstructionLine(line, nonce));
-
-    if (instructionLineIndex !== -1 && instructionLineIndex < endMarkerLineIndex) {
-      // Instruction visible: extract from after instruction to marker
-      const response = lines
-        .slice(instructionLineIndex + 1, endMarkerLineIndex)
-        .join('\n')
-        .trim();
-      return { response, truncated: false };
-    }
-
-    // Instruction not found - try larger capture if possible
-    if (currentCaptureLines >= maxCaptureLines) {
-      // Already at max, fall back to N lines before marker
-      if (debug) {
-        console.error(
-          `[DEBUG] Instruction line not found after max capture (${maxCaptureLines} lines), falling back`
-        );
-      }
-      truncated = true;
-      const startLine = Math.max(0, endMarkerLineIndex - responseLines);
-      const response = lines.slice(startLine, endMarkerLineIndex).join('\n').trim();
-      return { response, truncated };
-    }
-
-    // Double capture size and retry
-    currentCaptureLines = Math.min(currentCaptureLines * 2, maxCaptureLines);
-    if (debug) {
-      console.error(`[DEBUG] Expanding capture to ${currentCaptureLines} lines`);
-    }
-
-    try {
-      output = tmux.capture(pane, currentCaptureLines);
-    } catch {
-      // Capture failed, use what we have
-      truncated = true;
-      const startLine = Math.max(0, endMarkerLineIndex - responseLines);
-      const response = lines.slice(startLine, endMarkerLineIndex).join('\n').trim();
-      return { response, truncated };
-    }
-  }
-}
-
-/**
- * Build the final message with optional preamble.
- * Format: [SYSTEM: <preamble>]\n\n<message>
- *
- * Preamble injection frequency is controlled by preambleEvery config.
- * Default: inject every 3 messages per agent to save tokens.
- */
 interface PreparedMessage {
   readonly message: string;
   readonly preamble?: {
@@ -313,18 +159,10 @@ function prepareMessage(
   ctx: Context
 ): PreparedMessage {
   const { config, flags } = ctx;
+  if (config.preambleMode === 'disabled' || flags.noPreamble) return { message };
 
-  // Skip preamble if disabled or --no-preamble flag
-  if (config.preambleMode === 'disabled' || flags.noPreamble) {
-    return { message };
-  }
-
-  // preambleEvery = 0 disables lookup and counter mutation entirely.
   const preambleEvery = config.defaults.preambleEvery;
-  if (preambleEvery <= 0) return { message };
-
-  // Direct pane targets without a durable identity have no preamble owner.
-  if (!identityName) return { message };
+  if (preambleEvery <= 0 || !identityName) return { message };
   if (!ctx.preambleService) throw new Error('Preamble service is unavailable.');
 
   const result = ctx.preambleService.show(identityName);
@@ -342,32 +180,93 @@ function composeMessage(prepared: PreparedMessage, injectPreamble: boolean): str
   return `[SYSTEM: ${prepared.preamble.content}]\n\n${prepared.message}`;
 }
 
-function requestExpiryMs(wait: boolean, timeoutSeconds: number, enterDelayMs: number): number {
-  if (!Number.isFinite(enterDelayMs) || enterDelayMs < 0) {
-    throw new Error('The configured paste-enter delay must be a finite non-negative number.');
+function validateTiming(
+  waitEnabled: boolean,
+  timeoutSeconds: number,
+  pollIntervalSeconds: number,
+  enterDelayMs: number
+): void {
+  if (
+    waitEnabled &&
+    (!Number.isFinite(timeoutSeconds) ||
+      timeoutSeconds <= 0 ||
+      timeoutSeconds > MAX_OBSERVER_TIMEOUT_SECONDS)
+  ) {
+    throw new Error('Talk timeout must be finite, positive, and no greater than 24 hours.');
   }
-  if (wait && (!Number.isFinite(timeoutSeconds) || timeoutSeconds < 0)) {
-    throw new Error('The wait timeout must be a finite non-negative number.');
+  if (waitEnabled && (!Number.isFinite(pollIntervalSeconds) || pollIntervalSeconds <= 0)) {
+    throw new Error('The configured poll interval must be finite and positive.');
   }
+  if (!Number.isFinite(enterDelayMs) || enterDelayMs < 0 || enterDelayMs > MAX_TIMER_DELAY_MS) {
+    throw new Error(
+      'The configured paste-enter delay must be finite, non-negative, and within the timer limit.'
+    );
+  }
+}
 
-  const nowMs = Date.now();
+function validateDelay(delaySeconds: number | undefined): void {
+  if (delaySeconds === undefined) return;
+  if (
+    !Number.isFinite(delaySeconds) ||
+    delaySeconds < 0 ||
+    delaySeconds * 1000 > MAX_TIMER_DELAY_MS
+  ) {
+    throw new Error('Talk delay must be finite, non-negative, and within the timer limit.');
+  }
+}
+
+function requestExpiryMs(wait: boolean, timeoutSeconds: number, enterDelayMs: number): number {
   const timeoutMs = wait ? Math.ceil(timeoutSeconds * 1000) : 0;
   const delayMs = Math.ceil(enterDelayMs);
-  const budgetMs = timeoutMs + delayMs + 1000;
-  const retentionMs = Math.max(60 * 60 * 1000, wait ? budgetMs : delayMs + 1000);
   if (!Number.isSafeInteger(timeoutMs) || !Number.isSafeInteger(delayMs)) {
     throw new Error('The request timing budget is outside the supported range.');
   }
+  const budgetMs = timeoutMs + delayMs + 1000;
+  const retentionMs = Math.max(60 * 60 * 1000, wait ? budgetMs : delayMs + 1000);
+  const nowMs = Date.now();
   if (!Number.isSafeInteger(retentionMs) || !Number.isSafeInteger(nowMs + retentionMs)) {
     throw new Error('The request expiry is outside the supported range.');
   }
   return nowMs + retentionMs;
 }
 
-export async function cmdTalk(ctx: Context, target: string, message: string): Promise<void> {
+function responseDocument(
+  correlation: TalkCorrelation,
+  response: RequestResponseRecord
+): Record<string, unknown> {
+  return {
+    ...correlationDocument(correlation),
+    status: 'completed',
+    response: response.body,
+    bodyBytes: response.bodyBytes,
+    submittedAtMs: response.submittedAtMs,
+  };
+}
+
+function timeoutMessage(agentName: string, timeoutSeconds: number): string {
+  return `Timed out waiting for ${agentName} after ${timeoutSeconds}s`;
+}
+
+export async function cmdTalk(
+  ctx: Context,
+  target: string,
+  message: string,
+  runtime: TalkRuntime = {}
+): Promise<void> {
   const { ui, config, tmux, flags, exit } = ctx;
-  const waitEnabled = Boolean(flags.wait) || config.mode === 'wait';
+  const waitEnabled = !flags.detach;
+  const timeoutSeconds = flags.timeout ?? config.defaults.timeout;
+  const pollIntervalSeconds = config.defaults.pollInterval;
   const enterDelayMs = config.defaults.pasteEnterDelayMs;
+  const now = runtime.now ?? monotonicNow;
+  const sleep = runtime.sleep ?? sleepMs;
+
+  try {
+    validateDelay(flags.delay);
+    validateTiming(waitEnabled, timeoutSeconds, pollIntervalSeconds, enterDelayMs);
+  } catch (error) {
+    return failTiming(ctx, error instanceof Error ? error.message : 'Invalid talk timing.');
+  }
 
   const runtimeTmux = identityAwareTmux(tmux, ctx.identityService);
   const resolution = resolveTarget(runtimeTmux, target);
@@ -382,10 +281,7 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
   }
 
   const pane = resolution.value.paneId;
-  // Preserve identity-specific behavior (preambles and Gemini cleanup) while
-  // allowing direct pane targets to address unnamed panes.
   const agentName = resolution.value.identity?.name ?? pane;
-  const isGemini = normalizeName(agentName) === 'gemini';
   const identity = resolution.value.identity
     ? {
         name: resolution.value.identity.name,
@@ -393,44 +289,37 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
           resolution.value.identity.canonicalName || normalizeName(resolution.value.identity.name),
       }
     : undefined;
+  const requestId = makeRequestId();
+  const correlation: TalkCorrelation = { requestId, target, pane, ...(identity && { identity }) };
 
-  if (flags.delay && flags.delay > 0) {
-    await sleepMs(flags.delay * 1000);
-  }
+  if (flags.delay && flags.delay > 0) await sleep(flags.delay * 1000);
 
-  // Prepare once before either transport path or wait bookkeeping. A preamble
-  // lookup failure must not be reported as a delivery failure or send raw input.
   let preparedMessage: PreparedMessage;
   try {
     preparedMessage = prepareMessage(message, resolution.value.identity?.name, ctx);
   } catch (error) {
     failPreamble(ctx, error);
   }
-  const timeoutSeconds = flags.timeout ?? config.defaults.timeout;
-  const requestId = makeRequestId();
-  const nonce = waitEnabled ? makeNonce() : undefined;
-  const endMarker = nonce ? makeEndMarker(nonce) : undefined;
 
   let endpoint;
   try {
     if (!tmux.getEndpointSnapshot) throw new Error('Tmux endpoint evidence is unavailable.');
     endpoint = endpointFromSnapshot(tmux.getEndpointSnapshot(), pane);
   } catch (error) {
-    return failRequestState(ctx, false, error);
+    return failRequestState(ctx, correlation, false, error);
   }
 
   let requestService: RequestService;
   try {
     requestService = ctx.requestService;
   } catch (error) {
-    return failRequestState(ctx, false, error);
+    return failRequestState(ctx, correlation, false, error);
   }
 
   let preparation: RequestPreparation;
   try {
     preparation = requestService.prepare({
       requestId,
-      ...(nonce !== undefined && { nonce }),
       endpoint,
       wait: waitEnabled,
       expiresAtMs: requestExpiryMs(waitEnabled, timeoutSeconds, enterDelayMs),
@@ -442,28 +331,61 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
       }),
     });
   } catch (error) {
-    return failRequestState(ctx, false, error);
+    return failRequestState(ctx, correlation, false, error);
+  }
+
+  const releasePrepared = (): unknown => {
+    let cleanupError: unknown;
+    try {
+      requestService.settle(preparation.attemptId, 'definitely_failed');
+    } catch (error) {
+      cleanupError = error;
+      if (flags.debug) console.error('[DEBUG] Failed to refund prepared request:', error);
+    }
+    if (waitEnabled) {
+      try {
+        requestService.releaseWait(preparation.attemptId);
+      } catch (error) {
+        cleanupError ??= error;
+        if (flags.debug) console.error('[DEBUG] Request waiter cleanup failed:', error);
+      }
+    }
+    return cleanupError;
+  };
+
+  let receipt: string;
+  let instruction: string;
+  try {
+    const receiptValue: ReplyReceipt = {
+      version: 1,
+      requestId,
+      attemptId: preparation.attemptId,
+      endpoint,
+    };
+    receipt = encodeReplyReceipt(receiptValue);
+    instruction = buildDurableReplyInstruction(requestId, receipt);
+  } catch {
+    const cleanupError = releasePrepared();
+    if (cleanupError) return failRequestState(ctx, correlation, false, cleanupError);
+    return failPreparation(ctx, correlation);
   }
 
   if (waitEnabled && preparation.previousRequestId && !flags.json && !flags.force) {
     ui.warn(
-      `Another recent wait request exists for '${agentName}' (id: ${preparation.previousRequestId}). Results may interleave.`
+      `Another recent request exists for '${agentName}' (id: ${preparation.previousRequestId}). Input processing is not serialized; durable results remain associated by request ID.`
     );
   }
 
-  const messageWithPreamble = composeMessage(preparedMessage, preparation.injectPreamble);
-  const fullMessage = waitEnabled
-    ? `${messageWithPreamble}\n\n${makeEndMarkerInstruction(nonce!)}`
-    : messageWithPreamble;
-
+  const fullMessage = `${composeMessage(preparedMessage, preparation.injectPreamble)}\n\n${instruction}`;
   let waitReleased = false;
+
   const releaseWait = (possibleDelivery: boolean): void => {
     if (!waitEnabled || waitReleased) return;
     waitReleased = true;
     try {
       requestService.releaseWait(preparation.attemptId);
     } catch (error) {
-      failRequestState(ctx, possibleDelivery, error);
+      failRequestState(ctx, correlation, possibleDelivery, error);
     }
   };
 
@@ -474,9 +396,6 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
     try {
       requestService.settle(preparation.attemptId, outcome);
     } catch (error) {
-      // Once transport may have run, release the waiter before reporting the
-      // persistence failure. Cleanup is best effort and must not replace the
-      // primary state error.
       if (possibleDelivery && waitEnabled && !waitReleased) {
         waitReleased = true;
         try {
@@ -485,11 +404,11 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
           if (flags.debug) console.error('[DEBUG] Request waiter cleanup failed:', cleanupError);
         }
       }
-      failRequestState(ctx, possibleDelivery, error);
+      failRequestState(ctx, correlation, possibleDelivery, error);
     }
   };
 
-  const beginSend = (): void => {
+  const send = (): void => {
     try {
       requestService.beginSend(preparation.attemptId);
     } catch (error) {
@@ -498,313 +417,133 @@ export async function cmdTalk(ctx: Context, target: string, message: string): Pr
       } catch (cleanupError) {
         if (flags.debug) console.error('[DEBUG] Failed to refund prepared request:', cleanupError);
       }
-      if (waitEnabled && !waitReleased) {
-        waitReleased = true;
-        try {
-          requestService.releaseWait(preparation.attemptId);
-        } catch (cleanupError) {
-          if (flags.debug) console.error('[DEBUG] Request waiter cleanup failed:', cleanupError);
-        }
-      }
-      failRequestState(ctx, false, error);
+      releaseWait(false);
+      failRequestState(ctx, correlation, false, error);
     }
-  };
 
-  if (!waitEnabled) {
-    beginSend();
     try {
       tmux.send(pane, fullMessage, { enterDelayMs });
     } catch (error) {
       settle('uncertain', true);
-      failSend(ctx, pane, error);
+      releaseWait(true);
+      failSend(ctx, correlation, error);
     }
     settle('sent', true);
+  };
 
-    if (flags.json) {
-      ui.json({ target, pane, ...(identity && { identity }), status: 'sent' });
-    } else {
-      console.log(`${colors.green('→')} Sent to ${colors.cyan(target)} (${pane})`);
+  if (!waitEnabled) {
+    send();
+    if (flags.json) ui.json({ ...correlationDocument(correlation), status: 'sent' });
+    else {
+      ui.success(`Sent request ${requestId} to ${target} (${pane}).`);
+      ui.info(resultGuidance(correlation));
     }
     return;
   }
 
-  // Wait mode
-  const waitNonce = nonce!;
-  const waitEndMarker = endMarker!;
-  const pollIntervalSeconds = Math.max(0.1, config.defaults.pollInterval);
-  const captureLines = config.defaults.captureLines;
-
-  const startedAt = Date.now();
-  let lastNonTtyLogAt = 0;
-  const isTTY = process.stdout.isTTY && !flags.json;
-
-  // Debounce detection: wait for output to stabilize
-  // Adaptive: for very short timeouts (testing), reduce debounce thresholds
-  const timeoutMs = timeoutSeconds * 1000;
-  const MIN_WAIT_MS = Math.min(3000, timeoutMs * 0.3); // Wait at least 3s or 30% of timeout
-  const IDLE_THRESHOLD_MS = Math.min(3000, timeoutMs * 0.3); // Stable for 3s or 30% of timeout
-  let lastOutput = '';
-  let lastOutputChangeAt = Date.now();
-
+  // The deadline starts before beginSend and transport. It is never reset
+  // after Enter, so synchronous transport time counts against the observer.
+  let deadline = Number.NaN;
   let interrupted = false;
-  let pollWait: PollWait | undefined;
+  let pollTimer: ReturnType<typeof setTimeout> | undefined;
+  let wakePoll: (() => void) | undefined;
   const onSigint = (): void => {
     interrupted = true;
-    pollWait?.wake();
+    wakePoll?.();
   };
-
-  const waitForPoll = (delayMs: number): Promise<void> =>
-    new Promise((resolve) => {
-      let timer: ReturnType<typeof setTimeout>;
+  const waitForPoll = (delayMs: number): Promise<void> => {
+    if (runtime.sleep) return sleep(delayMs);
+    return new Promise((resolve) => {
       const finish = (): void => {
-        if (!pollWait || pollWait.timer !== timer) return;
-        pollWait = undefined;
-        clearTimeout(timer);
+        if (pollTimer === undefined) return;
+        clearTimeout(pollTimer);
+        pollTimer = undefined;
+        wakePoll = undefined;
         resolve();
       };
-      timer = setTimeout(finish, delayMs);
-      pollWait = { timer, wake: finish };
+      wakePoll = finish;
+      pollTimer = setTimeout(finish, delayMs);
     });
+  };
 
-  const handleInterrupt = (): never => {
+  const interrupt = (): never => {
     releaseWait(true);
-    if (!flags.json) process.stdout.write('\n');
-    ui.error('Interrupted.');
+    if (flags.json) {
+      ui.json({
+        ...correlationDocument(correlation),
+        error: { code: 'INTERRUPTED', message: 'Interrupted while waiting for a durable reply.' },
+      });
+    } else {
+      ui.error(
+        `Interrupted while waiting for request ${requestId}. ${inspectionGuidance(correlation)}`
+      );
+    }
     return exit(ExitCodes.ERROR);
   };
 
+  const timeout = (): never => {
+    releaseWait(true);
+    const messageText = timeoutMessage(agentName, timeoutSeconds);
+    const error = { code: 'TIMEOUT', message: messageText };
+    if (flags.json) ui.json({ ...correlationDocument(correlation), status: 'timeout', error });
+    else {
+      ui.error(
+        `${messageText}. Request ${requestId} remains available for a late reply. ${resultGuidance(correlation)} ${inspectionGuidance(correlation)}`
+      );
+    }
+    return exit(ExitCodes.TIMEOUT);
+  };
+
   process.once('SIGINT', onSigint);
-
   try {
-    beginSend();
-    const msg = fullMessage;
-
-    if (flags.debug) {
-      console.error(`[DEBUG] Starting wait mode for ${agentName}`);
-      console.error(`[DEBUG] End marker: ${endMarker}`);
-      console.error(`[DEBUG] Message sent:\n${msg}`);
-    }
-
-    try {
-      tmux.send(pane, msg, { enterDelayMs });
-    } catch (error) {
-      settle('uncertain', true);
-      releaseWait(true);
-      failSend(ctx, pane, error);
-    }
-    settle('sent', true);
+    // Set the observer bound immediately before beginSend and transport. It is
+    // never reset after Enter, so synchronous transport time counts.
+    deadline = now() + timeoutSeconds * 1000;
+    send();
 
     while (true) {
-      if (interrupted) handleInterrupt();
+      if (interrupted) interrupt();
+      if (now() >= deadline) timeout();
 
-      const elapsedSeconds = (Date.now() - startedAt) / 1000;
-      if (elapsedSeconds >= timeoutSeconds) {
-        // Capture partial response on timeout
-        const responseLines = flags.lines ?? 100;
-        let partialResponse: string | null = null;
-        try {
-          const output = tmux.capture(pane, captureLines);
-          const extracted = extractPartialResponse(output, waitEndMarker, responseLines);
-          if (extracted) {
-            partialResponse = isGemini ? cleanGeminiResponse(extracted) : extracted;
-          }
-        } catch {
-          // Ignore capture errors on timeout
-        }
-
-        if (isTTY) {
-          process.stdout.write('\r' + ' '.repeat(80) + '\r');
-        }
-
-        releaseWait(true);
-
-        if (flags.json) {
-          ui.json({
-            target,
-            pane,
-            ...(identity && { identity }),
-            status: 'timeout',
-            error: {
-              code: 'TIMEOUT',
-              message: `Timed out waiting for ${agentName} after ${Math.floor(timeoutSeconds)}s`,
-            },
-            requestId,
-            nonce: waitNonce,
-            endMarker: waitEndMarker,
-            partialResponse,
-          });
-          exit(ExitCodes.TIMEOUT);
-        }
-
-        ui.error(`Timed out waiting for ${target} after ${Math.floor(timeoutSeconds)}s.`);
-        if (partialResponse) {
-          console.log();
-          console.log(colors.yellow(`─── Partial response from ${agentName} (${pane}) ───`));
-          console.log(partialResponse);
-        }
-        exit(ExitCodes.TIMEOUT);
-      }
-
-      if (!flags.json) {
-        if (isTTY) {
-          process.stdout.write('\r' + renderWaitLine(agentName, elapsedSeconds));
-        } else if (flags.verbose || flags.debug) {
-          // Non-TTY progress logs only with --verbose or --debug
-          const now = Date.now();
-          if (now - lastNonTtyLogAt >= 30000) {
-            lastNonTtyLogAt = now;
-            console.error(
-              `[tmux-team] Waiting for ${target} (${Math.floor(elapsedSeconds)}s elapsed)`
-            );
-          }
-        }
-      }
-
-      await waitForPoll(pollIntervalSeconds * 1000);
-      if (interrupted) handleInterrupt();
-
-      let output = '';
+      // A snapshot is valid only while the observer is within its monotonic
+      // deadline. A synchronous read that crosses the bound loses.
+      let response: RequestResponseRecord | undefined;
       try {
-        output = tmux.capture(pane, captureLines);
-      } catch {
+        response = requestService.getResponse(requestId);
+      } catch (error) {
         releaseWait(true);
-        const error = {
-          code: 'ERROR',
-          message: `Failed to capture pane ${pane}. Is tmux running?`,
-        };
-        if (flags.json) ui.json({ error });
-        else ui.error(error.message);
-        exit(ExitCodes.ERROR);
+        failRequestState(ctx, correlation, true, error, 'access');
       }
-
-      // DEBUG: Log captured output
-      if (flags.debug) {
-        const elapsedSec = Math.floor((Date.now() - startedAt) / 1000);
-        const firstIdx = output.indexOf(waitEndMarker);
-        const lastIdx = output.lastIndexOf(waitEndMarker);
-        console.error(`\n[DEBUG ${elapsedSec}s] Output: ${output.length} chars`);
-        console.error(`[DEBUG ${elapsedSec}s] End marker: ${endMarker}`);
-        console.error(`[DEBUG ${elapsedSec}s] First index: ${firstIdx}, Last index: ${lastIdx}`);
-        console.error(
-          `[DEBUG ${elapsedSec}s] Two markers found: ${firstIdx !== -1 && firstIdx !== lastIdx}`
-        );
-
-        // Show content around markers if found
-        if (firstIdx !== -1) {
-          const context = output.slice(
-            Math.max(0, firstIdx - 50),
-            firstIdx + waitEndMarker.length + 50
-          );
-          console.error(`[DEBUG ${elapsedSec}s] First marker context:\n---\n${context}\n---`);
+      if (now() >= deadline) timeout();
+      if (response) {
+        releaseWait(true);
+        if (flags.json) ui.json(responseDocument(correlation, response));
+        else {
+          ui.success(`Completed request ${requestId} for ${agentName} (${pane}).`);
+          ui.info(response.body);
+          ui.info(resultGuidance(correlation));
         }
-        if (lastIdx !== -1 && lastIdx !== firstIdx) {
-          const context = output.slice(
-            Math.max(0, lastIdx - 50),
-            lastIdx + waitEndMarker.length + 50
-          );
-          console.error(`[DEBUG ${elapsedSec}s] Last marker context:\n---\n${context}\n---`);
-        }
-
-        // Show last 300 chars of output
-        console.error(`[DEBUG ${elapsedSec}s] Output tail:\n${output.slice(-300)}`);
+        return;
       }
 
-      // Track output changes for debounce detection
-      if (output !== lastOutput) {
-        lastOutput = output;
-        lastOutputChangeAt = Date.now();
-      }
-
-      const elapsedMs = Date.now() - startedAt;
-      const idleMs = Date.now() - lastOutputChangeAt;
-
-      // Find end marker (case-insensitive to handle agent variations)
-      // Must be an actual marker line, not the instruction line
-      const endMarkerRegex = makeEndMarkerRegex(waitNonce);
-      const hasEndMarker = hasActualEndMarker(output, waitNonce, endMarkerRegex);
-
-      // Completion conditions:
-      // 1. Must wait at least MIN_WAIT_MS
-      // 2. Must have end marker in output
-      // 3. Output must be stable for IDLE_THRESHOLD_MS (debounce)
-      if (elapsedMs < MIN_WAIT_MS || !hasEndMarker || idleMs < IDLE_THRESHOLD_MS) {
-        if (flags.debug && hasEndMarker) {
-          console.error(
-            `[DEBUG] Marker found, waiting for debounce (elapsed: ${elapsedMs}ms, idle: ${idleMs}ms)`
-          );
-        }
-        continue;
-      }
-
-      if (flags.debug) {
-        console.error(`[DEBUG] Agent completed (elapsed: ${elapsedMs}ms, idle: ${idleMs}ms)`);
-      }
-
-      // Extract response with expandable capture (handles long responses)
-      const responseLines = flags.lines ?? 100;
-      const maxCaptureLines = config.defaults.maxCaptureLines;
-
-      const { response: extractedResponse, truncated } = extractWithExpandableCapture(
-        tmux,
-        pane,
-        waitNonce,
-        endMarkerRegex,
-        output,
-        captureLines,
-        maxCaptureLines,
-        responseLines,
-        flags.debug
-      );
-
-      // Clean Gemini CLI UI artifacts
-      const response = isGemini ? cleanGeminiResponse(extractedResponse) : extractedResponse;
-
-      if (!flags.json && isTTY) {
-        process.stdout.write('\r' + ' '.repeat(80) + '\r');
-      } else if (!flags.json) {
-        // Ensure the next output starts on a new line
-        process.stdout.write('\n');
-      }
-
-      releaseWait(true);
-
-      const result: WaitResult = {
-        requestId,
-        nonce: waitNonce,
-        endMarker: waitEndMarker,
-        response,
-      };
-      if (flags.json) {
-        ui.json({
-          target,
-          pane,
-          ...(identity && { identity }),
-          status: 'completed',
-          truncated,
-          ...result,
-        });
-      } else {
-        if (truncated) {
-          ui.warn('Response may be truncated (instruction line not found in scrollback)');
-        }
-        console.log(colors.cyan(`─── Response from ${agentName} (${pane}) ───`));
-        console.log(response);
-      }
-      return;
+      const remainingMs = deadline - now();
+      if (remainingMs <= 0) timeout();
+      await waitForPoll(Math.min(pollIntervalSeconds * 1000, remainingMs));
     }
   } finally {
     process.removeListener('SIGINT', onSigint);
+    if (pollTimer !== undefined) {
+      clearTimeout(pollTimer);
+      pollTimer = undefined;
+      wakePoll = undefined;
+    }
     if (waitEnabled && !waitReleased) {
       waitReleased = true;
       try {
         requestService.releaseWait(preparation.attemptId);
       } catch (error) {
-        // Preserve an unexpected primary failure; cleanup is retried by the
-        // retention/expiry path when the request state service is available.
         if (flags.debug) console.error('[DEBUG] Request waiter cleanup failed:', error);
       }
     }
   }
 }
-
-// ─────────────────────────────────────────────────────────────

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -51,13 +51,11 @@ function context(json = false): Context {
       json: vi.fn(),
     },
     config: {
-      mode: 'polling',
       preambleMode: 'always',
       defaults: {
         timeout: 1,
         pollInterval: 1,
         captureLines: 1,
-        maxCaptureLines: 1,
         preambleEvery: 1,
         pasteEnterDelayMs: 0,
       },

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -202,7 +202,6 @@ describe('loadConfig', () => {
   it('returns default config when no config files exist', () => {
     const config = loadConfig(mockPaths);
 
-    expect(config.mode).toBe('wait');
     expect(config.preambleMode).toBe('always');
     expect(config.defaults.timeout).toBe(180);
     expect(config.defaults.pollInterval).toBe(1);
@@ -210,11 +209,11 @@ describe('loadConfig', () => {
     expect(config.defaults.pasteEnterDelayMs).toBe(500);
   });
 
-  it('loads and merges global config (mode, preambleMode, defaults only)', () => {
+  it('loads runtime settings while leaving obsolete mode and extraction keys opaque', () => {
     const globalConfig = {
-      mode: 'wait',
       preambleMode: 'disabled',
-      defaults: { timeout: 120 },
+      mode: 'wait',
+      defaults: { timeout: 120, maxCaptureLines: 999 },
     };
 
     vi.mocked(fs.existsSync).mockImplementation((p) => p === mockPaths.globalConfig);
@@ -222,9 +221,9 @@ describe('loadConfig', () => {
 
     const config = loadConfig(mockPaths);
 
-    expect(config.mode).toBe('wait');
     expect(config.preambleMode).toBe('disabled');
     expect(config.defaults.timeout).toBe(120);
+    expect(config.defaults).not.toHaveProperty('maxCaptureLines');
     expect(config.defaults.pollInterval).toBe(1); // Default preserved
   });
 
@@ -266,7 +265,7 @@ describe('loadConfig', () => {
     });
 
     const config = loadConfig(mockPaths);
-    expect(config.mode).toBe('wait');
+    expect(config).not.toHaveProperty('mode');
     expect(config.defaults.preambleEvery).toBe(5);
     expect(config).not.toHaveProperty('agents');
     expect(config).not.toHaveProperty('paneRegistry');

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import type {
+  ConfigDefaults,
   GlobalConfig,
   LocalConfigFile,
   LocalSettings,
@@ -20,13 +21,11 @@ const DATABASE_FILENAME = 'tmux-team.db';
 
 // Default configuration values
 const DEFAULT_CONFIG: GlobalConfig = {
-  mode: 'wait',
   preambleMode: 'always',
   defaults: {
     timeout: 180,
     pollInterval: 1,
     captureLines: 100,
-    maxCaptureLines: 2000, // max lines for final extraction (expandable capture)
     preambleEvery: 3, // inject preamble every N messages
     pasteEnterDelayMs: 500, // delay after paste before Enter
   },
@@ -156,13 +155,20 @@ export function loadConfig(paths: Paths): ResolvedConfig {
     defaults: { ...DEFAULT_CONFIG.defaults },
   };
 
-  // Merge global config (mode, preambleMode, defaults only)
+  // Merge global config. Legacy mode and extraction-only maxCaptureLines are
+  // intentionally ignored while remaining opaque in the raw file.
   const globalConfig = loadJsonFile<Partial<GlobalConfig>>(paths.globalConfig);
   if (globalConfig) {
-    if (globalConfig.mode) config.mode = globalConfig.mode;
     if (globalConfig.preambleMode) config.preambleMode = globalConfig.preambleMode;
     if (globalConfig.defaults) {
-      config.defaults = { ...config.defaults, ...globalConfig.defaults };
+      const rawDefaults = globalConfig.defaults as ConfigDefaults & {
+        readonly maxCaptureLines?: unknown;
+      };
+      const { maxCaptureLines: _obsoleteMaxCaptureLines, ...runtimeDefaults } = rawDefaults;
+      config.defaults = {
+        ...config.defaults,
+        ...(runtimeDefaults as Partial<ResolvedConfig['defaults']>),
+      };
     }
   }
 
@@ -174,7 +180,6 @@ export function loadConfig(paths: Paths): ResolvedConfig {
 
     // Merge local settings (override global)
     if (localSettings) {
-      if (localSettings.mode) config.mode = localSettings.mode;
       if (localSettings.preambleMode) config.preambleMode = localSettings.preambleMode;
       if (localSettings.preambleEvery !== undefined) {
         config.defaults.preambleEvery = localSettings.preambleEvery;

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -20,13 +20,11 @@ describe('createContext', () => {
       databaseFile: '/g/tmux-team.db',
     };
     const config: ResolvedConfig = {
-      mode: 'polling',
       preambleMode: 'always',
       defaults: {
         timeout: 180,
         pollInterval: 1,
         captureLines: 100,
-        maxCaptureLines: 2000,
         preambleEvery: 3,
         pasteEnterDelayMs: 500,
       },
@@ -79,13 +77,11 @@ describe('createContext', () => {
       databaseFile: '/g/tmux-team.db',
     };
     const config: ResolvedConfig = {
-      mode: 'polling',
       preambleMode: 'always',
       defaults: {
         timeout: 180,
         pollInterval: 1,
         captureLines: 100,
-        maxCaptureLines: 2000,
         preambleEvery: 3,
         pasteEnterDelayMs: 500,
       },

--- a/src/response-content.test.ts
+++ b/src/response-content.test.ts
@@ -56,8 +56,18 @@ describe('durable reply body input', () => {
     const close = vi.spyOn(fs, 'closeSync');
     try {
       expectInputError(() => readResponseFile(file), 'RESPONSE_INPUT_INVALID');
-      expect(close).toHaveBeenCalledTimes(1);
-      expect(() => fs.fstatSync(open.mock.results[0]!.value as number)).toThrow(/EBADF/);
+      const openIndex = open.mock.calls.findIndex(([openedPath]) => openedPath === file);
+      expect(openIndex).toBeGreaterThanOrEqual(0);
+      const openedFd = open.mock.results[openIndex]?.value as number;
+      const closeIndex = close.mock.calls.findIndex(([closedFd]) => closedFd === openedFd);
+      // This exact-FD assertion is the regression guard: omitting native closeSync
+      // cannot satisfy it, while a later worker reusing the number cannot create a
+      // false EBADF result.
+      expect(closeIndex).toBeGreaterThanOrEqual(0);
+      expect(close.mock.results[closeIndex]).toMatchObject({
+        type: 'return',
+        value: undefined,
+      });
     } finally {
       open.mockRestore();
       close.mockRestore();

--- a/src/talk-instruction.ts
+++ b/src/talk-instruction.ts
@@ -1,0 +1,27 @@
+import { MAX_RESPONSE_BYTES } from './domain/response.js';
+
+/**
+ * Build the only recipient-side framing used by durable talk. The fenced block
+ * ends the request instructions, not the recipient response; completion is
+ * accepted only by the public reply command and durable request service.
+ */
+export function buildDurableReplyInstruction(requestId: string, receipt: string): string {
+  return [
+    '[TMT-DURABLE-REPLY v1 BEGIN]',
+    '',
+    `request-id=${requestId}`,
+    `receipt=${receipt}`,
+    `body-limit-bytes=${MAX_RESPONSE_BYTES}`,
+    `stdin-command=tmt reply ${requestId} --receipt ${receipt} --stdin`,
+    `file-command=tmt reply ${requestId} --receipt ${receipt} --file <path>`,
+    'body-rules=strict-utf8;preserve-empty-whitespace-bom-nul-crlf-unicode;complete-body',
+    'summary-after=accepted',
+    '',
+    'Submit the complete final response with exactly one command above. Stdin input must reach EOF within five seconds.',
+    'The receipt is local correlation, not authentication. Successful submission means the response was delivered, not that the task succeeded.',
+    'After accepted submission, provide a short truthful summary of work, tests, and blockers.',
+    'Surface submission failure without a success summary. If summary generation fails after acceptance, do not resubmit.',
+    'Identical retries are safe only with the same receipt and body while the result is retained for seven days.',
+    '[TMT-DURABLE-REPLY v1 END]',
+  ].join('\n');
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,19 +23,16 @@ export interface ConfigDefaults {
   timeout: number; // seconds
   pollInterval: number; // seconds
   captureLines: number;
-  maxCaptureLines: number; // max lines for final extraction (default: 2000)
   preambleEvery: number; // inject preamble every N messages (default: 3)
   pasteEnterDelayMs: number; // delay after paste before Enter (default: 500)
 }
 
 export interface GlobalConfig {
-  mode: 'polling' | 'wait';
   preambleMode: 'always' | 'disabled';
   defaults: ConfigDefaults;
 }
 
 export interface LocalSettings {
-  mode?: 'polling' | 'wait';
   preambleMode?: 'always' | 'disabled';
   preambleEvery?: number; // local override for preamble frequency
   pasteEnterDelayMs?: number; // local override for paste-enter delay
@@ -47,7 +44,6 @@ export interface LocalConfigFile {
 }
 
 export interface ResolvedConfig {
-  mode: 'polling' | 'wait';
   preambleMode: 'always' | 'disabled';
   defaults: ConfigDefaults;
 }
@@ -59,9 +55,9 @@ export interface Flags {
   config?: string;
   force?: boolean;
   delay?: number; // seconds
-  wait?: boolean;
+  detach?: boolean;
   timeout?: number; // seconds
-  lines?: number; // lines to capture before end marker
+  lines?: number; // lines to capture for check
   noPreamble?: boolean;
 }
 
@@ -167,13 +163,6 @@ export interface RoleService {
 export interface RoleResult {
   readonly identity: Pick<DurableIdentity, 'id' | 'name' | 'canonicalName'>;
   readonly role: RoleProfile | null;
-}
-
-export interface WaitResult {
-  requestId: string;
-  nonce: string;
-  endMarker: string;
-  response: string;
 }
 
 export interface Context {

--- a/test/e2e/caller-context.e2e.test.ts
+++ b/test/e2e/caller-context.e2e.test.ts
@@ -225,20 +225,21 @@ describe.sequential('strict caller context', () => {
 
       const message = 'explicit outside caller';
       const talk = await fixture.runJsonCli<{ response: string }>(
-        ['talk', 'Peer', message, '--wait', '--timeout', '5'],
+        ['talk', 'Peer', message, '--timeout', '5'],
         { outsideTmux: true }
       );
       expect(talk.code).toBe(0);
       expect(talk.json?.response).toContain(`mock-agent response: ${message}`);
       await fixture.waitForEvent(
-        (event) => event.event === 'response' && event.pid === peer.pid && event.message === message
+        (event) =>
+          event.event === 'submitted' && event.pid === peer.pid && event.message === message
       );
 
       const checked = await fixture.runJsonCli<{ output: string }>(['check', 'Peer', '20'], {
         outsideTmux: true,
       });
       expect(checked.code).toBe(0);
-      expect(checked.json?.output).toContain(`mock-agent response: ${message}`);
+      expect(checked.json?.output).toContain(`mock-agent summary: ${message}`);
 
       const offlineSet = await fixture.runJsonCli(
         ['role', 'set', 'offline explicit profile', '--identity', 'Peer'],

--- a/test/e2e/cli-errors.e2e.test.ts
+++ b/test/e2e/cli-errors.e2e.test.ts
@@ -78,29 +78,47 @@ describe.sequential('single JSON command error boundary', () => {
     });
   }, 125_000);
 
-  it('reports a real capture failure once and releases only its sent waiter', async () => {
+  it('does not complete from pane closure and accepts a late public reply', async () => {
     await withE2EFixture(
       async (fixture) => {
         expect((await fixture.runJsonCli(['name', 'Receiver'])).code).toBe(0);
-        const request = fixture.runCliProcess([
-          '--json',
-          'talk',
-          'Receiver',
-          'capture failure request',
-          '--wait',
-          '--timeout',
-          '20',
-        ]);
+        const request = fixture.runCliProcess<{
+          requestId: string;
+          status: string;
+          response?: string;
+        }>(['--json', 'talk', 'Receiver', 'pane closure request', '--timeout', '20']);
         const event = await fixture.waitForEvent(
-          (item) => item.event === 'silent' && item.message === 'capture failure request',
+          (item) => item.event === 'request' && item.message === 'pane closure request',
+          5_000
+        );
+        await fixture.waitForEvent(
+          (item) => item.event === 'silent' && item.requestId === event.requestId,
           5_000
         );
         await fixture.waitFor(() => requestAttempts(fixture)[0]?.status === 'sent');
         fixture.tmux(['kill-pane', '-t', fixture.pane]);
-        expectError(await request.result, 1, 'ERROR');
+        expect(requestAttempts(fixture)[0]).toMatchObject({
+          request_id: event.requestId,
+          status: 'sent',
+          wait_active: 1,
+        });
+        const bodyPath = path.join(fixture.root, 'late-response.txt');
+        fs.writeFileSync(bodyPath, 'late response after pane closure');
+        const reply = await fixture.runJsonCli(
+          ['reply', event.requestId ?? '', '--receipt', event.receipt ?? '', '--file', bodyPath],
+          { outsideTmux: true }
+        );
+        expect(reply.code).toBe(0);
+        const completed = await request.result;
+        expect(completed.code).toBe(0);
+        expect(completed.json).toMatchObject({
+          status: 'completed',
+          requestId: event.requestId,
+          response: 'late response after pane closure',
+        });
         expect(requestAttempts(fixture)).toHaveLength(1);
         expect(requestAttempts(fixture)[0]).toMatchObject({
-          nonce: event.nonce,
+          request_id: event.requestId,
           status: 'sent',
           wait_active: 0,
         });
@@ -122,7 +140,6 @@ describe.sequential('single JSON command error boundary', () => {
           'talk',
           'Receiver',
           'interrupt long poll',
-          '--wait',
           '--timeout',
           '120',
         ]);
@@ -133,10 +150,10 @@ describe.sequential('single JSON command error boundary', () => {
         await fixture.waitFor(() => requestAttempts(fixture)[0]?.status === 'sent');
         request.kill('SIGINT');
         const result = await request.result;
-        expectError(result, 1, 'ERROR');
+        expectError(result, 1, 'INTERRUPTED');
         expect(requestAttempts(fixture)).toHaveLength(1);
         expect(requestAttempts(fixture)[0]).toMatchObject({
-          nonce: event.nonce,
+          request_id: event.requestId,
           status: 'sent',
           wait_active: 0,
         });

--- a/test/e2e/durable-talk.e2e.test.ts
+++ b/test/e2e/durable-talk.e2e.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type MockEvent } from './harness.js';
+
+interface TalkResult {
+  status?: string;
+  requestId?: string;
+  response?: string;
+  bodyBytes?: number;
+  submittedAtMs?: number;
+  error?: { code: string };
+}
+
+interface ResultOutput {
+  status?: string;
+  requestId?: string;
+  response?: string;
+  bodyBytes?: number;
+  submittedAtMs?: number;
+  error?: { code: string };
+}
+
+function submittedFor(events: MockEvent[], requestId: string): MockEvent[] {
+  return events.filter((event) => event.event === 'submitted' && event.requestId === requestId);
+}
+
+describe.sequential('TMT-39 durable talk contract', () => {
+  it.each([
+    ['empty', ''],
+    ['whitespace', ' \t  \n\r\n '],
+    ['structured unicode', '\uFEFF日本語🙂\u0000\r\nRESPONSE-END-fake-marker'],
+  ])('returns the exact %s response body', async (_label, body) => {
+    await withE2EFixture(
+      async (fixture) => {
+        const result = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          'exact body request',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        expect(result.code, result.stderr || result.stdout).toBe(0);
+        expect(result.json).toMatchObject({
+          status: 'completed',
+          response: body,
+          bodyBytes: Buffer.byteLength(body),
+          requestId: expect.stringMatching(/^req_[0-9a-f-]+$/),
+          submittedAtMs: expect.any(Number),
+        });
+        const event = submittedFor(fixture.events(), result.json?.requestId ?? '')[0];
+        expect(event).toMatchObject({ body, bodyBytes: Buffer.byteLength(body) });
+        expect(event?.submittedAtMs).toBe(result.json?.submittedAtMs);
+      },
+      { responseBodyBase64: Buffer.from(body, 'utf8').toString('base64') }
+    );
+  });
+
+  it('accepts the exact one-megabyte UTF-8 boundary and rejects one byte over it', async () => {
+    const boundary = '🙂'.repeat(Math.floor((1024 * 1024) / 4)) + 'a'.repeat((1024 * 1024) % 4);
+    await withE2EFixture(
+      async (fixture) => {
+        const result = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          'one megabyte',
+          '--no-preamble',
+          '--timeout',
+          '12',
+        ]);
+        expect(result.code, result.stderr || result.stdout).toBe(0);
+        expect(result.json?.response).toBe(boundary);
+        expect(result.json?.bodyBytes).toBe(1024 * 1024);
+        expect(submittedFor(fixture.events(), result.json?.requestId ?? '')[0]?.body).toBe(
+          boundary
+        );
+      },
+      { responseBytes: 1024 * 1024, responseMultibyte: true }
+    );
+
+    await withE2EFixture(
+      async (fixture) => {
+        const process = fixture.runCliProcess<TalkResult>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'oversize body',
+          '--no-preamble',
+          '--timeout',
+          '2',
+        ]);
+        const failure = await fixture.waitForEvent(
+          (event) => event.event === 'failure' && event.stage === 'reply'
+        );
+        expect(failure.error).toMatchObject({ code: 'RESPONSE_INPUT_TOO_LARGE' });
+        const result = await process.result;
+        expect(result.code).toBe(4);
+        expect(result.json).toMatchObject({ status: 'timeout', error: { code: 'TIMEOUT' } });
+        expect(fixture.events().some((event) => event.event === 'summary')).toBe(false);
+      },
+      { responseBytes: 1024 * 1024 + 1, responseMultibyte: true }
+    );
+  }, 30_000);
+
+  it('supports detach followed by result without confusing submission with task completion', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const sent = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          'detached request',
+          '--no-preamble',
+          '--detach',
+        ]);
+        expect(sent.code).toBe(0);
+        expect(sent.json).toMatchObject({ status: 'sent', requestId: expect.any(String) });
+        const submitted = await fixture.waitForEvent(
+          (event) => event.event === 'submitted' && event.requestId === sent.json?.requestId,
+          5_000
+        );
+        expect(submitted.body).toBe('mock-agent response: detached request');
+        const result = await fixture.runJsonCli<ResultOutput>([
+          'result',
+          sent.json?.requestId ?? '',
+        ]);
+        expect(result).toMatchObject({
+          code: 0,
+          json: {
+            status: 'completed',
+            requestId: sent.json?.requestId,
+            response: 'mock-agent response: detached request',
+            bodyBytes: Buffer.byteLength('mock-agent response: detached request'),
+          },
+        });
+      },
+      { replyDelayMs: 150 }
+    );
+  });
+
+  it('makes a late reply available after the observer times out', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const process = fixture.runCliProcess<TalkResult>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'late request',
+          '--no-preamble',
+          '--timeout',
+          '1',
+        ]);
+        const timedOut = await process.result;
+        expect(timedOut.code).toBe(4);
+        expect(timedOut.json).toMatchObject({ status: 'timeout', error: { code: 'TIMEOUT' } });
+        const submitted = await fixture.waitForEvent(
+          (event) => event.event === 'submitted' && event.requestId === timedOut.json?.requestId,
+          5_000
+        );
+        expect(submitted.body).toBe('mock-agent response: late request');
+        const result = await fixture.runJsonCli<ResultOutput>([
+          'result',
+          timedOut.json?.requestId ?? '',
+        ]);
+        expect(result).toMatchObject({
+          code: 0,
+          json: { status: 'completed', response: submitted.body },
+        });
+      },
+      { replyDelayMs: 1_500 }
+    );
+  }, 10_000);
+
+  it('records a fake marker as non-terminal output without a durable submission', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const process = fixture.runCliProcess<TalkResult>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'fake marker request',
+          '--no-preamble',
+          '--timeout',
+          '1',
+        ]);
+        const request = await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.message === 'fake marker request'
+        );
+        const marker = await fixture.waitForEvent(
+          (event) => event.event === 'fake-marker' && event.requestId === request.requestId
+        );
+        expect(marker.requestId).toBe(request.requestId);
+        const result = await process.result;
+        expect(result.code).toBe(4);
+        expect(result.json).toMatchObject({ status: 'timeout', error: { code: 'TIMEOUT' } });
+        expect(fixture.events().some((event) => event.event === 'submitted')).toBe(false);
+      },
+      { mode: 'fake-marker' }
+    );
+  });
+
+  it('correlates same-pane concurrent replies when the fast reply commits first', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const slow = fixture.runCliProcess<TalkResult>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'slow same pane',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        const fast = fixture.runCliProcess<TalkResult>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'fast same pane',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        const slowRequest = await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.message === 'slow same pane'
+        );
+        const fastRequest = await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.message === 'fast same pane'
+        );
+        expect(slowRequest.requestId).toEqual(expect.any(String));
+        expect(fastRequest.requestId).toEqual(expect.any(String));
+        fixture.releaseReplyGate(fastRequest.requestId!);
+        await fixture.waitForEvent(
+          (event) => event.event === 'submitted' && event.requestId === fastRequest.requestId
+        );
+        fixture.releaseReplyGate(slowRequest.requestId!);
+        const [slowResult, fastResult] = await Promise.all([slow.result, fast.result]);
+        expect(slowResult.code).toBe(0);
+        expect(fastResult.code).toBe(0);
+        expect(slowResult.json?.response).toBe('mock-agent response: slow same pane');
+        expect(fastResult.json?.response).toBe('mock-agent response: fast same pane');
+        const submissions = fixture
+          .events()
+          .filter((event) => event.event === 'submitted')
+          .filter(
+            (event) =>
+              event.requestId === slowResult.json?.requestId ||
+              event.requestId === fastResult.json?.requestId
+          );
+        expect(submissions.map((event) => event.message)).toEqual([
+          'fast same pane',
+          'slow same pane',
+        ]);
+        expect(submissions.map((event) => event.body)).toEqual([
+          'mock-agent response: fast same pane',
+          'mock-agent response: slow same pane',
+        ]);
+      },
+      { replyGate: true }
+    );
+  }, 15_000);
+
+  it('accepts an identical public reply retry without resubmitting a different body', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const result = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          'identical retry request',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        expect(result.code).toBe(0);
+        const requestId = result.json?.requestId ?? '';
+        await fixture.waitForEvent(
+          (event) =>
+            event.event === 'submitted' && event.requestId === requestId && event.stage === 'retry'
+        );
+        const submissions = submittedFor(fixture.events(), requestId);
+        expect(submissions).toHaveLength(2);
+        expect(submissions[0]?.body).toBe(submissions[1]?.body);
+        expect(submissions[0]?.submittedAtMs).toBe(submissions[1]?.submittedAtMs);
+      },
+      { replyRetry: true }
+    );
+  });
+
+  it('surfaces a failed submission without a success summary', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const process = fixture.runCliProcess<TalkResult>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'failed submission request',
+          '--no-preamble',
+          '--timeout',
+          '1',
+        ]);
+        const failure = await fixture.waitForEvent(
+          (event) => event.event === 'failure' && event.stage === 'reply'
+        );
+        expect(failure.error).toMatchObject({ code: 'RESPONSE_RECEIPT_MISMATCH' });
+        const result = await process.result;
+        expect(result.code).toBe(4);
+        expect(fixture.events().some((event) => event.event === 'summary')).toBe(false);
+      },
+      { replyFailure: true }
+    );
+  });
+
+  it('records accepted reply, retry, conflict, ack loss, and summary failure causally', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const result = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          'retry request',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        expect(result.code).toBe(0);
+        const requestId = result.json?.requestId ?? '';
+        await fixture.waitForEvent(
+          (event) => event.event === 'failure' && event.stage === 'ack-lost'
+        );
+        await fixture.waitForEvent(
+          (event) => event.event === 'submitted' && event.stage === 'retry'
+        );
+        expect(
+          submittedFor(fixture.events(), requestId).every(
+            (event) => event.body === result.json?.response
+          )
+        ).toBe(true);
+      },
+      { replyAckLoss: true }
+    );
+
+    await withE2EFixture(
+      async (fixture) => {
+        const result = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          'conflict request',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        expect(result.code).toBe(0);
+        const requestId = result.json?.requestId ?? '';
+        const conflict = await fixture.waitForEvent(
+          (event) => event.event === 'failure' && event.stage === 'conflict'
+        );
+        expect(conflict.error).toMatchObject({ code: 'RESPONSE_CONFLICT' });
+        expect(submittedFor(fixture.events(), requestId)).toHaveLength(1);
+      },
+      { replyConflict: true }
+    );
+
+    await withE2EFixture(
+      async (fixture) => {
+        const result = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          'summary failure request',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        expect(result.code).toBe(0);
+        const requestId = result.json?.requestId ?? '';
+        await fixture.waitForEvent(
+          (event) => event.event === 'failure' && event.stage === 'summary'
+        );
+        expect(submittedFor(fixture.events(), requestId)).toHaveLength(1);
+        expect(
+          fixture
+            .events()
+            .some((event) => event.event === 'summary' && event.requestId === requestId)
+        ).toBe(false);
+      },
+      { summaryFailure: true }
+    );
+  }, 35_000);
+});

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -16,14 +16,32 @@ export interface CliResult<T = unknown> {
 }
 
 export interface MockEvent {
-  event: 'ready' | 'request' | 'response' | 'silent' | 'malformed' | 'input' | 'stopped';
+  event:
+    | 'ready'
+    | 'request'
+    | 'submitted'
+    | 'summary'
+    | 'failure'
+    | 'fake-marker'
+    | 'child-start'
+    | 'child-close'
+    | 'silent'
+    | 'malformed'
+    | 'input'
+    | 'stopped';
   message?: string;
   line?: string;
-  nonce?: string;
+  requestId?: string;
+  receipt?: string;
+  body?: string;
+  bodyBytes?: number;
+  submittedAtMs?: number;
+  stage?: string;
+  exitCode?: number;
+  childPid?: number;
+  error?: { code?: string; message?: string };
   mode?: string;
   pid?: number;
-  response?: string;
-  responseLength?: number;
 }
 
 export interface MockPane {
@@ -67,6 +85,24 @@ export interface MetadataBarrierOptions {
   readonly operation?: 'publish' | 'clear';
 }
 
+export interface E2EFixtureOptions {
+  mode?: 'respond' | 'silent' | 'malformed' | 'virtualized' | 'fake-marker' | 'input-log';
+  delayMs?: number;
+  responseBodyBase64?: string;
+  responseBytes?: number;
+  responseMultibyte?: boolean;
+  replyDelayMs?: number;
+  replyGate?: boolean;
+  replyFailure?: boolean;
+  holdReplyEof?: boolean;
+  replyRetry?: boolean;
+  replyConflict?: boolean;
+  replyAckLoss?: boolean;
+  summaryFailure?: boolean;
+  globalDir?: string;
+  metadataBarrier?: MetadataBarrierOptions;
+}
+
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -82,6 +118,7 @@ export class E2EFixture {
   readonly transportTracePath = path.join(this.root, 'transport-trace.log');
   readonly forbiddenTmuxLogPath = path.join(this.root, 'forbidden-tmux.log');
   readonly metadataBarrierDirectory = path.join(this.root, 'metadata-barrier');
+  readonly replyGateDirectory = path.join(this.root, 'reply-gate');
   readonly socket = `tmt-e2e-${process.pid}-${Math.random().toString(16).slice(2)}`;
   readonly wrapperDir = path.join(this.root, 'bin');
   readonly tmuxPath: string;
@@ -113,13 +150,7 @@ export class E2EFixture {
     }
   }
 
-  async start(
-    options: {
-      mode?: 'respond' | 'silent' | 'malformed' | 'virtualized' | 'input-log';
-      delayMs?: number;
-      metadataBarrier?: MetadataBarrierOptions;
-    } = {}
-  ): Promise<void> {
+  async start(options: E2EFixtureOptions = {}): Promise<void> {
     try {
       fs.mkdirSync(this.workspace, { recursive: true });
       fs.mkdirSync(this.globalDir, { recursive: true });
@@ -243,7 +274,25 @@ exit ${'$'}status
         TMT_MOCK_MODE: options.mode ?? 'respond',
         TMT_MOCK_DELAY_MS: String(options.delayMs ?? 0),
         TMT_MOCK_LOG: this.logPath,
+        TMT_E2E_CLI_PATH: binPath,
       };
+      if (options.responseBodyBase64 !== undefined)
+        this.env.TMT_MOCK_RESPONSE_BODY_BASE64 = options.responseBodyBase64;
+      if (options.responseBytes !== undefined)
+        this.env.TMT_MOCK_RESPONSE_BYTES = String(options.responseBytes);
+      if (options.responseMultibyte) this.env.TMT_MOCK_RESPONSE_MULTIBYTE = '1';
+      if (options.replyDelayMs !== undefined)
+        this.env.TMT_MOCK_REPLY_DELAY_MS = String(options.replyDelayMs);
+      if (options.replyGate) {
+        fs.mkdirSync(this.replyGateDirectory);
+        this.env.TMT_MOCK_REPLY_GATE = this.replyGateDirectory;
+      }
+      if (options.replyFailure) this.env.TMT_MOCK_REPLY_FAILURE = '1';
+      if (options.holdReplyEof) this.env.TMT_MOCK_HOLD_REPLY_EOF = '1';
+      if (options.replyRetry) this.env.TMT_MOCK_REPLY_RETRY = '1';
+      if (options.replyConflict) this.env.TMT_MOCK_REPLY_CONFLICT = '1';
+      if (options.replyAckLoss) this.env.TMT_MOCK_REPLY_ACK_LOSS = '1';
+      if (options.summaryFailure) this.env.TMT_MOCK_SUMMARY_FAILURE = '1';
       if (options.metadataBarrier) {
         this.enableMetadataBarrier(options.metadataBarrier);
       }
@@ -307,10 +356,12 @@ exit ${'$'}status
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     if (child.pid) this.cliProcessPids.add(child.pid);
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
     let stdout = '';
     let stderr = '';
-    child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
-    child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
+    child.stdout.on('data', (chunk: string) => (stdout += chunk));
+    child.stderr.on('data', (chunk: string) => (stderr += chunk));
     const result = new Promise<CliResult<T>>((resolve) => {
       let settled = false;
       child.once('error', (error) => {
@@ -567,6 +618,17 @@ exit ${'$'}status
     fs.writeFileSync(path.join(this.metadataBarrierDirectory, 'release'), 'release');
   }
 
+  releaseReplyGate(requestId?: string): void {
+    if (!fs.existsSync(this.replyGateDirectory)) {
+      throw new Error('Reply gate is not enabled for this fixture.');
+    }
+    if (requestId !== undefined && !/^req_[0-9a-f-]+$/.test(requestId)) {
+      throw new Error(`Invalid request ID for reply gate: ${requestId}`);
+    }
+    const filename = requestId ? `${requestId}.release` : 'release';
+    fs.writeFileSync(path.join(this.replyGateDirectory, filename), 'release');
+  }
+
   enableMetadataBarrier(options: MetadataBarrierOptions): void {
     fs.mkdirSync(this.metadataBarrierDirectory, { recursive: true });
     for (const signal of ['entered', 'applied', 'release']) {
@@ -580,33 +642,36 @@ exit ${'$'}status
   async stop(): Promise<void> {
     const cliPids = [...this.cliProcessPids];
     let cleanupError: Error | undefined;
-    for (const pid of cliPids) {
-      try {
-        process.kill(-pid, 'SIGKILL');
-      } catch (error) {
-        if (!(error instanceof Error) || !('code' in error) || error.code !== 'ESRCH') {
-          cleanupError = new Error(`Could not kill E2E CLI process group ${pid}.`, {
-            cause: error,
-          });
+    const killAndWait = async (pids: number[], label: string): Promise<number[]> => {
+      for (const pid of pids) {
+        try {
+          process.kill(-pid, 'SIGKILL');
+        } catch (error) {
+          if (!(error instanceof Error) || !('code' in error) || error.code !== 'ESRCH') {
+            cleanupError ??= new Error(`Could not kill E2E ${label} process group ${pid}.`, {
+              cause: error,
+            });
+          }
         }
       }
-    }
-    const groupsRunning = (): number[] =>
-      cliPids.filter((pid) => {
-        try {
-          return this.processGroupIsRunning(pid);
-        } catch (error) {
-          cleanupError ??= new Error(`Could not inspect E2E CLI process group ${pid}.`, {
-            cause: error,
-          });
-          return false;
-        }
-      });
-    const deadline = Date.now() + 1_000;
-    while (Date.now() < deadline && groupsRunning().length > 0) {
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
-    const survivors = groupsRunning();
+      const groupsRunning = (): number[] =>
+        pids.filter((pid) => {
+          try {
+            return this.processGroupIsRunning(pid);
+          } catch (error) {
+            cleanupError ??= new Error(`Could not inspect E2E ${label} process group ${pid}.`, {
+              cause: error,
+            });
+            return false;
+          }
+        });
+      const deadline = Date.now() + 1_000;
+      while (Date.now() < deadline && groupsRunning().length > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      return groupsRunning();
+    };
+    const survivors = await killAndWait(cliPids, 'CLI');
     if (survivors.length > 0) {
       cleanupError = new Error(`E2E CLI process groups survived cleanup: ${survivors.join(', ')}`);
     }
@@ -631,6 +696,20 @@ exit ${'$'}status
     this.serverStarted = false;
     this.started = false;
     await this.waitForProcessExit();
+
+    const activeChildren = new Set<number>();
+    for (const event of this.events()) {
+      if (event.childPid === undefined) continue;
+      if (event.event === 'child-start') activeChildren.add(event.childPid);
+      if (event.event === 'child-close') activeChildren.delete(event.childPid);
+    }
+    const replyPids = [...activeChildren];
+    const replySurvivors = await killAndWait(replyPids, 'reply');
+    if (replySurvivors.length > 0) {
+      cleanupError ??= new Error(
+        `E2E reply process groups survived cleanup: ${replySurvivors.join(', ')}`
+      );
+    }
     fs.rmSync(this.root, { recursive: true, force: true });
     fs.rmSync(this.socketRoot, { recursive: true, force: true });
     if (cleanupError) throw cleanupError;
@@ -724,12 +803,7 @@ exit ${'$'}status
 
 export async function withE2EFixture<T>(
   callback: (fixture: E2EFixture) => Promise<T> | T,
-  options: {
-    mode?: 'respond' | 'silent' | 'malformed' | 'virtualized' | 'input-log';
-    delayMs?: number;
-    globalDir?: string;
-    metadataBarrier?: MetadataBarrierOptions;
-  } = {}
+  options: E2EFixtureOptions = {}
 ): Promise<T> {
   const fixture = new E2EFixture(options);
   try {

--- a/test/e2e/identity-lifecycle.e2e.test.ts
+++ b/test/e2e/identity-lifecycle.e2e.test.ts
@@ -75,7 +75,7 @@ function withoutVerificationTimestamp(
 
 function eventCount(
   fixture: E2EFixture,
-  event: 'request' | 'response',
+  event: 'request' | 'submitted',
   pid: number,
   message: string
 ): number {
@@ -99,29 +99,29 @@ async function talkToIdentity(
     identity: Identity;
     status: string;
     response: string;
-  }>(['talk', name, message, '--wait', '--timeout', '10']);
+  }>(['talk', name, message, '--timeout', '10']);
   expect(result.code).toBe(0);
   const output = json(result);
   expect(output).toMatchObject({ target: name, identity: { name }, status: 'completed' });
   expect(output.response).toContain(`mock-agent response: ${message}`);
   await fixture.waitForEvent(
-    (entry) => entry.event === 'response' && entry.pid === pid && entry.message === message
+    (entry) => entry.event === 'submitted' && entry.pid === pid && entry.message === message
   );
 
   const after = fixture.events();
   const beforeRequest = before.filter(
     (entry) => entry.event === 'request' && entry.pid === pid && entry.message === message
   ).length;
-  const beforeResponse = before.filter(
-    (entry) => entry.event === 'response' && entry.pid === pid && entry.message === message
+  const beforeSubmitted = before.filter(
+    (entry) => entry.event === 'submitted' && entry.pid === pid && entry.message === message
   ).length;
   expect(eventCount(fixture, 'request', pid, message) - beforeRequest).toBe(1);
-  expect(eventCount(fixture, 'response', pid, message) - beforeResponse).toBe(1);
+  expect(eventCount(fixture, 'submitted', pid, message) - beforeSubmitted).toBe(1);
   for (const otherPid of otherPids) {
     expect(
       after.filter(
         (entry) =>
-          (entry.event === 'request' || entry.event === 'response') &&
+          (entry.event === 'request' || entry.event === 'submitted') &&
           entry.pid === otherPid &&
           entry.message === message
       )
@@ -631,7 +631,7 @@ describe.sequential('global identity lifecycle', () => {
             .events()
             .filter(
               (event) =>
-                (event.event === 'request' || event.event === 'response') &&
+                (event.event === 'request' || event.event === 'submitted') &&
                 event.pid === pid &&
                 event.message === message
             )

--- a/test/e2e/identity-retention.e2e.test.ts
+++ b/test/e2e/identity-retention.e2e.test.ts
@@ -122,31 +122,30 @@ describe.sequential('committed identity retention', () => {
 
       const message = 'retained identity can now receive';
       const output = success(
-        await fixture.runJsonCli<{ status: string; nonce: string }>([
+        await fixture.runJsonCli<{ status: string; requestId: string }>([
           'talk',
           'Retained',
           message,
-          '--wait',
           '--timeout',
           '8',
         ])
       );
       expect(output.status).toBe('completed');
-      expect(output.nonce).toMatch(/^[a-z0-9]+$/);
+      expect(output.requestId).toMatch(/^req_[0-9a-f-]+$/);
       // The mock records logical nonblank lines, not the empty separator line.
       const payload = `[SYSTEM: ${preamble}]\n${message}`;
       await fixture.waitForEvent(
         (event) =>
-          event.event === 'response' &&
+          event.event === 'submitted' &&
           event.pid === peer.pid &&
-          event.nonce === output.nonce &&
+          event.requestId === output.requestId &&
           event.message === payload
       );
-      const events = fixture.events().filter((event) => event.nonce === output.nonce);
+      const events = fixture.events().filter((event) => event.requestId === output.requestId);
       expect(events.filter((event) => event.event === 'request')).toMatchObject([
         { pid: peer.pid, message: payload },
       ]);
-      expect(events.filter((event) => event.event === 'response')).toMatchObject([
+      expect(events.filter((event) => event.event === 'submitted')).toMatchObject([
         { pid: peer.pid, message: payload },
       ]);
       expect(fixture.paneMetadata()).toBe(originalMetadata);

--- a/test/e2e/mock-agent.mjs
+++ b/test/e2e/mock-agent.mjs
@@ -1,54 +1,286 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import { spawn } from 'node:child_process';
 import readline from 'node:readline';
 
 const mode = process.env.TMT_MOCK_MODE ?? 'respond';
 const delayMs = Number(process.env.TMT_MOCK_DELAY_MS ?? 0);
+const replyDelayMs = Number(process.env.TMT_MOCK_REPLY_DELAY_MS ?? delayMs);
 const logPath = process.env.TMT_MOCK_LOG;
+const cliPath = process.env.TMT_E2E_CLI_PATH;
 const virtualizedLineCount = 200;
+const maxReplyOutputBytes = 64 * 1024;
+const replyChildren = new Set();
+const replyGate = process.env.TMT_MOCK_REPLY_GATE;
 
 function appendEvent(event) {
   if (!logPath) return;
   fs.appendFileSync(logPath, `${JSON.stringify(event)}\n`);
 }
 
-function respond(message, nonce) {
-  if (mode === 'virtualized') {
-    const responseLines = [
-      `VIRTUALIZED-BEGIN:${message}`,
-      ...Array.from(
-        { length: virtualizedLineCount },
-        (_, index) => `VIRTUALIZED-LINE-${String(index + 1).padStart(3, '0')}:${message}`
-      ),
-      `VIRTUALIZED-END:${message}`,
-    ];
-    const response = responseLines.join('\n');
-    const visibleLines = responseLines.slice(-3).join('\n');
-    // The virtualized response replaces the terminal surface before rendering its
-    // short tail. The full plain-text body remains available only in the event log.
-    const output = `\u001b[2J\u001b[3J\u001b[H${visibleLines}\nRESPONSE-END-${nonce}\n`;
-    process.stdout.write(output, () =>
-      appendEvent({
-        event: 'response',
-        message,
-        nonce,
-        mode,
-        pid: process.pid,
-        response,
-        responseLength: response.length,
-      })
-    );
+function generatedBody(message) {
+  if (process.env.TMT_MOCK_RESPONSE_BODY_BASE64 !== undefined) {
+    const bytes = Buffer.from(process.env.TMT_MOCK_RESPONSE_BODY_BASE64, 'base64');
+    return new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
+  }
+  const requestedBytes = Number(process.env.TMT_MOCK_RESPONSE_BYTES ?? 0);
+  if (requestedBytes > 0) {
+    if (process.env.TMT_MOCK_RESPONSE_MULTIBYTE === '1') {
+      const unit = '🙂';
+      const unitBytes = Buffer.byteLength(unit);
+      return (
+        unit.repeat(Math.floor(requestedBytes / unitBytes)) + 'a'.repeat(requestedBytes % unitBytes)
+      );
+    }
+    return Buffer.alloc(requestedBytes, 'a').toString('utf8');
+  }
+  return `mock-agent response: ${message}`;
+}
+
+function virtualizedBody(message) {
+  const responseLines = [
+    `VIRTUALIZED-BEGIN:${message}`,
+    ...Array.from(
+      { length: virtualizedLineCount },
+      (_, index) => `VIRTUALIZED-LINE-${String(index + 1).padStart(3, '0')}:${message}`
+    ),
+    `VIRTUALIZED-END:${message}`,
+  ];
+  return responseLines.join('\n');
+}
+
+function renderDurableSurface(body, requestId) {
+  if (mode !== 'virtualized') return;
+  const visibleLines = body.split('\n').slice(-3).join('\n');
+  process.stdout.write(`\u001b[2J\u001b[3J\u001b[H${visibleLines}\nRESPONSE-END-${requestId}\n`);
+}
+
+function parseField(line, name) {
+  const match = line.match(new RegExp(`^${name}=(\\S+)$`, 'i'));
+  return match?.[1];
+}
+
+function parseCommand(line) {
+  const match = line.match(/^stdin-command=tmt\s+reply\s+(\S+)\s+--receipt\s+(\S+)\s+--stdin\s*$/);
+  return match ? { requestId: match[1], receipt: match[2] } : undefined;
+}
+
+function scheduleReply(requestId, receipt, body, message) {
+  const start = () => setTimeout(() => submit(requestId, receipt, body, message), replyDelayMs);
+  if (!replyGate) {
+    start();
     return;
   }
-  const output = `mock-agent response: ${message || '(empty)'}\nRESPONSE-END-${nonce}\n`;
-  process.stdout.write(output, () =>
-    appendEvent({ event: 'response', message, nonce, mode, pid: process.pid })
-  );
+  if (!/^req_[0-9a-f-]+$/.test(requestId)) {
+    appendEvent({ event: 'failure', stage: 'request-id', requestId, mode, pid: process.pid });
+    return;
+  }
+  const poll = setInterval(() => {
+    if (
+      !fs.existsSync(`${replyGate}/release`) &&
+      !fs.existsSync(`${replyGate}/${requestId}.release`)
+    ) {
+      return;
+    }
+    clearInterval(poll);
+    start();
+  }, 10);
+}
+
+function killReplyChild(child) {
+  if (!child.pid) return;
+  try {
+    process.kill(-child.pid, 'SIGKILL');
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ESRCH') throw error;
+  }
+}
+
+function runReply(requestId, receipt, body) {
+  if (!cliPath) throw new Error('TMT_E2E_CLI_PATH is required for durable mock replies.');
+  return new Promise((resolve) => {
+    const child = spawn(
+      process.execPath,
+      [cliPath, 'reply', requestId, '--receipt', receipt, '--stdin', '--json'],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env },
+        detached: true,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    );
+    replyChildren.add(child);
+    appendEvent({ event: 'child-start', requestId, childPid: child.pid, mode, pid: process.pid });
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    let stdout = '';
+    let stderr = '';
+    let outputBytes = 0;
+    let settled = false;
+    let stopping = false;
+    let forcedResult;
+    let killTimer;
+    let timeoutTimer;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutTimer);
+      if (killTimer) clearTimeout(killTimer);
+      replyChildren.delete(child);
+      resolve(forcedResult ?? value);
+    };
+    const stopWithBound = (value) => {
+      if (stopping) return;
+      stopping = true;
+      forcedResult = value;
+      killReplyChild(child);
+      killTimer = setTimeout(() => finish(value), 500);
+    };
+    timeoutTimer = setTimeout(
+      () => stopWithBound({ code: 124, stdout, stderr: `${stderr}reply subprocess timed out\n` }),
+      5_000
+    );
+    const consume = (target, chunk) => {
+      outputBytes += Buffer.byteLength(chunk, 'utf8');
+      if (outputBytes > maxReplyOutputBytes) {
+        stopWithBound({
+          code: 125,
+          stdout,
+          stderr: `${stderr}reply subprocess output exceeded bound\n`,
+        });
+        return;
+      }
+      if (target === 'stdout') stdout += chunk;
+      else stderr += chunk;
+    };
+    child.stdout.on('data', (chunk) => consume('stdout', chunk));
+    child.stderr.on('data', (chunk) => consume('stderr', chunk));
+    child.once('error', (error) =>
+      finish({ code: 1, stdout, stderr: `${stderr}${error.message}\n` })
+    );
+    child.once('close', (code) => {
+      appendEvent({
+        event: 'child-close',
+        requestId,
+        childPid: child.pid,
+        exitCode: code ?? 1,
+        mode,
+        pid: process.pid,
+      });
+      finish({ code: code ?? 1, stdout, stderr });
+    });
+    child.stdin.on('error', (error) => {
+      if (!(error instanceof Error) || !('code' in error) || error.code !== 'EPIPE') {
+        stderr += `${error instanceof Error ? error.message : String(error)}\n`;
+      }
+    });
+    if (process.env.TMT_MOCK_HOLD_REPLY_EOF !== '1') child.stdin.end(body, 'utf8');
+  });
+}
+
+function parseReplyResult(result) {
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    return undefined;
+  }
+}
+
+function successfulSubmission(result, requestId, body) {
+  const parsed = parseReplyResult(result);
+  if (
+    result.code !== 0 ||
+    parsed?.status !== 'submitted' ||
+    parsed.requestId !== requestId ||
+    parsed.bodyBytes !== Buffer.byteLength(body) ||
+    !Number.isSafeInteger(parsed.submittedAtMs)
+  ) {
+    return undefined;
+  }
+  return { parsed };
+}
+
+function submit(requestId, receipt, body, message) {
+  const submittedRequestId = process.env.TMT_MOCK_REPLY_FAILURE ? `${requestId}-wrong` : requestId;
+  runReply(submittedRequestId, receipt, body).then((result) => {
+    const success = successfulSubmission(result, requestId, body);
+    if (!success) {
+      appendEvent({
+        event: 'failure',
+        stage: 'reply',
+        requestId,
+        message,
+        mode,
+        pid: process.pid,
+        exitCode: result.code,
+        error: parseReplyResult(result)?.error,
+        stderr: result.stderr,
+      });
+      return;
+    }
+
+    const submitted = {
+      event: 'submitted',
+      requestId,
+      message,
+      body,
+      mode,
+      pid: process.pid,
+      submittedAtMs: success.parsed.submittedAtMs,
+      bodyBytes: success.parsed.bodyBytes,
+    };
+    if (process.env.TMT_MOCK_REPLY_ACK_LOSS) {
+      appendEvent({ ...submitted, event: 'failure', stage: 'ack-lost' });
+      runReply(requestId, receipt, body).then((retry) => {
+        const retrySuccess = successfulSubmission(retry, requestId, body);
+        if (retrySuccess && retrySuccess.parsed.submittedAtMs === submitted.submittedAtMs) {
+          appendEvent({ ...submitted, stage: 'retry' });
+        } else {
+          appendEvent({ event: 'failure', stage: 'retry', requestId, mode, pid: process.pid });
+        }
+      });
+      return;
+    }
+    appendEvent(submitted);
+
+    if (process.env.TMT_MOCK_REPLY_RETRY) {
+      runReply(requestId, receipt, body).then((retry) => {
+        const retrySuccess = successfulSubmission(retry, requestId, body);
+        if (retrySuccess && retrySuccess.parsed.submittedAtMs === submitted.submittedAtMs) {
+          appendEvent({ ...submitted, stage: 'retry' });
+        } else {
+          appendEvent({ event: 'failure', stage: 'retry', requestId, mode, pid: process.pid });
+        }
+      });
+    }
+    if (process.env.TMT_MOCK_REPLY_CONFLICT) {
+      runReply(requestId, receipt, `${body}\nconflict`).then((conflict) => {
+        const conflictJson = parseReplyResult(conflict);
+        appendEvent({
+          event: conflict.code === 0 ? 'submitted' : 'failure',
+          stage: 'conflict',
+          requestId,
+          mode,
+          pid: process.pid,
+          exitCode: conflict.code,
+          error: conflictJson?.error,
+        });
+      });
+    }
+    if (process.env.TMT_MOCK_SUMMARY_FAILURE) {
+      appendEvent({ event: 'failure', stage: 'summary', requestId, mode, pid: process.pid });
+      return;
+    }
+    const summary = `mock-agent summary: ${message || '(empty)'}`;
+    process.stdout.write(`${summary}\n`);
+    appendEvent({ event: 'summary', requestId, message, mode, pid: process.pid });
+  });
 }
 
 const input = readline.createInterface({ input: process.stdin, terminal: false });
 let messageLines = [];
+let frame;
 
 appendEvent({ event: 'ready', mode, pid: process.pid });
 
@@ -57,35 +289,88 @@ input.on('line', (line) => {
     appendEvent({ event: 'input', line, mode, pid: process.pid });
     return;
   }
-  const instruction = line.match(
-    /^When done, output exactly: RESPONSE-END-xxxx \(where xxxx = ([A-Za-z0-9]+)\)$/
-  );
-  if (!instruction) {
-    if (line.length > 0) messageLines.push(line);
+
+  if (line === '[TMT-DURABLE-REPLY v1 BEGIN]') {
+    frame = { requestId: undefined, receipt: undefined, command: undefined };
+    return;
+  }
+  if (frame) {
+    if (line === '[TMT-DURABLE-REPLY v1 END]') {
+      const current = frame;
+      frame = undefined;
+      const message = messageLines.join('\n').trim();
+      messageLines = [];
+      if (
+        !current.requestId ||
+        !current.receipt ||
+        !current.command ||
+        current.command.requestId !== current.requestId ||
+        current.command.receipt !== current.receipt
+      ) {
+        appendEvent({ event: 'failure', stage: 'frame', mode, pid: process.pid });
+        return;
+      }
+      const requestId = current.requestId;
+      const receipt = current.receipt;
+      appendEvent({ event: 'request', message, requestId, receipt, mode, pid: process.pid });
+      if (mode === 'silent') {
+        appendEvent({ event: 'silent', message, requestId, mode, pid: process.pid });
+        return;
+      }
+      if (mode === 'malformed') {
+        setTimeout(
+          () =>
+            process.stdout.write(`mock-agent malformed response: ${message}\n`, () =>
+              appendEvent({ event: 'malformed', message, requestId, mode, pid: process.pid })
+            ),
+          delayMs
+        );
+        return;
+      }
+      if (mode === 'fake-marker') {
+        process.stdout.write(`RESPONSE-END-${requestId}\n`, () =>
+          appendEvent({ event: 'fake-marker', message, requestId, mode, pid: process.pid })
+        );
+        return;
+      }
+      const body = mode === 'virtualized' ? virtualizedBody(message) : generatedBody(message);
+      renderDurableSurface(body, requestId);
+      scheduleReply(requestId, receipt, body, message);
+      return;
+    }
+    const requestId = parseField(line, 'request-id');
+    const receipt = parseField(line, 'receipt');
+    if (requestId) frame.requestId = requestId;
+    if (receipt) frame.receipt = receipt;
+    const command = parseCommand(line);
+    if (command) frame.command = command;
     return;
   }
 
-  const nonce = instruction[1];
-  const message = messageLines.join('\n').trim();
-  messageLines = [];
-  appendEvent({ event: 'request', message, nonce, mode, pid: process.pid });
-
-  if (mode === 'silent') {
-    appendEvent({ event: 'silent', message, nonce, mode, pid: process.pid });
-    return;
-  }
-  const send = () => respond(message, nonce);
-  if (mode === 'malformed') {
-    setTimeout(
-      () =>
-        process.stdout.write(`mock-agent malformed response: ${message}\n`, () =>
-          appendEvent({ event: 'malformed', message, nonce, mode, pid: process.pid })
-        ),
-      delayMs
-    );
-    return;
-  }
-  setTimeout(send, delayMs);
+  if (line.length > 0) messageLines.push(line);
 });
+
+process.on('exit', () => {
+  for (const child of replyChildren) {
+    try {
+      killReplyChild(child);
+    } catch {
+      // Best effort during process teardown.
+    }
+  }
+});
+
+for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+  process.on(signal, () => {
+    for (const child of replyChildren) {
+      try {
+        killReplyChild(child);
+      } catch {
+        // Best effort before terminating the mock process.
+      }
+    }
+    process.exit(128 + ({ SIGTERM: 15, SIGINT: 2, SIGHUP: 1 }[signal] ?? 1));
+  });
+}
 
 input.on('close', () => appendEvent({ event: 'stopped', pid: process.pid }));

--- a/test/e2e/multi-server.e2e.test.ts
+++ b/test/e2e/multi-server.e2e.test.ts
@@ -101,7 +101,6 @@ describe.sequential('global identities across isolated tmux servers', () => {
           'talk',
           'Local',
           message,
-          '--wait',
           '--timeout',
           '10',
         ])
@@ -110,7 +109,7 @@ describe.sequential('global identities across isolated tmux servers', () => {
       expect(talk.response).toContain(`mock-agent response: ${message}`);
       await a.waitForEvent(
         (event) =>
-          event.event === 'response' && event.pid === a.panePid && event.message === message
+          event.event === 'submitted' && event.pid === a.panePid && event.message === message
       );
       expect(b.events().filter((event) => event.event === 'request')).toEqual([]);
     });

--- a/test/e2e/preamble-lifecycle.e2e.test.ts
+++ b/test/e2e/preamble-lifecycle.e2e.test.ts
@@ -23,7 +23,7 @@ interface RoleValue {
 interface TalkResult {
   status: string;
   response: string;
-  nonce: string;
+  requestId: string;
 }
 
 function json<T>(result: CliResult<T>): T {
@@ -65,7 +65,6 @@ async function causalTalk(
     'talk',
     target,
     message,
-    '--wait',
     '--timeout',
     '8',
     ...extraArgs,
@@ -73,18 +72,18 @@ async function causalTalk(
   const output = json<TalkResult>(result);
   expect(output.status).toBe('completed');
   expect(output.response).toContain(message);
-  expect(output.nonce).toMatch(/^[a-z0-9]+$/);
+  expect(output.requestId).toMatch(/^req_[0-9a-f-]+$/);
   // readline in the fixture intentionally records the logical payload without
   // the empty separator line; the production transport still sends \n\n.
   const expectedMessage = expectedPreamble ? `[SYSTEM: ${expectedPreamble}]\n${message}` : message;
   const event = await fixture.waitForEvent(
     (entry) =>
-      entry.event === 'response' &&
+      entry.event === 'submitted' &&
       entry.pid === pid &&
-      entry.nonce === output.nonce &&
+      entry.requestId === output.requestId &&
       entry.message === expectedMessage
   );
-  expect(event.nonce).toBe(output.nonce);
+  expect(event.requestId).toBe(output.requestId);
   expect(
     fixture
       .events()
@@ -92,7 +91,7 @@ async function causalTalk(
         (entry) =>
           entry.event === 'request' &&
           entry.pid === pid &&
-          entry.nonce === event.nonce &&
+          entry.requestId === event.requestId &&
           entry.message === expectedMessage
       )
   ).toBe(true);

--- a/test/e2e/publication-race.e2e.test.ts
+++ b/test/e2e/publication-race.e2e.test.ts
@@ -170,7 +170,6 @@ async function assertPublished(fixture: E2EFixture, name: string): Promise<void>
     'talk',
     name,
     message,
-    '--wait',
     '--timeout',
     '5',
   ]);
@@ -181,7 +180,7 @@ async function assertPublished(fixture: E2EFixture, name: string): Promise<void>
   });
   await fixture.waitForEvent(
     (event) =>
-      event.event === 'response' && event.pid === fixture.panePid && event.message === message
+      event.event === 'submitted' && event.pid === fixture.panePid && event.message === message
   );
 }
 

--- a/test/e2e/reply-child-lifecycle.e2e.test.ts
+++ b/test/e2e/reply-child-lifecycle.e2e.test.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { E2EFixture, withE2EFixture } from './harness.js';
+
+function processGroupIsRunning(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+describe.sequential('durable reply child lifecycle', () => {
+  it('cleans a real reply child held before stdin EOF when the mock is SIGKILLed', async () => {
+    let failedFixture: E2EFixture | undefined;
+    let childPid = 0;
+    try {
+      await expect(
+        withE2EFixture(
+          async (fixture) => {
+            failedFixture = fixture;
+            const sent = await fixture.runJsonCli([
+              'talk',
+              fixture.pane,
+              'held reply child',
+              '--no-preamble',
+              '--detach',
+            ]);
+            expect(sent.code).toBe(0);
+            const child = await fixture.waitForEvent(
+              (event) => event.event === 'child-start' && event.requestId === sent.json?.requestId
+            );
+            childPid = child.childPid ?? 0;
+            expect(childPid).toBeGreaterThan(0);
+            expect(processGroupIsRunning(childPid)).toBe(true);
+            process.kill(-childPid, 'SIGSTOP');
+            process.kill(fixture.panePid, 'SIGKILL');
+            await fixture.waitFor(() => !fixture.mockProcessIsRunning(), 1_000, 'mock SIGKILL');
+            expect(processGroupIsRunning(childPid)).toBe(true);
+            throw new Error('simulated scenario failure after mock SIGKILL');
+          },
+          { holdReplyEof: true }
+        )
+      ).rejects.toThrow('simulated scenario failure after mock SIGKILL');
+      expect(failedFixture).toBeDefined();
+      expect(processGroupIsRunning(childPid)).toBe(false);
+      expect(failedFixture?.serverIsRunning()).toBe(false);
+      expect(failedFixture?.mockProcessIsRunning()).toBe(false);
+      expect(failedFixture && fs.existsSync(failedFixture.root)).toBe(false);
+    } finally {
+      // Safety cleanup follows the assertions, so it cannot hide a fixture leak.
+      if (childPid > 0 && processGroupIsRunning(childPid)) process.kill(-childPid, 'SIGKILL');
+    }
+  });
+});

--- a/test/e2e/request-state.e2e.test.ts
+++ b/test/e2e/request-state.e2e.test.ts
@@ -7,7 +7,6 @@ import { requestAttempts as attempts, preambleCounters } from './request-state-o
 interface TalkOutput {
   status: string;
   requestId: string;
-  nonce: string;
   response?: string;
   error?: { code: string; stage?: string };
 }
@@ -31,7 +30,6 @@ describe.sequential('transactional live request bookkeeping', () => {
           'talk',
           'Receiver',
           'first independent wait',
-          '--wait',
           '--timeout',
           '8',
         ]);
@@ -44,7 +42,6 @@ describe.sequential('transactional live request bookkeeping', () => {
           'talk',
           fixture.pane,
           'second independent wait',
-          '--wait',
           '--timeout',
           '20',
         ]);
@@ -54,7 +51,7 @@ describe.sequential('transactional live request bookkeeping', () => {
         );
         expect(firstEvent.pid).toBe(fixture.panePid);
         expect(secondEvent.pid).toBe(fixture.panePid);
-        expect(firstEvent.nonce).not.toBe(secondEvent.nonce);
+        expect(firstEvent.requestId).not.toBe(secondEvent.requestId);
         await fixture.waitFor(
           () =>
             attempts(fixture).filter((row) => row.wait_active === 1 && row.status === 'sent')
@@ -62,8 +59,8 @@ describe.sequential('transactional live request bookkeeping', () => {
         );
         const before = attempts(fixture);
         expect(new Set(before.map((row) => row.request_id)).size).toBe(2);
-        expect(before.map((row) => row.nonce).sort()).toEqual(
-          [firstEvent.nonce, secondEvent.nonce].sort()
+        expect(before.map((row) => row.request_id).sort()).toEqual(
+          [firstEvent.requestId, secondEvent.requestId].sort()
         );
         for (const row of before) {
           expect(row).toMatchObject({
@@ -82,24 +79,23 @@ describe.sequential('transactional live request bookkeeping', () => {
           code: 4,
           json: {
             status: 'timeout',
-            nonce: firstEvent.nonce,
+            requestId: firstEvent.requestId,
             error: { code: 'TIMEOUT', message: expect.stringContaining('Timed out') },
           },
         });
         expect(timedOut.stderr).toBe('');
         const timeoutOutput = JSON.parse(timedOut.stdout);
         expect(timeoutOutput).toMatchObject({
-          requestId: before.find((row) => row.nonce === firstEvent.nonce)?.request_id,
+          requestId: firstEvent.requestId,
           pane: fixture.pane,
-          endMarker: `RESPONSE-END-${firstEvent.nonce}`,
         });
-        expect(timeoutOutput).toHaveProperty('partialResponse');
+        expect(timeoutOutput).not.toHaveProperty('partialResponse');
         const afterFirst = attempts(fixture);
-        expect(afterFirst.find((row) => row.nonce === firstEvent.nonce)).toMatchObject({
+        expect(afterFirst.find((row) => row.request_id === firstEvent.requestId)).toMatchObject({
           wait_active: 0,
           status: 'sent',
         });
-        expect(afterFirst.find((row) => row.nonce === secondEvent.nonce)).toMatchObject({
+        expect(afterFirst.find((row) => row.request_id === secondEvent.requestId)).toMatchObject({
           wait_active: 1,
           status: 'sent',
         });
@@ -129,7 +125,6 @@ describe.sequential('transactional live request bookkeeping', () => {
             'talk',
             'First',
             'server one wait',
-            '--wait',
             '--timeout',
             '20',
           ]);
@@ -142,7 +137,6 @@ describe.sequential('transactional live request bookkeeping', () => {
             'talk',
             'Second',
             'server two wait',
-            '--wait',
             '--timeout',
             '20',
           ]);
@@ -157,18 +151,19 @@ describe.sequential('transactional live request bookkeeping', () => {
           expect(rows).toHaveLength(2);
           expect(new Set(rows.map((row) => row.server_id)).size).toBe(2);
           expect(new Set(rows.map((row) => row.socket_path)).size).toBe(2);
-          expect(rows.find((row) => row.nonce === firstEvent.nonce)).toMatchObject({
+          expect(rows.find((row) => row.request_id === firstEvent.requestId)).toMatchObject({
             pane_pid: firstServer.panePid,
             socket_path: firstServer.socketPath,
           });
-          expect(rows.find((row) => row.nonce === secondEvent.nonce)).toMatchObject({
+          expect(rows.find((row) => row.request_id === secondEvent.requestId)).toMatchObject({
             pane_pid: secondServer.panePid,
             socket_path: secondServer.socketPath,
           });
           first.kill('SIGINT');
           expect((await first.result).code).toBe(1);
           expect(
-            attempts(firstServer).find((row) => row.nonce === secondEvent.nonce)?.wait_active
+            attempts(firstServer).find((row) => row.request_id === secondEvent.requestId)
+              ?.wait_active
           ).toBe(1);
           second.kill('SIGINT');
           expect((await second.result).code).toBe(1);
@@ -189,7 +184,7 @@ describe.sequential('transactional live request bookkeeping', () => {
       ).toBe(0);
       expect((await fixture.runJsonCli(['config', 'set', 'preambleEvery', '3'])).code).toBe(0);
       const uncertain = await fixture.runJsonCli<TalkOutput>(
-        ['talk', 'RECEIVER', 'uncertain first input', '--wait', '--timeout', '8'],
+        ['talk', 'RECEIVER', 'uncertain first input', '--timeout', '8'],
         { transportFault: { stage: 'submit' } }
       );
       expect(uncertain).toMatchObject({
@@ -198,7 +193,7 @@ describe.sequential('transactional live request bookkeeping', () => {
       });
       const firstEvent = await fixture.waitForEvent(
         (event) =>
-          event.event === 'response' &&
+          event.event === 'submitted' &&
           event.message === '[SYSTEM: Review carefully.]\nuncertain first input'
       );
       expect(firstEvent.pid).toBe(fixture.panePid);
@@ -207,31 +202,32 @@ describe.sequential('transactional live request bookkeeping', () => {
         status: 'uncertain',
         wait_active: 0,
         inject_preamble: 1,
-        nonce: firstEvent.nonce,
+        request_id: firstEvent.requestId,
       });
       expect(cadence(fixture)).toBe(1);
       const next = await fixture.runJsonCli<TalkOutput>([
         'talk',
         fixture.pane,
         'second actual input',
-        '--wait',
         '--timeout',
         '8',
       ]);
       expect(next).toMatchObject({ code: 0, json: { status: 'completed' } });
       const nextEvent = await fixture.waitForEvent(
         (event) =>
-          event.event === 'response' &&
-          event.nonce === next.json?.nonce &&
+          event.event === 'submitted' &&
+          event.requestId === next.json?.requestId &&
           event.pid === fixture.panePid
       );
       expect(nextEvent.message).toBe('second actual input');
       expect(cadence(fixture)).toBe(2);
-      expect(attempts(fixture).find((row) => row.nonce === nextEvent.nonce)).toMatchObject({
-        status: 'sent',
-        wait_active: 0,
-        inject_preamble: 0,
-      });
+      expect(attempts(fixture).find((row) => row.request_id === nextEvent.requestId)).toMatchObject(
+        {
+          status: 'sent',
+          wait_active: 0,
+          inject_preamble: 0,
+        }
+      );
       expect(fixture.events().filter((event) => event.event === 'request')).toHaveLength(2);
       expect(
         fixture.transportTrace().filter((line) => line.startsWith('submit.before'))

--- a/test/e2e/response-integrity.e2e.test.ts
+++ b/test/e2e/response-integrity.e2e.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { withE2EFixture } from './harness.js';
 
 interface TalkResult {
-  nonce: string;
+  requestId: string;
   pane: string;
   response: string;
+  bodyBytes: number;
+  submittedAtMs: number;
   status: string;
-  truncated: boolean;
 }
 
 interface CheckResult {
@@ -24,54 +25,100 @@ function expectedVirtualizedResponse(token: string): string {
   ].join('\n');
 }
 
-describe.sequential('TMT-35 response-channel research characterization', () => {
-  it('shows that terminal capture cannot recover a virtualized full response', async () => {
-    // This is deliberately a research characterization of the current terminal-source
-    // limitation, not a complete-response acceptance test. A future structured-channel
-    // test must assert this exact full body and durable request correlation before delivery.
+describe.sequential('TMT-39 durable response integrity', () => {
+  it('returns the exact full body when the pane renders only a virtualized tail', async () => {
     await withE2EFixture(
       async (fixture) => {
         const peer = await fixture.createMockPane('virtualized-agent');
         const binding = await fixture.runJsonCli(['add', peer.pane, 'Virtualized']);
         expect(binding.code).toBe(0);
 
-        const token = 'tmt35-virtualized-response';
+        const token = 'tmt39-virtualized-response-🙂-日本語';
         const expectedResponse = expectedVirtualizedResponse(token);
         const talk = await fixture.runJsonCli<TalkResult>([
           'talk',
           'Virtualized',
           token,
           '--no-preamble',
-          '--wait',
           '--timeout',
           '8',
         ]);
 
         expect(talk.code).toBe(0);
-        expect(talk.json).toMatchObject({ status: 'completed', truncated: true });
+        expect(talk.json).toMatchObject({ status: 'completed' });
         expect(talk.json?.pane).toBe(peer.pane);
-        expect(talk.json?.nonce).toMatch(/^[a-f0-9]+$/);
-        expect(talk.json?.response).toContain(`VIRTUALIZED-END:${token}`);
-        expect(talk.json?.response).not.toContain(`VIRTUALIZED-LINE-100:${token}`);
+        expect(talk.json?.requestId).toMatch(/^req_[0-9a-f-]+$/);
+        expect(talk.json?.response).toBe(expectedResponse);
+        expect(talk.json?.bodyBytes).toBe(Buffer.byteLength(expectedResponse));
+        expect(talk.json).not.toHaveProperty('nonce');
+        expect(talk.json).not.toHaveProperty('endMarker');
+        expect(talk.json).not.toHaveProperty('truncated');
 
         const requestEvent = await fixture.waitForEvent(
           (event) =>
-            event.event === 'request' && event.pid === peer.pid && event.nonce === talk.json?.nonce
+            event.event === 'request' &&
+            event.pid === peer.pid &&
+            event.requestId === talk.json?.requestId
         );
         expect(requestEvent).toMatchObject({
           message: token,
           mode: 'virtualized',
-          nonce: talk.json?.nonce,
+          requestId: talk.json?.requestId,
           pid: peer.pid,
         });
         const responseEvent = await fixture.waitForEvent(
           (event) =>
-            event.event === 'response' && event.pid === peer.pid && event.nonce === talk.json?.nonce
+            event.event === 'submitted' &&
+            event.pid === peer.pid &&
+            event.requestId === talk.json?.requestId
         );
         expect(responseEvent.message).toBe(token);
-        expect(responseEvent.response).toBe(expectedResponse);
-        expect(responseEvent.responseLength).toBe(expectedResponse.length);
-        expect(responseEvent.response).toContain(`VIRTUALIZED-LINE-100:${token}`);
+        expect(responseEvent.body).toBe(expectedResponse);
+        expect(Buffer.byteLength(responseEvent.body ?? '')).toBe(
+          Buffer.byteLength(expectedResponse)
+        );
+        expect(responseEvent.bodyBytes).toBe(talk.json?.bodyBytes);
+        expect(responseEvent.submittedAtMs).toBe(talk.json?.submittedAtMs);
+        await fixture.waitForEvent(
+          (event) => event.event === 'summary' && event.requestId === talk.json?.requestId
+        );
+        const events = fixture.events();
+        const requestIndex = events.findIndex(
+          (event) =>
+            event.event === 'request' &&
+            event.pid === peer.pid &&
+            event.requestId === talk.json?.requestId
+        );
+        const responseIndex = events.findIndex(
+          (event) =>
+            event.event === 'submitted' &&
+            event.pid === peer.pid &&
+            event.requestId === talk.json?.requestId
+        );
+        const summaryIndex = events.findIndex(
+          (event) =>
+            event.event === 'summary' &&
+            event.pid === peer.pid &&
+            event.requestId === talk.json?.requestId
+        );
+        expect(requestIndex).toBeGreaterThanOrEqual(0);
+        expect(responseIndex).toBeGreaterThan(requestIndex);
+        expect(summaryIndex).toBeGreaterThan(responseIndex);
+
+        const retrieved = await fixture.runJsonCli<TalkResult>([
+          'result',
+          talk.json?.requestId ?? '',
+        ]);
+        expect(retrieved).toMatchObject({
+          code: 0,
+          json: {
+            status: 'completed',
+            requestId: talk.json?.requestId,
+            response: expectedResponse,
+            bodyBytes: Buffer.byteLength(expectedResponse),
+            submittedAtMs: talk.json?.submittedAtMs,
+          },
+        });
 
         const capturedAtDefault = await fixture.runJsonCli<CheckResult>([
           'check',

--- a/test/e2e/retired-commands.e2e.test.ts
+++ b/test/e2e/retired-commands.e2e.test.ts
@@ -178,7 +178,7 @@ describe.sequential('retired legacy registry commands', () => {
         identity: { name: string };
         status: string;
         response: string;
-      }>(['talk', 'SharedIdentity', '--wait', '--timeout', '10', '--', message]);
+      }>(['talk', 'SharedIdentity', '--timeout', '10', '--', message]);
       expect(result.code).toBe(0);
       expect(result.json).toMatchObject({
         pane: fixture.pane,
@@ -189,7 +189,7 @@ describe.sequential('retired legacy registry commands', () => {
 
       await fixture.waitForEvent(
         (event) =>
-          event.event === 'response' && event.pid === fixture.panePid && event.message === message
+          event.event === 'submitted' && event.pid === fixture.panePid && event.message === message
       );
       const events = fixture.events();
       expect(
@@ -201,7 +201,7 @@ describe.sequential('retired legacy registry commands', () => {
       expect(
         events.some(
           (event) =>
-            (event.event === 'request' || event.event === 'response') &&
+            (event.event === 'request' || event.event === 'submitted') &&
             event.pid === peer.pid &&
             event.message === message
         )

--- a/test/e2e/role-lifecycle.e2e.test.ts
+++ b/test/e2e/role-lifecycle.e2e.test.ts
@@ -49,7 +49,6 @@ describe.sequential('durable role profiles', () => {
         'talk',
         'Alice',
         'profile-not-injected',
-        '--wait',
         '--timeout',
         '5',
       ]);

--- a/test/e2e/routing.e2e.test.ts
+++ b/test/e2e/routing.e2e.test.ts
@@ -89,7 +89,7 @@ describe.sequential('global identity and runtime routing', () => {
         identity: IdentitySummary;
         status: string;
         response: string;
-      }>(['talk', normalizedTarget, alphaMessage, '--wait', '--timeout', '10'], {
+      }>(['talk', normalizedTarget, alphaMessage, '--timeout', '10'], {
         cwd: callerWorkspace,
       });
       expect(alphaTalk.code).toBe(0);
@@ -102,7 +102,7 @@ describe.sequential('global identity and runtime routing', () => {
       expect(alphaTalk.json?.response).toContain(`mock-agent response: ${alphaMessage}`);
       await fixture.waitForEvent(
         (event) =>
-          event.event === 'response' && event.pid === alpha.pid && event.message === alphaMessage
+          event.event === 'submitted' && event.pid === alpha.pid && event.message === alphaMessage
       );
       expect(
         fixture
@@ -119,7 +119,7 @@ describe.sequential('global identity and runtime routing', () => {
         pane: string;
         identity: IdentitySummary;
         status: string;
-      }>(['talk', 'all', allMessage, '--wait', '--timeout', '10'], { cwd: callerWorkspace });
+      }>(['talk', 'all', allMessage, '--timeout', '10'], { cwd: callerWorkspace });
       expect(allTalk).toMatchObject({
         code: 0,
         json: {
@@ -131,7 +131,7 @@ describe.sequential('global identity and runtime routing', () => {
       });
       await fixture.waitForEvent(
         (event) =>
-          event.event === 'response' && event.pid === all.pid && event.message === allMessage
+          event.event === 'submitted' && event.pid === all.pid && event.message === allMessage
       );
       expect(
         fixture
@@ -148,7 +148,7 @@ describe.sequential('global identity and runtime routing', () => {
         target: string;
         pane: string;
         status: string;
-      }>(['talk', directTarget, directMessage, '--wait', '--timeout', '10'], {
+      }>(['talk', directTarget, directMessage, '--timeout', '10'], {
         cwd: callerWorkspace,
       });
       expect(directTalk).toMatchObject({
@@ -158,7 +158,7 @@ describe.sequential('global identity and runtime routing', () => {
       expect(directTalk.json).not.toHaveProperty('identity');
       await fixture.waitForEvent(
         (event) =>
-          event.event === 'response' &&
+          event.event === 'submitted' &&
           event.pid === fixture.panePid &&
           event.message === directMessage
       );
@@ -179,7 +179,7 @@ describe.sequential('global identity and runtime routing', () => {
           lines: 25,
         },
       });
-      expect(checked.json?.output).toContain(`mock-agent response: ${alphaMessage}`);
+      expect(checked.json?.output).toContain(`mock-agent summary: ${alphaMessage}`);
 
       const focused = await fixture.runJsonCli<{
         target: string;

--- a/test/e2e/smoke.e2e.test.ts
+++ b/test/e2e/smoke.e2e.test.ts
@@ -2,6 +2,13 @@ import fs from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { E2EFixture, withE2EFixture } from './harness.js';
 
+interface TalkResult {
+  status?: string;
+  requestId?: string;
+  response?: string;
+  error?: { code: string };
+}
+
 describe.sequential('Docker/Vitest tmux foundation smoke scenarios', () => {
   it('propagates real CLI stdout, stderr, and exit codes', async () => {
     await withE2EFixture(async (fixture) => {
@@ -19,59 +26,69 @@ describe.sequential('Docker/Vitest tmux foundation smoke scenarios', () => {
     });
   });
 
-  it('transports deterministic mock-agent input/output through real tmux', async () => {
+  it('transports a durable request and records request, submission, and summary through real tmux', async () => {
     await withE2EFixture(async (fixture) => {
       expect(fixture.serverIsRunning()).toBe(true);
       expect(fixture.tmux(['list-panes', '-a']).trim()).toContain(fixture.pane);
 
-      const nonce = 'foundation123';
-      fixture.sendMockInput([
-        'hello from the foundation',
-        '',
-        `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`,
+      const message = 'hello from the foundation';
+      const result = await fixture.runJsonCli<TalkResult>([
+        'talk',
+        fixture.pane,
+        message,
+        '--no-preamble',
+        '--timeout',
+        '5',
       ]);
-      const output = await fixture.waitForCapture(
-        (capture) =>
-          capture.includes('mock-agent response: hello from the foundation') &&
-          capture.includes(`RESPONSE-END-${nonce}`)
+      expect(result.code).toBe(0);
+      expect(result.json).toMatchObject({
+        status: 'completed',
+        response: `mock-agent response: ${message}`,
+      });
+      const request = await fixture.waitForEvent(
+        (event) => event.event === 'request' && event.requestId === result.json?.requestId
       );
-      await fixture.waitForEvent((event) => event.event === 'response' && event.nonce === nonce);
-
+      const submitted = await fixture.waitForEvent(
+        (event) => event.event === 'submitted' && event.requestId === result.json?.requestId
+      );
+      const summary = await fixture.waitForEvent(
+        (event) => event.event === 'summary' && event.requestId === result.json?.requestId
+      );
+      expect(request.message).toBe(message);
+      expect(submitted.body).toBe(result.json?.response);
+      expect(summary.message).toBe(message);
       const events = fixture.events();
-      expect(events[0]).toEqual({
-        event: 'ready',
-        mode: 'respond',
-        pid: fixture.panePid,
-      });
-      expect(events).toContainEqual({
-        event: 'request',
-        message: 'hello from the foundation',
-        nonce,
-        mode: 'respond',
-        pid: fixture.panePid,
-      });
-      expect(events).toContainEqual({
-        event: 'response',
-        message: 'hello from the foundation',
-        nonce,
-        mode: 'respond',
-        pid: fixture.panePid,
-      });
-      expect(output).toContain('mock-agent response: hello from the foundation');
+      const requestIndex = events.findIndex(
+        (event) => event.event === 'request' && event.requestId === result.json?.requestId
+      );
+      const submittedIndex = events.findIndex(
+        (event) => event.event === 'submitted' && event.requestId === result.json?.requestId
+      );
+      const summaryIndex = events.findIndex(
+        (event) => event.event === 'summary' && event.requestId === result.json?.requestId
+      );
+      expect(requestIndex).toBeGreaterThanOrEqual(0);
+      expect(submittedIndex).toBeGreaterThan(requestIndex);
+      expect(summaryIndex).toBeGreaterThan(submittedIndex);
     });
   });
 
   it('records a silent mock-agent lifecycle without fabricating a response', async () => {
     await withE2EFixture(
       async (fixture) => {
-        const nonce = 'silent123';
-        fixture.sendMockInput([
+        const result = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
           'silent request',
-          '',
-          `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`,
+          '--no-preamble',
+          '--timeout',
+          '1',
         ]);
-        await fixture.waitForEvent((event) => event.event === 'silent' && event.nonce === nonce);
-
+        expect(result.code).toBe(4);
+        expect(result.json).toMatchObject({ status: 'timeout', error: { code: 'TIMEOUT' } });
+        await fixture.waitForEvent(
+          (event) => event.event === 'silent' && event.requestId === result.json?.requestId
+        );
         const events = fixture.events();
         expect(events.map((event) => event.event)).toEqual(['ready', 'request', 'silent']);
         expect(fixture.capture()).not.toContain('mock-agent response: silent request');
@@ -83,20 +100,23 @@ describe.sequential('Docker/Vitest tmux foundation smoke scenarios', () => {
   it('records malformed output separately from a valid response', async () => {
     await withE2EFixture(
       async (fixture) => {
-        const nonce = 'malformed123';
-        fixture.sendMockInput([
+        const process = fixture.runCliProcess<TalkResult>([
+          '--json',
+          'talk',
+          fixture.pane,
           'malformed request',
-          '',
-          `When done, output exactly: RESPONSE-END-xxxx (where xxxx = ${nonce})`,
+          '--no-preamble',
+          '--timeout',
+          '1',
         ]);
-        const output = await fixture.waitForCapture((capture) =>
-          capture.includes('mock-agent malformed response: malformed request')
-        );
-        await fixture.waitForEvent((event) => event.event === 'malformed' && event.nonce === nonce);
-
+        const malformed = await fixture.waitForEvent((event) => event.event === 'malformed');
+        const result = await process.result;
+        expect(result.code).toBe(4);
+        expect(result.json).toMatchObject({ status: 'timeout', error: { code: 'TIMEOUT' } });
         const events = fixture.events();
         expect(events.map((event) => event.event)).toEqual(['ready', 'request', 'malformed']);
-        expect(output).not.toContain(`RESPONSE-END-${nonce}`);
+        expect(malformed.message).toBe('malformed request');
+        expect(fixture.capture()).not.toContain('RESPONSE-END-');
       },
       { mode: 'malformed' }
     );

--- a/test/e2e/transport-safety.e2e.test.ts
+++ b/test/e2e/transport-safety.e2e.test.ts
@@ -3,7 +3,7 @@ import { E2EFixture, withE2EFixture } from './harness.js';
 import { requestAttempts } from './request-state-oracle.js';
 
 interface TalkResult {
-  nonce?: string;
+  requestId?: string;
   response?: string;
   status?: string;
 }
@@ -74,16 +74,15 @@ describe.sequential('TMT-24 safe transport', () => {
         'Normal',
         message,
         '--no-preamble',
-        '--wait',
         '--timeout',
         '8',
       ]);
       expect(normalTalk).toMatchObject({ code: 0, json: { status: 'completed' } });
       const normalResponse = await fixture.waitForEvent(
         (event) =>
-          event.event === 'response' &&
+          event.event === 'submitted' &&
           event.pid === normal.pid &&
-          event.nonce === normalTalk.json?.nonce
+          event.requestId === normalTalk.json?.requestId
       );
       expect(normalResponse.message).toBe(expected);
 
@@ -91,15 +90,15 @@ describe.sequential('TMT-24 safe transport', () => {
       fixture.tmux(['set-buffer', '-b', sentinel, '--', 'keep-this-buffer']);
       const traceStart = fixture.transportTrace().length;
       const fallbackTalk = await fixture.runJsonCli<TalkResult>(
-        ['talk', 'Fallback', message, '--no-preamble', '--wait', '--timeout', '8'],
+        ['talk', 'Fallback', message, '--no-preamble', '--timeout', '8'],
         { transportFault: { stage: 'set-buffer' } }
       );
       expect(fallbackTalk).toMatchObject({ code: 0, json: { status: 'completed' } });
       const fallbackResponse = await fixture.waitForEvent(
         (event) =>
-          event.event === 'response' &&
+          event.event === 'submitted' &&
           event.pid === fallback.pid &&
-          event.nonce === fallbackTalk.json?.nonce
+          event.requestId === fallbackTalk.json?.requestId
       );
       expect(fallbackResponse.message).toBe(expected);
       expect(showBuffer(fixture, sentinel)).toBe('keep-this-buffer');
@@ -120,12 +119,9 @@ describe.sequential('TMT-24 safe transport', () => {
     });
   }, 30_000);
 
-  it('reports uncertain paste and submit without replay in config-driven polling mode', async () => {
+  it('reports uncertain paste and submit without replay in explicit detach mode', async () => {
     await withE2EFixture(
       async (fixture) => {
-        const configured = await fixture.runJsonCli(['config', 'set', 'mode', 'polling']);
-        expect(configured.code).toBe(0);
-
         const literalPeer = await fixture.createMockPane('literal-fault');
         const pastePeer = await fixture.createMockPane('paste-fault');
         const submitPeer = await fixture.createMockPane('submit-fault');
@@ -137,7 +133,7 @@ describe.sequential('TMT-24 safe transport', () => {
         fixture.tmux(['set-buffer', '-b', literalSentinel, '--', 'keep-literal-buffer']);
         const literalTraceStart = fixture.transportTrace().length;
         const literal = await fixture.runJsonCli<TalkResult>(
-          ['talk', 'LiteralFault', 'Enter', '--no-preamble'],
+          ['talk', 'LiteralFault', 'Enter', '--no-preamble', '--detach'],
           { transportFault: { stage: 'set-buffer' } }
         );
         expect(literal).toMatchObject({ code: 0, json: { status: 'sent' } });
@@ -157,7 +153,7 @@ describe.sequential('TMT-24 safe transport', () => {
         fixture.tmux(['set-buffer', '-b', pasteSentinel, '--', 'keep-paste-buffer']);
         const pasteTraceStart = fixture.transportTrace().length;
         const paste = await fixture.runJsonCli<ErrorResult>(
-          ['talk', 'PasteFault', 'C-c', '--no-preamble'],
+          ['talk', 'PasteFault', 'C-c', '--no-preamble', '--detach'],
           { transportFault: { stage: 'paste' } }
         );
         expect(paste).toMatchObject({
@@ -190,7 +186,7 @@ describe.sequential('TMT-24 safe transport', () => {
         fixture.tmux(['set-buffer', '-b', submitSentinel, '--', 'keep-submit-buffer']);
         const submitTraceStart = fixture.transportTrace().length;
         const submit = await fixture.runJsonCli<ErrorResult>(
-          ['talk', 'SubmitFault', '--no-preamble', '--', '--leading-dash'],
+          ['talk', 'SubmitFault', '--no-preamble', '--detach', '--', '--leading-dash'],
           { transportFault: { stage: 'submit' } }
         );
         expect(submit).toMatchObject({
@@ -233,7 +229,7 @@ describe.sequential('TMT-24 safe transport', () => {
         expect((await fixture.runJsonCli(['add', peer.pane, 'WaitSubmitFault'])).code).toBe(0);
 
         const result = await fixture.runJsonCli<ErrorResult>(
-          ['talk', 'WaitSubmitFault', 'state cleanup', '--no-preamble', '--wait', '--timeout', '8'],
+          ['talk', 'WaitSubmitFault', 'state cleanup', '--no-preamble', '--timeout', '8'],
           { transportFault: { stage: 'submit' } }
         );
         expect(result).toMatchObject({


### PR DESCRIPTION
## Scope

- Issue: [TMT-39](https://linear.app/tigerpig-dev/issue/TMT-39/switch-talk-to-durable-completion-and-retire-terminal-wait-modes), completing the live cutover under TMT-37 after TMT-38 / PR #61.
- Make `talk` / `send` wait for an immutable durable reply by default, with bounded `--timeout` or explicit `--detach`.
- Retire terminal capture completion, provider cleanup, `--wait`, and runtime polling/wait mode. Preserve obsolete raw settings without automatic migration.
- Update the user-installed skills, plugin commands, help, learn, completion, installation instructions, architecture, and development guidance together.
- No daemon, inbox, MCP, memory, schema migration, dependency change, release/version bump, or publication.

## Architecture and review

- Reuse the existing request service, SQLite lifecycle, reply receipt codec, public reply/result adapters, target resolver, preamble reservations, and protected tmux transport. No parallel completion store or fallback channel.
- `talk.ts` composes request lifecycle and a bounded monotonic observer. `talk-instruction.ts` owns recipient instructions only; its frame is not a terminal completion boundary.
- Check the deadline before and after each synchronous response read. Equality and read overruns time out without a final post-deadline read; timeout and interruption never cancel recipient work or justify replay.
- Preserve bounded request correlation when a pending JSON document is replaced by a cleanup/output failure, without leaking response bodies or receipts.
- Primary reviewer: Codex, with a Luna high pattern audit and supplementary Luna/Gemini production review. Primary personally reviewed the changed production, installed documentation, test fixtures, assertions, and callers.
- Findings resolved: inaccurate sub-second diagnostics; direct timing validation; exact-body preservation; request-ID-based test correlation; real poll-timer cleanup; post-send failure correlation; stale marker-era test expectations; restoration of independent foundation invariants; causal reply ordering; and concurrent numeric file-descriptor reuse in a cleanup assertion.
- Reviewed commit: `e110c78c4955f63371b21a26698ff2962b456519`.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests, including the final lifecycle additions.
- [x] Local unit suite: 576 tests across 46 files; 95.12% statements and 88.46% branches, with unchanged 90/85 coverage gates.
- [x] `pnpm check`: type checks, lint, formatting, and maintained documentation checks passed without warnings.
- [x] All three distributable skill validators and explicit user-facing Markdown formatting checks passed.
- [x] Actual packed native installation passed on darwin/arm64, including SQLite/FTS5, CLI launch, and disposable skill installation.
- [x] Negative controls: `.trim()` made the exact-body test fail; disabling reply-child collection made the isolated Docker cleanup test fail. Both restored implementations passed their focused tests. No mutation remains.
- [x] `pnpm test:e2e` twice: 70/70 scenarios across 16 files on each run (231.18 s and 230.78 s), including restored foundation and detached-child cleanup checks.
- [x] All protected CI and six native installation targets passed on exact head `e110c78c4955f63371b21a26698ff2962b456519`: [CI run 33982136816](https://github.com/wkh237/tmux-team/actions/runs/33982136816). Docker E2E passed in 5m19s; no bypass or rerun was needed.

Docker uses real CLI/tmux and deterministic mock agents invoking the public `reply` command. Scenarios assert exact empty/whitespace/BOM/NUL/CRLF/Unicode/1 MiB bodies, full results despite virtualized terminal output, detach and late replies, same-pane out-of-order correlation, immutable retry/conflict behavior, summary ordering, transport uncertainty without replay, and cleanup.

The final packed tarball passed clean native verification and matches the reviewed talk/skill source hashes. SHA-256: `d1d33e7a75bc7e497c54aa7ad0a08eab232d39a0030d417ca41b9aefd4e78c15`.

## Project lifecycle

- Scope, accepted/rejected design decisions, review findings, and verification are maintained in TMT-39. TMT-39 and parent TMT-37 are Done after the verified merge.
- Branch/worktree: `codex/tmt-39-durable-talk` / `/Users/benhsieh/dev/tmt-39-durable-talk`; base `main` at `b485bcd`.
- Required protected checks: Code quality, Unit tests, Docker E2E, and Native package matrix. No bypass or lowered gate.
- Merged as `9a4cc746b93f2a91a8c4b62cea7c92d63e8561e6`; clean local main and its linked CLI/installed skill are synchronized. The clean, safely pushed issue worktree was removed after confirming tree equality with merged main, and stale metadata was pruned. The v4 maintenance line is unchanged. No npm publication occurred.
