### PR TITLE
fix: share capture and timing bounds (TMT-47)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -233,6 +233,16 @@ unavailable output cancels recipient work or changes service retention.
 
 ## Talk observer and retired settings
 
+`src/domain/interaction-limits.ts` owns pure capture and timing validity rules.
+The parser owns decimal/duration syntax and maps failures to usage errors;
+talk retains its timing error translation and conditional wait validation.
+Check validates its effective capture count before target lookup: integers
+0 through 2,147,483,647 are accepted, with zero preserving visible-pane capture.
+Invalid runtime counts return `INVALID_CAPTURE_LINES` (exit 1), without capture
+or reconciliation. These argument limits do not replace tmux's existing
+one-second timeout and 4 MiB output bound. Config loading/writing consolidation
+and command-option ownership remain TMT-46 and TMT-22 work respectively.
+
 The parser rejects retired `--wait`, talk `--lines`, and explicit
 `--timeout`/`--detach` combinations before Context effects. `send` follows the
 same talk semantics. Runtime timing validation precedes preamble/request mutation:

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -31,6 +31,9 @@ Successful submission also does not guarantee exactly-once agent processing.
 markers, idle output, a summary, or process exit as completion. A cooperating
 recipient must invoke `tmt reply`; otherwise there is no final result yet.
 `check` is only a diagnostic snapshot, not correlated result retrieval.
+Its positional count or `--lines` accepts integers from 0 through 2147483647;
+zero captures the visible pane. Invalid counts are rejected, not clamped.
+Invalid configured capture counts also fail before target lookup or capture.
 
 ## JSON results and failures
 

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -28,6 +28,9 @@ Successful submission also does not guarantee exactly-once agent processing.
 markers, idle output, a summary, or process exit as completion. A cooperating
 recipient must invoke `tmt reply`; otherwise there is no final result yet.
 `check` is only a diagnostic snapshot, not correlated result retrieval.
+Its positional count or `--lines` accepts integers from 0 through 2147483647;
+zero captures the visible pane. Invalid counts are rejected, not clamped.
+Invalid configured capture counts also fail before target lookup or capture.
 
 ## JSON results and failures
 

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -28,6 +28,9 @@ Successful submission also does not guarantee exactly-once agent processing.
 markers, idle output, a summary, or process exit as completion. A cooperating
 recipient must invoke `tmt reply`; otherwise there is no final result yet.
 `check` is only a diagnostic snapshot, not correlated result retrieval.
+Its positional count or `--lines` accepts integers from 0 through 2147483647;
+zero captures the visible pane. Invalid counts are rejected, not clamped.
+Invalid configured capture counts also fail before target lookup or capture.
 
 ## JSON results and failures
 

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -24,6 +24,9 @@ Successful submission also does not guarantee exactly-once agent processing.
 markers, idle output, a summary, or process exit as completion. A cooperating
 recipient must invoke `tmt reply`; otherwise there is no final result yet.
 `check` is only a diagnostic snapshot, not correlated result retrieval.
+Its positional count or `--lines` accepts integers from 0 through 2147483647;
+zero captures the visible pane. Invalid counts are rejected, not clamped.
+Invalid configured capture counts also fail before target lookup or capture.
 
 ## JSON results and failures
 

--- a/src/cli-runner.test.ts
+++ b/src/cli-runner.test.ts
@@ -78,6 +78,28 @@ describe('CLI runner lifecycle', () => {
     }
   });
 
+  it.each([
+    ['check', 'missing', '9'.repeat(400)],
+    ['read', 'missing', '--lines=2147483648'],
+    ['--lines', '2147483648', 'check', 'missing', '0'],
+    ['talk', 'missing', 'message', '--timeout', '86400.001s'],
+    ['talk', 'missing', 'message', '--delay', '2147483648ms'],
+  ])('rejects invalid numeric arguments before initialization: %j', async (...args) => {
+    const output = captureStdout();
+    const startup = vi.fn();
+    const dispatch = vi.fn();
+    try {
+      const { runCli, createContext } = await loadRunner({ startup, dispatch });
+      await expect(runCli(['--json', ...args])).resolves.toBe(1);
+      expect(document(output.chunks)).toMatchObject({ error: { code: 'USAGE_ERROR' } });
+      expect(createContext).not.toHaveBeenCalled();
+      expect(startup).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      output.restore();
+    }
+  });
+
   it('disposes once when startup fails and emits an internal error', async () => {
     const output = captureStdout();
     let outputAtDisposal: string[] | undefined;

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { CliParseError, parseArgs } from './parser.js';
 import { encodeReplyReceipt } from '../reply-receipt.js';
+import {
+  MAX_CAPTURE_LINES,
+  MAX_OBSERVER_TIMEOUT_SECONDS,
+  MAX_TIMER_DELAY_MS,
+} from '../domain/interaction-limits.js';
 
 const receipt = encodeReplyReceipt({
   version: 1,
@@ -77,6 +82,40 @@ describe('declarative CLI parser', () => {
     expect(() => parseArgs(['talk', 'claude', 'hello', '--wait'])).toThrow(CliParseError);
     expect(() => parseArgs(['talk', 'claude', 'hello', '--lines', '10'])).toThrow(CliParseError);
     expect(() => parseArgs(['check', 'claude', '--lines', '10'])).not.toThrow();
+  });
+
+  it('bounds capture lines for both positional and explicit options', () => {
+    expect(parseArgs(['check', 'claude', '0']).invocation).toMatchObject({ lines: 0 });
+    expect(parseArgs(['check', 'claude', '--lines', String(MAX_CAPTURE_LINES)])).toMatchObject({
+      flags: { lines: MAX_CAPTURE_LINES },
+    });
+    expect(
+      parseArgs(['check', 'claude', '0', '--lines', String(MAX_CAPTURE_LINES)]).invocation
+    ).toMatchObject({ lines: 0 });
+    for (const args of [
+      ['check', 'claude', String(MAX_CAPTURE_LINES + 1)],
+      ['check', 'claude', '--lines', String(MAX_CAPTURE_LINES + 1)],
+      ['check', 'claude', '--lines', '999999999999999999999999999999'],
+      ['check', 'claude', '--lines', '10junk'],
+    ]) {
+      expect(() => parseArgs(args)).toThrow(CliParseError);
+    }
+  });
+
+  it('accepts timing limits at their supported boundaries', () => {
+    expect(
+      parseArgs(['talk', 'claude', 'hello', '--timeout', `${MAX_OBSERVER_TIMEOUT_SECONDS}s`]).flags
+        .timeout
+    ).toBe(MAX_OBSERVER_TIMEOUT_SECONDS);
+    expect(
+      parseArgs(['talk', 'claude', 'hello', '--delay', `${MAX_TIMER_DELAY_MS}ms`]).flags.delay
+    ).toBe(MAX_TIMER_DELAY_MS / 1000);
+    expect(() =>
+      parseArgs(['talk', 'claude', 'hello', '--delay', `${MAX_TIMER_DELAY_MS + 1}ms`])
+    ).toThrow(CliParseError);
+    expect(() =>
+      parseArgs(['talk', 'claude', 'hello', '--timeout', `${MAX_OBSERVER_TIMEOUT_SECONDS + 1}s`])
+    ).toThrow(CliParseError);
   });
 
   it('applies no-preamble regardless of whether it appears before or after talk', () => {

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -10,6 +10,12 @@ import type {
   RoleRequest,
 } from './requests.js';
 import { validateReplyRequestId } from '../reply-receipt.js';
+import {
+  MAX_CAPTURE_LINES,
+  isValidCaptureLines,
+  isValidObserverTimeoutSeconds,
+  isValidTimerDelayMs,
+} from '../domain/interaction-limits.js';
 export type { IdentitySelector } from '../identity-context.js';
 
 export type ParsedInvocation =
@@ -101,8 +107,15 @@ function parseTime(value: string): number {
 
 function parseLines(value: string): number {
   if (!/^\d+$/.test(value))
-    throw new CliParseError(`Invalid lines value: ${value}. Use a non-negative integer.`);
-  return parseInt(value, 10);
+    throw new CliParseError(
+      `Invalid lines value: ${value}. Use an integer between 0 and ${MAX_CAPTURE_LINES}.`
+    );
+  const lines = Number(value);
+  if (!isValidCaptureLines(lines))
+    throw new CliParseError(
+      `Invalid lines value: ${value}. Use an integer between 0 and ${MAX_CAPTURE_LINES}.`
+    );
+  return lines;
 }
 
 function flagsFrom(options: CommonOptions, argv: readonly string[] = []): Flags {
@@ -116,11 +129,7 @@ function flagsFrom(options: CommonOptions, argv: readonly string[] = []): Flags 
   if (options.delay !== undefined) flags.delay = parseTime(options.delay);
   if (options.detach) flags.detach = true;
   if (options.timeout !== undefined) flags.timeout = parseTime(options.timeout);
-  if (options.lines !== undefined) {
-    if (!/^\d+$/.test(options.lines))
-      throw new CliParseError(`Invalid lines value: ${options.lines}. Use a non-negative integer.`);
-    flags.lines = parseInt(options.lines, 10);
-  }
+  if (options.lines !== undefined) flags.lines = parseLines(options.lines);
   if (options.noPreamble || options.preamble === false || argv.includes('--no-preamble'))
     flags.noPreamble = true;
   return flags;
@@ -241,11 +250,7 @@ function setupProgram(capture: Capture): Command {
       }
       if (optionWasProvided(command, 'timeout') && options.timeout !== undefined) {
         const timeoutSeconds = parseTime(options.timeout);
-        if (
-          !Number.isFinite(timeoutSeconds) ||
-          timeoutSeconds <= 0 ||
-          timeoutSeconds > 24 * 60 * 60
-        ) {
+        if (!isValidObserverTimeoutSeconds(timeoutSeconds)) {
           throw new CliParseError(
             'Talk timeout must be finite, positive, and no greater than 24 hours.'
           );
@@ -253,7 +258,7 @@ function setupProgram(capture: Capture): Command {
       }
       if (optionWasProvided(command, 'delay') && options.delay !== undefined) {
         const delaySeconds = parseTime(options.delay);
-        if (delaySeconds * 1000 > 2_147_483_647) {
+        if (!isValidTimerDelayMs(delaySeconds * 1000)) {
           throw new CliParseError('Talk delay exceeds the supported timer limit.');
         }
       }

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -7,6 +7,7 @@ import type { Context, Flags, IdentityService, Paths, ResolvedConfig, Tmux, UI }
 import { IdentityServiceError } from '../identity-service.js';
 import { ExitCodes } from '../exits.js';
 import { IdentitySelectionError } from '../identity-context.js';
+import { MAX_CAPTURE_LINES } from '../domain/interaction-limits.js';
 
 import { cmdInit } from './init.js';
 import { cmdAdd } from './add.js';
@@ -413,6 +414,61 @@ describe('basic commands', () => {
     cmdCheck(ctx, 'claude', 10);
     expect(ctx.tmux.capture).toHaveBeenCalledWith('1.0', 10);
     expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('cmdCheck accepts the maximum capture count', () => {
+    const ctx = createCtx(testDir, {
+      flags: { json: true },
+      identities: [{ name: 'claude', canonicalName: 'claude', paneId: '1.0' }],
+    });
+    cmdCheck(ctx, 'claude', MAX_CAPTURE_LINES);
+    expect(ctx.tmux.capture).toHaveBeenCalledWith('1.0', MAX_CAPTURE_LINES);
+  });
+
+  it('cmdCheck accepts zero capture lines', () => {
+    const ctx = createCtx(testDir, {
+      flags: { json: true },
+      identities: [{ name: 'claude', canonicalName: 'claude', paneId: '1.0' }],
+    });
+    cmdCheck(ctx, 'claude', 0);
+    expect(ctx.tmux.capture).toHaveBeenCalledWith('1.0', 0);
+  });
+
+  it.each([
+    { label: 'explicit count', lines: MAX_CAPTURE_LINES + 1, config: undefined },
+    {
+      label: 'configured count',
+      lines: undefined,
+      config: {
+        defaults: {
+          timeout: 180,
+          pollInterval: 1,
+          captureLines: MAX_CAPTURE_LINES + 1,
+          preambleEvery: 3,
+          pasteEnterDelayMs: 500,
+        },
+      },
+    },
+  ])('cmdCheck rejects an invalid $label before target resolution', ({ lines, config }) => {
+    const ctx = createCtx(testDir, {
+      flags: { json: true },
+      config,
+      identities: [{ name: 'claude', canonicalName: 'claude', paneId: '1.0' }],
+    });
+
+    expect(() => cmdCheck(ctx, 'claude', lines)).toThrow(`exit(${ExitCodes.ERROR})`);
+    const jsonCalls = (ctx.ui as UI & { jsonCalls: unknown[] }).jsonCalls;
+    expect(jsonCalls).toEqual([
+      {
+        error: {
+          code: 'INVALID_CAPTURE_LINES',
+          message: `Capture lines must be an integer between 0 and ${MAX_CAPTURE_LINES}.`,
+        },
+      },
+    ]);
+    expect(ctx.identityService.activeIdentities).not.toHaveBeenCalled();
+    expect(ctx.tmux.resolvePaneTarget).not.toHaveBeenCalled();
+    expect(ctx.tmux.capture).not.toHaveBeenCalled();
   });
 
   it('cmdCheck errors when agent missing', () => {

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -8,9 +8,19 @@ import { colors } from '../ui.js';
 import { resolveTarget } from '../target-resolver.js';
 import { normalizeName } from '../domain/names.js';
 import { identityAwareTmux } from '../identity-service.js';
+import { isValidCaptureLines, MAX_CAPTURE_LINES } from '../domain/interaction-limits.js';
 
 export function cmdCheck(ctx: Context, target: string, lines?: number): void {
-  const { ui, config, tmux, flags, exit } = ctx;
+  const { ui, config, flags, exit } = ctx;
+  const captureLines = lines ?? config.defaults.captureLines;
+  if (!isValidCaptureLines(captureLines)) {
+    const message = `Capture lines must be an integer between 0 and ${MAX_CAPTURE_LINES}.`;
+    if (flags.json) ui.json({ error: { code: 'INVALID_CAPTURE_LINES', message } });
+    else ui.error(message);
+    return exit(ExitCodes.ERROR);
+  }
+
+  const { tmux } = ctx;
   const runtimeTmux = identityAwareTmux(tmux, ctx.identityService);
   const resolution = resolveTarget(runtimeTmux, target);
   if (!resolution.ok) {
@@ -24,7 +34,6 @@ export function cmdCheck(ctx: Context, target: string, lines?: number): void {
   }
 
   const pane = resolution.value.paneId;
-  const captureLines = lines ?? config.defaults.captureLines;
 
   try {
     const output = tmux.capture(pane, captureLines);

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -4,6 +4,7 @@
 
 import { colors } from '../ui.js';
 import { VERSION } from '../version.js';
+import { MAX_CAPTURE_LINES, MAX_TIMER_DELAY_MS } from '../domain/interaction-limits.js';
 
 export interface HelpConfig {
   timeout?: number;
@@ -79,11 +80,15 @@ ${colors.yellow('CALLER CONTEXT')}
   Outside tmux, use explicit add/talk/check targets or role --identity <name>.
 
 ${colors.yellow('TALK OPTIONS')}
-  ${colors.green('--delay')} <seconds>           Wait before sending
+  ${colors.green('--delay')} <seconds>           Wait before sending (0 through ${MAX_TIMER_DELAY_MS}ms)
   ${colors.green('--timeout')} <time>            Observer bound (current: ${timeout}s; positive, at most 24h)
   ${colors.green('--detach')}                    Return request ID after sending; no explicit --timeout
   ${colors.green('--no-preamble')}               Skip agent preamble for this message
   ${colors.green('--debug')}                     Show debug output
+
+${colors.yellow('CHECK OPTIONS')}
+  check/read <target> [lines] or --lines <count>: integer 0 through ${MAX_CAPTURE_LINES}.
+  Zero captures the visible pane. Invalid CLI/configured counts are rejected.
 
 ${colors.yellow('REPLY / RESULT')}
   tmt reply <request-id> --receipt <receipt> (--message <text> | --file <path> | --stdin) [--json]

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -16,6 +16,7 @@ import { openIdentityRepository, type IdentityRepository } from '../storage/iden
 import { ExitCodes } from '../exits.js';
 import { TmuxDeliveryError } from '../message-delivery.js';
 import { decodeReplyReceipt } from '../reply-receipt.js';
+import { MAX_OBSERVER_TIMEOUT_SECONDS, MAX_TIMER_DELAY_MS } from '../domain/interaction-limits.js';
 import { cmdTalk } from './talk.js';
 
 const ENDPOINT = {
@@ -690,15 +691,75 @@ describe('cmdTalk durable completion', () => {
     expect(onlyAttempt(fixture.service).status).toBe('sent');
   });
 
+  it('accepts the maximum observer timeout and timer delay', async () => {
+    const root = temporaryDirectory('tmt-talk-timing-boundary-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const sleeps: number[] = [];
+    const tmux = createMockTmux({
+      onSend: (message) =>
+        submitFor(fixture.service, attemptFromInstruction(fixture.service, message), 'boundary'),
+    });
+    const ctx = createContext(root, {
+      tmux,
+      flags: {
+        delay: MAX_TIMER_DELAY_MS / 1000,
+        timeout: MAX_OBSERVER_TIMEOUT_SECONDS,
+      },
+    });
+
+    await cmdTalk(ctx, 'claude', 'Hello', {
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
+    });
+
+    expect(sleeps).toEqual([MAX_TIMER_DELAY_MS]);
+    expect(tmux.sends).toHaveLength(1);
+    expect(onlyAttempt(fixture.service).status).toBe('sent');
+  });
+
+  it('does not validate wait-only timing when detached', async () => {
+    const root = temporaryDirectory('tmt-talk-detached-timing-');
+    const fixture = requestFixture(createPaths(root).databaseFile);
+    const tmux = createMockTmux();
+    const ctx = createContext(root, {
+      tmux,
+      flags: { detach: true, timeout: 0 },
+      config: createConfig({ pollInterval: 0 }),
+    });
+
+    await cmdTalk(ctx, 'claude', 'Detached');
+
+    expect(tmux.sends).toHaveLength(1);
+    expect(onlyAttempt(fixture.service).status).toBe('sent');
+  });
+
   it.each([
     { name: 'zero timeout', flags: { timeout: 0 } },
+    {
+      name: 'over-limit timeout',
+      flags: { timeout: MAX_OBSERVER_TIMEOUT_SECONDS + 0.001 },
+    },
     { name: 'infinite timeout', flags: { timeout: Infinity } },
     { name: 'negative delay', flags: { delay: -1 } },
     { name: 'non-finite delay', flags: { delay: Number.NaN } },
     { name: 'infinite delay', flags: { delay: Infinity } },
+    {
+      name: 'over-limit delay',
+      flags: { delay: (MAX_TIMER_DELAY_MS + 1) / 1000 },
+    },
     { name: 'zero poll interval', config: { pollInterval: 0 } },
     { name: 'non-finite poll interval', config: { pollInterval: Number.NaN } },
     { name: 'non-finite enter delay', config: { pasteEnterDelayMs: Number.NaN } },
+    {
+      name: 'over-limit enter delay',
+      config: { pasteEnterDelayMs: MAX_TIMER_DELAY_MS + 1 },
+    },
+    {
+      name: 'over-limit enter delay while detached',
+      flags: { detach: true },
+      config: { pasteEnterDelayMs: MAX_TIMER_DELAY_MS + 1 },
+    },
   ])('rejects invalid $name before send or request preparation', async ({ flags, config }) => {
     const root = temporaryDirectory('tmt-talk-invalid-timing-');
     requestFixture(createPaths(root).databaseFile);

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -20,9 +20,11 @@ import { PreambleContentError } from '../domain/preamble.js';
 import { identityAwareTmux } from '../identity-service.js';
 import { TmuxDeliveryError } from '../message-delivery.js';
 import { buildDurableReplyInstruction } from '../talk-instruction.js';
-
-const MAX_OBSERVER_TIMEOUT_SECONDS = 24 * 60 * 60;
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
+import {
+  isValidObserverTimeoutSeconds,
+  isValidPollIntervalSeconds,
+  isValidTimerDelayMs,
+} from '../domain/interaction-limits.js';
 
 export interface TalkRuntime {
   readonly now?: () => number;
@@ -186,18 +188,13 @@ function validateTiming(
   pollIntervalSeconds: number,
   enterDelayMs: number
 ): void {
-  if (
-    waitEnabled &&
-    (!Number.isFinite(timeoutSeconds) ||
-      timeoutSeconds <= 0 ||
-      timeoutSeconds > MAX_OBSERVER_TIMEOUT_SECONDS)
-  ) {
+  if (waitEnabled && !isValidObserverTimeoutSeconds(timeoutSeconds)) {
     throw new Error('Talk timeout must be finite, positive, and no greater than 24 hours.');
   }
-  if (waitEnabled && (!Number.isFinite(pollIntervalSeconds) || pollIntervalSeconds <= 0)) {
+  if (waitEnabled && !isValidPollIntervalSeconds(pollIntervalSeconds)) {
     throw new Error('The configured poll interval must be finite and positive.');
   }
-  if (!Number.isFinite(enterDelayMs) || enterDelayMs < 0 || enterDelayMs > MAX_TIMER_DELAY_MS) {
+  if (!isValidTimerDelayMs(enterDelayMs)) {
     throw new Error(
       'The configured paste-enter delay must be finite, non-negative, and within the timer limit.'
     );
@@ -206,11 +203,7 @@ function validateTiming(
 
 function validateDelay(delaySeconds: number | undefined): void {
   if (delaySeconds === undefined) return;
-  if (
-    !Number.isFinite(delaySeconds) ||
-    delaySeconds < 0 ||
-    delaySeconds * 1000 > MAX_TIMER_DELAY_MS
-  ) {
+  if (!isValidTimerDelayMs(delaySeconds * 1000)) {
     throw new Error('Talk delay must be finite, non-negative, and within the timer limit.');
   }
 }

--- a/src/domain/interaction-limits.test.ts
+++ b/src/domain/interaction-limits.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_CAPTURE_LINES,
+  MAX_OBSERVER_TIMEOUT_SECONDS,
+  MAX_TIMER_DELAY_MS,
+  isValidCaptureLines,
+  isValidObserverTimeoutSeconds,
+  isValidPollIntervalSeconds,
+  isValidTimerDelayMs,
+} from './interaction-limits.js';
+
+describe('interaction numeric limits', () => {
+  it('keeps the external timer and capture ceilings explicit', () => {
+    expect(MAX_CAPTURE_LINES).toBe(2_147_483_647);
+    expect(MAX_OBSERVER_TIMEOUT_SECONDS).toBe(86_400);
+    expect(MAX_TIMER_DELAY_MS).toBe(2_147_483_647);
+  });
+
+  it.each([0, MAX_CAPTURE_LINES])('accepts capture line boundary %s', (value) => {
+    expect(isValidCaptureLines(value)).toBe(true);
+  });
+
+  it.each([-1, MAX_CAPTURE_LINES + 1, 1.5, Infinity, '10', null])(
+    'rejects invalid capture lines %s',
+    (value) => {
+      expect(isValidCaptureLines(value)).toBe(false);
+    }
+  );
+
+  it.each([1, MAX_OBSERVER_TIMEOUT_SECONDS])('accepts timeout boundary %s', (value) => {
+    expect(isValidObserverTimeoutSeconds(value)).toBe(true);
+  });
+
+  it.each([0, -1, MAX_OBSERVER_TIMEOUT_SECONDS + 1, Infinity, Number.NaN, '30'])(
+    'rejects invalid observer timeout %s',
+    (value) => {
+      expect(isValidObserverTimeoutSeconds(value)).toBe(false);
+    }
+  );
+
+  it.each([Number.MIN_VALUE, 1, 0.001])('accepts positive poll interval %s', (value) => {
+    expect(isValidPollIntervalSeconds(value)).toBe(true);
+  });
+
+  it.each([0, -1, Infinity, Number.NaN, '1'])('rejects invalid poll interval %s', (value) => {
+    expect(isValidPollIntervalSeconds(value)).toBe(false);
+  });
+
+  it.each([0, MAX_TIMER_DELAY_MS, 0.5])('accepts timer delay boundary %s', (value) => {
+    expect(isValidTimerDelayMs(value)).toBe(true);
+  });
+
+  it.each([-1, MAX_TIMER_DELAY_MS + 1, Infinity, Number.NaN, '0'])(
+    'rejects invalid timer delay %s',
+    (value) => {
+      expect(isValidTimerDelayMs(value)).toBe(false);
+    }
+  );
+});

--- a/src/domain/interaction-limits.ts
+++ b/src/domain/interaction-limits.ts
@@ -1,0 +1,31 @@
+export const MAX_CAPTURE_LINES = 2_147_483_647;
+export const MAX_OBSERVER_TIMEOUT_SECONDS = 24 * 60 * 60;
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export function isValidCaptureLines(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= MAX_CAPTURE_LINES
+  );
+}
+
+export function isValidObserverTimeoutSeconds(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value > 0 &&
+    value <= MAX_OBSERVER_TIMEOUT_SECONDS
+  );
+}
+
+export function isValidPollIntervalSeconds(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+export function isValidTimerDelayMs(value: unknown): value is number {
+  return (
+    typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= MAX_TIMER_DELAY_MS
+  );
+}

--- a/test/e2e/capture-limits.e2e.test.ts
+++ b/test/e2e/capture-limits.e2e.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture } from './harness.js';
+
+describe.sequential('capture numeric contract', () => {
+  it('rejects an invalid loaded count without touching tmux or rewriting its config', async () => {
+    await withE2EFixture(async (fixture) => {
+      const configFile = path.join(fixture.globalDir, 'config.json');
+      const configBytes = JSON.stringify({ defaults: { captureLines: '12junk' }, unrelated: true });
+      fs.writeFileSync(configFile, configBytes);
+      const result = await fixture.runJsonCli<{ error: { code: string } }>(['check', 'missing'], {
+        withoutTmux: true,
+      });
+      expect(result).toMatchObject({
+        code: 1,
+        json: { error: { code: 'INVALID_CAPTURE_LINES' } },
+      });
+      expect(fs.readFileSync(configFile, 'utf8')).toBe(configBytes);
+      expect(fs.existsSync(path.join(fixture.globalDir, 'tmux-team.db'))).toBe(false);
+      expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+    });
+  });
+
+  it('rejects invalid counts before creating storage or invoking tmux', async () => {
+    await withE2EFixture(async (fixture) => {
+      const database = path.join(fixture.globalDir, 'tmux-team.db');
+      expect(fs.existsSync(database)).toBe(false);
+      const metadata = fixture.paneMetadata(fixture.pane);
+      for (const args of [
+        ['check', fixture.pane, '9'.repeat(400)],
+        ['read', fixture.pane, '--lines=2147483648'],
+        ['--lines', '2147483648', 'check', fixture.pane, '0'],
+      ]) {
+        const result = await fixture.runJsonCli<{ error: { code: string } }>(args, {
+          withoutTmux: true,
+        });
+        expect(result).toMatchObject({ code: 1, json: { error: { code: 'USAGE_ERROR' } } });
+      }
+      expect(fs.existsSync(database)).toBe(false);
+      expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+      expect(fixture.paneMetadata(fixture.pane)).toBe(metadata);
+    });
+  });
+
+  it('captures causal mock output at zero and the supported maximum without changing binding', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect((await fixture.runJsonCli(['name', 'CapturePeer'])).code).toBe(0);
+      const message = 'capture boundary response';
+      expect(
+        (await fixture.runJsonCli(['talk', 'CapturePeer', message, '--timeout', '10'])).code
+      ).toBe(0);
+      await fixture.waitForEvent((event) => event.event === 'summary' && event.message === message);
+      const metadata = fixture.paneMetadata(fixture.pane);
+      for (const [command, value] of [
+        ['check', '0'],
+        ['read', '2147483647'],
+      ] as const) {
+        const result = await fixture.runJsonCli<{ lines: number; output: string }>([
+          command,
+          'CapturePeer',
+          `--lines=${value}`,
+        ]);
+        expect(result.code).toBe(0);
+        expect(result.json?.lines).toBe(Number(value));
+        expect(result.json?.output).toContain(`mock-agent summary: ${message}`);
+      }
+      expect(fixture.paneMetadata(fixture.pane)).toBe(metadata);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Give capture and timing bounds one pure domain owner, reused by parser and runtime adapters.
- Reject invalid capture counts before target lookup, including configured values; preserve zero, valid output, timing units and detached behavior.
- Update help, architecture and the four shipped skill variants without changing provider names or inventing a new conversion framework.

Closes TMT-47. Numeric prerequisite only: TMT-22 option grammar, TMT-46 configuration ownership and TMT-29 source/package consolidation remain gated work.

## Architecture review

Primary reviewed all changed files, parser/dispatcher callers, check/talk lifecycle, shared predicates and existing test fixtures. Lexical parsing and public error translations remain adapter-owned. No storage, transport, transaction, teardown or schema changes. A proposed floating-point conversion helper was rejected after direct verification disproved the hypothesis; no clamping layer remains. Luna performed the required high-reasoning pattern audit and supplementary production review. Gemini remains blocked on its prior permission prompt; no new request was injected there.

## Verification

- `pnpm check`: passed.
- `pnpm test:run`: 51 files / 676 tests passed; 95.18% lines, 89.01% branches.
- `pnpm test:e2e`: 17 files / 75 tests passed locally in 236.94 seconds, using real isolated tmux and mock agents.
- Baseline runner regressions failed on three oversized capture paths before the fix.
- Removing the shared capture upper bound caused six expected failures across domain, parser, runner and command tests; restored before final full verification.
- New E2E checks prove invalid config preservation, no tmux/database effects on invalid argv, and causal mock output at zero and maximum counts.
- Shipped Markdown formatting passed. Existing frontmatter and links manually inspected; standalone skill validator could not run because its Python environment lacks PyYAML.

One local verification cycle before push. Required CI must pass on the reviewed head before merge; no bypass or publication.
