### PR TITLE
feat: add inline replies and concise recipient guidance (TMT-40)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,7 +154,9 @@ and one exact valid Unicode body, bounded to 1,048,576 UTF-8 bytes. It accepts o
 live pane. `getResponse` returns the original body and association, not a capture.
 Empty bodies, whitespace, BOM, NUL, CR/LF and marker-like text are preserved.
 Role/preamble normalization is not applied; only the Unicode predicate is shared.
-The reply adapter decodes bounded file/stdin input before invoking this service.
+The reply adapter passes inline text or decodes bounded file/stdin input before
+invoking this service. All three sources share the service's exact-body
+validation; the CLI parser only enforces source selection.
 
 The same immediate transaction validates the fence and inserts the final plus its
 attempt's `responseSubmittedAtMs` marker. Retained identical retries return the
@@ -181,13 +183,18 @@ provider-specific state machine or alternate database is introduced.
 
 ### Explicit reply and result adapters
 
-`reply <request-id> --receipt <receipt> (--file <path> | --stdin)` submits one
+`reply <request-id> --receipt <receipt> (--message <text> | --file <path> | --stdin)` submits one
 complete final. `result <request-id>` reads a retained final without waiting.
 Both select storage-only Context capabilities: no live caller, pane reconciliation
 or tmux construction is required. Neither infers a request from a pane or name.
 `talk` generates the exact receipt after preparation and sends it inside the
 single recipient instruction frame, for both default waiting and detach. The
-frame bounds request instructions, not terminal output or result extraction.
+frame uses `<tmt-reply>` tags to group a single reply-command template, with
+the receipt included once. It does not promise hidden provider rendering or
+bound terminal output/result extraction. HTML comments are not used: their
+ASCII exclamation mark conflicts with the shared shell-mode protection.
+Only short submission/summary/error guidance travels with each request;
+input limits and retry/retention details remain in installed skills and help.
 An instruction/encoding failure before beginSend settles definitely_failed and
 releases its waiter, refunding cadence through the existing service.
 
@@ -205,7 +212,9 @@ role input share bounded file decoding, not feature limits or normalization.
 Stdin requires explicit `--stdin`, rejects a TTY, and completes only on EOF within
 five seconds and the 1 MiB body cap. Failure removes input listeners/timers and
 does not submit a partial body. Fatal UTF-8 decoding preserves BOM and exact text.
-No storage transaction spans either input path.
+Inline input may be explicitly empty and is never normalized. Shell quoting
+and operating-system argv limits apply; NUL and large bodies require file/stdin.
+No storage transaction spans input acquisition.
 
 Submission returns `status: submitted`, request ID, byte count and the original
 submission timestamp, including on an identical retry. Result JSON returns
@@ -399,8 +408,9 @@ unwritable output streams are outside the one-document guarantee.
 | [test/e2e/](test/e2e/), [scripts/](scripts/), [.github/workflows/ci.yml](.github/workflows/ci.yml)                                                                         | Docker fixtures/scenarios, orchestration/pack verification and CI. Unit tests are colocated with source; concurrency workers currently also live in `src/`.             |
 
 `src/commands/talk.ts` owns the bounded observer and existing request lifecycle
-composition. `src/talk-instruction.ts` owns recipient guidance only, using the
-shared response byte limit; it does not parse or infer terminal completion.
+composition. `src/talk-instruction.ts` owns concise recipient guidance only;
+input limits remain enforced by the shared response service. The instruction
+builder does not parse or infer terminal completion.
 The test mock independently recognizes the documented request instruction frame
 and invokes the public reply CLI, rather than importing a production response
 store or completing requests through a test-only endpoint.
@@ -458,12 +468,11 @@ These links identify owners of unresolved work, not permission to widen an
 unrelated PR. Update this section and the current map in the delivering PR when
 a gap is resolved; do not leave a permanent exception or label a proposal as shipped.
 
-| Gap                                                                                                                                     | Owning issue                                                                                                                                                           |
-| --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Numeric/flag validation needs hardening.                                                                                                | [TMT-22](https://linear.app/tigerpig-dev/issue/TMT-22)                                                                                                                 |
-| Terminal completion/extraction cannot guarantee a complete correlated body; the durable final service still needs live CLI integration. | [TMT-37](https://linear.app/tigerpig-dev/issue/TMT-37)                                                                                                                 |
-| Shipped skill/help inventories drift; packed verification does not yet prove application migrations.                                    | [TMT-29](https://linear.app/tigerpig-dev/issue/TMT-29)                                                                                                                 |
-| Non-tmux identity management, memory and durable inbox are future capabilities, not installed APIs.                                     | [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
+| Gap                                                                                                  | Owning issue                                                                                                                                                           |
+| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Numeric/flag validation needs hardening.                                                             | [TMT-22](https://linear.app/tigerpig-dev/issue/TMT-22)                                                                                                                 |
+| Shipped skill/help inventories drift; packed verification does not yet prove application migrations. | [TMT-29](https://linear.app/tigerpig-dev/issue/TMT-29)                                                                                                                 |
+| Non-tmux identity management, memory and durable inbox are future capabilities, not installed APIs.  | [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
 
 ## Maintenance contract
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -104,7 +104,7 @@ The live CLI consumes this same service; Docker/mock-agent scenarios verify
 request correlation and exact-body retrieval across the real CLI/tmux boundary.
 
 Reply adapter verification additionally exercises the real CLI in an isolated
-home and SQLite database, including file/stdin decoding, exact result text,
+home and SQLite database, including inline text and file/stdin decoding, exact result text,
 idempotent retry across invocations and rejection without partial finalization.
 Input tests cover EOF, byte/deadline limits and listener/descriptor cleanup.
 These storage-only checks do not substitute for live tmux cutover tests. The

--- a/README.md
+++ b/README.md
@@ -116,25 +116,25 @@ tmux display-message -p '#{pane_id}'
 
 ## Commands
 
-| Command                                                           | Description                                                 |
-| ----------------------------------------------------------------- | ----------------------------------------------------------- |
-| `install [claude\|codex\|gemini\|all]`                            | Install or repair agent integrations                        |
-| `upgrade`                                                         | Upgrade tmux-team; managed skill links update automatically |
-| `name <global-name>`                                              | Bind the current pane to a global identity                  |
-| `this <global-name>`                                              | Exact supported alias for `name`                            |
-| `add <pane-target> <global-name>`                                 | Bind an explicit pane to a global identity                  |
-| `whoami`                                                          | Show the current pane's global identity, if any             |
-| `unbind`                                                          | Remove the current pane's global identity                   |
-| `role show [--identity <name>]`                                   | Read an identity's optional role profile                    |
-| `role set <profile> [--identity <name>]`                          | Replace an identity's role profile                          |
-| `role set --file <path> [--identity <name>]`                      | Replace a profile from a UTF-8 file                         |
-| `role clear [--identity <name>]`                                  | Remove only the role profile                                |
-| `talk <target> "msg"`                                             | Send a message to a global name or pane target              |
-| `check <target> [lines]`                                          | Read output from a global name or pane target               |
-| `reply <request-id> --receipt <receipt> (--file <path>\|--stdin)` | Submit a complete result                                    |
-| `result <request-id>`                                             | Retrieve a retained result or report it unavailable         |
-| `list [target]`                                                   | List active identities, or one target's pane status         |
-| `learn`                                                           | Show the educational guide                                  |
+| Command                                                                             | Description                                                 |
+| ----------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `install [claude\|codex\|gemini\|all]`                                              | Install or repair agent integrations                        |
+| `upgrade`                                                                           | Upgrade tmux-team; managed skill links update automatically |
+| `name <global-name>`                                                                | Bind the current pane to a global identity                  |
+| `this <global-name>`                                                                | Exact supported alias for `name`                            |
+| `add <pane-target> <global-name>`                                                   | Bind an explicit pane to a global identity                  |
+| `whoami`                                                                            | Show the current pane's global identity, if any             |
+| `unbind`                                                                            | Remove the current pane's global identity                   |
+| `role show [--identity <name>]`                                                     | Read an identity's optional role profile                    |
+| `role set <profile> [--identity <name>]`                                            | Replace an identity's role profile                          |
+| `role set --file <path> [--identity <name>]`                                        | Replace a profile from a UTF-8 file                         |
+| `role clear [--identity <name>]`                                                    | Remove only the role profile                                |
+| `talk <target> "msg"`                                                               | Send a message to a global name or pane target              |
+| `check <target> [lines]`                                                            | Read output from a global name or pane target               |
+| `reply <request-id> --receipt <receipt> (--message <text>\|--file <path>\|--stdin)` | Submit a complete result                                    |
+| `result <request-id>`                                                               | Retrieve a retained result or report it unavailable         |
+| `list [target]`                                                                     | List active identities, or one target's pane status         |
+| `learn`                                                                             | Show the educational guide                                  |
 
 `list` also has the `ls` alias. With no target it shows all active global
 identities. With a target it resolves a global name or direct pane target and
@@ -157,11 +157,25 @@ ID/receipt to the recipient, who must submit a reply. The storage-only result
 adapters work without tmux and can accept a late reply after a pane closes:
 
 ```bash
+tmt reply <request-id> --receipt <receipt> --message 'Review complete.'
 tmt reply <request-id> --receipt <receipt> --file response.md
 tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id>
 tmt result <request-id> --json
 ```
+
+Use `--message` for short replies, including an explicit empty string. Quote
+the body for your shell; use `--message='-leading text'` for a leading hyphen.
+Choose exactly one of `--message`, `--file`, or `--stdin`. Inline arguments
+have operating-system size limits and cannot contain NUL; use file/stdin for
+large bodies or NUL-containing text. All sources share the same exact-body
+validation and immutable submission rules.
+
+Received instructions group the reply command in `<tmt-reply>` tags, with the
+request ID and receipt supplied once. These tags do not guarantee hidden UI
+rendering and are not terminal-output completion markers. Replace the message
+placeholder with your complete response, or use file/stdin with the same
+request ID and receipt.
 
 Use exactly one input source. The receipt must be supplied by TMT; do not
 manufacture one, look up the latest request, or infer a current pane. Detached

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -67,14 +67,14 @@ Rejected submissions preserve attempts, cadence and responses. Storage failures
 remain storage failures. No cancellation operation, retry routing policy or new
 CLI command is introduced by this service contract itself.
 
-### TMT-38 explicit CLI adapters
+### Explicit CLI adapters (TMT-38, extended by TMT-40)
 
 TMT-37 is split into TMT-38 (bounded submission/retrieval) and TMT-39 (default
 durable `talk`, obsolete-mode removal and the exact-body Docker cutover).
-TMT-38 adds:
+The current grammar includes TMT-40's inline source:
 
 ```text
-tmt reply <request-id> --receipt <receipt> (--file <path> | --stdin) [--json]
+tmt reply <request-id> --receipt <receipt> (--message <text> | --file <path> | --stdin) [--json]
 tmt result <request-id> [--json]
 ```
 
@@ -88,6 +88,17 @@ Files must resolve to regular files; symlinks are followed, and descriptors are
 closed after bounded reads. Explicit stdin requires EOF within five seconds.
 Both reject malformed UTF-8 and bodies beyond 1,048,576 bytes before submission,
 preserving empty text, BOM, NUL, CR/LF and whitespace without normalization.
+
+Inline `--message` passes its exact string to the same service validation.
+Exactly one source is required; an explicit empty inline string is valid.
+Shell quoting and OS argv size limits apply, and argv cannot contain NUL.
+Use file/stdin for larger or NUL-containing bodies.
+
+TMT-40 groups one reply command in `<tmt-reply>` tags, including the receipt
+once, with brief submission/summary/error guidance outside. This is request
+grouping, not a hidden UI promise or terminal-output boundary. HTML comments
+would conflict with ASCII `!` protection, which remains unchanged. Detailed
+input and retry rules remain in installed skills/help instead of every request.
 
 Reply success returns `status: submitted`, `requestId`, `bodyBytes` and
 `submittedAtMs`. Identical retries preserve the timestamp; different bodies

--- a/plugins/tmux-team/commands/learn.md
+++ b/plugins/tmux-team/commands/learn.md
@@ -96,10 +96,24 @@ Same-pane input serialization and exactly-once processing are not guaranteed.
 When TMT supplies an exact receipt, submit a complete response without tmux:
 
 ```bash
+tmt reply <request-id> --receipt <receipt> --message 'Review complete.'
 tmt reply <request-id> --receipt <receipt> --file response.md
 tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
+
+Use `--message` for short replies, including an explicit empty string. Quote
+the body for your shell; use `--message='-leading text'` for a leading hyphen.
+Choose exactly one of `--message`, `--file`, or `--stdin`. Inline arguments
+have operating-system size limits and cannot contain NUL; use file/stdin for
+large bodies or NUL-containing text. All sources share the same exact-body
+validation and immutable submission rules.
+
+Received instructions group the reply command in `<tmt-reply>` tags, with the
+request ID and receipt supplied once. These tags do not guarantee hidden UI
+rendering and are not terminal-output completion markers. Replace the message
+placeholder with your complete response, or use file/stdin with the same
+request ID and receipt.
 
 Use exactly one input source and the exact request ID/receipt from the received
 talk instruction, including detached requests. Never manufacture a receipt,

--- a/plugins/tmux-team/commands/team.md
+++ b/plugins/tmux-team/commands/team.md
@@ -37,10 +37,24 @@ When TMT gives you a receipt, submit the complete response through the
 storage-only result adapter:
 
 ```bash
+tmt reply <request-id> --receipt <receipt> --message 'Review complete.'
 tmt reply <request-id> --receipt <receipt> --file response.md
 tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
+
+Use `--message` for short replies, including an explicit empty string. Quote
+the body for your shell; use `--message='-leading text'` for a leading hyphen.
+Choose exactly one of `--message`, `--file`, or `--stdin`. Inline arguments
+have operating-system size limits and cannot contain NUL; use file/stdin for
+large bodies or NUL-containing text. All sources share the same exact-body
+validation and immutable submission rules.
+
+Received instructions group the reply command in `<tmt-reply>` tags, with the
+request ID and receipt supplied once. These tags do not guarantee hidden UI
+rendering and are not terminal-output completion markers. Replace the message
+placeholder with your complete response, or use file/stdin with the same
+request ID and receipt.
 
 Use exactly one input source and the request ID/receipt supplied by `talk`,
 including detached requests. Never manufacture a receipt, look up the latest

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -56,10 +56,24 @@ When TMT supplies an exact receipt, submit the complete result through the
 storage-only adapters:
 
 ```bash
+tmt reply <request-id> --receipt <receipt> --message 'Review complete.'
 tmt reply <request-id> --receipt <receipt> --file response.md
 tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
+
+Use `--message` for short replies, including an explicit empty string. Quote
+the body for your shell; use `--message='-leading text'` for a leading hyphen.
+Choose exactly one of `--message`, `--file`, or `--stdin`. Inline arguments
+have operating-system size limits and cannot contain NUL; use file/stdin for
+large bodies or NUL-containing text. All sources share the same exact-body
+validation and immutable submission rules.
+
+Received instructions group the reply command in `<tmt-reply>` tags, with the
+request ID and receipt supplied once. These tags do not guarantee hidden UI
+rendering and are not terminal-output completion markers. Replace the message
+placeholder with your complete response, or use file/stdin with the same
+request ID and receipt.
 
 Use exactly one input source and the exact request ID/receipt supplied in the
 received `talk` instruction, including detached requests. Never manufacture a

--- a/skills/README.md
+++ b/skills/README.md
@@ -78,10 +78,24 @@ When TMT supplies an exact receipt, an agent can submit a complete result
 without tmux:
 
 ```bash
+tmt reply <request-id> --receipt <receipt> --message 'Review complete.'
 tmt reply <request-id> --receipt <receipt> --file response.md
 tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
+
+Use `--message` for short replies, including an explicit empty string. Quote
+the body for your shell; use `--message='-leading text'` for a leading hyphen.
+Choose exactly one of `--message`, `--file`, or `--stdin`. Inline arguments
+have operating-system size limits and cannot contain NUL; use file/stdin for
+large bodies or NUL-containing text. All sources share the same exact-body
+validation and immutable submission rules.
+
+Received instructions group the reply command in `<tmt-reply>` tags, with the
+request ID and receipt supplied once. These tags do not guarantee hidden UI
+rendering and are not terminal-output completion markers. Replace the message
+placeholder with your complete response, or use file/stdin with the same
+request ID and receipt.
 
 Use exactly one input source and the request ID/receipt supplied by `talk`,
 including detached requests. Do not invent a receipt, guess the latest

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -53,10 +53,24 @@ When TMT supplies an exact receipt, submit the complete result through the
 storage-only adapters:
 
 ```bash
+tmt reply <request-id> --receipt <receipt> --message 'Review complete.'
 tmt reply <request-id> --receipt <receipt> --file response.md
 tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
+
+Use `--message` for short replies, including an explicit empty string. Quote
+the body for your shell; use `--message='-leading text'` for a leading hyphen.
+Choose exactly one of `--message`, `--file`, or `--stdin`. Inline arguments
+have operating-system size limits and cannot contain NUL; use file/stdin for
+large bodies or NUL-containing text. All sources share the same exact-body
+validation and immutable submission rules.
+
+Received instructions group the reply command in `<tmt-reply>` tags, with the
+request ID and receipt supplied once. These tags do not guarantee hidden UI
+rendering and are not terminal-output completion markers. Replace the message
+placeholder with your complete response, or use file/stdin with the same
+request ID and receipt.
 
 Use exactly one input source and the exact request ID/receipt supplied in the
 received `talk` instruction, including detached requests. Never manufacture a

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -53,10 +53,24 @@ When TMT supplies an exact receipt, submit the complete result through the
 storage-only adapters:
 
 ```bash
+tmt reply <request-id> --receipt <receipt> --message 'Review complete.'
 tmt reply <request-id> --receipt <receipt> --file response.md
 tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
+
+Use `--message` for short replies, including an explicit empty string. Quote
+the body for your shell; use `--message='-leading text'` for a leading hyphen.
+Choose exactly one of `--message`, `--file`, or `--stdin`. Inline arguments
+have operating-system size limits and cannot contain NUL; use file/stdin for
+large bodies or NUL-containing text. All sources share the same exact-body
+validation and immutable submission rules.
+
+Received instructions group the reply command in `<tmt-reply>` tags, with the
+request ID and receipt supplied once. These tags do not guarantee hidden UI
+rendering and are not terminal-output completion markers. Replace the message
+placeholder with your complete response, or use file/stdin with the same
+request ID and receipt.
 
 Use exactly one input source and the exact request ID/receipt supplied in the
 received `talk` instruction, including detached requests. Never manufacture a

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -49,10 +49,24 @@ When TMT supplies an exact receipt, submit the complete result through the
 storage-only adapters:
 
 ```bash
+tmt reply <request-id> --receipt <receipt> --message 'Review complete.'
 tmt reply <request-id> --receipt <receipt> --file response.md
 tmt reply <request-id> --receipt <receipt> --stdin < response.md
 tmt result <request-id> --json
 ```
+
+Use `--message` for short replies, including an explicit empty string. Quote
+the body for your shell; use `--message='-leading text'` for a leading hyphen.
+Choose exactly one of `--message`, `--file`, or `--stdin`. Inline arguments
+have operating-system size limits and cannot contain NUL; use file/stdin for
+large bodies or NUL-containing text. All sources share the same exact-body
+validation and immutable submission rules.
+
+Received instructions group the reply command in `<tmt-reply>` tags, with the
+request ID and receipt supplied once. These tags do not guarantee hidden UI
+rendering and are not terminal-output completion markers. Replace the message
+placeholder with your complete response, or use file/stdin with the same
+request ID and receipt.
 
 Use exactly one input source and the exact request ID/receipt supplied in the
 received `talk` instruction, including detached requests. Never manufacture a

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -315,6 +315,39 @@ describe('declarative CLI parser', () => {
       receipt,
       stdin: true,
     });
+    expect(
+      parseArgs(['reply', 'request-1', '--receipt', receipt, '--message', 'inline response'])
+        .invocation
+    ).toEqual({
+      kind: 'reply',
+      requestId: 'request-1',
+      receipt,
+      message: 'inline response',
+    });
+    expect(
+      parseArgs(['reply', 'request-1', '--receipt', receipt, '--message', '']).invocation
+    ).toEqual({
+      kind: 'reply',
+      requestId: 'request-1',
+      receipt,
+      message: '',
+    });
+    expect(
+      parseArgs(['reply', 'request-1', '--receipt', receipt, '--message=-leading text']).invocation
+    ).toEqual({
+      kind: 'reply',
+      requestId: 'request-1',
+      receipt,
+      message: '-leading text',
+    });
+    expect(
+      parseArgs(['reply', 'request-1', '--receipt', receipt, '--message=--json']).invocation
+    ).toEqual({
+      kind: 'reply',
+      requestId: 'request-1',
+      receipt,
+      message: '--json',
+    });
     expect(parseArgs(['result', 'request-1', '--json'])).toMatchObject({
       invocation: { kind: 'result', requestId: 'request-1' },
       metadata: expect.objectContaining({ capability: 'storage', commandPath: ['result'] }),
@@ -325,6 +358,8 @@ describe('declarative CLI parser', () => {
     const invalid = [
       ['reply', 'request-1', '--receipt', receipt],
       ['reply', 'request-1', '--receipt', receipt, '--file', '/tmp/reply', '--stdin'],
+      ['reply', 'request-1', '--receipt', receipt, '--file', '/tmp/reply', '--message', 'inline'],
+      ['reply', 'request-1', '--receipt', receipt, '--stdin', '--message', 'inline'],
       ['reply', 'request-1', '--receipt', receipt, '--wait', '--stdin'],
       ['reply', 'request-1', '--receipt', receipt, '--team', 'legacy', '--stdin'],
       ['--wait', 'reply', 'request-1', '--receipt', receipt, '--stdin'],

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -77,6 +77,7 @@ interface CommandOptions extends CommonOptions {
   global?: boolean;
   identity?: string;
   file?: string;
+  message?: string;
 }
 
 interface Capture {
@@ -287,7 +288,9 @@ function setupProgram(capture: Capture): Command {
     return false;
   };
   const rejectIrrelevantStorageOptions = (command: Command, kind: 'reply' | 'result'): void => {
-    const allowed = new Set(kind === 'reply' ? ['json', 'receipt', 'file', 'stdin'] : ['json']);
+    const allowed = new Set(
+      kind === 'reply' ? ['json', 'receipt', 'file', 'stdin', 'message'] : ['json']
+    );
     const seen = new Set<string>();
     let current: Command | null = command;
     while (current) {
@@ -451,7 +454,8 @@ function setupProgram(capture: Capture): Command {
   const reply = storageOnly(program.command('reply').argument('<request-id>'))
     .requiredOption('--receipt <receipt>')
     .option('--file <path>')
-    .option('--stdin');
+    .option('--stdin')
+    .option('--message <text>');
   reply.action(function (requestId: string) {
     rejectIrrelevantStorageOptions(this, 'reply');
     try {
@@ -465,16 +469,24 @@ function setupProgram(capture: Capture): Command {
     };
     const hasFile = options.file !== undefined;
     const hasStdin = options.stdin === true;
-    if (hasFile === hasStdin || options.receipt === undefined) {
+    const hasMessage = options.message !== undefined;
+    if (
+      [hasFile, hasStdin, hasMessage].filter(Boolean).length !== 1 ||
+      options.receipt === undefined
+    ) {
       throw new CliParseError(
-        'Usage: tmux-team reply <request-id> --receipt <receipt> (--file <path> | --stdin) [--json]'
+        'Usage: tmux-team reply <request-id> --receipt <receipt> (--file <path> | --stdin | --message <text>) [--json]'
       );
     }
     action(this, {
       kind: 'reply',
       requestId,
       receipt: options.receipt,
-      ...(hasFile ? { file: options.file! } : { stdin: true }),
+      ...(hasFile
+        ? { file: options.file! }
+        : hasStdin
+          ? { stdin: true }
+          : { message: options.message! }),
     });
   });
   const result = storageOnly(program.command('result').argument('<request-id>'));

--- a/src/cli/requests.ts
+++ b/src/cli/requests.ts
@@ -15,8 +15,9 @@ export type ReplyRequest = {
   readonly requestId: string;
   readonly receipt: string;
 } & (
-  | { readonly file: string; readonly stdin?: never }
-  | { readonly file?: never; readonly stdin: true }
+  | { readonly message: string; readonly file?: never; readonly stdin?: never }
+  | { readonly file: string; readonly message?: never; readonly stdin?: never }
+  | { readonly file?: never; readonly message?: never; readonly stdin: true }
 );
 
 export type ResultRequest = {

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -46,7 +46,7 @@ _tmux-team() {
         fi
         ;;
       reply)
-        compadd -- "--receipt" "--file" "--stdin" "--json"
+        compadd -- "--receipt" "--message" "--file" "--stdin" "--json"
         ;;
       result)
         compadd -- "--json"
@@ -67,7 +67,7 @@ _tmux-team() {
         compadd -- "--delay" "--detach" "--timeout"
         ;;
       reply)
-        compadd -- "--receipt" "--file" "--stdin" "--json"
+        compadd -- "--receipt" "--message" "--file" "--stdin" "--json"
         ;;
       result)
         compadd -- "--json"
@@ -99,7 +99,7 @@ const bashCompletion = `_tmux_team() {
         COMPREPLY=( $(compgen -W "\${agents}" -- \${cur}) )
         ;;
       reply)
-        COMPREPLY=( $(compgen -W "--receipt --file --stdin --json" -- \${cur}) )
+        COMPREPLY=( $(compgen -W "--receipt --message --file --stdin --json" -- \${cur}) )
         ;;
       result)
         COMPREPLY=( $(compgen -W "--json" -- \${cur}) )
@@ -120,7 +120,7 @@ const bashCompletion = `_tmux_team() {
         COMPREPLY=( $(compgen -W "--delay --detach --timeout" -- \${cur}) )
         ;;
       reply)
-        COMPREPLY=( $(compgen -W "--receipt --file --stdin --json" -- \${cur}) )
+        COMPREPLY=( $(compgen -W "--receipt --message --file --stdin --json" -- \${cur}) )
         ;;
       result)
         COMPREPLY=( $(compgen -W "--json" -- \${cur}) )

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -78,9 +78,11 @@ ${colors.yellow('TALK OPTIONS')}
   ${colors.green('--debug')}                     Show debug output
 
 ${colors.yellow('REPLY / RESULT')}
-  tmt reply <request-id> --receipt <receipt> (--file <path> | --stdin) [--json]
+  tmt reply <request-id> --receipt <receipt> (--message <text> | --file <path> | --stdin) [--json]
   tmt result <request-id> [--json]
   Use exactly one input source and the request ID/receipt from the talk instruction.
+  Quote short inline text; use --message='-text' for a leading hyphen.
+  Use file/stdin for large bodies or NUL; operating-system argv limits apply.
   Do not invent a receipt, select the latest request, or infer a current pane.
   A recipient must submit a final; markers, idle output and summaries do not complete talk.
   Reply/result work without tmux on the same local database; check is diagnostic only.

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -32,10 +32,13 @@ ${colors.yellow('ESSENTIAL COMMANDS')}
 ${colors.yellow('DURABLE REPLIES AND RESULTS')}
 
   When TMT supplies an exact receipt, submit a complete response without tmux:
+  ${colors.cyan("tmt reply <request-id> --receipt <receipt> --message 'Review complete.'")}
   ${colors.cyan('tmt reply <request-id> --receipt <receipt> --file response.md')}
   ${colors.cyan('tmt reply <request-id> --receipt <receipt> --stdin < response.md')}
   ${colors.cyan('tmt result <request-id> --json')}
 
+  Short replies can use --message; quote for the shell and use --message='-text'
+  for a leading hyphen. Use file/stdin for large bodies or NUL (argv limits apply).
   Use exactly one input source and never manufacture a receipt, select the
   latest request, or infer a pane. talk supplies the exact request ID/receipt
   for both default wait and detached requests. Submission confirms result

--- a/src/commands/reply-result.test.ts
+++ b/src/commands/reply-result.test.ts
@@ -4,8 +4,10 @@ import os from 'node:os';
 import path from 'node:path';
 import type { Context, UI } from '../types.js';
 import type { RequestService } from '../request-service.js';
-import { ResponseError } from '../domain/response.js';
+import { MAX_RESPONSE_BYTES, ResponseError } from '../domain/response.js';
 import { encodeReplyReceipt } from '../reply-receipt.js';
+import { createRequestService } from '../request-service.js';
+import { openIdentityRepository } from '../storage/identity-repository.js';
 import { cmdReply } from './reply.js';
 import { cmdResult } from './result.js';
 
@@ -108,6 +110,75 @@ describe('reply and result command adapters', () => {
     expect(JSON.stringify(ctx.output)).not.toContain(receipt);
     expect(JSON.stringify(ctx.output)).not.toContain(endpoint.socketPath);
   });
+
+  it('passes an inline message unchanged to the existing response service', async () => {
+    const body = '\ufeffinline\r\n  日本語  ';
+    const requestId = 'request-inline';
+    const receipt = encodeReplyReceipt({ version: 1, requestId, attemptId: 'attempt-1', endpoint });
+    const submitResponse = vi.fn(() => ({
+      requestId,
+      attemptId: 'attempt-1',
+      endpoint,
+      body,
+      bodyBytes: Buffer.byteLength(body),
+      submittedAtMs: 99,
+    }));
+    const ctx = createContext({ submitResponse });
+
+    await cmdReply(ctx, { kind: 'reply', requestId, receipt, message: body });
+
+    expect(submitResponse).toHaveBeenCalledWith({
+      requestId,
+      attemptId: 'attempt-1',
+      endpoint,
+      body,
+    });
+    expect(ctx.output).toEqual([
+      { status: 'submitted', requestId, bodyBytes: Buffer.byteLength(body), submittedAtMs: 99 },
+    ]);
+  });
+
+  it.each([
+    ['lone surrogate', '\ud800', 'RESPONSE_INPUT_INVALID'],
+    ['oversized body', 'x'.repeat(MAX_RESPONSE_BYTES + 1), 'RESPONSE_INPUT_TOO_LARGE'],
+  ])(
+    'leaves no final when the response service rejects an inline %s',
+    async (_name, body, code) => {
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-inline-invalid-'));
+      let repository: ReturnType<typeof openIdentityRepository> | undefined;
+      try {
+        const database = path.join(directory, 'tmux-team.db');
+        repository = openIdentityRepository(database);
+        const service = createRequestService({ repository });
+        const requestId = `request-inline-invalid-${Date.now()}`;
+        const prepared = service.prepare({
+          requestId,
+          endpoint,
+          wait: false,
+          expiresAtMs: Date.now() + 60_000,
+        });
+        service.beginSend(prepared.attemptId);
+        service.settle(prepared.attemptId, 'sent');
+        const beforeAttempt = service.getAttempt(prepared.attemptId);
+        const receipt = encodeReplyReceipt({
+          version: 1,
+          requestId,
+          attemptId: prepared.attemptId,
+          endpoint,
+        });
+        const ctx = createContext(service);
+        await expect(
+          cmdReply(ctx, { kind: 'reply', requestId, receipt, message: body })
+        ).rejects.toMatchObject({ exitCode: 1 });
+        expect(service.getResponse(requestId)).toBeUndefined();
+        expect(service.getAttempt(prepared.attemptId)).toEqual(beforeAttempt);
+        expect(ctx.output).toEqual([{ error: { code, message: expect.any(String) } }]);
+      } finally {
+        repository?.close();
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    }
+  );
 
   it('maps receipt and service errors without opening storage for invalid input', async () => {
     const submitResponse = vi.fn();

--- a/src/commands/reply.ts
+++ b/src/commands/reply.ts
@@ -42,7 +42,11 @@ export async function cmdReply(ctx: Context, request: ReplyRequest): Promise<voi
   try {
     const receipt = decodeReplyReceipt(request.receipt, request.requestId);
     const body =
-      request.file !== undefined ? readResponseFile(request.file) : await readResponseStdin();
+      request.file !== undefined
+        ? readResponseFile(request.file)
+        : request.stdin
+          ? await readResponseStdin()
+          : request.message;
     record = ctx.requestService.submitResponse({
       requestId: request.requestId,
       attemptId: receipt.attemptId,

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -272,8 +272,9 @@ function onlyAttempt(service: RequestService): RequestAttemptRecord {
 }
 
 function attemptFromInstruction(service: RequestService, message: string): RequestAttemptRecord {
-  const requestId = message.match(/^request-id=([^\n]+)$/m)?.[1];
-  const encodedReceipt = message.match(/^receipt=([^\n]+)$/m)?.[1];
+  const match = message.match(/^tmt reply (\S+) --receipt (\S+) --message <text>$/m);
+  const requestId = match?.[1];
+  const encodedReceipt = match?.[2];
   if (!requestId || !encodedReceipt) throw new Error('Durable receipt instruction is incomplete.');
   const receipt = decodeReplyReceipt(encodedReceipt, requestId);
   const attempt = service.getAttempt(receipt.attemptId);
@@ -341,12 +342,14 @@ describe('cmdTalk durable completion', () => {
     ]);
     expect(tmux.captureCalls).toBe(0);
     expect(tmux.sends[0]?.message).toContain(attempt.requestId);
-    expect(tmux.sends[0]?.message).toContain('tmt reply');
+    expect(tmux.sends[0]?.message).toContain('<tmt-reply>');
     expect(tmux.sends[0]?.message).toContain('--receipt');
-    expect(tmux.sends[0]?.message).toContain('--file');
-    expect(tmux.sends[0]?.message).toContain('--stdin');
-    expect(tmux.sends[0]?.message).toContain('body-limit-bytes=1048576');
-    const receipt = tmux.sends[0]?.message.match(/^receipt=([^\n]+)$/m)?.[1];
+    expect(tmux.sends[0]?.message).toContain('--message <text>');
+    expect(tmux.sends[0]?.message).not.toContain('--file');
+    expect(tmux.sends[0]?.message).not.toContain('--stdin');
+    const receipt = tmux.sends[0]?.message.match(
+      /^tmt reply \S+ --receipt (\S+) --message <text>$/m
+    )?.[1];
     expect(receipt).toBeTruthy();
     expect(decodeReplyReceipt(receipt!, attempt.requestId)).toMatchObject({
       version: 1,
@@ -624,7 +627,7 @@ describe('cmdTalk durable completion', () => {
       await cmdTalk(ctx, 'claude', 'Hello');
       expect(preambleService.show).not.toHaveBeenCalled();
       expect(stateSnapshot(root).cadence).toEqual([]);
-      expect(tmux.sends[0]?.message).toMatch(/^Hello\n\n\[TMT-DURABLE-REPLY v1 BEGIN\]/);
+      expect(tmux.sends[0]?.message).toMatch(/^Hello\n\n<tmt-reply>/);
     }
   });
 

--- a/src/installed-reply-guidance.test.ts
+++ b/src/installed-reply-guidance.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseArgs } from './cli/parser.js';
+
+// Provider wrappers differ, but each shipped entry point must teach the same
+// reply input contract. Real CLI and Docker tests own execution semantics.
+describe('shipped reply guidance', () => {
+  it.each([
+    'skills/tmux-team/SKILL.md',
+    'skills/codex/SKILL.md',
+    'skills/claude/team.md',
+    'plugins/tmux-team/skills/tmux-team/SKILL.md',
+    'plugins/tmux-team/commands/team.md',
+    'plugins/tmux-team/commands/learn.md',
+  ])('%s exposes inline and streaming/file alternatives', (relativePath) => {
+    const source = fs.readFileSync(
+      fileURLToPath(new URL(`../${relativePath}`, import.meta.url)),
+      'utf8'
+    );
+    expect(source).toContain(
+      "tmt reply <request-id> --receipt <receipt> --message 'Review complete.'"
+    );
+    expect(source).toContain('tmt reply <request-id> --receipt <receipt> --file response.md');
+    expect(source).toContain('tmt reply <request-id> --receipt <receipt> --stdin');
+    expect(source).toContain('operating-system size limits');
+    expect(source).toContain('cannot contain NUL');
+    expect(source).toContain('do not guarantee hidden UI');
+  });
+
+  it('keeps the short reply example compatible with the public parser', () => {
+    expect(
+      parseArgs(['reply', 'request-1', '--receipt', 'receipt', '--message', 'Review complete.'])
+        .invocation
+    ).toEqual({
+      kind: 'reply',
+      requestId: 'request-1',
+      receipt: 'receipt',
+      message: 'Review complete.',
+    });
+  });
+});

--- a/src/reply-cli-contract.test.ts
+++ b/src/reply-cli-contract.test.ts
@@ -141,13 +141,118 @@ describe('real reply/result CLI process contract', () => {
   );
 
   it(
+    'submits an exact inline body, including empty and Unicode text, through the same final service',
+    { timeout: 15_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const seeded = seedAttempt(sandbox, 'request-inline-cli', { reservePreamble: true });
+        const body = '\ufeffinline\r\n  日本語 😀  ';
+        const submitted = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          seeded.receipt,
+          '--message',
+          body,
+          '--json',
+        ]);
+        expect(submitted.status).toBe(0);
+        expect(parseWholeStdout(submitted)).toMatchObject({
+          status: 'submitted',
+          requestId: seeded.requestId,
+          bodyBytes: Buffer.byteLength(body),
+        });
+
+        const result = await runCli(sandbox, ['result', seeded.requestId, '--json']);
+        expect(parseWholeStdout(result)).toMatchObject({
+          status: 'completed',
+          requestId: seeded.requestId,
+          response: body,
+          bodyBytes: Buffer.byteLength(body),
+        });
+
+        const empty = seedAttempt(sandbox, 'request-inline-empty');
+        const emptyResult = await runCli(sandbox, [
+          'reply',
+          empty.requestId,
+          '--receipt',
+          empty.receipt,
+          '--message',
+          '',
+          '--json',
+        ]);
+        expect(emptyResult.status).toBe(0);
+        expect(parseWholeStdout(emptyResult)).toMatchObject({
+          status: 'submitted',
+          requestId: empty.requestId,
+          bodyBytes: 0,
+        });
+        const emptyRetrieved = await runCli(sandbox, ['result', empty.requestId, '--json']);
+        expect(emptyRetrieved.status).toBe(0);
+        expect(parseWholeStdout(emptyRetrieved)).toMatchObject({
+          status: 'completed',
+          requestId: empty.requestId,
+          response: '',
+          bodyBytes: 0,
+        });
+
+        const leading = seedAttempt(sandbox, 'request-inline-leading');
+        const leadingResult = await runCli(sandbox, [
+          'reply',
+          leading.requestId,
+          '--receipt',
+          leading.receipt,
+          '--message=-leading text',
+          '--json',
+        ]);
+        expect(leadingResult.status).toBe(0);
+        expect(parseWholeStdout(leadingResult)).toMatchObject({
+          status: 'submitted',
+          requestId: leading.requestId,
+          bodyBytes: Buffer.byteLength('-leading text'),
+        });
+        const leadingRetrieved = await runCli(sandbox, ['result', leading.requestId, '--json']);
+        expect(parseWholeStdout(leadingRetrieved)).toMatchObject({
+          status: 'completed',
+          requestId: leading.requestId,
+          response: '-leading text',
+        });
+
+        const flagLooking = seedAttempt(sandbox, 'request-inline-flag-looking');
+        const flagLookingResult = await runCli(sandbox, [
+          'reply',
+          flagLooking.requestId,
+          '--receipt',
+          flagLooking.receipt,
+          '--message=--json',
+          '--json',
+        ]);
+        expect(flagLookingResult.status).toBe(0);
+        expect(parseWholeStdout(flagLookingResult)).toMatchObject({
+          status: 'submitted',
+          requestId: flagLooking.requestId,
+          bodyBytes: Buffer.byteLength('--json'),
+        });
+        const flagLookingRetrieved = await runCli(sandbox, [
+          'result',
+          flagLooking.requestId,
+          '--json',
+        ]);
+        expect(parseWholeStdout(flagLookingRetrieved)).toMatchObject({
+          status: 'completed',
+          requestId: flagLooking.requestId,
+          response: '--json',
+        });
+      })
+  );
+
+  it(
     'keeps identical retries idempotent and conflicting replies unchanged',
     { timeout: 15_000 },
     () =>
       withSandbox(async (sandbox) => {
         const seeded = seedAttempt(sandbox, 'request-idempotent', { reservePreamble: true });
         const original = temporaryFile(sandbox, 'original.txt', 'original\r\n日本語');
-        const conflict = temporaryFile(sandbox, 'conflict.txt', 'different');
         try {
           const first = await runCli(sandbox, [
             'reply',
@@ -166,8 +271,8 @@ describe('real reply/result CLI process contract', () => {
             seeded.requestId,
             '--receipt',
             seeded.receipt,
-            '--file',
-            original,
+            '--message',
+            'original\r\n日本語',
             '--json',
           ]);
           expect(second.status).toBe(0);
@@ -181,8 +286,8 @@ describe('real reply/result CLI process contract', () => {
             seeded.requestId,
             '--receipt',
             seeded.receipt,
-            '--file',
-            conflict,
+            '--message',
+            'different',
             '--json',
           ]);
           expect(rejected.status).toBe(5);
@@ -196,7 +301,6 @@ describe('real reply/result CLI process contract', () => {
           });
         } finally {
           fs.rmSync(original, { force: true });
-          fs.rmSync(conflict, { force: true });
         }
       })
   );

--- a/src/talk-instruction.test.ts
+++ b/src/talk-instruction.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { buildDurableReplyInstruction } from './talk-instruction.js';
+
+describe('durable reply instruction', () => {
+  it('uses concise HTML-style framing and includes the receipt exactly once', () => {
+    const receipt = 'receipt-token';
+    const instruction = buildDurableReplyInstruction('request-1', receipt);
+    const lines = instruction.split('\n');
+
+    expect(lines.slice(0, 3)).toEqual([
+      '<tmt-reply>',
+      'tmt reply request-1 --receipt receipt-token --message <text>',
+      '</tmt-reply>',
+    ]);
+    expect(lines[3]).toContain('Submit your response with the command above.');
+    expect(lines[3]).toContain('Chat output alone does not complete the request.');
+    expect(lines[3]).toContain('After successful submission, show a brief summary;');
+    expect(lines[3]).toContain('report submission errors.');
+    expect(instruction.match(new RegExp(receipt, 'g'))).toHaveLength(1);
+    expect(instruction).not.toContain('!');
+    expect(instruction.length - receipt.length).toBeLessThan(300);
+    const longReceipt = 'a'.repeat(8192);
+    expect(buildDurableReplyInstruction('request-1', longReceipt).length).toBe(
+      instruction.length - receipt.length + longReceipt.length
+    );
+  });
+});

--- a/src/talk-instruction.ts
+++ b/src/talk-instruction.ts
@@ -1,27 +1,13 @@
-import { MAX_RESPONSE_BYTES } from './domain/response.js';
-
 /**
- * Build the only recipient-side framing used by durable talk. The fenced block
- * ends the request instructions, not the recipient response; completion is
+ * Build the only recipient-side framing used by durable talk. The HTML-style
+ * grouping ends the request instructions, not the recipient response; completion is
  * accepted only by the public reply command and durable request service.
  */
 export function buildDurableReplyInstruction(requestId: string, receipt: string): string {
   return [
-    '[TMT-DURABLE-REPLY v1 BEGIN]',
-    '',
-    `request-id=${requestId}`,
-    `receipt=${receipt}`,
-    `body-limit-bytes=${MAX_RESPONSE_BYTES}`,
-    `stdin-command=tmt reply ${requestId} --receipt ${receipt} --stdin`,
-    `file-command=tmt reply ${requestId} --receipt ${receipt} --file <path>`,
-    'body-rules=strict-utf8;preserve-empty-whitespace-bom-nul-crlf-unicode;complete-body',
-    'summary-after=accepted',
-    '',
-    'Submit the complete final response with exactly one command above. Stdin input must reach EOF within five seconds.',
-    'The receipt is local correlation, not authentication. Successful submission means the response was delivered, not that the task succeeded.',
-    'After accepted submission, provide a short truthful summary of work, tests, and blockers.',
-    'Surface submission failure without a success summary. If summary generation fails after acceptance, do not resubmit.',
-    'Identical retries are safe only with the same receipt and body while the result is retained for seven days.',
-    '[TMT-DURABLE-REPLY v1 END]',
+    '<tmt-reply>',
+    `tmt reply ${requestId} --receipt ${receipt} --message <text>`,
+    '</tmt-reply>',
+    'Submit your response with the command above. Chat output alone does not complete the request. After successful submission, show a brief summary; report submission errors.',
   ].join('\n');
 }

--- a/test/e2e/durable-talk.e2e.test.ts
+++ b/test/e2e/durable-talk.e2e.test.ts
@@ -55,6 +55,55 @@ describe.sequential('TMT-39 durable talk contract', () => {
     );
   });
 
+  it('submits an exact Unicode and whitespace body through the inline public reply', async () => {
+    const body = '  日本語🙂\t\nline two  \r\n';
+    await withE2EFixture(
+      async (fixture) => {
+        const talk = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          'inline public reply request',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        expect(talk.code, talk.stderr || talk.stdout).toBe(0);
+        expect(talk.json).toMatchObject({
+          status: 'completed',
+          response: body,
+          bodyBytes: Buffer.byteLength(body),
+        });
+
+        const requestId = talk.json?.requestId ?? '';
+        const child = await fixture.waitForEvent(
+          (event) => event.event === 'child-start' && event.requestId === requestId
+        );
+        expect(child.replyInput).toBe('message');
+        const submitted = await fixture.waitForEvent(
+          (event) => event.event === 'submitted' && event.requestId === requestId
+        );
+        expect(submitted.body).toBe(body);
+        expect(submitted.bodyBytes).toBe(Buffer.byteLength(body));
+
+        const result = await fixture.runJsonCli<ResultOutput>(['result', requestId]);
+        expect(result).toMatchObject({
+          code: 0,
+          json: {
+            status: 'completed',
+            requestId,
+            response: body,
+            bodyBytes: Buffer.byteLength(body),
+            submittedAtMs: talk.json?.submittedAtMs,
+          },
+        });
+      },
+      {
+        replyInput: 'message',
+        responseBodyBase64: Buffer.from(body, 'utf8').toString('base64'),
+      }
+    );
+  });
+
   it('accepts the exact one-megabyte UTF-8 boundary and rejects one byte over it', async () => {
     const boundary = '🙂'.repeat(Math.floor((1024 * 1024) / 4)) + 'a'.repeat((1024 * 1024) % 4);
     await withE2EFixture(

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -39,6 +39,7 @@ export interface MockEvent {
   stage?: string;
   exitCode?: number;
   childPid?: number;
+  replyInput?: 'stdin' | 'message';
   error?: { code?: string; message?: string };
   mode?: string;
   pid?: number;
@@ -91,6 +92,7 @@ export interface E2EFixtureOptions {
   responseBodyBase64?: string;
   responseBytes?: number;
   responseMultibyte?: boolean;
+  replyInput?: 'stdin' | 'message';
   replyDelayMs?: number;
   replyGate?: boolean;
   replyFailure?: boolean;
@@ -281,6 +283,7 @@ exit ${'$'}status
       if (options.responseBytes !== undefined)
         this.env.TMT_MOCK_RESPONSE_BYTES = String(options.responseBytes);
       if (options.responseMultibyte) this.env.TMT_MOCK_RESPONSE_MULTIBYTE = '1';
+      if (options.replyInput !== undefined) this.env.TMT_MOCK_REPLY_INPUT = options.replyInput;
       if (options.replyDelayMs !== undefined)
         this.env.TMT_MOCK_REPLY_DELAY_MS = String(options.replyDelayMs);
       if (options.replyGate) {

--- a/test/e2e/mock-agent.mjs
+++ b/test/e2e/mock-agent.mjs
@@ -11,8 +11,10 @@ const logPath = process.env.TMT_MOCK_LOG;
 const cliPath = process.env.TMT_E2E_CLI_PATH;
 const virtualizedLineCount = 200;
 const maxReplyOutputBytes = 64 * 1024;
+const maxInlineReplyBytes = 4 * 1024;
 const replyChildren = new Set();
 const replyGate = process.env.TMT_MOCK_REPLY_GATE;
+const replyInput = process.env.TMT_MOCK_REPLY_INPUT ?? 'stdin';
 
 function appendEvent(event) {
   if (!logPath) return;
@@ -56,13 +58,8 @@ function renderDurableSurface(body, requestId) {
   process.stdout.write(`\u001b[2J\u001b[3J\u001b[H${visibleLines}\nRESPONSE-END-${requestId}\n`);
 }
 
-function parseField(line, name) {
-  const match = line.match(new RegExp(`^${name}=(\\S+)$`, 'i'));
-  return match?.[1];
-}
-
 function parseCommand(line) {
-  const match = line.match(/^stdin-command=tmt\s+reply\s+(\S+)\s+--receipt\s+(\S+)\s+--stdin\s*$/);
+  const match = line.match(/^tmt reply (\S+) --receipt (\S+) --message <text>$/);
   return match ? { requestId: match[1], receipt: match[2] } : undefined;
 }
 
@@ -99,10 +96,20 @@ function killReplyChild(child) {
 
 function runReply(requestId, receipt, body) {
   if (!cliPath) throw new Error('TMT_E2E_CLI_PATH is required for durable mock replies.');
+  if (replyInput !== 'stdin' && replyInput !== 'message') {
+    throw new Error(`Unsupported mock reply input mode '${replyInput}'.`);
+  }
+  if (
+    replyInput === 'message' &&
+    (Buffer.byteLength(body, 'utf8') > maxInlineReplyBytes || body.includes('\u0000'))
+  ) {
+    throw new Error('Inline mock reply body exceeds the bounded fixture grammar.');
+  }
+  const inputArgs = replyInput === 'message' ? ['--message', body] : ['--stdin'];
   return new Promise((resolve) => {
     const child = spawn(
       process.execPath,
-      [cliPath, 'reply', requestId, '--receipt', receipt, '--stdin', '--json'],
+      [cliPath, 'reply', requestId, '--receipt', receipt, ...inputArgs, '--json'],
       {
         cwd: process.cwd(),
         env: { ...process.env },
@@ -111,7 +118,14 @@ function runReply(requestId, receipt, body) {
       }
     );
     replyChildren.add(child);
-    appendEvent({ event: 'child-start', requestId, childPid: child.pid, mode, pid: process.pid });
+    appendEvent({
+      event: 'child-start',
+      requestId,
+      childPid: child.pid,
+      replyInput,
+      mode,
+      pid: process.pid,
+    });
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
     let stdout = '';
@@ -175,7 +189,10 @@ function runReply(requestId, receipt, body) {
         stderr += `${error instanceof Error ? error.message : String(error)}\n`;
       }
     });
-    if (process.env.TMT_MOCK_HOLD_REPLY_EOF !== '1') child.stdin.end(body, 'utf8');
+    if (replyInput === 'message' || process.env.TMT_MOCK_HOLD_REPLY_EOF !== '1') {
+      if (replyInput === 'message') child.stdin.end();
+      else child.stdin.end(body, 'utf8');
+    }
   });
 }
 
@@ -281,6 +298,7 @@ function submit(requestId, receipt, body, message) {
 const input = readline.createInterface({ input: process.stdin, terminal: false });
 let messageLines = [];
 let frame;
+let guidancePending = false;
 
 appendEvent({ event: 'ready', mode, pid: process.pid });
 
@@ -290,28 +308,35 @@ input.on('line', (line) => {
     return;
   }
 
-  if (line === '[TMT-DURABLE-REPLY v1 BEGIN]') {
-    frame = { requestId: undefined, receipt: undefined, command: undefined };
+  if (guidancePending) {
+    if (line === '<tmt-reply>') {
+      appendEvent({ event: 'failure', stage: 'frame-guidance', mode, pid: process.pid });
+      guidancePending = false;
+      frame = { lines: [] };
+      return;
+    }
+    guidancePending = false;
+    return;
+  }
+
+  if (line === '<tmt-reply>') {
+    frame = { lines: [] };
     return;
   }
   if (frame) {
-    if (line === '[TMT-DURABLE-REPLY v1 END]') {
+    if (line === '</tmt-reply>') {
       const current = frame;
       frame = undefined;
+      guidancePending = true;
       const message = messageLines.join('\n').trim();
       messageLines = [];
-      if (
-        !current.requestId ||
-        !current.receipt ||
-        !current.command ||
-        current.command.requestId !== current.requestId ||
-        current.command.receipt !== current.receipt
-      ) {
+      const command = current.lines.length === 1 ? parseCommand(current.lines[0]) : undefined;
+      if (!command) {
         appendEvent({ event: 'failure', stage: 'frame', mode, pid: process.pid });
         return;
       }
-      const requestId = current.requestId;
-      const receipt = current.receipt;
+      const requestId = command.requestId;
+      const receipt = command.receipt;
       appendEvent({ event: 'request', message, requestId, receipt, mode, pid: process.pid });
       if (mode === 'silent') {
         appendEvent({ event: 'silent', message, requestId, mode, pid: process.pid });
@@ -338,12 +363,7 @@ input.on('line', (line) => {
       scheduleReply(requestId, receipt, body, message);
       return;
     }
-    const requestId = parseField(line, 'request-id');
-    const receipt = parseField(line, 'receipt');
-    if (requestId) frame.requestId = requestId;
-    if (receipt) frame.receipt = receipt;
-    const command = parseCommand(line);
-    if (command) frame.command = command;
+    frame.lines.push(line);
     return;
   }
 

--- a/test/e2e/transport-safety.e2e.test.ts
+++ b/test/e2e/transport-safety.e2e.test.ts
@@ -222,6 +222,44 @@ describe.sequential('TMT-24 safe transport', () => {
     );
   }, 30_000);
 
+  it('preserves the single-receipt reply frame across protected transport', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const message = protectedMessage();
+        const sent = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          message,
+          '--no-preamble',
+          '--detach',
+        ]);
+        expect(sent).toMatchObject({ code: 0, json: { status: 'sent' } });
+        await waitForInput(fixture, fixture.panePid, '</tmt-reply>');
+
+        const lines = fixture
+          .events()
+          .filter((event) => event.event === 'input' && event.pid === fixture.panePid)
+          .map((event) => event.line);
+        expect(lines).toContain('！ protected bang');
+        const begin = lines.indexOf('<tmt-reply>');
+        const end = lines.indexOf('</tmt-reply>');
+        expect(begin).toBeGreaterThanOrEqual(0);
+        expect(end).toBeGreaterThan(begin);
+        const frame = lines.slice(begin, end + 1);
+        expect(frame).toHaveLength(3);
+        expect(frame[0]).toBe('<tmt-reply>');
+        expect(frame[2]).toBe('</tmt-reply>');
+        expect(frame[1]).toMatch(
+          /^tmt reply req_[0-9a-f-]+ --receipt [A-Za-z0-9_-]+ --message <text>$/
+        );
+        const receipt = frame[1]?.match(/--receipt (\S+) --message/)?.[1];
+        expect(receipt).toBeTruthy();
+        expect(lines.filter((line) => line?.includes(receipt ?? '')).length).toBe(1);
+      },
+      { mode: 'input-log' }
+    );
+  });
+
   it('clears wait request state after an uncertain submit', async () => {
     await withE2EFixture(
       async (fixture) => {


### PR DESCRIPTION
## Summary

- Add `reply --message <text>` alongside mutually exclusive file/stdin sources, using the existing exact-body response service.
- Replace verbose recipient framing with one HTML-style `<tmt-reply>` command block and short submission/summary/error guidance. The receipt appears once; existing exclamation shell-mode protection is unchanged.
- Update all shipped skill/provider/plugin instructions, help, learn, completion, and architecture guidance. Document argv quoting/size/NUL limits and avoid claiming hidden UI rendering.

## Architecture and review

Linear: https://linear.app/tigerpig-dev/issue/TMT-40

Primary-reviewed head: `24e2383d3734b7f7fa052e6896925758e0026ad0`.
Reviewed every changed file and relevant parser/dispatcher, reply/service/domain, talk/transport, mock/harness, and documentation callers. No new service, storage schema, dependency, daemon, routing, or completion heuristic.

Luna high pattern audit preceded edits. Primary review replaced mocked "no final" claims with real SQLite/attempt-state assertions, strengthened exact persisted empty/flag-looking bodies, bounded instruction overhead, and removed tautological mock frame checks. Gemini supplied supplementary design review through TMT; accepted argv/viewer concerns and corrected inaccurate NUL/backup suggestions. TMT-41 separately owns skill viewing and custom-directory installation; TMT-29 remains open for its broader acceptance.

## Local verification

- `pnpm check`: passed, no lint warnings/errors.
- `pnpm test:run`: passed with unchanged 90% statement / 85% branch gates.
- Focused final guidance and real CLI checks: 21 passed.
- Two corrected Docker runs: 16 files / 72 tests each, 231.14s and 234.90s. Real tmux/mock/public reply exact-body, timeout, retry/conflict, virtualization, transport protection and teardown coverage retained.
- Negative control: temporarily trimming inline input made the exact-body adapter regression fail; restored before final checks/commit.
- All three skill frontmatter validators and explicit shipped Markdown formatting passed.
- Actual packed native install: darwin/arm64, SQLite prebuild + FTS5 + CLI passed. No package version change or publication.

## Delivery gate

Merge only after required CI passes on this exact reviewed head. Do not bypass protection. Dedicated worktree is removed only after committed/pushed handoff and clean-state verification.
