### PR TITLE
refactor: share active binding evidence (TMT-45)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -289,6 +289,13 @@ possible unused names for durable observation safety; no feature-table-specific
 deletion guards, automatic garbage collection or identity deletion API exist.
 Active discovery still requires a verified binding; explicit data access does not.
 
+Discovery and reconciliation use one local binding-evidence evaluator in
+`identity-service.ts`, composing identity/pane presence, server and process
+evidence, and durable metadata agreement. Reconciliation alone applies the
+foreign-socket preservation guard before evaluation; discovery still excludes
+bindings that do not match the current server. The shared predicate does not
+change publication, transaction, or routing policy.
+
 Binding publication, active reconciliation and unbind share the repository's
 SQLite immediate-transaction boundary. Authoritative endpoint snapshots are
 taken after acquiring the write lock, so a reconciler cannot prune a new

--- a/src/identity-service.test.ts
+++ b/src/identity-service.test.ts
@@ -77,22 +77,26 @@ function createTestService(test: ReturnType<typeof fixture>) {
   return createIdentityService({ tmux: test.tmux, repository });
 }
 
-function seedForeignBinding(test: ReturnType<typeof fixture>, name = 'Foreign') {
+function seedForeignBinding(
+  test: ReturnType<typeof fixture>,
+  name = 'Foreign',
+  pane?: { paneId?: string; panePid?: number }
+) {
   const repository = openIdentityRepository(test.paths.databaseFile);
+  repositories.push(repository);
   const identity = repository.createIdentity(name, name.toLowerCase());
   const binding = repository.createBinding({
     identityId: identity.id,
     transport: 'tmux',
-    paneId: '%foreign',
+    paneId: pane?.paneId ?? '%foreign',
     serverId: 'server-foreign',
     socketPath: '/tmp/tmt-foreign',
     serverPid: 999999,
     serverStartTime: 'foreign-start',
-    panePid: 8888,
+    panePid: pane?.panePid ?? 8888,
     boundAt: 'foreign-bound',
     lastVerifiedAt: 'foreign-verified',
   });
-  repository.close();
   return { identity, binding };
 }
 
@@ -354,6 +358,127 @@ describe('durable identity service', () => {
       panes: [{ ...test.pane }],
     });
     expect(service.activeIdentities()).toEqual([]);
+  });
+
+  it.each([
+    ['missing pane', (snapshot: TmuxEndpointSnapshot) => ({ ...snapshot, panes: [] })],
+    [
+      'different server ID',
+      (snapshot: TmuxEndpointSnapshot) => ({
+        ...snapshot,
+        server: { ...snapshot.server, serverId: 'server-restarted' },
+      }),
+    ],
+    [
+      'different server PID',
+      (snapshot: TmuxEndpointSnapshot) => ({
+        ...snapshot,
+        server: { ...snapshot.server, serverPid: snapshot.server.serverPid + 1 },
+      }),
+    ],
+    [
+      'different server start time',
+      (snapshot: TmuxEndpointSnapshot) => ({
+        ...snapshot,
+        server: { ...snapshot.server, serverStartTime: 'server-restarted' },
+      }),
+    ],
+    [
+      'different pane PID',
+      (snapshot: TmuxEndpointSnapshot) => ({
+        ...snapshot,
+        panes: snapshot.panes.map((pane) =>
+          pane.id === '%1' ? { ...pane, panePid: (pane.panePid ?? 0) + 1 } : pane
+        ),
+      }),
+    ],
+    [
+      'missing durable metadata',
+      (snapshot: TmuxEndpointSnapshot) => ({
+        ...snapshot,
+        panes: snapshot.panes.map((pane) =>
+          pane.id === '%1' ? { ...pane, metadata: undefined } : pane
+        ),
+      }),
+    ],
+    [
+      'mismatched durable metadata',
+      (snapshot: TmuxEndpointSnapshot) => ({
+        ...snapshot,
+        panes: snapshot.panes.map((pane) =>
+          pane.id === '%1' && pane.metadata?.globalIdentity
+            ? {
+                ...pane,
+                metadata: {
+                  ...pane.metadata,
+                  globalIdentity: { ...pane.metadata.globalIdentity, bindingId: 'other-binding' },
+                },
+              }
+            : pane
+        ),
+      }),
+    ],
+  ] as const)('reconciliation removes a binding with %s evidence', (_label, mutate) => {
+    const test = fixture();
+    const service = createTestService(test);
+    const identity = service.bindCurrent('evidence-check');
+    const profileRepository = openIdentityRepository(test.paths.databaseFile);
+    repositories.push(profileRepository);
+    profileRepository.setRole(identity.id, 'Retain this profile.');
+    test.setSnapshot(mutate(test.tmux.getEndpointSnapshot!()));
+
+    service.reconcile();
+
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    repositories.push(repository);
+    expect(repository.findBindings()).toEqual([]);
+    expect(repository.findByCanonicalName(identity.canonicalName)).toEqual(identity);
+    expect(repository.findRole(identity.id)).toMatchObject({ content: 'Retain this profile.' });
+  });
+
+  it('retains matching evidence and refreshes its verification timestamp', () => {
+    const test = fixture();
+    const service = createTestService(test);
+    const identity = service.bindCurrent('valid-evidence');
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    repositories.push(repository);
+    const binding = repository.findBindings()[0];
+    repository.touchBinding(binding.id, 'previous-verification');
+
+    service.reconcile();
+
+    const retained = repository.findBindings();
+    expect(retained).toHaveLength(1);
+    expect(retained[0]).toEqual({ ...binding, lastVerifiedAt: expect.any(String) });
+    expect(retained[0].lastVerifiedAt).not.toBe('previous-verification');
+    expect(service.activeIdentities()).toMatchObject([{ identity, binding: { id: binding.id } }]);
+  });
+
+  it('mapper rejects foreign-socket evidence without pruning the foreign binding', () => {
+    const test = fixture();
+    const foreign = seedForeignBinding(test, 'Foreign', {
+      paneId: '%1',
+      panePid: test.pane.panePid,
+    });
+    const { identity, binding } = foreign;
+    test.pane.metadata = {
+      version: 1,
+      globalIdentity: {
+        name: identity.name,
+        canonicalName: identity.canonicalName,
+        identityId: identity.id,
+        bindingId: binding.id,
+        serverId: binding.serverId,
+        panePid: binding.panePid,
+      },
+    };
+    const service = createTestService(test);
+
+    expect(service.activeIdentities()).toEqual([]);
+
+    const after = openIdentityRepository(test.paths.databaseFile);
+    repositories.push(after);
+    expect(after.findBindings()).toContainEqual(binding);
   });
 
   it('preserves a binding owned by another live socket while discovering only the current server', () => {

--- a/src/identity-service.ts
+++ b/src/identity-service.ts
@@ -124,6 +124,29 @@ function findPane(snapshot: TmuxEndpointSnapshot, paneId: string): PaneInfo | un
   return snapshot.panes.find((pane) => pane.id === paneId);
 }
 
+interface BindingEvidence {
+  readonly identity: DurableIdentity;
+  readonly pane: PaneInfo;
+}
+
+function verifiedBindingEvidence(
+  binding: TmuxBinding,
+  identity: DurableIdentity | undefined,
+  snapshot: TmuxEndpointSnapshot
+): BindingEvidence | undefined {
+  const pane = findPane(snapshot, binding.paneId);
+  if (
+    !identity ||
+    !pane ||
+    !serverMatches(binding, snapshot.server) ||
+    !paneMatches(binding, pane) ||
+    !metadataMatches(pane, identity, binding)
+  ) {
+    return undefined;
+  }
+  return { identity, pane };
+}
+
 function mapActive(
   repository: IdentityRepository,
   snapshot: TmuxEndpointSnapshot,
@@ -131,17 +154,8 @@ function mapActive(
 ): Array<{ identity: DurableIdentity; binding: TmuxBinding; pane: PaneInfo }> {
   const identities = new Map(repository.listIdentities().map((item) => [item.id, item]));
   return bindings.flatMap((binding) => {
-    const identity = identities.get(binding.identityId);
-    const pane = findPane(snapshot, binding.paneId);
-    if (
-      !identity ||
-      !pane ||
-      !serverMatches(binding, snapshot.server) ||
-      !paneMatches(binding, pane)
-    ) {
-      return [];
-    }
-    return metadataMatches(pane, identity, binding) ? [{ identity, binding, pane }] : [];
+    const evidence = verifiedBindingEvidence(binding, identities.get(binding.identityId), snapshot);
+    return evidence ? [{ identity: evidence.identity, binding, pane: evidence.pane }] : [];
   });
 }
 
@@ -262,15 +276,12 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
       // binding owned by another socket merely because its panes are absent
       // from this endpoint snapshot.
       if (binding.socketPath !== snapshot.server.socketPath) continue;
-      const identity = identities.get(binding.identityId);
-      const pane = findPane(snapshot, binding.paneId);
-      if (
-        !identity ||
-        !pane ||
-        !serverMatches(binding, snapshot.server) ||
-        !paneMatches(binding, pane) ||
-        !metadataMatches(pane, identity, binding)
-      ) {
+      const evidence = verifiedBindingEvidence(
+        binding,
+        identities.get(binding.identityId),
+        snapshot
+      );
+      if (!evidence) {
         repository.removeBinding(binding.id);
       } else {
         repository.touchBinding(binding.id, new Date().toISOString());


### PR DESCRIPTION
## Summary

- Use one private binding-evidence evaluator for active identity mapping and reconciliation.
- Reuse existing server, pane and metadata predicates without changing foreign-socket preservation, publication, transaction or deadline policies.
- Add real-storage evidence regressions with durable identity/profile retention and independent foreign-binding discovery coverage.
- Document the shared policy in ARCHITECTURE.md.

Closes TMT-45.

## Primary architecture and test review

The mandatory Luna high audit was accepted before implementation. The primary reviewed all changed files, both evaluator consumers, binding/unbinding callers, snapshot/metadata rules and fixture lifecycle. The helper stays private to the identity service; no new resolver, manager or repository abstraction was created. Active result field order is preserved.

The mapper test uses a natural independent path: reconciliation skips foreign sockets, while mapping must reject their evidence even with matching pane ID/PID and durable metadata. Other stale evidence cases exercise reconciliation against real SQLite and prove identities/profiles survive binding removal. Tests do not corrupt foreign-key invariants to manufacture impossible orphan rows. Touched repository handles are registered for cleanup even after failures.

## Verification

- `pnpm check`: passed.
- `pnpm test:run`: 50 files / 626 tests passed; unchanged coverage gates passed (95.10% lines/statements, 88.88% branches). Primary added a positive control proving matching evidence remains active and refreshes its verification timestamp.
- Negative control removed server matching from the shared evaluator: four regressions failed, including the independent mapper test. Restored before full verification.
- Two consecutive local `pnpm test:e2e` runs passed 16 files / 72 tests each (239.65s and 234.41s). Production code was identical across both; the second also includes the additional unit-only positive-control test.

No intended CLI/state-policy change, new dependencies, publication, memory or inbox. Acquisition, teardown and transaction ordering are unchanged. Two consecutive local Docker runs exercise the touched binding cleanup path before push. Required exact-head CI must pass before merge. TMT-18's broader consolidation gate remains open.
