### PR TITLE
feat: expose bundled skill viewing and custom installation (TMT-41)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -382,6 +382,37 @@ before effects; upgrade retains its JSON rejection. No new text-command schemas
 or grammar are introduced. Runtime boot failures before application loading and
 unwritable output streams are outside the one-document guarantee.
 
+## Bundled skill viewing and installation
+
+`learn --skill` emits the exact bundled universal `SKILL.md`, without startup
+checks, ANSI formatting, or an added newline. It is text-only and rejects JSON
+before effects. Plain `learn` remains the educational guide.
+
+`install --dir <skills-root>` resolves exactly `<skills-root>/tmux-team` against
+the invocation directory. It is mutually exclusive with an explicit provider
+or `all`; empty directory input is rejected before effects. Custom mode links
+the universal skill and never migrates default-provider paths. Existing managed
+links are no-ops; unmanaged paths are refused unless explicit force requests a
+recoverable adjacent backup. Unrelated siblings remain outside the operation.
+Before mutation, source/destination overlap is rejected, including destination
+parents that alias the bundled source through symlinks. Force is not permission
+to move the installed package source or create a recursive self-link.
+
+`src/skill-installation.ts` owns shared package-root, bundled-source, target and
+link knowledge used by install, the viewer and local drift inspection. The
+installer owns provider detection/presentation and optional legacy backup;
+the update checker owns reminder policy. No custom-install registry, arbitrary
+folder scan, provider plugin update or agent reload is implied. Links follow
+source updates at the same package path; reinstall explicitly after relocation.
+Automatic drift inspection covers known defaults only, and npm version checking
+is not an alpha-channel skill version tracker.
+
+The existing packed native verifier also invokes the packed viewer and default
+and custom installation in an isolated home. It verifies actual link contents,
+repeat no-op, unrelated sibling preservation and source-update visibility;
+unit/CLI contract tests cover conflicts, backups and invalid input. This does
+not close TMT-29's separate packed application-storage/migration acceptance.
+
 ## Current module map
 
 | Location                                                                                                                                                                   | Responsibility and integration points                                                                                                                                   |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -143,6 +143,12 @@ prebuild for the current platform, architecture, and libc. A successful run
 therefore proves that no source compilation is required. Temporary projects
 and caches are removed on every exit path.
 
+The same verifier exercises `learn --skill` and default/custom skill installs
+from the packed executable in an isolated home. It compares actual source bytes,
+checks managed links and repeated no-op, preserves an unrelated sibling, and
+changes only the disposable installed source to prove update visibility. This
+does not substitute for application storage/migration verification in TMT-29.
+
 Example:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ tmux display-message -p '#{pane_id}'
 
 ## Commands
 
+View the exact bundled universal skill with `tmt learn --skill`; plain
+`tmt learn` shows the guide. Both modes are text-only.
+
+```bash
+tmt install --dir './project skills'
+```
+
+This installs a managed link at `./project skills/tmux-team`, relative to the
+current directory. Do not combine a custom directory with a provider or `all`.
+Existing unmanaged content is preserved unless `--force` requests a recoverable
+backup. Repeating the same install is a no-op for a correct link. Custom mode
+does not migrate default-provider paths or touch unrelated sibling files.
+
+Choose a folder your provider discovers; installation does not reload an active
+agent. Managed links follow bundled updates at the same package path. Rerun
+the same install command after package relocation to repair a custom link.
+Automatic drift reminders cover known default paths, not arbitrary custom
+folders or provider-managed plugins. The npm version check uses `latest`,
+not an alpha-channel skill version tracker.
+
 | Command                                                                             | Description                                                 |
 | ----------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | `install [claude\|codex\|gemini\|all]`                                              | Install or repair agent integrations                        |

--- a/plugins/tmux-team/commands/learn.md
+++ b/plugins/tmux-team/commands/learn.md
@@ -154,3 +154,23 @@ Install integrations with `tmt install`. `tmt upgrade` updates the package, and
 managed skill links then use the new bundled files automatically. Sending pane
 input is an external action and must be authorized by the user; preserve
 multiline text.
+
+## View and install the bundled skill
+
+`tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`
+shows the guide. Both are text-only. Install default integrations with
+`tmt install [claude|codex|gemini|all]`, or choose a skills root explicitly:
+
+```bash
+tmt install --dir ./my-skills
+```
+
+This links `./my-skills/tmux-team`; do not also specify a provider. Choose a
+folder your provider actually discovers and reload its skills if needed.
+Managed links follow bundled updates at the same package path. Re-run the same
+install command to inspect/repair the target after relocation; existing
+unmanaged content is preserved unless `--force` requests a recoverable backup.
+Automatic drift reminders inspect known default paths, not custom folders.
+They do not reload an active agent, update provider-managed plugins, or track
+alpha release channels. Package upgrades and skill installation are separate
+from provider discovery.

--- a/plugins/tmux-team/commands/team.md
+++ b/plugins/tmux-team/commands/team.md
@@ -122,3 +122,23 @@ do not complete a request. Same-pane input serialization is not guaranteed.
 - Craft clear, specific messages for the other agent
 - Preserve multiline messages and do not send pane input without authorization
 - After receiving a response, summarize it for the user
+
+## View and install the bundled skill
+
+`tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`
+shows the guide. Both are text-only. Install default integrations with
+`tmt install [claude|codex|gemini|all]`, or choose a skills root explicitly:
+
+```bash
+tmt install --dir ./my-skills
+```
+
+This links `./my-skills/tmux-team`; do not also specify a provider. Choose a
+folder your provider actually discovers and reload its skills if needed.
+Managed links follow bundled updates at the same package path. Re-run the same
+install command to inspect/repair the target after relocation; existing
+unmanaged content is preserved unless `--force` requests a recoverable backup.
+Automatic drift reminders inspect known default paths, not custom folders.
+They do not reload an active agent, update provider-managed plugins, or track
+alpha release channels. Package upgrades and skill installation are separate
+from provider discovery.

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -240,3 +240,23 @@ tmux-team talk codex "Review this authentication code" --json
   and requires user authorization; do not infer permission to send commands.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.
+
+## View and install the bundled skill
+
+`tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`
+shows the guide. Both are text-only. Install default integrations with
+`tmt install [claude|codex|gemini|all]`, or choose a skills root explicitly:
+
+```bash
+tmt install --dir ./my-skills
+```
+
+This links `./my-skills/tmux-team`; do not also specify a provider. Choose a
+folder your provider actually discovers and reload its skills if needed.
+Managed links follow bundled updates at the same package path. Re-run the same
+install command to inspect/repair the target after relocation; existing
+unmanaged content is preserved unless `--force` requests a recoverable backup.
+Automatic drift reminders inspect known default paths, not custom folders.
+They do not reload an active agent, update provider-managed plugins, or track
+alpha release channels. Package upgrades and skill installation are separate
+from provider discovery.

--- a/scripts/verify-packed-native-install.mjs
+++ b/scripts/verify-packed-native-install.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
+import assert from 'node:assert/strict';
 
 function usage() {
   console.log(`verify-packed-native-install
@@ -15,7 +16,7 @@ Usage:
 
 The verifier installs the packed package into an isolated temporary project,
 blocks compiler fallback, loads better-sqlite3's native binding, and executes
-an FTS5 query.
+an FTS5 query, and verifies bundled skill viewing and isolated installation.
 `);
 }
 
@@ -141,6 +142,81 @@ function verifyPackedCli(projectDirectory) {
   }
 }
 
+function verifyPackedSkills(projectDirectory) {
+  const executable = path.join(projectDirectory, 'node_modules', '.bin', 'tmt');
+  const home = path.join(projectDirectory, 'skill-home');
+  fs.mkdirSync(home);
+  const env = {
+    ...process.env,
+    HOME: home,
+    CODEX_HOME: path.join(home, '.codex'),
+    XDG_CONFIG_HOME: path.join(home, '.config'),
+  };
+  for (const key of ['TMUX', 'TMUX_PANE', 'TMUX_TEAM_HOME']) delete env[key];
+  const run = (args, expectedStatus = 0) => {
+    const result = spawnSync(executable, args, {
+      cwd: projectDirectory,
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+      maxBuffer: 1024 * 1024,
+    });
+    if (result.error) throw result.error;
+    assert.equal(result.status, expectedStatus, `Packed skill command failed: ${result.stderr}`);
+    assert.equal(result.stderr, '', 'Packed skill command emitted unexpected diagnostics');
+    return result.stdout;
+  };
+
+  const packageRoot = path.join(projectDirectory, 'node_modules', 'tmux-team');
+  const source = path.join(packageRoot, 'skills', 'tmux-team', 'SKILL.md');
+  const content = fs.readFileSync(source, 'utf8');
+  assert.equal(run(['learn', '--skill']), content, 'Skill viewer must preserve exact bundled text');
+  const sourceParent = path.dirname(path.dirname(source));
+  const sourceSiblings = fs.readdirSync(sourceParent).sort();
+  const overlap = JSON.parse(run(['install', '--dir', sourceParent, '--force', '--json'], 1));
+  assert.ok(overlap.error, 'Overlapping custom target must fail explicitly');
+  assert.equal(fs.readFileSync(source, 'utf8'), content);
+  assert.deepEqual(fs.readdirSync(sourceParent).sort(), sourceSiblings);
+  const installed = JSON.parse(run(['install', 'all', '--json']));
+  assert.deepEqual(
+    installed.installed.map((item) => item.agent),
+    ['claude', 'codex', 'gemini']
+  );
+  const universal = path.join(home, '.agents', 'skills', 'tmux-team');
+  const claude = path.join(home, '.claude', 'commands', 'team.md');
+  assert.ok(fs.lstatSync(universal).isSymbolicLink());
+  assert.equal(fs.readFileSync(path.join(universal, 'SKILL.md'), 'utf8'), content);
+  assert.ok(fs.lstatSync(claude).isSymbolicLink());
+  assert.equal(
+    fs.readFileSync(claude, 'utf8'),
+    fs.readFileSync(path.join(packageRoot, 'skills', 'claude', 'team.md'), 'utf8')
+  );
+
+  const customRoot = path.join(projectDirectory, 'custom skills');
+  fs.mkdirSync(customRoot);
+  const sibling = path.join(customRoot, 'unrelated.txt');
+  fs.writeFileSync(sibling, 'preserve this sibling');
+  const custom = JSON.parse(run(['install', '--dir', './custom skills', '--json']));
+  const target = path.join(fs.realpathSync(customRoot), 'tmux-team');
+  assert.equal(custom.installed.length, 1);
+  assert.equal(custom.installed[0].target, target);
+  assert.equal(custom.installed[0].changed, true);
+  assert.ok(fs.lstatSync(target).isSymbolicLink());
+  assert.equal(fs.realpathSync(target), fs.realpathSync(path.dirname(source)));
+  const repeated = JSON.parse(run(['install', '--dir', './custom skills', '--json']));
+  assert.equal(repeated.installed[0].changed, false);
+  assert.equal(fs.readFileSync(sibling, 'utf8'), 'preserve this sibling');
+
+  // Only the disposable installed package is changed, proving links and the
+  // viewer follow source updates without writing to the host's installed skill.
+  const updated = `${content}\nPacked verification update.\n`;
+  fs.writeFileSync(source, updated);
+  assert.equal(fs.readFileSync(path.join(target, 'SKILL.md'), 'utf8'), updated);
+  assert.equal(fs.readFileSync(path.join(universal, 'SKILL.md'), 'utf8'), updated);
+  assert.equal(run(['learn', '--skill']), updated);
+}
+
 function main() {
   const options = parseArgs(process.argv.slice(2));
   const tarball = path.resolve(options.packageTarball);
@@ -163,6 +239,7 @@ function main() {
     installPackage({ projectDirectory, tarball, cacheDirectory });
     loadAndVerifySqlite(projectDirectory, options.expectedLibc);
     verifyPackedCli(projectDirectory);
+    verifyPackedSkills(projectDirectory);
     console.log(
       `Packed install verified: ${process.platform}/${process.arch}/${
         options.expectedLibc === 'auto' ? 'detected libc' : options.expectedLibc

--- a/skills/README.md
+++ b/skills/README.md
@@ -51,6 +51,32 @@ tmt install codex
 tmt install gemini
 ```
 
+To inspect the exact bundled universal skill without installing it:
+
+```bash
+tmt learn --skill
+```
+
+Plain `tmt learn` remains the educational guide. Both modes are text-only.
+For a custom provider-discovered skills root:
+
+```bash
+tmt install --dir './project skills'
+```
+
+The destination is exactly `./project skills/tmux-team`, resolved against the
+current directory. Do not combine `--dir` with a provider or `all`. Custom
+mode never migrates default-provider paths. Repeating the command is a no-op
+for a correct link; `--force` backs up conflicting user content before repair.
+Unrelated siblings are untouched. Choose a folder the provider discovers;
+installation does not cause a running agent to reload its instructions.
+
+Managed custom links follow source updates at the same package path. After
+package relocation, rerun the same custom install command to repair the link.
+Automatic drift reminders inspect known default paths, not arbitrary custom
+folders; they do not manage provider-installed plugins. The npm update check
+uses `latest`, not an alpha-channel skill version tracker.
+
 After installation, use `tmux-team name <global-name>` (or its exact `this`
 alias) inside each agent's tmux pane. To bind another pane, run
 `tmux-team add <pane-target> <global-name>`; targets are resolved to stable
@@ -164,14 +190,14 @@ Codex discovers user skills in `~/.agents/skills` and repository skills in
 
 ```bash
 mkdir -p ~/.agents/skills/tmux-team
-cp skills/codex/SKILL.md ~/.agents/skills/tmux-team/SKILL.md
+cp skills/tmux-team/SKILL.md ~/.agents/skills/tmux-team/SKILL.md
 ```
 
 ### Usage
 
 ```bash
 # Explicit invocation
-$tmt talk codex "Review this PR" --json
+$tmux-team
 
 # Implicit - Codex auto-selects when you mention other agents
 "Ask the codex agent to review the authentication code"

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -262,3 +262,23 @@ identity/profile. Do not delete old user files as a migration workaround.
 - Sending pane input is an external action requiring user authorization.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.
+
+## View and install the bundled skill
+
+`tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`
+shows the guide. Both are text-only. Install default integrations with
+`tmt install [claude|codex|gemini|all]`, or choose a skills root explicitly:
+
+```bash
+tmt install --dir ./my-skills
+```
+
+This links `./my-skills/tmux-team`; do not also specify a provider. Choose a
+folder your provider actually discovers and reload its skills if needed.
+Managed links follow bundled updates at the same package path. Re-run the same
+install command to inspect/repair the target after relocation; existing
+unmanaged content is preserved unless `--force` requests a recoverable backup.
+Automatic drift reminders inspect known default paths, not custom folders.
+They do not reload an active agent, update provider-managed plugins, or track
+alpha release channels. Package upgrades and skill installation are separate
+from provider discovery.

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -263,3 +263,23 @@ identity/profile. Do not delete old user files as a migration workaround.
   with user authorization; do not send secrets or unrelated commands.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.
+
+## View and install the bundled skill
+
+`tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`
+shows the guide. Both are text-only. Install default integrations with
+`tmt install [claude|codex|gemini|all]`, or choose a skills root explicitly:
+
+```bash
+tmt install --dir ./my-skills
+```
+
+This links `./my-skills/tmux-team`; do not also specify a provider. Choose a
+folder your provider actually discovers and reload its skills if needed.
+Managed links follow bundled updates at the same package path. Re-run the same
+install command to inspect/repair the target after relocation; existing
+unmanaged content is preserved unless `--force` requests a recoverable backup.
+Automatic drift reminders inspect known default paths, not custom folders.
+They do not reload an active agent, update provider-managed plugins, or track
+alpha release channels. Package upgrades and skill installation are separate
+from provider discovery.

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -238,3 +238,23 @@ clearly authorizes it; do not infer permission for unrelated changes. Use
 after sending, and `--delay <seconds>` to delay sending.
 
 Install integrations with `tmt install` (auto-detects supported agents) or `tmt install all --force` to refresh managed links. Upgrade the CLI with `tmt upgrade`; managed links automatically use the updated bundled skill. Run install when an integration is missing or has drifted.
+
+## View and install the bundled skill
+
+`tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`
+shows the guide. Both are text-only. Install default integrations with
+`tmt install [claude|codex|gemini|all]`, or choose a skills root explicitly:
+
+```bash
+tmt install --dir ./my-skills
+```
+
+This links `./my-skills/tmux-team`; do not also specify a provider. Choose a
+folder your provider actually discovers and reload its skills if needed.
+Managed links follow bundled updates at the same package path. Re-run the same
+install command to inspect/repair the target after relocation; existing
+unmanaged content is preserved unless `--force` requests a recoverable backup.
+Automatic drift reminders inspect known default paths, not custom folders.
+They do not reload an active agent, update provider-managed plugins, or track
+alpha release channels. Package upgrades and skill installation are separate
+from provider discovery.

--- a/src/cli-contract.test.ts
+++ b/src/cli-contract.test.ts
@@ -9,7 +9,7 @@ import {
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
-import { getSkillConfigs } from './commands/install.js';
+import { getSkillConfigs } from './skill-installation.js';
 import { CURRENT_MIGRATIONS } from './storage/migrations.js';
 import {
   expectError,
@@ -35,6 +35,33 @@ function readMigrationHistory(sandbox: Sandbox): Array<{ version: number; name: 
 
 describe('real CLI process contract', () => {
   it(
+    'prints the bundled universal skill byte-for-byte without startup effects',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const expected = readFileSync(
+          path.join(getSkillConfigs().codex.source, 'SKILL.md'),
+          'utf8'
+        );
+        writeFileSync(sandbox.localConfig, '{ malformed config');
+        const legacy = path.join(sandbox.home, '.codex', 'skills', 'tmux-team');
+        mkdirSync(legacy, { recursive: true });
+        writeFileSync(path.join(legacy, 'SKILL.md'), 'Unmanaged legacy content.');
+        const before = fileSnapshot(sandbox.root);
+        const result = await runCli(sandbox, ['learn', '--skill']);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toBe(expected);
+        expect(result.stderr).toBe('');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+
+        const json = await runCli(sandbox, ['learn', '--skill', '--json']);
+        expect(json.status).toBe(1);
+        expectError(json, 'JSON_UNSUPPORTED');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+      })
+  );
+
+  it(
     'installs all skill integrations into isolated HOME with shipped source bytes',
     { timeout: 10_000 },
     () =>
@@ -57,6 +84,54 @@ describe('real CLI process contract', () => {
         expect(readFileSync(path.join(universalTarget, 'SKILL.md'))).toEqual(
           readFileSync(path.join(configs.codex.source, 'SKILL.md'))
         );
+      })
+  );
+
+  it(
+    'installs the universal skill into a relative custom directory and repeats idempotently',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const customParent = path.join(sandbox.cwd, 'custom skills');
+        mkdirSync(customParent, { recursive: true });
+        writeFileSync(path.join(customParent, 'sibling.txt'), 'keep');
+        const target = path.join(realpathSync(customParent), 'tmux-team');
+
+        const first = await runCli(sandbox, ['install', '--dir', 'custom skills', '--json']);
+        expect(first.status).toBe(0);
+        expect(parseWholeStdout(first)).toEqual({
+          installed: [{ target, changed: true }],
+        });
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+        expect(readFileSync(path.join(target, 'SKILL.md'))).toEqual(
+          readFileSync(path.join(getSkillConfigs().codex.source, 'SKILL.md'))
+        );
+        expect(readFileSync(path.join(customParent, 'sibling.txt'), 'utf8')).toBe('keep');
+
+        const second = await runCli(sandbox, ['install', '--dir', 'custom skills', '--json']);
+        expect(second.status).toBe(0);
+        expect(parseWholeStdout(second)).toEqual({
+          installed: [{ target, changed: false }],
+        });
+      })
+  );
+
+  it(
+    'rejects custom install selectors before creating state or touching targets',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const before = fileSnapshot(sandbox.root);
+        for (const args of [
+          ['install', 'codex', '--dir', 'custom skills', '--json'],
+          ['install', 'all', '--dir', 'custom skills', '--json'],
+          ['install', '--dir', '   ', '--json'],
+        ]) {
+          const result = await runCli(sandbox, args);
+          expect(result.status).toBe(1);
+          expectError(result, 'USAGE_ERROR');
+          expect(fileSnapshot(sandbox.root)).toEqual(before);
+        }
       })
   );
 

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -2,6 +2,7 @@ import { ConfigParseError } from './config.js';
 import { createContext, ExitCodes } from './context.js';
 import { cmdHelp, type HelpConfig } from './commands/help.js';
 import { cmdCompletion } from './commands/completion.js';
+import { cmdLearn } from './commands/learn.js';
 import { UNSUPPORTED_TEAM_MESSAGE } from './commands/unsupported-team.js';
 import { runStartupChecks } from './update-check.js';
 import { CliParseError, parseArgs, type ParsedArgs, type ParsedInvocation } from './cli/parser.js';
@@ -231,6 +232,16 @@ export async function runCli(argv: readonly string[]): Promise<number> {
   if (invocation.kind === 'completion') {
     try {
       cmdCompletion(invocation.shell);
+      return ExitCodes.SUCCESS;
+    } catch (error) {
+      writeHumanError(output, errorMessage(error));
+      return ExitCodes.ERROR;
+    }
+  }
+
+  if (invocation.kind === 'learn' && invocation.skill === true) {
+    try {
+      cmdLearn(invocation.skill);
       return ExitCodes.SUCCESS;
     } catch (error) {
       writeHumanError(output, errorMessage(error));

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -221,7 +221,7 @@ describe('cli', () => {
     const { runCli } = await import('./cli-runner.js');
     expect(await runCli(['install', 'claude'])).toBe(0);
 
-    expect(installSpy).toHaveBeenCalledWith(ctx, 'claude');
+    expect(installSpy).toHaveBeenCalledWith(ctx, 'claude', undefined);
   });
 
   it('routes preamble command', async () => {

--- a/src/cli/application.test.ts
+++ b/src/cli/application.test.ts
@@ -74,6 +74,7 @@ describe('application dispatcher', () => {
       ['learn', {}],
     ] as const;
     for (const [kind, values] of cases) await dispatchCommand(ctx, parsed({ kind, ...values }));
+    await dispatchCommand(ctx, parsed({ kind: 'learn', skill: true }));
     expect(handlers.cmdInit).toHaveBeenCalledWith(ctx);
     expect(handlers.cmdList).toHaveBeenCalledWith(ctx, 'claude');
     expect(handlers.cmdTalk).toHaveBeenCalledWith(ctx, 'claude', 'hello');
@@ -98,6 +99,7 @@ describe('application dispatcher', () => {
       ctx,
       expect.objectContaining({ kind: 'result', requestId: 'request-1' })
     );
+    expect(handlers.cmdLearn).toHaveBeenLastCalledWith(true);
   });
 
   it('does not route presentation-only invocations to application services', async () => {

--- a/src/cli/application.ts
+++ b/src/cli/application.ts
@@ -58,13 +58,13 @@ export async function dispatchCommand(ctx: Context, parsed: ParsedArgs): Promise
     case 'result':
       return cmdResult(ctx, request);
     case 'install':
-      return cmdInstall(ctx, request.target);
+      return cmdInstall(ctx, request.target, request.directory);
     case 'completion':
       return;
     case 'upgrade':
       return cmdUpgrade(ctx);
     case 'learn':
-      return cmdLearn();
+      return cmdLearn(request.skill);
     default:
       return assertNever(request);
   }

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -295,6 +295,17 @@ describe('declarative CLI parser', () => {
     expect(() => parseArgs(['role', 'set', 'a', 'b'])).toThrow(CliParseError);
   });
 
+  it('parses skill viewing and custom install directories', () => {
+    expect(parseArgs(['learn', '--skill']).invocation).toEqual({ kind: 'learn', skill: true });
+    expect(parseArgs(['install', '--dir', 'relative skills']).invocation).toEqual({
+      kind: 'install',
+      directory: 'relative skills',
+    });
+    expect(() => parseArgs(['install', '--dir', '   '])).toThrow(CliParseError);
+    expect(() => parseArgs(['install', 'codex', '--dir', '/tmp/skills'])).toThrow(CliParseError);
+    expect(() => parseArgs(['install', 'all', '--dir', '/tmp/skills'])).toThrow(CliParseError);
+  });
+
   it('parses storage-only reply/result commands with explicit input and no tmux capability', () => {
     expect(
       parseArgs(['reply', 'request-1', '--receipt', receipt, '--file', '/tmp/reply.txt', '--json'])

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -10,8 +10,9 @@ export type ParsedInvocation =
   | { readonly kind: 'help'; readonly showIntro: boolean }
   | { readonly kind: 'version' }
   | { readonly kind: 'completion'; readonly shell?: string }
-  | { readonly kind: 'install'; readonly target?: string }
-  | { readonly kind: 'init' | 'whoami' | 'unbind' | 'upgrade' | 'learn' }
+  | { readonly kind: 'install'; readonly target?: string; readonly directory?: string }
+  | { readonly kind: 'init' | 'whoami' | 'unbind' | 'upgrade' }
+  | { readonly kind: 'learn'; readonly skill?: boolean }
   | { readonly kind: 'list'; readonly target?: IdentitySelector }
   | { readonly kind: 'add'; readonly pane: string; readonly name: string }
   | { readonly kind: 'this' | 'name'; readonly name: string }
@@ -78,6 +79,8 @@ interface CommandOptions extends CommonOptions {
   identity?: string;
   file?: string;
   message?: string;
+  dir?: string;
+  skill?: boolean;
 }
 
 interface Capture {
@@ -499,20 +502,36 @@ function setupProgram(capture: Capture): Command {
     }
     action(this, { kind: 'result', requestId });
   });
-  const install = leaf(program.command('install').argument('[agent]'));
+  const install = leaf(program.command('install').argument('[agent]')).option('--dir <path>');
   install.action(function (agent?: string) {
-    action(this, { kind: 'install', target: agent });
+    const options = commandOptions(this);
+    if (options.dir !== undefined && options.dir.trim() === '') {
+      throw new CliParseError('Install directory must not be empty.');
+    }
+    if (options.dir !== undefined && agent !== undefined) {
+      throw new CliParseError('The --dir option cannot be combined with an agent or all.');
+    }
+    action(this, {
+      kind: 'install',
+      ...(agent !== undefined ? { target: agent } : {}),
+      ...(options.dir !== undefined ? { directory: options.dir } : {}),
+    });
   });
   const completion = leaf(program.command('completion').argument('[shell]'));
   completion.action(function (shell?: string) {
     action(this, { kind: 'completion', shell });
   });
-  for (const kind of ['upgrade', 'learn', 'whoami', 'unbind'] as const) {
+  for (const kind of ['upgrade', 'whoami', 'unbind'] as const) {
     const command = leaf(program.command(kind));
     command.action(function () {
       action(this, { kind });
     });
   }
+  const learn = leaf(program.command('learn')).option('--skill');
+  learn.action(function () {
+    const options = commandOptions(this);
+    action(this, { kind: 'learn', ...(options.skill ? { skill: true } : {}) });
+  });
   return program;
 }
 

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -55,7 +55,10 @@ _tmux-team() {
         compadd "zsh" "bash"
         ;;
       install)
-        compadd "claude" "codex" "gemini" "all"
+        compadd -- "claude" "codex" "gemini" "all" "--dir"
+        ;;
+      learn)
+        compadd -- "--skill"
         ;;
       role)
         compadd "show" "set" "clear"
@@ -108,7 +111,10 @@ const bashCompletion = `_tmux_team() {
         COMPREPLY=( $(compgen -W "zsh bash" -- \${cur}) )
         ;;
       install)
-        COMPREPLY=( $(compgen -W "claude codex gemini all" -- \${cur}) )
+        COMPREPLY=( $(compgen -W "claude codex gemini all --dir" -- \${cur}) )
+        ;;
+      learn)
+        COMPREPLY=( $(compgen -W "--skill" -- \${cur}) )
         ;;
       role)
         COMPREPLY=( $(compgen -W "show set clear" -- \${cur}) )

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -51,7 +51,15 @@ ${colors.yellow('COMMANDS')}
   ${colors.green('role')} <show|set|clear>      Manage durable identity role profiles
   ${colors.green('completion')}                  Output shell completion script
   ${colors.green('learn')}                       Show educational guide
+  ${colors.green('learn --skill')}               Print the exact bundled universal skill
   ${colors.green('help')}                        Show this help message
+
+${colors.yellow('SKILL INSTALLATION')}
+  tmt install --dir <skills-root> [--force] [--json]
+  Links <skills-root>/tmux-team; do not combine with a provider or all.
+  Unmanaged paths require --force and are backed up, not deleted.
+  Choose a folder the provider discovers; active agents may need a reload.
+  Automatic drift reminders cover default paths, not custom folders.
 
 ${colors.yellow('OPTIONS')}
   ${colors.green('--json')}                      Output in JSON format

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -91,6 +91,7 @@ describe('cmdInstall', () => {
     process.env.CODEX_HOME = originalCodexHome;
     fs.rmSync(testDir, { recursive: true, force: true });
     fs.rmSync(homeDir, { recursive: true, force: true });
+    vi.doUnmock('../skill-installation.js');
     vi.restoreAllMocks();
   });
 
@@ -223,7 +224,7 @@ describe('cmdInstall', () => {
       default: { homedir: () => homeDir },
       homedir: () => homeDir,
     }));
-    const { ensureManagedLink } = await import('./install.js');
+    const { ensureManagedLink } = await import('../skill-installation.js');
     const source = path.join(testDir, 'source');
     const target = path.join(testDir, 'nested', 'skill');
     fs.mkdirSync(source);
@@ -242,7 +243,7 @@ describe('cmdInstall', () => {
   });
 
   it('can replace a broken symlink while preserving it as a backup', async () => {
-    const { ensureManagedLink } = await import('./install.js');
+    const { ensureManagedLink } = await import('../skill-installation.js');
     const source = path.join(testDir, 'source-file');
     const target = path.join(testDir, 'broken-file');
     fs.writeFileSync(source, 'canonical');
@@ -285,6 +286,156 @@ describe('cmdInstall', () => {
         installed: expect.arrayContaining([expect.objectContaining({ agent: 'codex' })]),
       })
     );
+  });
+
+  it('installs the universal skill into a custom directory without inventing an agent', async () => {
+    vi.resetModules();
+    vi.doMock('node:os', () => ({
+      default: { homedir: () => homeDir },
+      homedir: () => homeDir,
+    }));
+    const { cmdInstall } = await import('./install.js');
+    const customDirectory = path.join(testDir, 'custom skills');
+    const ctx = createCtx(testDir, { flags: { force: true, json: true } });
+
+    await cmdInstall(ctx, undefined, customDirectory);
+    await cmdInstall(ctx, undefined, customDirectory);
+
+    const target = path.join(customDirectory, 'tmux-team');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(ctx.ui.json).toHaveBeenLastCalledWith({
+      installed: [{ target, changed: false }],
+    });
+  });
+
+  it('preserves custom legacy paths and backs up unmanaged custom targets only with force', async () => {
+    vi.resetModules();
+    vi.doMock('node:os', () => ({
+      default: { homedir: () => homeDir },
+      homedir: () => homeDir,
+    }));
+    const { cmdInstall } = await import('./install.js');
+    const customDirectory = path.join(testDir, 'custom skills');
+    const target = path.join(customDirectory, 'tmux-team');
+    const legacy = path.join(homeDir, '.codex', 'skills', 'tmux-team');
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.writeFileSync(path.join(legacy, 'SKILL.md'), 'legacy');
+    fs.mkdirSync(target, { recursive: true });
+    fs.writeFileSync(path.join(target, 'user.md'), 'user-owned content');
+    fs.writeFileSync(path.join(customDirectory, 'sibling.txt'), 'keep');
+
+    const refused = createCtx(testDir);
+    await expect(cmdInstall(refused, undefined, customDirectory)).rejects.toThrow(
+      `exit(${ExitCodes.ERROR})`
+    );
+    expect(fs.readFileSync(path.join(target, 'user.md'), 'utf8')).toBe('user-owned content');
+    expect(fs.existsSync(path.join(legacy, 'SKILL.md'))).toBe(true);
+
+    const forced = createCtx(testDir, { flags: { force: true } });
+    await cmdInstall(forced, undefined, customDirectory);
+    expect(fs.readFileSync(path.join(customDirectory, 'sibling.txt'), 'utf8')).toBe('keep');
+    expect(fs.existsSync(path.join(legacy, 'SKILL.md'))).toBe(true);
+    const backup = fs
+      .readdirSync(customDirectory)
+      .find((entry) => entry.startsWith('tmux-team.backup-'));
+    expect(backup).toBeDefined();
+    expect(fs.statSync(path.join(customDirectory, backup!)).isDirectory()).toBe(true);
+    expect(fs.readFileSync(path.join(customDirectory, backup!, 'user.md'), 'utf8')).toBe(
+      'user-owned content'
+    );
+  });
+
+  it('rejects source-equal targets reached through symlinked parents without mutation', async () => {
+    const { assertSafeSkillTarget } = await import('../skill-installation.js');
+    const source = path.join(testDir, 'bundled', 'tmux-team');
+    const sourceFile = path.join(source, 'SKILL.md');
+    const sourceParentAlias = path.join(testDir, 'source parent alias');
+    fs.mkdirSync(source, { recursive: true });
+    fs.writeFileSync(sourceFile, 'disposable source');
+    fs.symlinkSync(path.dirname(source), sourceParentAlias, 'dir');
+    const target = path.join(sourceParentAlias, 'tmux-team');
+
+    expect(() => assertSafeSkillTarget(source, target)).toThrow(
+      `Skill target overlaps bundled source: ${target}`
+    );
+    expect(() => assertSafeSkillTarget(source, path.dirname(source))).toThrow(
+      'Skill target overlaps bundled source'
+    );
+    expect(fs.readFileSync(sourceFile, 'utf8')).toBe('disposable source');
+    expect(fs.lstatSync(source).isDirectory()).toBe(true);
+    expect(
+      fs.readdirSync(path.dirname(source)).some((entry) => entry.startsWith('tmux-team.backup-'))
+    ).toBe(false);
+  });
+
+  it('rejects targets beneath a source child whose name begins with two dots', async () => {
+    const { assertSafeSkillTarget } = await import('../skill-installation.js');
+    const source = path.join(testDir, 'bundled', 'tmux-team');
+    const nestedDirectory = path.join(source, '..nested');
+    const sourceFile = path.join(source, 'SKILL.md');
+    fs.mkdirSync(source, { recursive: true });
+    fs.writeFileSync(sourceFile, 'disposable source');
+    fs.mkdirSync(nestedDirectory);
+    const target = path.join(nestedDirectory, 'tmux-team');
+
+    try {
+      expect(() => assertSafeSkillTarget(source, target)).toThrow(
+        `Skill target overlaps bundled source: ${target}`
+      );
+
+      expect(fs.readFileSync(sourceFile, 'utf8')).toBe('disposable source');
+      expect(fs.readdirSync(nestedDirectory)).toEqual([]);
+    } finally {
+      fs.rmSync(path.join(testDir, 'bundled'), { recursive: true, force: true });
+    }
+  });
+
+  it('checks a missing bundled source before backing up a custom target', async () => {
+    vi.resetModules();
+    const fixtureRoot = path.join(testDir, 'missing-source-package');
+    const customDirectory = path.join(testDir, 'custom missing source');
+    const target = path.join(customDirectory, 'tmux-team');
+    fs.mkdirSync(target, { recursive: true });
+    fs.writeFileSync(path.join(target, 'user.md'), 'user-owned content');
+    vi.doMock('../skill-installation.js', async () => {
+      const actual = await vi.importActual<typeof import('../skill-installation.js')>(
+        '../skill-installation.js'
+      );
+      return { ...actual, packageRoot: () => fixtureRoot };
+    });
+
+    const { cmdInstall } = await import('./install.js');
+    const ctx = createCtx(testDir, { flags: { force: true } });
+    await expect(cmdInstall(ctx, undefined, customDirectory)).rejects.toThrow(
+      `exit(${ExitCodes.ERROR})`
+    );
+    expect(fs.readFileSync(path.join(target, 'user.md'), 'utf8')).toBe('user-owned content');
+    expect(fs.readdirSync(customDirectory)).toEqual(['tmux-team']);
+  });
+
+  it('requires SKILL.md before backing up a custom target', async () => {
+    vi.resetModules();
+    const fixtureRoot = path.join(testDir, 'incomplete-source-package');
+    const source = path.join(fixtureRoot, 'skills', 'tmux-team');
+    const customDirectory = path.join(testDir, 'custom incomplete source');
+    const target = path.join(customDirectory, 'tmux-team');
+    fs.mkdirSync(source, { recursive: true });
+    fs.mkdirSync(target, { recursive: true });
+    fs.writeFileSync(path.join(target, 'user.md'), 'user-owned content');
+    vi.doMock('../skill-installation.js', async () => {
+      const actual = await vi.importActual<typeof import('../skill-installation.js')>(
+        '../skill-installation.js'
+      );
+      return { ...actual, packageRoot: () => fixtureRoot };
+    });
+
+    const { cmdInstall } = await import('./install.js');
+    const ctx = createCtx(testDir, { flags: { force: true } });
+    await expect(cmdInstall(ctx, undefined, customDirectory)).rejects.toThrow(
+      `exit(${ExitCodes.ERROR})`
+    );
+    expect(fs.readFileSync(path.join(target, 'user.md'), 'utf8')).toBe('user-owned content');
+    expect(fs.readdirSync(customDirectory)).toEqual(['tmux-team']);
   });
 
   it('preserves a legacy Codex copy without force and explains migration', async () => {
@@ -350,7 +501,7 @@ describe('cmdInstall', () => {
       default: { homedir: () => homeDir },
       homedir: () => homeDir,
     }));
-    const { getCodexHome } = await import('./install.js');
+    const { getCodexHome } = await import('../skill-installation.js');
     const configured = process.env.CODEX_HOME;
     delete process.env.CODEX_HOME;
     try {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -5,55 +5,31 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import type { Context } from '../types.js';
 import { ExitCodes } from '../exits.js';
 import { colors } from '../ui.js';
+import {
+  backupPath,
+  assertSafeSkillTarget,
+  ensureManagedLink,
+  getCodexHome,
+  getCustomSkillConfig,
+  getSkillConfigs,
+  hasBundledSkillSource,
+  isCorrectLink,
+  packageRoot,
+  targetExists,
+} from '../skill-installation.js';
+import type { SkillAgent, SkillConfig } from '../skill-installation.js';
 
-export type AgentType = 'claude' | 'codex' | 'gemini';
-export type InstallTarget = AgentType | 'all';
+export type InstallTarget = SkillAgent | 'all';
 
 interface InstallResult {
-  agent: AgentType;
+  agent?: SkillAgent;
   target: string;
   changed: boolean;
   backup?: string;
   legacyBackups?: string[];
-}
-
-interface SkillConfig {
-  source: string;
-  target: string;
-}
-
-export function getCodexHome(): string {
-  return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
-}
-
-function packageRoot(): string {
-  const currentFile = fileURLToPath(import.meta.url);
-  let dir = path.dirname(currentFile);
-  for (let i = 0; i < 6; i++) {
-    if (fs.existsSync(path.join(dir, 'package.json'))) return dir;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(path.dirname(currentFile), '..', '..');
-}
-
-export function getSkillConfigs(root = packageRoot()): Record<AgentType, SkillConfig> {
-  const home = os.homedir();
-  const universal = path.join(root, 'skills', 'tmux-team');
-  return {
-    claude: {
-      source: path.join(root, 'skills', 'claude', 'team.md'),
-      target: path.join(home, '.claude', 'commands', 'team.md'),
-    },
-    // Codex and Gemini intentionally share one official user-global location.
-    codex: { source: universal, target: path.join(home, '.agents', 'skills', 'tmux-team') },
-    gemini: { source: universal, target: path.join(home, '.agents', 'skills', 'tmux-team') },
-  };
 }
 
 const SUPPORTED_AGENTS: InstallTarget[] = ['claude', 'codex', 'gemini', 'all'];
@@ -70,9 +46,9 @@ function commandExists(command: string): boolean {
 }
 
 /** Detect installed agent environments without prompting the user. */
-export function detectEnvironment(): AgentType[] {
+export function detectEnvironment(): SkillAgent[] {
   const home = os.homedir();
-  const detected: AgentType[] = [];
+  const detected: SkillAgent[] = [];
   if (fs.existsSync(path.join(home, '.claude')) || commandExists('claude')) detected.push('claude');
   if (
     fs.existsSync(path.join(home, '.agents')) ||
@@ -84,34 +60,6 @@ export function detectEnvironment(): AgentType[] {
   }
   if (fs.existsSync(path.join(home, '.gemini')) || commandExists('gemini')) detected.push('gemini');
   return detected;
-}
-
-function targetExists(target: string): boolean {
-  // existsSync is false for broken links; lstat is needed so --force can back them up.
-  try {
-    fs.lstatSync(target);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function isCorrectLink(target: string, source: string): boolean {
-  try {
-    const stat = fs.lstatSync(target);
-    if (!stat.isSymbolicLink()) return false;
-    return path.resolve(path.dirname(target), fs.readlinkSync(target)) === path.resolve(source);
-  } catch {
-    return false;
-  }
-}
-
-function backupPath(target: string): string {
-  const base = `${target}.backup-${Date.now()}`;
-  let candidate = base;
-  let suffix = 1;
-  while (targetExists(candidate)) candidate = `${base}-${suffix++}`;
-  return candidate;
 }
 
 function legacyCodexDirectories(): string[] {
@@ -146,44 +94,35 @@ export function migrateLegacyCodex(ctx: Context): string[] {
   return backups;
 }
 
-/** Create a managed symlink, preserving an unmanaged target when forced. */
-export function ensureManagedLink(
-  target: string,
-  source: string,
-  force = false
-): string | undefined {
-  if (isCorrectLink(target, source)) return undefined;
-  let backup: string | undefined;
-  if (targetExists(target)) {
-    if (!force) {
-      throw new Error(`Refusing to replace existing unmanaged path: ${target} (use --force)`);
-    }
-    backup = backupPath(target);
-    fs.renameSync(target, backup);
-  }
-  fs.mkdirSync(path.dirname(target), { recursive: true });
-  // Omitting the platform-specific type keeps this portable on Darwin and Linux.
-  fs.symlinkSync(source, target);
-  return backup;
-}
-
-function installAgent(ctx: Context, agent: AgentType): InstallResult {
+function installSelectedSkill(ctx: Context, selected: SkillConfig): Omit<InstallResult, 'agent'> {
   if (process.platform !== 'darwin' && process.platform !== 'linux') {
     throw new Error('Skill installation is supported on Darwin and Linux only.');
   }
-  const selected = getSkillConfigs()[agent];
-  if (!fs.existsSync(selected.source))
+  if (!hasBundledSkillSource(selected.source))
     throw new Error(`Bundled skill source not found: ${selected.source}`);
   const wasCorrect = isCorrectLink(selected.target, selected.source);
+  if (!wasCorrect) assertSafeSkillTarget(selected.source, selected.target);
   const backup = ensureManagedLink(selected.target, selected.source, ctx.flags.force);
-  const legacyBackups = agent === 'codex' ? migrateLegacyCodex(ctx) : [];
   return {
-    agent,
     target: selected.target,
     changed: !wasCorrect,
     ...(backup ? { backup } : {}),
+  };
+}
+
+function installAgent(ctx: Context, agent: SkillAgent): InstallResult {
+  const base = installSelectedSkill(ctx, getSkillConfigs()[agent]);
+  const legacyBackups = agent === 'codex' ? migrateLegacyCodex(ctx) : [];
+  return {
+    agent,
+    ...base,
     ...(legacyBackups.length > 0 ? { legacyBackups } : {}),
   };
+}
+
+function installCustom(ctx: Context, directory: string): InstallResult {
+  const selected = getCustomSkillConfig(packageRoot(), directory);
+  return installSelectedSkill(ctx, selected);
 }
 
 function printNextSteps(ctx: Context, installed: InstallResult[]): void {
@@ -194,10 +133,11 @@ function printNextSteps(ctx: Context, installed: InstallResult[]): void {
   const seenTargets = new Set<string>();
   for (const item of installed) {
     const shared = seenTargets.has(item.target);
+    const label = item.agent === undefined ? 'custom skill' : `${item.agent} skill`;
     ctx.ui.success(
       shared
         ? `${item.agent} integration uses the shared skill at ${item.target}`
-        : `${item.agent} skill linked at ${item.target}`
+        : `${label} linked at ${item.target}`
     );
     seenTargets.add(item.target);
     if (item.backup) ctx.ui.info(`Previous path moved to recoverable backup: ${item.backup}`);
@@ -218,7 +158,17 @@ function printNextSteps(ctx: Context, installed: InstallResult[]): void {
   console.log(`  ${colors.cyan('tmt result <request-id> --json')} (after timeout or --detach)`);
 }
 
-export async function cmdInstall(ctx: Context, agent?: string): Promise<void> {
+export async function cmdInstall(ctx: Context, agent?: string, directory?: string): Promise<void> {
+  if (directory !== undefined) {
+    if (agent !== undefined) {
+      ctx.ui.error('The --dir option cannot be combined with an agent or all.');
+      ctx.exit(ExitCodes.ERROR);
+    }
+    if (directory.trim() === '') {
+      ctx.ui.error('Install directory must not be empty.');
+      ctx.exit(ExitCodes.ERROR);
+    }
+  }
   const requested = agent?.toLowerCase() as InstallTarget | undefined;
   if (requested && !SUPPORTED_AGENTS.includes(requested)) {
     ctx.ui.error(`Unknown agent: ${agent}`);
@@ -226,19 +176,22 @@ export async function cmdInstall(ctx: Context, agent?: string): Promise<void> {
     ctx.exit(ExitCodes.ERROR);
   }
 
-  let agents: AgentType[];
-  if (requested === 'all') agents = ['claude', 'codex', 'gemini'];
-  else if (requested) agents = [requested];
-  else {
-    agents = detectEnvironment();
-    // A clean machine gets the universal Open Agent Skill.
-    if (agents.length === 0) agents = ['codex'];
-  }
-
   const installed: InstallResult[] = [];
   try {
-    for (const selected of agents) {
-      installed.push(installAgent(ctx, selected));
+    if (directory !== undefined) {
+      installed.push(installCustom(ctx, directory));
+    } else {
+      let agents: SkillAgent[];
+      if (requested === 'all') agents = ['claude', 'codex', 'gemini'];
+      else if (requested) agents = [requested];
+      else {
+        agents = detectEnvironment();
+        // A clean machine gets the universal Open Agent Skill.
+        if (agents.length === 0) agents = ['codex'];
+      }
+      for (const selected of agents) {
+        installed.push(installAgent(ctx, selected));
+      }
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -2,9 +2,15 @@
 // learn command - educational guide for tmux-team
 // ─────────────────────────────────────────────────────────────
 
+import { readFileSync } from 'node:fs';
 import { colors } from '../ui.js';
+import { getUniversalSkillFile } from '../skill-installation.js';
 
-export function cmdLearn(): void {
+export function cmdLearn(skill = false): void {
+  if (skill) {
+    process.stdout.write(readFileSync(getUniversalSkillFile(), 'utf8'));
+    return;
+  }
   console.log(`
 ${colors.cyan('tmux-team')} - Multi-Agent Coordination Guide
 

--- a/src/skill-installation.ts
+++ b/src/skill-installation.ts
@@ -1,0 +1,154 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type SkillAgent = 'claude' | 'codex' | 'gemini';
+
+export interface SkillConfig {
+  readonly source: string;
+  readonly target: string;
+}
+
+/** Resolve the package root containing the bundled skill sources. */
+export function packageRoot(): string {
+  const currentFile = fileURLToPath(import.meta.url);
+  let directory = path.dirname(currentFile);
+  for (let index = 0; index < 6; index += 1) {
+    if (fs.existsSync(path.join(directory, 'package.json'))) return directory;
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return path.resolve(path.dirname(currentFile), '..');
+}
+
+export function getCodexHome(home = os.homedir()): string {
+  return process.env.CODEX_HOME || path.join(home, '.codex');
+}
+
+export function getUniversalSkillSource(root = packageRoot()): string {
+  return path.join(root, 'skills', 'tmux-team');
+}
+
+export function getUniversalSkillFile(root = packageRoot()): string {
+  return path.join(getUniversalSkillSource(root), 'SKILL.md');
+}
+
+export function hasBundledSkillSource(source: string): boolean {
+  try {
+    const stat = fs.statSync(source);
+    return (
+      stat.isFile() || (stat.isDirectory() && fs.statSync(path.join(source, 'SKILL.md')).isFile())
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getSkillConfigs(
+  root = packageRoot(),
+  home = os.homedir()
+): Record<SkillAgent, SkillConfig> {
+  const universal = getUniversalSkillSource(root);
+  return {
+    claude: {
+      source: path.join(root, 'skills', 'claude', 'team.md'),
+      target: path.join(home, '.claude', 'commands', 'team.md'),
+    },
+    // Codex and Gemini intentionally share one official user-global location.
+    codex: { source: universal, target: path.join(home, '.agents', 'skills', 'tmux-team') },
+    gemini: { source: universal, target: path.join(home, '.agents', 'skills', 'tmux-team') },
+  };
+}
+
+export function getCustomSkillConfig(root: string, directory: string): SkillConfig {
+  return {
+    source: getUniversalSkillSource(root),
+    target: path.join(path.resolve(directory), 'tmux-team'),
+  };
+}
+
+export function targetExists(target: string): boolean {
+  // existsSync is false for broken links; lstat is needed so --force can back them up.
+  try {
+    fs.lstatSync(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isCorrectLink(target: string, source: string): boolean {
+  try {
+    const stat = fs.lstatSync(target);
+    if (!stat.isSymbolicLink()) return false;
+    return path.resolve(path.dirname(target), fs.readlinkSync(target)) === path.resolve(source);
+  } catch {
+    return false;
+  }
+}
+
+export function backupPath(target: string): string {
+  const base = `${target}.backup-${Date.now()}`;
+  let candidate = base;
+  let suffix = 1;
+  while (targetExists(candidate)) candidate = `${base}-${suffix++}`;
+  return candidate;
+}
+
+function resolvedPathForComparison(value: string): string {
+  const absolute = path.resolve(value);
+  let current = absolute;
+  const suffix: string[] = [];
+  while (true) {
+    try {
+      const resolved = fs.realpathSync(current);
+      return path.join(resolved, ...suffix);
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) return absolute;
+      suffix.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+function containsPath(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  const traversesParent = relative === '..' || relative.startsWith(`..${path.sep}`);
+  return relative === '' || (!traversesParent && !path.isAbsolute(relative));
+}
+
+/** Reject a target that could rename or overwrite any part of its bundled source. */
+export function assertSafeSkillTarget(source: string, target: string): void {
+  const resolvedSource = resolvedPathForComparison(source);
+  const resolvedTarget = resolvedPathForComparison(target);
+  if (
+    containsPath(resolvedSource, resolvedTarget) ||
+    containsPath(resolvedTarget, resolvedSource)
+  ) {
+    throw new Error(`Skill target overlaps bundled source: ${target}`);
+  }
+}
+
+/** Create a managed symlink, preserving an unmanaged target when forced. */
+export function ensureManagedLink(
+  target: string,
+  source: string,
+  force = false
+): string | undefined {
+  if (isCorrectLink(target, source)) return undefined;
+  let backup: string | undefined;
+  if (targetExists(target)) {
+    if (!force) {
+      throw new Error(`Refusing to replace existing unmanaged path: ${target} (use --force)`);
+    }
+    backup = backupPath(target);
+    fs.renameSync(target, backup);
+  }
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  // Omitting the platform-specific type keeps this portable on Darwin and Linux.
+  fs.symlinkSync(source, target);
+  return backup;
+}

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -4,7 +4,13 @@ import fs from 'node:fs';
 import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import {
+  getCodexHome,
+  getSkillConfigs,
+  isCorrectLink,
+  packageRoot,
+  targetExists,
+} from './skill-installation.js';
 import type { Context } from './types.js';
 import { VERSION } from './version.js';
 
@@ -14,47 +20,14 @@ export interface DriftIssue {
   message: string;
 }
 
-function packageRoot(): string {
-  const currentFile = fileURLToPath(import.meta.url);
-  let dir = path.dirname(currentFile);
-  for (let i = 0; i < 6; i++) {
-    if (fs.existsSync(path.join(dir, 'package.json'))) return dir;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(path.dirname(currentFile), '..');
-}
-
-function existsAsPath(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function correctLink(target: string, source: string): boolean {
-  try {
-    const stat = fs.lstatSync(target);
-    return (
-      stat.isSymbolicLink() &&
-      path.resolve(path.dirname(target), fs.readlinkSync(target)) === path.resolve(source)
-    );
-  } catch {
-    return false;
-  }
-}
-
 function linkIssue(
   target: string,
   source: string,
   label: string,
   allowCopiedFile = false
 ): DriftIssue | undefined {
-  if (!existsAsPath(target)) return undefined;
-  if (correctLink(target, source)) return undefined;
+  if (!targetExists(target)) return undefined;
+  if (isCorrectLink(target, source)) return undefined;
   let kind: DriftIssue['kind'] = 'wrong-link';
   try {
     const stat = fs.lstatSync(target);
@@ -83,18 +56,19 @@ export interface DriftOptions {
 export function inspectLocalDrift(options: DriftOptions = {}): DriftIssue[] {
   const home = options.home ?? os.homedir();
   const root = options.root ?? packageRoot();
-  const codexHome = options.codexHome ?? process.env.CODEX_HOME ?? path.join(home, '.codex');
-  const universal = path.join(root, 'skills', 'tmux-team');
-  const claudeSource = path.join(root, 'skills', 'claude', 'team.md');
-  const agentsTarget = path.join(home, '.agents', 'skills', 'tmux-team');
-  const claudeTarget = path.join(home, '.claude', 'commands', 'team.md');
+  const codexHome = options.codexHome ?? getCodexHome(home);
+  const configs = getSkillConfigs(root, home);
+  const universal = configs.codex.source;
+  const claudeSource = configs.claude.source;
+  const agentsTarget = configs.codex.target;
+  const claudeTarget = configs.claude.target;
   const issues: DriftIssue[] = [];
 
   for (const legacy of [
     path.join(home, '.codex', 'skills', 'tmux-team', 'SKILL.md'),
     path.join(codexHome, 'skills', 'tmux-team', 'SKILL.md'),
   ]) {
-    if (existsAsPath(legacy) && !issues.some((issue) => issue.path === legacy)) {
+    if (targetExists(legacy) && !issues.some((issue) => issue.path === legacy)) {
       issues.push({
         kind: 'legacy',
         path: legacy,


### PR DESCRIPTION
## Summary

- Add `tmt learn --skill` for exact bundled universal skill text without startup effects.
- Add `tmt install --dir <skills-root>` with explicit selector validation, managed-link idempotence, recoverable backups and source-overlap protection.
- Share source/target/link knowledge across installation, viewing and drift checks; preserve default provider behavior.
- Extend the existing packed-install verifier and synchronize shipped documentation and skills.

## Architecture and primary review

Reviewed head: `630f0526a2d282353b6bcfce9bd2f9ec611ed84b`.

The primary reviewed all 25 changed files and relevant callers, parser/runner/dispatcher boundaries, installer/drift policy, filesystem fixtures and packed verification. The new `skill-installation.ts` owns shared filesystem knowledge, not provider detection or reminder policy. `learn --skill` alone bypasses Context; plain `learn` retains its existing behavior. No schema, dependency, daemon, custom registry, plugin rename or publication changes.

Review corrections: reject child names beginning with two dots correctly; isolate source-overlap fixtures from the checkout; assert preserved user bytes rather than directory existence; handle macOS temporary-path aliases in the packed test oracle; exercise viewing with malformed config and legacy drift. Gemini provided supplementary read-only review through TMT; primary review remains authoritative.

Updated ARCHITECTURE.md and DEVELOPMENT.md. Claude command/skill/plugin consolidation follows separately after this bounded feature; TMT-29 still owns broader inventory and packed application-migration acceptance.

## Verification

- `pnpm check` passed.
- `pnpm test:run` passed unchanged coverage gates.
- Focused real CLI and drift tests: 22 passed; final installation tests: 20 passed.
- Negative control: restoring the faulty two-dot prefix check failed its regression; restored implementation passed.
- Three skill validators and explicit Markdown formatting passed.
- Actual packed darwin/arm64 native binding, FTS5, viewer, default/custom installs, no-op, overlap rejection, sibling preservation and source-update visibility passed.
- `pnpm test:e2e`: all 16 files / 72 tests passed locally (233.11 seconds).
- Rebase onto merged TMT-40 changed no tree content.

Required CI must pass on this exact reviewed head before merge; no protection bypass or release publication.

## Tracking

Closes TMT-41

https://linear.app/tigerpig-dev/issue/TMT-41/expose-bundled-skill-viewing-and-explicit-custom-directory
