### PR TITLE
test: consolidate bounded concurrency workers (TMT-42)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -436,7 +436,7 @@ not close TMT-29's separate packed application-storage/migration acceptance.
 | [src/request-service.ts](src/request-service.ts), [src/storage/request-repository.ts](src/storage/request-repository.ts), [src/domain/response.ts](src/domain/response.ts) | Application-owned request/cadence/final-response policy, composed SQL adapter and exact-body validation. Context owns the shared connection.                            |
 | [src/ui.ts](src/ui.ts), [src/exits.ts](src/exits.ts)                                                                                                                       | Presentation helpers and exit-code registry; do not invent conflicting mappings.                                                                                        |
 | [src/commands/install.ts](src/commands/install.ts), [src/update-check.ts](src/update-check.ts), [skills/](skills/), [plugins/](plugins/)                                   | User-facing integrations, instructions and updates. These differ from repository developer skills in `.agents/skills/`.                                                 |
-| [test/e2e/](test/e2e/), [scripts/](scripts/), [.github/workflows/ci.yml](.github/workflows/ci.yml)                                                                         | Docker fixtures/scenarios, orchestration/pack verification and CI. Unit tests are colocated with source; concurrency workers currently also live in `src/`.             |
+| [test/e2e/](test/e2e/), [scripts/](scripts/), [.github/workflows/ci.yml](.github/workflows/ci.yml)                                                                         | Docker fixtures/scenarios, orchestration/pack verification and CI. Unit tests are colocated with source; concurrency entrypoints live in `src/test-support/workers/`.   |
 
 `src/commands/talk.ts` owns the bounded observer and existing request lifecycle
 composition. `src/talk-instruction.ts` owns concise recipient guidance only;
@@ -445,6 +445,15 @@ builder does not parse or infer terminal completion.
 The test mock independently recognizes the documented request instruction frame
 and invokes the public reply CLI, rather than importing a production response
 store or completing requests through a test-only endpoint.
+
+Identity, request and response concurrency suites share the bounded process
+harness in `src/test-support/request-workers.ts`. Each scenario owns its handles
+and stops workers in `finally` before deleting fixture files. Worker entrypoints
+are resolved relative to their modules, not the caller's working directory.
+Readiness barriers, result collection and forced teardown remain test-only;
+they do not add production synchronization or change SQLite retry policy.
+Package exclusion is a separate inventory concern: fixture placement alone
+does not prove that npm omits those files.
 
 ## Dependency and module design rules
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -93,9 +93,14 @@ tests forbidden examples as well as repository files. It does not prove semantic
 architecture correctness; primary review and the architecture-impact record
 remain required.
 
-Request and response concurrency suites share bounded worker startup, barriers,
+Identity, request and response concurrency suites share bounded worker startup, barriers,
 result collection and termination in `src/test-support/request-workers.ts`.
-Scenario assertions and worker operations remain in their owning test modules.
+Scenario assertions stay in their owning test modules; process entrypoints live
+in `src/test-support/workers/` and use module-relative resolution. Scenarios stop
+their workers in `finally` before fixture removal, including failure before the
+release barrier. Harness regressions verify early exit, parent failure and
+forced termination through observable process absence, and exercise an unrelated
+working directory without adding dependencies to the fixture.
 Test-support infrastructure is excluded from production coverage, like worker
 fixtures; this does not exclude the request service, domain rules or SQL adapter.
 Final-response tests use real temporary SQLite and an injected clock for exact

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -74,12 +74,9 @@ function violations(file: string, text: string): string[] {
 function productionFiles(directory: string): string[] {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const location = path.join(directory, entry.name);
+    if (directory === sourceRoot && entry.name === 'test-support') return [];
     if (entry.isDirectory()) return productionFiles(location);
-    return entry.name.endsWith('.ts') &&
-      !entry.name.endsWith('.test.ts') &&
-      !entry.name.endsWith('-worker.ts')
-      ? [location]
-      : [];
+    return entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts') ? [location] : [];
   });
 }
 

--- a/src/identity-concurrency.test.ts
+++ b/src/identity-concurrency.test.ts
@@ -1,33 +1,17 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 import { openIdentityRepository } from './storage/identity-repository.js';
+import {
+  collectResults,
+  runWorker as spawnWorker,
+  stopWorkers,
+  waitForFiles,
+  workerMessage,
+} from './test-support/request-workers.js';
 
 const directories: string[] = [];
-function runWorker(
-  worker: string,
-  databaseFile: string,
-  barrierDirectory: string,
-  variant: string
-): Promise<{ code: number | null; output: string }> {
-  return new Promise((resolve) => {
-    const child = spawn(
-      process.execPath,
-      ['--import', 'tsx', worker, databaseFile, barrierDirectory, variant],
-      {
-        cwd: process.cwd(),
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }
-    );
-    let output = '';
-    child.stdout.on('data', (chunk: Buffer) => (output += chunk.toString()));
-    child.stderr.on('data', (chunk: Buffer) => (output += chunk.toString()));
-    child.on('close', (code) => resolve({ code, output }));
-  });
-}
-
 afterEach(() => {
   for (const directory of directories.splice(0))
     fs.rmSync(directory, { recursive: true, force: true });
@@ -40,29 +24,33 @@ describe('identity repository multi-process races', () => {
     const barrier = path.join(directory, 'barrier');
     fs.mkdirSync(barrier);
     const databaseFile = path.join(directory, 'tmux-team.db');
-    const worker = path.join(process.cwd(), 'src/identity-concurrency-worker.ts');
-    const first = runWorker(worker, databaseFile, barrier, 'a');
-    const second = runWorker(worker, databaseFile, barrier, 'b');
-    for (
-      let i = 0;
-      i < 100 &&
-      (!fs.existsSync(path.join(barrier, 'ready-a')) ||
-        !fs.existsSync(path.join(barrier, 'ready-b')));
-      i++
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    const worker = new URL(
+      './test-support/workers/identity-concurrency-worker.ts',
+      import.meta.url
+    );
+    const handles = ['a', 'b'].map((variant) =>
+      spawnWorker(worker, [databaseFile, barrier, variant], variant, directory)
+    );
+    try {
+      await waitForFiles(
+        ['a', 'b'].map((variant) => path.join(barrier, `ready-${variant}`)),
+        handles
+      );
+      fs.writeFileSync(path.join(barrier, 'go'), 'go');
+      const results = await collectResults(handles);
+      const messages = results.map((result) => workerMessage<{ id: string }>(result));
+      const ids = messages.map((message) => message.id);
+      expect(ids[0]).toBe(ids[1]);
+      const repository = openIdentityRepository(databaseFile);
+      try {
+        expect(repository.listIdentities()).toHaveLength(1);
+        expect(repository.findBindings()).toHaveLength(1);
+        expect(repository.findBindings()[0]?.identityId).toBe(ids[0]);
+      } finally {
+        repository.close();
+      }
+    } finally {
+      await stopWorkers(handles);
     }
-    expect(fs.existsSync(path.join(barrier, 'ready-a'))).toBe(true);
-    expect(fs.existsSync(path.join(barrier, 'ready-b'))).toBe(true);
-    fs.writeFileSync(path.join(barrier, 'go'), 'go');
-    const results = await Promise.all([first, second]);
-    expect(results.every((result) => result.code === 0)).toBe(true);
-    const ids = results.map((result) => JSON.parse(result.output.trim()).id);
-    expect(ids[0]).toBe(ids[1]);
-    const repository = openIdentityRepository(databaseFile);
-    expect(repository.listIdentities()).toHaveLength(1);
-    expect(repository.findBindings()).toHaveLength(1);
-    expect(repository.findBindings()[0]?.identityId).toBe(ids[0]);
-    repository.close();
-  }, 15_000);
+  }, 30_000);
 });

--- a/src/request-concurrency.test.ts
+++ b/src/request-concurrency.test.ts
@@ -49,8 +49,13 @@ function runWorker(
   variant: string,
   mode = 'prepare'
 ): WorkerHandle {
-  const worker = path.join(process.cwd(), 'src/request-concurrency-worker.ts');
-  return spawnWorker(worker, [database, barrier, identity, variant, mode], variant, process.cwd());
+  const worker = new URL('./test-support/workers/request-concurrency-worker.ts', import.meta.url);
+  return spawnWorker(
+    worker,
+    [database, barrier, identity, variant, mode],
+    variant,
+    path.dirname(barrier)
+  );
 }
 
 afterEach(() => {
@@ -94,7 +99,7 @@ describe('request service multi-process races', () => {
     } finally {
       await stopWorkers(handles);
     }
-  }, 15_000);
+  }, 30_000);
 
   it('keeps same-pane waits independent when server endpoint evidence differs', async () => {
     const fixture = databaseFixture();
@@ -129,7 +134,7 @@ describe('request service multi-process races', () => {
     } finally {
       await stopWorkers(handles);
     }
-  }, 15_000);
+  }, 30_000);
 
   it('releases exactly one attempt without changing another waiter', async () => {
     const fixture = databaseFixture();
@@ -179,7 +184,7 @@ describe('request service multi-process races', () => {
     } finally {
       await stopWorkers(handles);
     }
-  }, 15_000);
+  }, 30_000);
 
   it('rolls back an uncommitted attempt and cadence mutation after SIGKILL', async () => {
     const fixture = databaseFixture();
@@ -211,5 +216,5 @@ describe('request service multi-process races', () => {
     } finally {
       await stopWorkers([handle]);
     }
-  }, 15_000);
+  }, 30_000);
 });

--- a/src/request-response-concurrency.test.ts
+++ b/src/request-response-concurrency.test.ts
@@ -82,7 +82,10 @@ function runWorker(
   mode: string,
   body?: string
 ): WorkerHandle {
-  const worker = path.join(process.cwd(), 'src/request-response-concurrency-worker.ts');
+  const worker = new URL(
+    './test-support/workers/request-response-concurrency-worker.ts',
+    import.meta.url
+  );
   return spawnWorker(
     worker,
     [
@@ -95,7 +98,7 @@ function runWorker(
       ...(body === undefined ? [] : [body]),
     ],
     variant,
-    process.cwd()
+    path.dirname(value.barrier)
   );
 }
 

--- a/src/test-support/fixtures/ignore-term.ts
+++ b/src/test-support/fixtures/ignore-term.ts
@@ -1,0 +1,8 @@
+import fs from 'node:fs';
+
+const [readyFile] = process.argv.slice(2);
+if (!readyFile) throw new Error('Missing readiness file.');
+
+process.on('SIGTERM', () => undefined);
+fs.writeFileSync(readyFile, 'ready');
+Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 60_000);

--- a/src/test-support/fixtures/large-output.ts
+++ b/src/test-support/fixtures/large-output.ts
@@ -1,0 +1,1 @@
+process.stdout.write('x'.repeat(1024 * 1024 + 1));

--- a/src/test-support/fixtures/split-utf8.ts
+++ b/src/test-support/fixtures/split-utf8.ts
@@ -1,0 +1,13 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { waitForBarrier } from '../workers/barrier.js';
+
+const [barrierDirectory] = process.argv.slice(2);
+if (!barrierDirectory) throw new Error('Missing barrier directory.');
+
+const body = Buffer.from('{"message":"😀"}\n', 'utf8');
+const emojiStart = body.indexOf(Buffer.from('😀', 'utf8'));
+process.stdout.write(body.subarray(0, emojiStart + 1));
+fs.writeFileSync(path.join(barrierDirectory, 'first-byte-written'), 'ready');
+waitForBarrier(path.join(barrierDirectory, 'go'), 5_000);
+process.stdout.write(body.subarray(emojiStart + 1));

--- a/src/test-support/request-workers.test.ts
+++ b/src/test-support/request-workers.test.ts
@@ -1,0 +1,171 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  WORKER_OUTPUT_LIMIT_BYTES,
+  collectResults,
+  runWorker,
+  stopWorkers,
+  waitForFiles,
+  workerMessage,
+  workerExited,
+  type WorkerHandle,
+} from './request-workers.js';
+import { waitForBarrier } from './workers/barrier.js';
+
+const directories: string[] = [];
+
+function fixture(): { directory: string; barrier: string } {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-worker-lifecycle-'));
+  directories.push(directory);
+  const barrier = path.join(directory, 'barrier');
+  fs.mkdirSync(barrier);
+  return { directory, barrier };
+}
+
+function processExists(pid: number | undefined): boolean {
+  if (pid === undefined) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('concurrency worker lifecycle', () => {
+  it('stops all workers when the parent fails before releasing the barrier', async () => {
+    const value = fixture();
+    const worker = new URL('./workers/identity-concurrency-worker.ts', import.meta.url);
+    const handles = ['a', 'b'].map((variant) =>
+      runWorker(
+        worker,
+        [path.join(value.directory, 'missing.db'), value.barrier, variant],
+        variant,
+        value.directory
+      )
+    );
+    const pids = handles.map((handle) => handle.child.pid);
+    await expect(
+      (async () => {
+        try {
+          await waitForFiles(
+            ['a', 'b'].map((variant) => path.join(value.barrier, `ready-${variant}`)),
+            handles
+          );
+          throw new Error('simulated parent failure before go');
+        } finally {
+          await stopWorkers(handles);
+        }
+      })()
+    ).rejects.toThrow('simulated parent failure before go');
+    expect(fs.existsSync(path.join(value.barrier, 'go'))).toBe(false);
+    expect(handles.every(workerExited)).toBe(true);
+    expect(pids.every((pid) => !processExists(pid))).toBe(true);
+  }, 15_000);
+
+  it('reports an early worker exit instead of waiting indefinitely for readiness', async () => {
+    const value = fixture();
+    const worker = new URL('./workers/identity-concurrency-worker.ts', import.meta.url);
+    const handle = runWorker(worker, [], 'early', value.directory);
+    try {
+      await expect(
+        waitForFiles([path.join(value.barrier, 'ready-early')], [handle])
+      ).rejects.toThrow('Worker exited before its barrier');
+    } finally {
+      await stopWorkers([handle]);
+    }
+    expect(workerExited(handle)).toBe(true);
+    expect(processExists(handle.child.pid)).toBe(false);
+  }, 15_000);
+
+  it('escalates a child that ignores graceful termination to bounded SIGKILL cleanup', async () => {
+    const value = fixture();
+    const ready = path.join(value.barrier, 'ready-stubborn');
+    const worker = new URL('./fixtures/ignore-term.ts', import.meta.url);
+    const handle: WorkerHandle = runWorker(worker, [ready], 'stubborn', value.directory);
+    try {
+      await waitForFiles([ready], [handle]);
+    } finally {
+      await stopWorkers([handle]);
+    }
+    const [result] = await collectResults([handle], 2_000);
+    expect(result.signal).toBe('SIGKILL');
+    expect(workerExited(handle)).toBe(true);
+    expect(processExists(handle.child.pid)).toBe(false);
+  }, 15_000);
+
+  it('reports a failed spawn without leaving an untracked child', async () => {
+    const value = fixture();
+    const worker = new URL('./workers/identity-concurrency-worker.ts', import.meta.url);
+    const handle = runWorker(worker, [], 'spawn-error', path.join(value.directory, 'missing-cwd'));
+    try {
+      await expect(
+        waitForFiles([path.join(value.barrier, 'ready-spawn-error')], [handle])
+      ).rejects.toThrow('Worker exited before its barrier');
+    } finally {
+      await stopWorkers([handle]);
+    }
+    expect(workerExited(handle)).toBe(true);
+    expect(processExists(handle.child.pid)).toBe(false);
+  }, 15_000);
+
+  it('bounds worker output and rejects an exceeded zero-exit result explicitly', async () => {
+    const value = fixture();
+    const worker = new URL('./fixtures/large-output.ts', import.meta.url);
+    const handle = runWorker(worker, [], 'large-output', value.directory);
+    const pid = handle.child.pid;
+    try {
+      const [result] = await collectResults([handle], 2_000);
+      expect(result.outputExceeded).toBe(true);
+      expect(result.output.length).toBeLessThanOrEqual(WORKER_OUTPUT_LIMIT_BYTES + 100);
+      expect(() => workerMessage(result)).toThrow('Worker output exceeded');
+    } finally {
+      await stopWorkers([handle]);
+    }
+    expect(workerExited(handle)).toBe(true);
+    expect(processExists(pid)).toBe(false);
+    expect(() =>
+      workerMessage({
+        code: 0,
+        signal: null,
+        output: '{"message":"complete"}',
+        outputExceeded: true,
+      })
+    ).toThrow('Worker output exceeded');
+  }, 15_000);
+
+  it('reassembles a UTF-8 character split across worker output chunks', async () => {
+    const value = fixture();
+    const worker = new URL('./fixtures/split-utf8.ts', import.meta.url);
+    const handle = runWorker(worker, [value.barrier], 'split-utf8', value.directory);
+    const pid = handle.child.pid;
+    try {
+      await waitForFiles([path.join(value.barrier, 'first-byte-written')], [handle]);
+      fs.writeFileSync(path.join(value.barrier, 'go'), 'go');
+      const [result] = await collectResults([handle], 2_000);
+      expect(workerMessage<{ message: string }>(result)).toEqual({ message: '😀' });
+    } finally {
+      await stopWorkers([handle]);
+    }
+    expect(workerExited(handle)).toBe(true);
+    expect(processExists(pid)).toBe(false);
+  }, 15_000);
+
+  it('accepts an existing barrier with zero budget and rejects a missing one', () => {
+    const value = fixture();
+    const existing = path.join(value.barrier, 'existing');
+    fs.writeFileSync(existing, 'ready');
+    expect(() => waitForBarrier(existing, 0)).not.toThrow();
+    expect(() => waitForBarrier(path.join(value.barrier, 'missing'), 0)).toThrow(
+      'Timed out waiting for barrier'
+    );
+  });
+});

--- a/src/test-support/request-workers.ts
+++ b/src/test-support/request-workers.ts
@@ -1,43 +1,73 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { spawn, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 export const WORKER_TIMEOUT_MS = 10_000;
+export const WORKER_OUTPUT_LIMIT_BYTES = 1024 * 1024;
+const TSX_LOADER = createRequire(import.meta.url).resolve('tsx');
 
 export interface WorkerResult {
   readonly code: number | null;
   readonly signal: NodeJS.Signals | null;
   readonly output: string;
+  readonly outputExceeded: boolean;
 }
 
 export interface WorkerHandle {
   readonly child: ChildProcess;
   readonly result: Promise<WorkerResult>;
   readonly variant: string;
+  readonly isExited: () => boolean;
 }
 
 export function runWorker(
-  worker: string,
+  worker: string | URL,
   args: readonly string[],
   variant: string,
   cwd = process.cwd()
 ): WorkerHandle {
-  const child = spawn(process.execPath, ['--import', 'tsx', worker, ...args], {
+  const workerPath = worker instanceof URL ? fileURLToPath(worker) : worker;
+  const child = spawn(process.execPath, ['--import', TSX_LOADER, workerPath, ...args], {
     cwd,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+  let spawnFailed = false;
+  let closed = false;
   let output = '';
-  child.stdout?.on('data', (chunk: Buffer) => (output += chunk.toString()));
-  child.stderr?.on('data', (chunk: Buffer) => (output += chunk.toString()));
+  let outputBytes = 0;
+  let outputExceeded = false;
+  const captureOutput = (chunk: string): void => {
+    const bytes = Buffer.from(chunk);
+    const remaining = Math.max(0, WORKER_OUTPUT_LIMIT_BYTES - outputBytes);
+    if (remaining > 0) output += bytes.subarray(0, remaining).toString();
+    outputBytes += bytes.byteLength;
+    if (outputBytes > WORKER_OUTPUT_LIMIT_BYTES && !outputExceeded) {
+      outputExceeded = true;
+      output += `\nWorker output exceeded ${WORKER_OUTPUT_LIMIT_BYTES} bytes.\n`;
+      child.kill('SIGKILL');
+    }
+  };
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', captureOutput);
+  child.stderr?.on('data', captureOutput);
   const result = new Promise<WorkerResult>((resolve) => {
-    child.on('close', (code, signal) => resolve({ code, signal, output }));
-    child.on('error', (error) => (output += `${String(error)}\n`));
+    child.on('close', (code, signal) => {
+      closed = true;
+      resolve({ code, signal, output, outputExceeded });
+    });
+    child.on('error', (error) => {
+      if (child.pid === undefined) spawnFailed = true;
+      captureOutput(`${String(error)}\n`);
+    });
   });
-  return { child, result, variant };
+  return { child, result, variant, isExited: () => spawnFailed || closed };
 }
 
 export function workerExited(handle: WorkerHandle): boolean {
-  return handle.child.exitCode !== null || handle.child.signalCode !== null;
+  return handle.child.exitCode !== null || handle.child.signalCode !== null || handle.isExited();
 }
 
 export async function waitForFiles(
@@ -107,6 +137,9 @@ export async function stopWorkers(handles: readonly WorkerHandle[]): Promise<voi
 }
 
 export function workerMessage<T>(result: WorkerResult): T {
+  if (result.outputExceeded) {
+    throw new Error(`Worker output exceeded ${WORKER_OUTPUT_LIMIT_BYTES} bytes.`);
+  }
   if (result.code !== 0) throw new Error(`Worker failed (${result.signal}): ${result.output}`);
   const lines = result.output.trim().split('\n');
   const line = lines.at(-1);

--- a/src/test-support/workers/barrier.ts
+++ b/src/test-support/workers/barrier.ts
@@ -1,0 +1,10 @@
+import fs from 'node:fs';
+
+export function waitForBarrier(file: string, timeoutMs: number): void {
+  const deadline = Date.now() + timeoutMs;
+  const sleepBuffer = new Int32Array(new SharedArrayBuffer(4));
+  while (!fs.existsSync(file)) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for barrier '${file}'.`);
+    Atomics.wait(sleepBuffer, 0, 0, 10);
+  }
+}

--- a/src/test-support/workers/identity-concurrency-worker.ts
+++ b/src/test-support/workers/identity-concurrency-worker.ts
@@ -1,12 +1,15 @@
 /* c8 ignore file */
 import fs from 'node:fs';
 import path from 'node:path';
-import { createIdentityService } from './identity-service.js';
-import { openIdentityRepository } from './storage/identity-repository.js';
-import type { PaneInfo, Tmux } from './types.js';
+import { createIdentityService } from '../../identity-service.js';
+import { openIdentityRepository } from '../../storage/identity-repository.js';
+import type { PaneInfo, Tmux } from '../../types.js';
+import { waitForBarrier } from './barrier.js';
 
 const [databaseFile, barrierDirectory, variant] = process.argv.slice(2);
 if (!databaseFile || !barrierDirectory || !variant) throw new Error('Invalid worker arguments.');
+
+const BARRIER_TIMEOUT_MS = 30_000;
 
 const pane: PaneInfo = {
   id: '%race',
@@ -41,12 +44,7 @@ const tmux = {
   },
 } as unknown as Tmux;
 fs.writeFileSync(path.join(barrierDirectory, `ready-${variant}`), 'ready');
-while (!fs.existsSync(path.join(barrierDirectory, 'go'))) {
-  // A short synchronous wait keeps both real processes behind the same
-  // barrier without introducing a test-only synchronization primitive.
-  const until = Date.now() + 5;
-  while (Date.now() < until) {}
-}
+waitForBarrier(path.join(barrierDirectory, 'go'), BARRIER_TIMEOUT_MS);
 
 const repository = openIdentityRepository(databaseFile);
 try {

--- a/src/test-support/workers/request-concurrency-worker.ts
+++ b/src/test-support/workers/request-concurrency-worker.ts
@@ -1,8 +1,9 @@
 /* c8 ignore file */
 import fs from 'node:fs';
 import path from 'node:path';
-import { createRequestService, type RequestEndpoint } from './request-service.js';
-import { openIdentityRepository } from './storage/identity-repository.js';
+import { createRequestService, type RequestEndpoint } from '../../request-service.js';
+import { openIdentityRepository } from '../../storage/identity-repository.js';
+import { waitForBarrier } from './barrier.js';
 
 const [databaseFile, barrierDirectory, identityId, variant, mode = 'prepare'] =
   process.argv.slice(2);
@@ -20,15 +21,6 @@ function barrierPath(name: string): string {
 
 function signal(name: string, content = 'ready'): void {
   fs.writeFileSync(barrierPath(name), content);
-}
-
-function waitForBarrier(name: string): void {
-  const deadline = Date.now() + BARRIER_TIMEOUT_MS;
-  const sleepBuffer = new Int32Array(new SharedArrayBuffer(4));
-  while (!fs.existsSync(barrierPath(name))) {
-    if (Date.now() >= deadline) throw new Error(`Timed out waiting for barrier '${name}'.`);
-    Atomics.wait(sleepBuffer, 0, 0, 10);
-  }
 }
 
 function endpointFor(currentMode: string, currentVariant: string): RequestEndpoint {
@@ -89,17 +81,17 @@ try {
       // back both the service-created attempt and its cadence reservation.
       service.prepare(requestInput(`uncommitted-${variant}`, endpoint, identityId));
       signal(`transaction-open-${variant}`);
-      waitForBarrier(`kill-${variant}`);
+      waitForBarrier(barrierPath(`kill-${variant}`), BARRIER_TIMEOUT_MS);
     });
     process.stdout.write(JSON.stringify({ ok: true, rolledBack: false }) + '\n');
   } else {
     signal(`ready-${variant}`);
-    waitForBarrier('go');
+    waitForBarrier(barrierPath('go'), BARRIER_TIMEOUT_MS);
     const prepared = service.prepare(requestInput(variant, endpoint, identityId));
 
     if (mode === 'release') {
       signal(`prepared-${variant}`, prepared.attemptId);
-      waitForBarrier(`release-${variant}`);
+      waitForBarrier(barrierPath(`release-${variant}`), BARRIER_TIMEOUT_MS);
       service.releaseWait(prepared.attemptId);
       signal(`released-${variant}`);
     }

--- a/src/test-support/workers/request-response-concurrency-worker.ts
+++ b/src/test-support/workers/request-response-concurrency-worker.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
-import { openIdentityRepository } from './storage/identity-repository.js';
-import { createRequestService, type RequestEndpoint } from './request-service.js';
+import { openIdentityRepository } from '../../storage/identity-repository.js';
+import { createRequestService, type RequestEndpoint } from '../../request-service.js';
+import { waitForBarrier } from './barrier.js';
 
 const [, , database, barrier, requestId, attemptId, variant, mode, body] = process.argv;
 if (!database || !barrier || !requestId || !attemptId || !variant || !mode) {
@@ -23,14 +24,6 @@ if (!['submit', 'submit-gated', 'fail', 'fail-gated'].includes(mode)) {
   throw new Error(`Unknown response race mode '${mode}'.`);
 }
 
-function waitForFile(file: string): void {
-  const deadline = Date.now() + 15_000;
-  while (!fs.existsSync(file)) {
-    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${file}`);
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
-  }
-}
-
 function output(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value)}\n`);
 }
@@ -38,7 +31,7 @@ function output(value: unknown): void {
 try {
   fs.writeFileSync(`${barrier}/ready-${variant}`, 'ready');
   const gate = mode === 'submit-gated' ? 'go-submit' : mode === 'fail-gated' ? 'go-fail' : 'go';
-  waitForFile(`${barrier}/${gate}`);
+  waitForBarrier(`${barrier}/${gate}`, 15_000);
 
   if (mode === 'fail' || mode === 'fail-gated') {
     service.settle(attemptId, 'definitely_failed');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     coverage: {
       all: true,
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/*-worker.ts', 'src/test-support/**'],
+      exclude: ['src/**/*.test.ts', 'src/test-support/**'],
       reporter: ['text', 'json-summary'],
       reportsDirectory: 'coverage',
     },


### PR DESCRIPTION
## Summary

- Reuse one bounded subprocess harness for identity, request, and response concurrency tests.
- Move all concurrency worker entrypoints into `src/test-support/workers` and resolve entrypoints and the TypeScript loader independently of the child working directory.
- Guarantee teardown on parent failure, preserve split UTF-8 output, bound captured output, and report spawn failures.
- Update architecture, development guidance, and test-only inventory rules without changing production CLI, persistence, schema, or retry behavior.

Closes TMT-42.

## Architecture and review

The primary reviewer accepted the required Luna high read-only pattern audit before implementation and personally reviewed every changed file, the shared harness callers, worker entrypoints, fixtures, and existing race assertions. Existing SQLite race tests still use independent real processes and assert durable state; they were not replaced by mocks.

Review corrections included using a genuinely thrown parent error around `finally`, checking OS-level process absence, handling UTF-8 across stream chunks, distinguishing spawn failure from other child errors, resolving the loader outside the child working directory, and bounding result collection. New tests also cover early exit, SIGTERM-resistant children, output overflow, and missing barriers.

Test infrastructure ownership is documented in ARCHITECTURE.md and DEVELOPMENT.md. Package-content exclusion remains separate TMT-29 work; moving workers alone does not remove them from published packages. Provider naming, memory, inbox, and production storage retry policy are outside this PR.

## Verification

- `pnpm check`: passed.
- `pnpm test:run`: 49 files / 605 tests passed; coverage gates passed (95.08% lines/statements, 88.77% branches, 97.20% functions).
- `pnpm exec prettier --check vitest.config.ts`: passed.
- Focused worker/race regression rerun: 4 files / 15 tests passed. Negative control removing UTF-8 stream decoding failed with corrupted output as expected; restoring the implementation returned all focused tests to green, with no unstaged diff.
- `pnpm test:e2e && pnpm test:e2e`: both consecutive local Docker runs passed 16 files / 72 tests (231.50s and 231.96s), using real tmux and deterministic mock agents.

Merge requires all required CI checks to pass on the reviewed PR head. No release or npm publication is included.
