### PR TITLE
TMT-22: Consolidate command option grammar, help, and completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.23.2
+      - name: Install shell test dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y zsh
       - name: Activate pinned pnpm
         run: corepack enable && corepack prepare pnpm@10.33.0 --activate
       - name: Install dependencies

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -241,7 +241,7 @@ Check validates its effective capture count before target lookup: integers
 Invalid runtime counts return `INVALID_CAPTURE_LINES` (exit 1), without capture
 or reconciliation. These argument limits do not replace tmux's existing
 one-second timeout and 4 MiB output bound. Config loading/writing consolidation
-and command-option ownership remain TMT-46 and TMT-22 work respectively.
+remains TMT-46 work.
 
 The parser rejects retired `--wait`, talk `--lines`, and explicit
 `--timeout`/`--detach` combinations before Context effects. `send` follows the
@@ -379,6 +379,21 @@ cover direct literal imports/re-exports in maintained production sources; they
 are not a complete semantic dependency or dynamically computed-import analysis.
 
 ## CLI output and lifecycle
+
+The Commander registrations in `src/cli/parser.ts` own command arguments,
+aliases and option acceptance. Help and shell completion project that grammar
+instead of maintaining independent command/option inventories. Recognition of
+historically common options at the root preserves meaningful pre-command
+placement; the selected command still rejects unrelated options before Context
+creation. Command-local options remain local. Hidden retired or unsupported
+options are rejection contracts, not advertised capabilities.
+
+Parser diagnostics use parsed option values and sources rather than searching
+raw argv for flag-like strings. Literal payloads and option values do not enable
+JSON or debug output. Root help/version requests undergo the same option
+validation before text-only JSON rejection. Reply/result retain their narrow
+option contracts; an ignored `--config` path override is rejected rather than
+stored in the typed flags or silently changing configuration precedence.
 
 The invocation runner owns parsing, initialization, startup checks, dispatch and
 final disposal. Context remains the sole repository lifetime owner; the runner
@@ -536,11 +551,11 @@ These links identify owners of unresolved work, not permission to widen an
 unrelated PR. Update this section and the current map in the delivering PR when
 a gap is resolved; do not leave a permanent exception or label a proposal as shipped.
 
-| Gap                                                                                                  | Owning issue                                                                                                                                                           |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Numeric/flag validation needs hardening.                                                             | [TMT-22](https://linear.app/tigerpig-dev/issue/TMT-22)                                                                                                                 |
-| Shipped skill/help inventories drift; packed verification does not yet prove application migrations. | [TMT-29](https://linear.app/tigerpig-dev/issue/TMT-29)                                                                                                                 |
-| Non-tmux identity management, memory and durable inbox are future capabilities, not installed APIs.  | [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
+| Gap                                                                                                      | Owning issue                                                                                                                                                           |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Configuration defaults and loaded-setting validation remain split.                                       | [TMT-46](https://linear.app/tigerpig-dev/issue/TMT-46)                                                                                                                 |
+| Shipped skill/provider inventories drift; packed verification does not yet prove application migrations. | [TMT-29](https://linear.app/tigerpig-dev/issue/TMT-29)                                                                                                                 |
+| Non-tmux identity management, memory and durable inbox are future capabilities, not installed APIs.      | [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
 
 ## Maintenance contract
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,6 +41,11 @@ pnpm test:watch
 pnpm test:run
 ```
 
+The completion renderer tests execute both Bash and Zsh probes. Local test
+environments need `bash` and `zsh`; the unit-test CI job installs the Zsh
+package explicitly because the hosted runner shell set is not a project
+dependency guarantee.
+
 - Docker-backed CLI/tmux end-to-end tests:
 
 ```bash

--- a/plugins/tmux-team/commands/learn.md
+++ b/plugins/tmux-team/commands/learn.md
@@ -155,6 +155,22 @@ managed skill links then use the new bundled files automatically. Sending pane
 input is an external action and must be authorized by the user; preserve
 multiline text.
 
+## Command option scope
+
+Options apply only to commands that use them. `--timeout`, `--delay`,
+`--detach`, and `--no-preamble` belong to talk/send; `--lines` belongs to
+check/read; `--force` belongs to talk/send and install. Unrelated options
+and the unsupported `--config` path override fail with `USAGE_ERROR` before
+execution. Use `tmt help` for the command-specific option inventory.
+
+Meaningful common options may precede the command, such as
+`tmt --timeout 30 talk reviewer "Review this"`. Put command-local options
+such as reply `--receipt` or install `--dir` after their command. Use `--`
+before a positional message beginning with a hyphen, or equals syntax for
+an option value, such as `--message='--json is literal text'`. Literal text
+does not enable diagnostic flags. Reply/result accept only their documented
+options; `--verbose` and `--debug` are not supported there.
+
 ## View and install the bundled skill
 
 `tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`

--- a/plugins/tmux-team/commands/team.md
+++ b/plugins/tmux-team/commands/team.md
@@ -123,6 +123,22 @@ do not complete a request. Same-pane input serialization is not guaranteed.
 - Preserve multiline messages and do not send pane input without authorization
 - After receiving a response, summarize it for the user
 
+## Command option scope
+
+Options apply only to commands that use them. `--timeout`, `--delay`,
+`--detach`, and `--no-preamble` belong to talk/send; `--lines` belongs to
+check/read; `--force` belongs to talk/send and install. Unrelated options
+and the unsupported `--config` path override fail with `USAGE_ERROR` before
+execution. Use `tmt help` for the command-specific option inventory.
+
+Meaningful common options may precede the command, such as
+`tmt --timeout 30 talk reviewer "Review this"`. Put command-local options
+such as reply `--receipt` or install `--dir` after their command. Use `--`
+before a positional message beginning with a hyphen, or equals syntax for
+an option value, such as `--message='--json is literal text'`. Literal text
+does not enable diagnostic flags. Reply/result accept only their documented
+options; `--verbose` and `--debug` are not supported there.
+
 ## View and install the bundled skill
 
 `tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -244,6 +244,22 @@ tmux-team talk codex "Review this authentication code" --json
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.
 
+## Command option scope
+
+Options apply only to commands that use them. `--timeout`, `--delay`,
+`--detach`, and `--no-preamble` belong to talk/send; `--lines` belongs to
+check/read; `--force` belongs to talk/send and install. Unrelated options
+and the unsupported `--config` path override fail with `USAGE_ERROR` before
+execution. Use `tmt help` for the command-specific option inventory.
+
+Meaningful common options may precede the command, such as
+`tmt --timeout 30 talk reviewer "Review this"`. Put command-local options
+such as reply `--receipt` or install `--dir` after their command. Use `--`
+before a positional message beginning with a hyphen, or equals syntax for
+an option value, such as `--message='--json is literal text'`. Literal text
+does not enable diagnostic flags. Reply/result accept only their documented
+options; `--verbose` and `--debug` are not supported there.
+
 ## View and install the bundled skill
 
 `tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -266,6 +266,22 @@ identity/profile. Do not delete old user files as a migration workaround.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.
 
+## Command option scope
+
+Options apply only to commands that use them. `--timeout`, `--delay`,
+`--detach`, and `--no-preamble` belong to talk/send; `--lines` belongs to
+check/read; `--force` belongs to talk/send and install. Unrelated options
+and the unsupported `--config` path override fail with `USAGE_ERROR` before
+execution. Use `tmt help` for the command-specific option inventory.
+
+Meaningful common options may precede the command, such as
+`tmt --timeout 30 talk reviewer "Review this"`. Put command-local options
+such as reply `--receipt` or install `--dir` after their command. Use `--`
+before a positional message beginning with a hyphen, or equals syntax for
+an option value, such as `--message='--json is literal text'`. Literal text
+does not enable diagnostic flags. Reply/result accept only their documented
+options; `--verbose` and `--debug` are not supported there.
+
 ## View and install the bundled skill
 
 `tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -267,6 +267,22 @@ identity/profile. Do not delete old user files as a migration workaround.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.
 
+## Command option scope
+
+Options apply only to commands that use them. `--timeout`, `--delay`,
+`--detach`, and `--no-preamble` belong to talk/send; `--lines` belongs to
+check/read; `--force` belongs to talk/send and install. Unrelated options
+and the unsupported `--config` path override fail with `USAGE_ERROR` before
+execution. Use `tmt help` for the command-specific option inventory.
+
+Meaningful common options may precede the command, such as
+`tmt --timeout 30 talk reviewer "Review this"`. Put command-local options
+such as reply `--receipt` or install `--dir` after their command. Use `--`
+before a positional message beginning with a hyphen, or equals syntax for
+an option value, such as `--message='--json is literal text'`. Literal text
+does not enable diagnostic flags. Reply/result accept only their documented
+options; `--verbose` and `--debug` are not supported there.
+
 ## View and install the bundled skill
 
 `tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -242,6 +242,22 @@ after sending, and `--delay <seconds>` to delay sending.
 
 Install integrations with `tmt install` (auto-detects supported agents) or `tmt install all --force` to refresh managed links. Upgrade the CLI with `tmt upgrade`; managed links automatically use the updated bundled skill. Run install when an integration is missing or has drifted.
 
+## Command option scope
+
+Options apply only to commands that use them. `--timeout`, `--delay`,
+`--detach`, and `--no-preamble` belong to talk/send; `--lines` belongs to
+check/read; `--force` belongs to talk/send and install. Unrelated options
+and the unsupported `--config` path override fail with `USAGE_ERROR` before
+execution. Use `tmt help` for the command-specific option inventory.
+
+Meaningful common options may precede the command, such as
+`tmt --timeout 30 talk reviewer "Review this"`. Put command-local options
+such as reply `--receipt` or install `--dir` after their command. Use `--`
+before a positional message beginning with a hyphen, or equals syntax for
+an option value, such as `--message='--json is literal text'`. Literal text
+does not enable diagnostic flags. Reply/result accept only their documented
+options; `--verbose` and `--debug` are not supported there.
+
 ## View and install the bundled skill
 
 `tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`

--- a/src/cli-contract.test.ts
+++ b/src/cli-contract.test.ts
@@ -155,6 +155,104 @@ describe('real CLI process contract', () => {
   );
 
   it(
+    'rejects ignored options before creating storage or changing sandbox files',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const before = fileSnapshot(sandbox.root);
+        for (const args of [
+          ['list', '--config', '/tmp/ignored.json', '--json'],
+          ['--config', '/tmp/ignored.json', 'list', '--json'],
+          ['list', '--timeout', '1s', '--json'],
+          ['--timeout', '1s', 'list', '--json'],
+          ['role', 'show', '--timeout', '1s', '--json'],
+          ['--timeout', '1s', 'role', 'show', '--json'],
+        ]) {
+          const result = await runCli(sandbox, args);
+          expect(result.status).toBe(1);
+          expectError(result, 'USAGE_ERROR');
+          expect(fileSnapshot(sandbox.root)).toEqual(before);
+          expect(existsSync(sandbox.database)).toBe(false);
+        }
+      })
+  );
+
+  it(
+    'validates invalid options before root help or version and preserves JSON errors',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const before = fileSnapshot(sandbox.root);
+        for (const args of [
+          ['--json', 'help', '--timeout', '1s'],
+          ['--json', '--help', '--timeout', '1s'],
+          ['--json', '--version', '--timeout', '1s'],
+        ]) {
+          const result = await runCli(sandbox, args);
+          expect(result.status).toBe(1);
+          expectError(result, 'USAGE_ERROR');
+          expect(fileSnapshot(sandbox.root)).toEqual(before);
+          expect(existsSync(sandbox.database)).toBe(false);
+        }
+      })
+  );
+
+  it('keeps JSON leaf grammar failures before context creation', { timeout: 10_000 }, () =>
+    withSandbox(async (sandbox) => {
+      const before = fileSnapshot(sandbox.root);
+      for (const args of [
+        ['--json', 'role', 'set'],
+        ['--json', 'role', 'set', '--file', 'profile.md', '--', '--file=--json'],
+      ]) {
+        const result = await runCli(sandbox, args);
+        expect(result.status).toBe(1);
+        expectError(result, 'USAGE_ERROR');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+        expect(existsSync(sandbox.database)).toBe(false);
+      }
+    })
+  );
+
+  it('does not treat --json after -- as a JSON diagnostic flag', { timeout: 10_000 }, () =>
+    withSandbox(async (sandbox) => {
+      const before = fileSnapshot(sandbox.root);
+      const result = await runCli(sandbox, ['list', '--', '--json', 'extra']);
+      expect(result.status).toBe(1);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toMatch(/too many arguments|Usage/i);
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect(existsSync(sandbox.database)).toBe(false);
+    })
+  );
+
+  it('keeps a literal --file=--json body in a human grammar failure', { timeout: 10_000 }, () =>
+    withSandbox(async (sandbox) => {
+      const before = fileSnapshot(sandbox.root);
+      const result = await runCli(sandbox, ['role', 'set', 'body', '--file=--json']);
+      expect(result.status).toBe(1);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toMatch(/Usage|file/i);
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect(existsSync(sandbox.database)).toBe(false);
+    })
+  );
+
+  it('does not reinterpret --json as a missing --config value', { timeout: 10_000 }, () =>
+    withSandbox(async (sandbox) => {
+      const before = fileSnapshot(sandbox.root);
+      const result = await runCli(sandbox, ['learn', '--config', '--json']);
+      expect(result.status).toBe(1);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toMatch(/config|option|Usage/i);
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect(existsSync(sandbox.database)).toBe(false);
+    })
+  );
+
+  it(
     'reports malformed configuration before initialization and preserves the file',
     { timeout: 10_000 },
     () =>
@@ -321,6 +419,7 @@ describe('real CLI process contract', () => {
           ['help', '--json'],
           ['--json', '--help'],
           ['--version', '--json'],
+          ['--json', '--version'],
           ['completion', 'bash', '--json'],
           ['learn', '--json'],
         ];

--- a/src/cli-runner.test.ts
+++ b/src/cli-runner.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Context, UI } from './types.js';
 import { ExitCodes } from './exits.js';
+import type { ParsedArgs } from './cli/parser.js';
 
 function baseContext(): Context {
   return {
@@ -21,22 +22,32 @@ function baseContext(): Context {
 
 async function loadRunner(
   options: {
-    dispatch?: (ctx: Context) => Promise<void> | void;
+    dispatch?: (ctx: Context, parsed: ParsedArgs) => Promise<void> | void;
     startup?: (ctx: Context) => Promise<void> | void;
     dispose?: () => void;
   } = {}
 ) {
   vi.resetModules();
-  const createContext = vi.fn((contextOptions: { ui: UI; exit: Context['exit'] }) => {
-    const ctx = baseContext();
-    ctx.ui = contextOptions.ui;
-    ctx.exit = contextOptions.exit;
-    ctx.dispose = options.dispose ?? ctx.dispose;
-    return ctx;
-  });
+  const createContext = vi.fn(
+    (contextOptions: {
+      argv: string[];
+      flags: Context['flags'];
+      capability: 'none' | 'storage' | 'tmux';
+      ui: UI;
+      exit: Context['exit'];
+    }) => {
+      const ctx = baseContext();
+      ctx.argv = contextOptions.argv;
+      ctx.flags = contextOptions.flags;
+      ctx.ui = contextOptions.ui;
+      ctx.exit = contextOptions.exit;
+      ctx.dispose = options.dispose ?? ctx.dispose;
+      return ctx;
+    }
+  );
   vi.doMock('./context.js', () => ({ ExitCodes, createContext }));
   vi.doMock('./cli/application.js', () => ({
-    dispatchCommand: vi.fn((ctx: Context) => options.dispatch?.(ctx)),
+    dispatchCommand: vi.fn((ctx: Context, parsed: ParsedArgs) => options.dispatch?.(ctx, parsed)),
   }));
   vi.doMock('./update-check.js', () => ({
     runStartupChecks: vi.fn((ctx: Context) => options.startup?.(ctx)),
@@ -95,6 +106,99 @@ describe('CLI runner lifecycle', () => {
       expect(createContext).not.toHaveBeenCalled();
       expect(startup).not.toHaveBeenCalled();
       expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      output.restore();
+    }
+  });
+
+  it.each([
+    ['--json', 'list', '--config', '/tmp/ignored.json'],
+    ['--json', '--config', '/tmp/ignored.json', 'list'],
+    ['--json', 'list', '--timeout', '1s'],
+    ['--json', '--timeout', '1s', 'list'],
+    ['--json', 'role', 'show', '--timeout', '1s'],
+    ['--json', '--timeout', '1s', 'role', 'show'],
+  ])('rejects ignored command options before any lifecycle effect: %j', async (...argv) => {
+    const output = captureStdout();
+    const startup = vi.fn();
+    const dispatch = vi.fn();
+    try {
+      const { runCli, createContext } = await loadRunner({ startup, dispatch });
+      await expect(runCli(argv)).resolves.toBe(1);
+      expect(document(output.chunks)).toMatchObject({ error: { code: 'USAGE_ERROR' } });
+      expect(createContext).not.toHaveBeenCalled();
+      expect(startup).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      output.restore();
+    }
+  });
+
+  it.each([
+    ['--json', 'help', '--timeout', '1s'],
+    ['--json', '--help', '--timeout', '1s'],
+    ['--json', '--version', '--timeout', '1s'],
+  ])('validates invalid options before special output: %j', async (...argv) => {
+    const output = captureStdout();
+    const startup = vi.fn();
+    const dispatch = vi.fn();
+    try {
+      const { runCli, createContext } = await loadRunner({ startup, dispatch });
+      await expect(runCli(argv)).resolves.toBe(1);
+      expect(document(output.chunks)).toMatchObject({ error: { code: 'USAGE_ERROR' } });
+      expect(createContext).not.toHaveBeenCalled();
+      expect(startup).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      output.restore();
+    }
+  });
+
+  it.each([
+    ['--json', 'role', 'set'],
+    ['--json', 'role', 'set', '--file', 'profile.md', '--', '--file=--json'],
+  ])('keeps JSON usage errors meaningful for leaf grammar failures: %j', async (...argv) => {
+    const output = captureStdout();
+    const startup = vi.fn();
+    const dispatch = vi.fn();
+    try {
+      const { runCli, createContext } = await loadRunner({ startup, dispatch });
+      await expect(runCli(argv)).resolves.toBe(1);
+      expect(document(output.chunks)).toMatchObject({ error: { code: 'USAGE_ERROR' } });
+      expect(createContext).not.toHaveBeenCalled();
+      expect(startup).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      output.restore();
+    }
+  });
+
+  it('does not interpret option-looking payload after -- as runner flags', async () => {
+    const output = captureStdout();
+    const dispatch = vi.fn();
+    try {
+      const { runCli, createContext } = await loadRunner({ dispatch });
+      await expect(runCli(['talk', 'Alice', '--', '--timeout --json'])).resolves.toBe(0);
+      expect(createContext).toHaveBeenCalledOnce();
+      expect(dispatch).toHaveBeenCalledOnce();
+      expect(createContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          argv: ['talk', 'Alice', '--', '--timeout --json'],
+          flags: { json: false, verbose: false },
+        })
+      );
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          flags: { json: false, verbose: false },
+          invocation: {
+            kind: 'talk',
+            target: { value: 'Alice', kind: 'identity', explicit: false },
+            message: '--timeout --json',
+          },
+        })
+      );
+      expect(output.chunks).toEqual([]);
     } finally {
       output.restore();
     }
@@ -441,11 +545,14 @@ describe('CLI runner lifecycle', () => {
     }
   });
 
-  it('rejects JSON text-only commands before Context creation', async () => {
+  it.each([
+    ['--json', 'help'],
+    ['--json', '--version'],
+  ])('rejects JSON text-only commands before Context creation: %j', async (...argv) => {
     const output = captureStdout();
     try {
       const { runCli, createContext } = await loadRunner();
-      await expect(runCli(['--json', 'help'])).resolves.toBe(1);
+      await expect(runCli(argv)).resolves.toBe(1);
       expect(document(output.chunks)).toMatchObject({ error: { code: 'JSON_UNSUPPORTED' } });
       expect(createContext).not.toHaveBeenCalled();
     } finally {

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CliParseError, parseArgs } from './parser.js';
+import { CliParseError, getCliCommandMetadata, parseArgs } from './parser.js';
 import { encodeReplyReceipt } from '../reply-receipt.js';
 import {
   MAX_CAPTURE_LINES,
@@ -121,6 +121,63 @@ describe('declarative CLI parser', () => {
   it('applies no-preamble regardless of whether it appears before or after talk', () => {
     expect(parseArgs(['--no-preamble', 'talk', 'claude', 'hello']).flags.noPreamble).toBe(true);
     expect(parseArgs(['talk', 'claude', 'hello', '--no-preamble']).flags.noPreamble).toBe(true);
+  });
+
+  it('does not reinterpret a required option value as another option', () => {
+    const parsed = parseArgs(['talk', 'peer', '--team', '--no-preamble', 'message']);
+    expect(parsed.invocation).toMatchObject({ kind: 'talk', message: 'message' });
+    expect(parsed.flags.noPreamble).toBeUndefined();
+    expect(parsed.metadata.unsupportedTeam).toBe(true);
+  });
+
+  it('rejects the unconsumed config option at the selected command boundary', () => {
+    expect(() => parseArgs(['learn', '--config', '/tmp/tmt.json'])).toThrow(
+      "Unknown option '--config' for learn."
+    );
+    expect(() => parseArgs(['role', 'show', '--timeout', '2'])).toThrow(
+      "Unknown option '--timeout' for show."
+    );
+  });
+
+  it('enforces command-local option ownership while retaining aliases and root placement', () => {
+    expect(parseArgs(['talk', 'peer', 'message', '--force']).flags.force).toBe(true);
+    expect(parseArgs(['install', '--force']).flags.force).toBe(true);
+    expect(parseArgs(['--timeout', '2', 'send', 'peer', 'message']).flags.timeout).toBe(2);
+    expect(parseArgs(['read', 'peer', '--lines', '0']).invocation).toMatchObject({ lines: 0 });
+    for (const args of [
+      ['list', '--force'],
+      ['name', 'Alice', '--force'],
+      ['role', 'show', '--force'],
+      ['list', '--delay', '1'],
+      ['role', 'show', '--no-preamble'],
+      ['read', 'peer', '--timeout', '2'],
+    ]) {
+      expect(() => parseArgs(args)).toThrow(CliParseError);
+    }
+  });
+
+  it('projects help and completion metadata from the Commander tree', () => {
+    const metadata = getCliCommandMetadata();
+    const talk = metadata.commands.find((command) => command.name === 'talk');
+    const check = metadata.commands.find((command) => command.name === 'check');
+    expect(talk?.description).toBe('Send a message to an identity or pane');
+    expect(check?.description).toBe('Capture output from an agent pane');
+    expect(talk?.options.some((option) => option.long === '--timeout')).toBe(true);
+    expect(talk?.options.some((option) => option.long === '--lines')).toBe(false);
+    expect(check?.options.some((option) => option.long === '--lines')).toBe(true);
+    expect(
+      metadata.commands
+        .find((command) => command.name === 'learn')
+        ?.options.some((option) => option.long === '--config')
+    ).toBe(false);
+    expect(metadata.options.some((option) => option.long === '--timeout')).toBe(true);
+    expect(metadata.options.some((option) => option.long === '--config')).toBe(true);
+    expect(metadata.options.find((option) => option.long === '--config')).toMatchObject({
+      hidden: true,
+      rootRecognized: true,
+      rootAllowed: false,
+    });
+    expect(metadata.commands.find((command) => command.name === 'team')?.hidden).toBe(true);
   });
 
   it.each([
@@ -259,6 +316,36 @@ describe('declarative CLI parser', () => {
     expect(() => parseArgs(['--json', 'config', 'set', 'mode'])).toThrow(CliParseError);
   });
 
+  it('does not mistake a later command-shaped operand for the unknown command', () => {
+    expect(() => parseArgs(['no-command', 'talk'])).toThrow(
+      "Unknown command: no-command. Run 'tmux-team help' for usage."
+    );
+    expect(() => parseArgs(['--timeout', 'check', 'talk', 'peer', 'message'])).toThrow(
+      'Invalid time format: check'
+    );
+    expect(() => parseArgs(['send'])).toThrow('Usage: tmux-team send <target> <message>');
+  });
+
+  it('rejects command-local options before a command and preserves diagnostic flags', () => {
+    for (const args of [
+      ['--receipt', 'receipt', 'reply', 'request-1'],
+      ['--dir', '/tmp/skills', 'install'],
+      ['--identity', 'Alice', 'role', 'show'],
+      ['--bogus', 'hello'],
+    ]) {
+      expect(() => parseArgs(args)).toThrow(`unknown option '${args[0]}'`);
+    }
+    try {
+      parseArgs(['--json', 'list', '--nope', '--debug', '--verbose']);
+      throw new Error('expected parse failure');
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'CliParseError',
+        flags: { json: true, debug: true, verbose: true },
+      });
+    }
+  });
+
   it('supports top-level help and version with options before the special flag', () => {
     expect(parseArgs(['--json', '--help'])).toMatchObject({
       invocation: { kind: 'help', showIntro: false },
@@ -279,32 +366,12 @@ describe('declarative CLI parser', () => {
     });
   });
 
-  it('normalizes all common flags and records unsupported team scope', () => {
-    const parsed = parseArgs([
-      '--json',
-      '--verbose',
-      '--debug',
-      '--force',
-      '--config',
-      '/tmp/tmt.json',
-      '--delay',
-      '250ms',
-      '--timeout',
-      '3s',
-      '--detach',
-      '--team',
-      'legacy',
-      'list',
-    ]);
+  it('normalizes true globals and records unsupported team scope', () => {
+    const parsed = parseArgs(['--json', '--verbose', '--debug', '--team', 'legacy', 'list']);
     expect(parsed.flags).toMatchObject({
       json: true,
       verbose: true,
       debug: true,
-      force: true,
-      config: '/tmp/tmt.json',
-      delay: 0.25,
-      timeout: 3,
-      detach: true,
     });
     expect(parsed.metadata).toMatchObject({ unsupportedTeam: true, commandPath: ['list'] });
   });

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -1,4 +1,4 @@
-import { Command, CommanderError } from 'commander';
+import { Command, CommanderError, Help, Option } from 'commander';
 import { isPaneTarget } from '../domain/names.js';
 import type { Flags } from '../types.js';
 import type { IdentitySelector } from '../identity-context.js';
@@ -51,11 +51,17 @@ export interface ParsedArgs {
 
 export class CliParseError extends Error {
   readonly flags: Flags;
+  readonly commanderCode?: string;
 
-  constructor(message: string, flags: Flags = { json: false, verbose: false }) {
+  constructor(
+    message: string,
+    flags: Flags = { json: false, verbose: false },
+    commanderCode?: string
+  ) {
     super(message);
     this.name = 'CliParseError';
     this.flags = flags;
+    this.commanderCode = commanderCode;
   }
 }
 
@@ -82,6 +88,8 @@ interface CommandOptions extends CommonOptions {
   message?: string;
   dir?: string;
   skill?: boolean;
+  help?: boolean;
+  version?: boolean;
 }
 
 interface Capture {
@@ -89,6 +97,163 @@ interface Capture {
   command?: Command;
   commandPath: string[];
   unsupportedTeam: boolean;
+}
+
+interface OptionSpec {
+  readonly flags: string;
+  readonly description?: string;
+  readonly hidden?: boolean;
+  readonly rootRecognized?: boolean;
+  readonly rootAllowed?: boolean;
+}
+
+const optionSpecs = {
+  json: {
+    flags: '--json',
+    description: 'Output in JSON format',
+    rootRecognized: true,
+    rootAllowed: true,
+  },
+  verbose: {
+    flags: '-v, --verbose',
+    description: 'Show detailed output',
+    rootRecognized: true,
+    rootAllowed: true,
+  },
+  debug: {
+    flags: '--debug',
+    description: 'Show diagnostic output',
+    rootRecognized: true,
+    rootAllowed: true,
+  },
+  force: {
+    flags: '-f, --force',
+    description: 'Skip warnings',
+    rootRecognized: true,
+  },
+  config: { flags: '--config <path>', hidden: true, rootRecognized: true },
+  delay: { flags: '--delay <time>', description: 'Wait before sending', rootRecognized: true },
+  wait: {
+    flags: '--wait',
+    description: 'Retired; talk waits by default',
+    hidden: true,
+    rootRecognized: true,
+  },
+  detach: {
+    flags: '--detach',
+    description: 'Return after sending',
+    rootRecognized: true,
+  },
+  timeout: {
+    flags: '--timeout <time>',
+    description: 'Bound durable waiting',
+    rootRecognized: true,
+  },
+  lines: { flags: '--lines <count>', description: 'Lines to capture', rootRecognized: true },
+  noPreamble: {
+    flags: '--no-preamble',
+    description: 'Skip agent preamble',
+    rootRecognized: true,
+  },
+  team: { flags: '--team <team>', hidden: true, rootRecognized: true, rootAllowed: true },
+  help: { flags: '-h, --help', hidden: true, rootRecognized: true, rootAllowed: true },
+  version: { flags: '-V, --version', hidden: true, rootRecognized: true, rootAllowed: true },
+  global: { flags: '-g, --global', description: 'Use global settings' },
+  identity: { flags: '--identity <name>', description: 'Select an explicit identity' },
+  file: { flags: '--file <path>', description: 'Read content from a file' },
+  receipt: { flags: '--receipt <receipt>', description: 'Receipt from the talk instruction' },
+  stdin: { flags: '--stdin', description: 'Read content from standard input' },
+  message: { flags: '--message <text>', description: 'Submit inline content' },
+  dir: { flags: '--dir <path>', description: 'Install skills in this directory' },
+  skill: { flags: '--skill', description: 'Print the bundled universal skill' },
+} satisfies Record<string, OptionSpec>;
+
+type OptionName = keyof typeof optionSpecs;
+
+const optionMetadata = new WeakMap<Option, OptionSpec>();
+const optionSpecNames = new Map<OptionSpec, OptionName>(
+  Object.entries(optionSpecs).map(([name, spec]) => [spec, name as OptionName])
+);
+
+function option(spec: OptionSpec): Option {
+  const result = new Option(spec.flags, spec.description);
+  if (spec.hidden) result.hideHelp();
+  return result;
+}
+
+function registerOptions(
+  command: Command,
+  names: readonly OptionName[],
+  mandatoryNames: readonly OptionName[] = []
+): void {
+  for (const name of names) {
+    const registered = option(optionSpecs[name]);
+    if (mandatoryNames.includes(name)) registered.makeOptionMandatory();
+    command.addOption(registered);
+    optionMetadata.set(registered, optionSpecs[name]);
+  }
+}
+
+export interface CliCommandOptionMetadata {
+  readonly name: string;
+  readonly flags: string;
+  readonly short?: string;
+  readonly long?: string;
+  readonly required: boolean;
+  readonly optional: boolean;
+  readonly variadic: boolean;
+  readonly description?: string;
+  readonly hidden: boolean;
+  readonly rootRecognized: boolean;
+  readonly rootAllowed: boolean;
+}
+
+export interface CliCommandArgumentMetadata {
+  readonly name: string;
+  readonly required: boolean;
+  readonly variadic: boolean;
+  readonly description: string;
+}
+
+export interface CliCommandMetadata {
+  readonly name: string;
+  readonly aliases: readonly string[];
+  readonly hidden: boolean;
+  readonly description: string;
+  readonly usage: string;
+  readonly arguments: readonly CliCommandArgumentMetadata[];
+  readonly options: readonly CliCommandOptionMetadata[];
+  readonly commands: readonly CliCommandMetadata[];
+}
+
+function projectCommand(command: Command, helper: Help, parent?: Command): CliCommandMetadata {
+  return {
+    name: command.name(),
+    aliases: command.aliases(),
+    hidden: parent ? !helper.visibleCommands(parent).includes(command) : false,
+    description: command.description(),
+    usage: command.usage(),
+    arguments: command.registeredArguments.map((argument) => ({
+      name: argument.name(),
+      required: argument.required,
+      variadic: argument.variadic,
+      description: argument.description,
+    })),
+    options: command.options.map((registered) => ({
+      name: registered.attributeName(),
+      flags: registered.flags,
+      short: registered.short,
+      long: registered.long,
+      required: registered.required,
+      optional: registered.optional,
+      variadic: registered.variadic,
+      description: registered.description,
+      hidden: registered.hidden,
+      rootRecognized: optionMetadata.get(registered)?.rootRecognized === true,
+      rootAllowed: optionMetadata.get(registered)?.rootAllowed === true,
+    })),
+    commands: command.commands.map((child) => projectCommand(child, helper, command)),
+  };
 }
 
 function parseTime(value: string): number {
@@ -118,31 +283,30 @@ function parseLines(value: string): number {
   return lines;
 }
 
-function flagsFrom(options: CommonOptions, argv: readonly string[] = []): Flags {
+function flagsFrom(options: CommonOptions): Flags {
   const flags: Flags = {
     json: options.json === true,
     verbose: options.verbose === true,
   };
   if (options.debug) flags.debug = true;
   if (options.force) flags.force = true;
-  if (options.config !== undefined) flags.config = options.config;
   if (options.delay !== undefined) flags.delay = parseTime(options.delay);
   if (options.detach) flags.detach = true;
   if (options.timeout !== undefined) flags.timeout = parseTime(options.timeout);
   if (options.lines !== undefined) flags.lines = parseLines(options.lines);
-  if (options.noPreamble || options.preamble === false || argv.includes('--no-preamble'))
-    flags.noPreamble = true;
+  if (options.noPreamble || options.preamble === false) flags.noPreamble = true;
   return flags;
 }
 
-function flagsFromArgv(argv: readonly string[]): Flags {
+function flagsFromOptions(options: CommonOptions): Flags {
   return {
-    json: argv.includes('--json'),
-    verbose: argv.includes('--verbose') || argv.includes('-v'),
+    json: options.json === true,
+    verbose: options.verbose === true,
+    ...(options.debug === true && { debug: true }),
   };
 }
 
-function compatibilityUsage(argv: readonly string[], message: string): string | undefined {
+function compatibilityUsage(commandName: string | undefined, message: string): string | undefined {
   if (!/missing required argument|too many arguments/.test(message)) return undefined;
   const usage: Record<string, string> = {
     name: 'Usage: tmux-team name <global-name>',
@@ -156,8 +320,9 @@ function compatibilityUsage(argv: readonly string[], message: string): string | 
     unbind: 'Usage: tmux-team unbind',
     role: 'Usage: tmux-team role show|set|clear [options]',
   };
-  const command = argv.find((token) => Object.prototype.hasOwnProperty.call(usage, token));
-  return command ? usage[command] : undefined;
+  return commandName && Object.prototype.hasOwnProperty.call(usage, commandName)
+    ? usage[commandName]
+    : undefined;
 }
 
 function selector(value: string, explicit: boolean): IdentitySelector {
@@ -194,23 +359,6 @@ function capabilityFor(invocation: ParsedInvocation): ParsedMetadata['capability
   }
 }
 
-function commonOptions(command: Command): Command {
-  command
-    .option('--json')
-    .option('-v, --verbose')
-    .option('--debug')
-    .option('-f, --force')
-    .option('--config <path>')
-    .option('--delay <time>')
-    .option('--wait')
-    .option('--detach')
-    .option('--timeout <time>')
-    .option('--lines <count>')
-    .option('--no-preamble')
-    .option('--team <team>');
-  return command;
-}
-
 function commandOptions(command: Command): CommandOptions {
   const options: CommandOptions = {};
   const chain: Command[] = [];
@@ -220,50 +368,92 @@ function commandOptions(command: Command): CommandOptions {
     current = current.parent;
   }
   for (const item of chain) Object.assign(options, item.opts() as CommandOptions);
+  // Commander consumes options shared by the root and a leaf through the
+  // root. Re-apply CLI-sourced values so a negated option's child default
+  // cannot overwrite a value supplied by the caller.
+  for (const item of chain) {
+    for (const registered of item.options) {
+      const name = registered.attributeName();
+      if (item.getOptionValueSource(name) === 'cli') {
+        (options as Record<string, unknown>)[name] = item.opts()[name];
+      }
+    }
+  }
   return options;
 }
 
+function optionAttribute(name: OptionName): string {
+  return option(optionSpecs[name]).attributeName();
+}
+
+function optionWasProvided(command: Command, name: string): boolean {
+  let current: Command | null = command;
+  while (current) {
+    if (current.getOptionValueSource(name) === 'cli') return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function rejectUnsupportedOptions(command: Command): void {
+  const allowed = new Set(
+    command.parent === null
+      ? command.options
+          .filter((item) => optionMetadata.get(item)?.rootAllowed === true)
+          .map((item) => item.attributeName())
+      : command.options.map((item) => item.attributeName())
+  );
+  const seen = new Set<string>();
+  let current: Command | null = command;
+  while (current) {
+    for (const item of current.options) {
+      const name = item.attributeName();
+      if (seen.has(name)) continue;
+      seen.add(name);
+      if (optionWasProvided(command, name) && !allowed.has(name)) {
+        throw new CliParseError(
+          `Unknown option '${item.long ?? item.flags}' for ${command.name()}.`
+        );
+      }
+    }
+    current = current.parent;
+  }
+}
+
+function registeredOptions(command: Command): readonly Option[] {
+  const result: Option[] = [];
+  const visit = (current: Command): void => {
+    result.push(...current.options);
+    for (const child of current.commands) visit(child);
+  };
+  visit(command);
+  return result;
+}
+
 function setupProgram(capture: Capture): Command {
-  const program = commonOptions(new Command()).name('tmux-team').helpOption(false);
+  const program = new Command().name('tmux-team').helpOption(false);
   program.exitOverride((error) => {
-    if (error instanceof CommanderError) throw new CliParseError(error.message);
+    if (error instanceof CommanderError)
+      throw new CliParseError(error.message, { json: false, verbose: false }, error.code);
     throw error;
   });
   program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  // These are root-owned parser controls. `config` is intentionally hidden
+  // and rejected by command validation because it has no runtime consumer.
+  registerOptions(program, ['help', 'version', 'config']);
 
-  const action = (command: Command, invocation: ParsedInvocation): void => {
-    const commandName = command.name();
-    if (optionWasProvided(command, 'wait')) {
-      throw new CliParseError(
-        'The --wait option is retired. talk waits for a durable reply by default; use --timeout or --detach.'
-      );
-    }
-    if ((commandName === 'talk' || commandName === 'send') && optionWasProvided(command, 'lines')) {
-      throw new CliParseError(
-        'The --lines option is only supported by check/read; talk retrieves the complete durable response.'
-      );
-    }
-    if (commandName === 'talk' || commandName === 'send') {
-      const options = commandOptions(command);
-      if (options.detach && optionWasProvided(command, 'timeout')) {
-        throw new CliParseError('Use either --timeout or --detach, not both.');
-      }
-      if (optionWasProvided(command, 'timeout') && options.timeout !== undefined) {
-        const timeoutSeconds = parseTime(options.timeout);
-        if (!isValidObserverTimeoutSeconds(timeoutSeconds)) {
-          throw new CliParseError(
-            'Talk timeout must be finite, positive, and no greater than 24 hours.'
-          );
-        }
-      }
-      if (optionWasProvided(command, 'delay') && options.delay !== undefined) {
-        const delaySeconds = parseTime(options.delay);
-        if (!isValidTimerDelayMs(delaySeconds * 1000)) {
-          throw new CliParseError('Talk delay exceeds the supported timer limit.');
-        }
-      }
-    }
-    capture.invocation = invocation;
+  const generalOptions: readonly OptionName[] = ['json', 'verbose', 'debug', 'wait', 'team'];
+  const talkOptions: readonly OptionName[] = [
+    ...generalOptions,
+    'force',
+    'delay',
+    'detach',
+    'timeout',
+    'noPreamble',
+  ];
+  const checkOptions: readonly OptionName[] = [...generalOptions, 'lines'];
+  const storageOptions: readonly OptionName[] = ['json'];
+  const captureCommand = (command: Command): void => {
     capture.command = command;
     const path: string[] = [];
     let current: Command | null = command;
@@ -272,68 +462,118 @@ function setupProgram(capture: Capture): Command {
       current = current.parent;
     }
     capture.commandPath = path;
-    capture.unsupportedTeam ||= Boolean(commandOptions(command).team);
   };
-  const leaf = <T extends Command>(command: T): T => {
-    commonOptions(command);
+  program.hook('preSubcommand', (_parent, command) => captureCommand(command));
+  const register = (command: Command, names: readonly OptionName[]): Command => {
+    registerOptions(command, names);
+    command.hook('preSubcommand', (_parent, subCommand) => captureCommand(subCommand));
     return command;
   };
-  const storageOnly = <T extends Command>(command: T): T => {
-    command.option('--json');
-    return command;
-  };
-  const optionWasProvided = (command: Command, name: string): boolean => {
-    let current: Command | null = command;
-    while (current) {
-      if (current.getOptionValueSource(name) === 'cli') return true;
-      current = current.parent;
+  const action = (command: Command, invocation: ParsedInvocation): void => {
+    const commandName = command.name();
+    if (optionWasProvided(command, optionAttribute('wait'))) {
+      throw new CliParseError(
+        'The --wait option is retired. talk waits for a durable reply by default; use --timeout or --detach.'
+      );
     }
-    return false;
-  };
-  const rejectIrrelevantStorageOptions = (command: Command, kind: 'reply' | 'result'): void => {
-    const allowed = new Set(
-      kind === 'reply' ? ['json', 'receipt', 'file', 'stdin', 'message'] : ['json']
-    );
-    const seen = new Set<string>();
-    let current: Command | null = command;
-    while (current) {
-      for (const option of current.options) {
-        const name = option.attributeName();
-        if (seen.has(name)) continue;
-        seen.add(name);
-        if (!allowed.has(name) && optionWasProvided(command, name)) {
-          throw new CliParseError(`Unknown option '${option.long ?? option.flags}' for ${kind}.`);
+    if (
+      (commandName === 'talk' || commandName === 'send') &&
+      optionWasProvided(command, optionAttribute('lines'))
+    ) {
+      throw new CliParseError(
+        'The --lines option is only supported by check/read; talk retrieves the complete durable response.'
+      );
+    }
+    if (commandName === 'talk' || commandName === 'send') {
+      const options = commandOptions(command);
+      if (options.detach && optionWasProvided(command, optionAttribute('timeout'))) {
+        throw new CliParseError('Use either --timeout or --detach, not both.');
+      }
+      if (optionWasProvided(command, optionAttribute('timeout')) && options.timeout !== undefined) {
+        const timeoutSeconds = parseTime(options.timeout);
+        if (!isValidObserverTimeoutSeconds(timeoutSeconds)) {
+          throw new CliParseError(
+            'Talk timeout must be finite, positive, and no greater than 24 hours.'
+          );
         }
       }
-      current = current.parent;
+      if (optionWasProvided(command, optionAttribute('delay')) && options.delay !== undefined) {
+        const delaySeconds = parseTime(options.delay);
+        if (!isValidTimerDelayMs(delaySeconds * 1000)) {
+          throw new CliParseError('Talk delay exceeds the supported timer limit.');
+        }
+      }
     }
+    capture.invocation = invocation;
+    captureCommand(command);
+    capture.unsupportedTeam ||= Boolean(commandOptions(command).team);
+    rejectUnsupportedOptions(command);
   };
-
-  program.action(() => action(program, { kind: 'help', showIntro: true }));
-  commonOptions(program.command('help')).action(function () {
-    action(this, { kind: 'help', showIntro: false });
+  const storageOnly = <T extends Command>(command: T): T => {
+    register(command, storageOptions);
+    return command;
+  };
+  program.action(() => {
+    const options = program.opts() as CommandOptions;
+    action(
+      program,
+      options.version === true
+        ? { kind: 'version' }
+        : { kind: 'help', showIntro: options.help !== true }
+    );
   });
-  const team = commonOptions(program.command('team').argument('[scope]'));
+  register(program.command('help').description('Show this help message'), generalOptions).action(
+    function () {
+      action(this, { kind: 'help', showIntro: false });
+    }
+  );
+  const team = register(
+    program
+      .command('team', { hidden: true })
+      .description('Retired compatibility command')
+      .argument('[scope]'),
+    generalOptions
+  );
   team.action(function () {
     capture.unsupportedTeam = true;
     action(this, { kind: 'help', showIntro: false });
   });
-  commonOptions(program.command('init')).action(function () {
+  register(
+    program.command('init').description('Create empty tmux-team.json'),
+    generalOptions
+  ).action(function () {
     action(this, { kind: 'init' });
   });
-  const list = leaf(program.command('list').alias('ls').argument('[target]'));
+  const list = register(
+    program
+      .command('list')
+      .description('List active identities or pane status')
+      .alias('ls')
+      .argument('[target]'),
+    generalOptions
+  );
   list.action(function (target?: string) {
     action(this, {
       kind: 'list',
       target: target ? selector(target, false) : undefined,
     });
   });
-  const add = leaf(program.command('add').argument('<pane-target>').argument('<global-name>'));
+  const add = register(
+    program
+      .command('add')
+      .description('Bind an explicit pane identity')
+      .argument('<pane-target>')
+      .argument('<global-name>'),
+    generalOptions
+  );
   add.action(function (pane: string, name: string) {
     action(this, { kind: 'add', pane, name });
   });
   for (const kind of ['this', 'name'] as const) {
-    const command = leaf(program.command(kind).argument('<name>'));
+    const command = register(
+      program.command(kind).description('Bind the current pane identity').argument('<name>'),
+      generalOptions
+    );
     command.action(function (name: string) {
       action(this, { kind, name });
     });
@@ -342,7 +582,14 @@ function setupProgram(capture: Capture): Command {
     ['talk', 'talk'],
     ['send', 'talk'],
   ] as const) {
-    const command = leaf(program.command(name).argument('<target>').argument('<message>'));
+    const command = register(
+      program
+        .command(name)
+        .description('Send a message to an identity or pane')
+        .argument('<target>')
+        .argument('<message>'),
+      talkOptions
+    );
     command.action(function (target: string, message: string) {
       action(this, {
         kind,
@@ -355,7 +602,14 @@ function setupProgram(capture: Capture): Command {
     ['check', 'check'],
     ['read', 'check'],
   ] as const) {
-    const command = leaf(program.command(name).argument('<target>').argument('[lines]'));
+    const command = register(
+      program
+        .command(name)
+        .description('Capture output from an agent pane')
+        .argument('<target>')
+        .argument('[lines]'),
+      checkOptions
+    );
     command.action(function (target: string, lines?: string) {
       const options = commandOptions(this);
       const value = lines ?? options.lines;
@@ -366,17 +620,24 @@ function setupProgram(capture: Capture): Command {
       });
     });
   }
-  const config = leaf(program.command('config'));
+  const config = register(
+    program.command('config').description('View or modify settings'),
+    generalOptions
+  );
   config.action(function () {
     action(this, { kind: 'config', operation: 'show', global: false });
   });
-  const configShow = config.command('show');
-  commonOptions(configShow);
+  const configShow = config.command('show').description('Show current settings');
+  register(configShow, generalOptions);
   configShow.action(function () {
     action(this, { kind: 'config', operation: 'show', global: false });
   });
-  const configSet = config.command('set').argument('<key>').argument('<value>');
-  commonOptions(configSet).option('-g, --global');
+  const configSet = config
+    .command('set')
+    .description('Set a setting')
+    .argument('<key>')
+    .argument('<value>');
+  register(configSet, [...generalOptions, 'global']);
   configSet.action(function (key: string, value: string) {
     action(this, {
       kind: 'config',
@@ -386,8 +647,8 @@ function setupProgram(capture: Capture): Command {
       global: Boolean((this.opts() as { global?: boolean }).global),
     });
   });
-  const configClear = config.command('clear').argument('[key]');
-  commonOptions(configClear);
+  const configClear = config.command('clear').description('Clear a setting').argument('[key]');
+  register(configClear, generalOptions);
   configClear.action(function (key?: string) {
     action(this, {
       kind: 'config',
@@ -396,28 +657,47 @@ function setupProgram(capture: Capture): Command {
       global: false,
     });
   });
-  const preamble = leaf(program.command('preamble'));
+  const preamble = register(
+    program.command('preamble').description('Manage identity preambles'),
+    generalOptions
+  );
   preamble.action(function () {
     action(this, { kind: 'preamble', operation: 'show' });
   });
-  const preambleShow = preamble.command('show').argument('[agent]');
-  commonOptions(preambleShow);
+  const preambleShow = preamble
+    .command('show')
+    .description('Show stored preambles')
+    .argument('[agent]');
+  register(preambleShow, generalOptions);
   preambleShow.action(function (agent?: string) {
     action(this, { kind: 'preamble', operation: 'show', agent });
   });
-  const preambleSet = preamble.command('set').argument('<agent>').argument('<preamble...>');
-  commonOptions(preambleSet);
+  const preambleSet = preamble
+    .command('set')
+    .description('Set an identity preamble')
+    .argument('<agent>')
+    .argument('<preamble...>');
+  register(preambleSet, generalOptions);
   preambleSet.action(function (agent: string, values: string[]) {
     action(this, { kind: 'preamble', operation: 'set', agent, preamble: values.join(' ') });
   });
-  const preambleClear = preamble.command('clear').argument('<agent>');
-  commonOptions(preambleClear);
+  const preambleClear = preamble
+    .command('clear')
+    .description('Clear an identity preamble')
+    .argument('<agent>');
+  register(preambleClear, generalOptions);
   preambleClear.action(function (agent: string) {
     action(this, { kind: 'preamble', operation: 'clear', agent });
   });
-  const role = leaf(program.command('role')).option('--identity <name>');
-  const roleShow = role.command('show');
-  commonOptions(roleShow).option('--identity <name>');
+  const role = register(
+    program
+      .command('role')
+      .description('Manage identity role profiles')
+      .usage('[options] <command>'),
+    [...generalOptions, 'identity']
+  );
+  const roleShow = role.command('show').description('Show an identity role profile');
+  register(roleShow, [...generalOptions, 'identity']);
   roleShow.action(function () {
     const options = commandOptions(this);
     action(this, {
@@ -426,8 +706,11 @@ function setupProgram(capture: Capture): Command {
       ...(options.identity !== undefined && { selector: selector(options.identity, true) }),
     });
   });
-  const roleSet = role.command('set').argument('[content]');
-  commonOptions(roleSet).option('--identity <name>').option('--file <path>');
+  const roleSet = role
+    .command('set')
+    .description('Set an identity role profile')
+    .argument('[content]');
+  register(roleSet, [...generalOptions, 'identity', 'file']);
   roleSet.action(function (content?: string) {
     const options = commandOptions(this);
     const hasContent = content !== undefined;
@@ -444,8 +727,8 @@ function setupProgram(capture: Capture): Command {
       ...(options.identity !== undefined && { selector: selector(options.identity, true) }),
     });
   });
-  const roleClear = role.command('clear');
-  commonOptions(roleClear).option('--identity <name>');
+  const roleClear = role.command('clear').description('Clear an identity role profile');
+  register(roleClear, [...generalOptions, 'identity']);
   roleClear.action(function () {
     const options = commandOptions(this);
     action(this, {
@@ -454,13 +737,20 @@ function setupProgram(capture: Capture): Command {
       ...(options.identity !== undefined && { selector: selector(options.identity, true) }),
     });
   });
-  const reply = storageOnly(program.command('reply').argument('<request-id>'))
-    .requiredOption('--receipt <receipt>')
-    .option('--file <path>')
-    .option('--stdin')
-    .option('--message <text>');
+  const reply = program
+    .command('reply')
+    .description('Submit a complete result with a receipt')
+    .argument('<request-id>');
+  const replyOptions: readonly OptionName[] = [
+    ...storageOptions,
+    'receipt',
+    'file',
+    'stdin',
+    'message',
+  ];
+  registerOptions(reply, replyOptions, ['receipt']);
   reply.action(function (requestId: string) {
-    rejectIrrelevantStorageOptions(this, 'reply');
+    rejectUnsupportedOptions(this);
     try {
       validateReplyRequestId(requestId);
     } catch (error) {
@@ -492,9 +782,11 @@ function setupProgram(capture: Capture): Command {
           : { message: options.message! }),
     });
   });
-  const result = storageOnly(program.command('result').argument('<request-id>'));
+  const result = storageOnly(
+    program.command('result').description('Retrieve a retained result').argument('<request-id>')
+  );
   result.action(function (requestId: string) {
-    rejectIrrelevantStorageOptions(this, 'result');
+    rejectUnsupportedOptions(this);
     try {
       validateReplyRequestId(requestId);
     } catch (error) {
@@ -502,7 +794,10 @@ function setupProgram(capture: Capture): Command {
     }
     action(this, { kind: 'result', requestId });
   });
-  const install = leaf(program.command('install').argument('[agent]')).option('--dir <path>');
+  const install = register(
+    program.command('install').description('Install or refresh agent skills').argument('[agent]'),
+    [...generalOptions, 'force', 'dir']
+  );
   install.action(function (agent?: string) {
     const options = commandOptions(this);
     if (options.dir !== undefined && options.dir.trim() === '') {
@@ -517,22 +812,59 @@ function setupProgram(capture: Capture): Command {
       ...(options.dir !== undefined ? { directory: options.dir } : {}),
     });
   });
-  const completion = leaf(program.command('completion').argument('[shell]'));
+  const completion = register(
+    program.command('completion').description('Output shell completion script').argument('[shell]'),
+    generalOptions
+  );
   completion.action(function (shell?: string) {
     action(this, { kind: 'completion', shell });
   });
   for (const kind of ['upgrade', 'whoami', 'unbind'] as const) {
-    const command = leaf(program.command(kind));
+    const command = register(
+      program
+        .command(kind)
+        .description(
+          kind === 'upgrade'
+            ? 'Upgrade tmux-team and refresh skills'
+            : kind === 'whoami'
+              ? 'Show the current pane identity'
+              : 'Remove the current pane identity'
+        ),
+      generalOptions
+    );
     command.action(function () {
       action(this, { kind });
     });
   }
-  const learn = leaf(program.command('learn')).option('--skill');
+  const learn = register(program.command('learn').description('Show the learning guide'), [
+    ...generalOptions,
+    'skill',
+  ]);
   learn.action(function () {
     const options = commandOptions(this);
     action(this, { kind: 'learn', ...(options.skill ? { skill: true } : {}) });
   });
+  const rootNames = new Set<OptionName>();
+  for (const registered of registeredOptions(program)) {
+    const spec = optionMetadata.get(registered);
+    const name = spec ? optionSpecNames.get(spec) : undefined;
+    if (name && spec?.rootRecognized === true) rootNames.add(name);
+  }
+  const existingRootOptions = new Set(program.options.map((item) => item.attributeName()));
+  registerOptions(
+    program,
+    [...rootNames].filter((name) => !existingRootOptions.has(optionAttribute(name)))
+  );
   return program;
+}
+
+/**
+ * Read-only projection of the Commander registration tree. Help and completion
+ * consumers use this instead of maintaining a second option inventory.
+ */
+export function getCliCommandMetadata(): CliCommandMetadata {
+  const program = setupProgram({ commandPath: [], unsupportedTeam: false });
+  return projectCommand(program, new Help());
 }
 
 export function parseArgs(argv: readonly string[]): ParsedArgs {
@@ -540,57 +872,7 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
   if (raw.length === 0) {
     return {
       invocation: { kind: 'help', showIntro: raw.length === 0 },
-      flags: { json: raw.includes('--json'), verbose: false },
-      metadata: {
-        argv: raw,
-        commandPath: [],
-        unsupportedTeam: false,
-        capability: 'none',
-      },
-    };
-  }
-  const terminator = raw.indexOf('--');
-  const commandTokens = terminator === -1 ? raw : raw.slice(0, terminator);
-  const valueOptions = new Set(['--config', '--delay', '--timeout', '--lines', '--team']);
-  let firstCommandToken: string | undefined;
-  for (let index = 0; index < commandTokens.length; index++) {
-    const token = commandTokens[index];
-    if (valueOptions.has(token)) {
-      index++;
-      continue;
-    }
-    if (token.startsWith('--team=')) continue;
-    if (
-      token.startsWith('-') &&
-      token !== '--help' &&
-      token !== '-h' &&
-      token !== '--version' &&
-      token !== '-V'
-    ) {
-      continue;
-    }
-    firstCommandToken = token;
-    break;
-  }
-  if (firstCommandToken === '--help' || firstCommandToken === '-h') {
-    return {
-      invocation: { kind: 'help', showIntro: false },
-      flags: {
-        json: commandTokens.includes('--json'),
-        verbose: commandTokens.includes('--verbose') || commandTokens.includes('-v'),
-      },
-      metadata: {
-        argv: raw,
-        commandPath: [],
-        unsupportedTeam: false,
-        capability: 'none',
-      },
-    };
-  }
-  if (firstCommandToken === '--version' || firstCommandToken === '-V') {
-    return {
-      invocation: { kind: 'version' },
-      flags: flagsFromArgv(commandTokens),
+      flags: { json: false, verbose: false },
       metadata: {
         argv: raw,
         commandPath: [],
@@ -601,26 +883,37 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
   }
   const capture: Capture = { commandPath: [], unsupportedTeam: false };
   const program = setupProgram(capture);
-  if (
-    firstCommandToken &&
-    !firstCommandToken.startsWith('-') &&
-    !program.commands.some(
-      (command) =>
-        command.name() === firstCommandToken || command.aliases().includes(firstCommandToken)
-    )
-  ) {
-    throw new CliParseError(
-      `Unknown command: ${firstCommandToken}. Run 'tmux-team help' for usage.`,
-      flagsFromArgv(commandTokens)
-    );
-  }
   try {
     program.parse(['node', 'tmux-team', ...raw], { from: 'node' });
   } catch (error) {
     if (error instanceof CliParseError) {
+      const commanderUnknown =
+        error.commanderCode === 'commander.unknownCommand'
+          ? error.message.match(/unknown command ['"]([^'"]+)['"]/i)
+          : undefined;
+      const rootOperand = program.args[0];
+      const rootOperandIsKnownCommand = rootOperand
+        ? program.commands.some(
+            (command) => command.name() === rootOperand || command.aliases().includes(rootOperand)
+          )
+        : false;
+      const unknownCommand =
+        commanderUnknown?.[1] ??
+        (!capture.command &&
+        rootOperand &&
+        !rootOperandIsKnownCommand &&
+        (error.commanderCode === 'commander.excessArguments' || !rootOperand.startsWith('-'))
+          ? rootOperand
+          : undefined);
+      const message = unknownCommand
+        ? `Unknown command: ${unknownCommand}. Run 'tmux-team help' for usage.`
+        : error.message;
       throw new CliParseError(
-        compatibilityUsage(commandTokens, error.message) ?? error.message,
-        flagsFromArgv(commandTokens)
+        compatibilityUsage(capture.command?.name(), message) ?? message,
+        flagsFromOptions(
+          capture.command ? commandOptions(capture.command) : (program.opts() as CommonOptions)
+        ),
+        error.commanderCode
       );
     }
     throw new CliParseError(error instanceof Error ? error.message : String(error));
@@ -630,12 +923,11 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
   let flags: Flags;
   try {
     flags = flagsFrom(
-      capture.command ? commandOptions(capture.command) : (program.opts() as CommonOptions),
-      commandTokens
+      capture.command ? commandOptions(capture.command) : (program.opts() as CommonOptions)
     );
   } catch (error) {
     if (error instanceof CliParseError) {
-      throw new CliParseError(error.message, flagsFromArgv(commandTokens));
+      throw new CliParseError(error.message, flagsFromOptions(program.opts() as CommonOptions));
     }
     throw error;
   }

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -625,19 +626,112 @@ describe('basic commands', () => {
 
   it('cmdCompletion prints scripts', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const shellRunOptions = { encoding: 'utf8' as const, timeout: 5000 };
     cmdCompletion('bash');
     const bashOutput = logSpy.mock.calls.join('\n');
     expect(bashOutput).toContain('complete -F _tmux_team');
-    expect(bashOutput).toContain('name this whoami unbind');
+    expect(bashOutput).toContain('list ls add this name talk send check read');
+    expect(bashOutput).not.toContain(' team ');
+    expect(bashOutput).not.toContain('--wait');
+    expect(bashOutput).not.toContain('--help');
+    const bashSyntax = spawnSync('bash', ['-n'], { ...shellRunOptions, input: bashOutput });
+    expect(bashSyntax.error).toBeUndefined();
+    expect(bashSyntax.status).toBe(0);
+
+    const runBashCompletion = (words: string[], current: number) =>
+      spawnSync(
+        'bash',
+        [
+          '-c',
+          `${bashOutput}\nCOMP_WORDS=(${words.join(' ')}); COMP_CWORD=${current}; _tmux_team; printf '%s\\n' "\${COMPREPLY[@]}"`,
+        ],
+        shellRunOptions
+      );
+    const completionCases = [
+      {
+        label: 'role set',
+        words: ['tmux-team', 'role', 'set', '--'],
+        required: ['--file'],
+        absent: [],
+      },
+      {
+        label: 'role clear',
+        words: ['tmux-team', 'role', 'clear', '--'],
+        required: ['--identity'],
+        absent: ['--file'],
+      },
+      {
+        label: 'config set',
+        words: ['tmux-team', 'config', 'set', '--'],
+        required: ['--global'],
+        absent: [],
+      },
+      {
+        label: 'check',
+        words: ['tmux-team', 'check', 'target', '--'],
+        required: ['--lines'],
+        absent: [],
+      },
+      {
+        label: 'talk',
+        words: ['tmux-team', 'talk', 'target', '--'],
+        required: ['--timeout'],
+        absent: ['--lines'],
+      },
+      {
+        label: 'read',
+        words: ['tmux-team', 'read', 'target', '--'],
+        required: ['--lines'],
+        absent: [],
+      },
+      {
+        label: 'send',
+        words: ['tmux-team', 'send', 'target', '--'],
+        required: ['--timeout'],
+        absent: ['--lines'],
+      },
+    ];
+    for (const testCase of completionCases) {
+      const result = runBashCompletion(testCase.words, 3);
+      const label = `bash ${testCase.label}`;
+      expect(result.error, label).toBeUndefined();
+      expect(result.status, label).toBe(0);
+      expect(result.stderr, label).toBe('');
+      for (const token of testCase.required) expect(result.stdout, label).toContain(token);
+      for (const token of testCase.absent) expect(result.stdout, label).not.toContain(token);
+    }
 
     logSpy.mockClear();
     cmdCompletion('zsh');
     const zshOutput = logSpy.mock.calls.join('\n');
     expect(zshOutput).toContain('#compdef tmux-team');
-    expect(zshOutput).toContain('name:Bind the current pane identity');
-    expect(zshOutput).toContain('this:Bind the current pane identity');
-    expect(zshOutput).toContain('whoami:Show the current pane identity');
-    expect(zshOutput).toContain('unbind:Remove the current pane identity');
+    expect(zshOutput).toContain("    'ls:");
+    expect(zshOutput).toContain("    'send:");
+    expect(zshOutput).not.toContain("    'team'");
+    expect(zshOutput).not.toContain('--wait');
+    expect(zshOutput).not.toContain('--help');
+    const zshSyntax = spawnSync('zsh', ['-n'], { ...shellRunOptions, input: zshOutput });
+    expect(zshSyntax.error).toBeUndefined();
+    expect(zshSyntax.status).toBe(0);
+
+    const runZshCompletion = (words: string[], current: number) =>
+      spawnSync(
+        'zsh',
+        [
+          '-fc',
+          `compadd() { reply=("$@"); }; _describe() { :; }; ${zshOutput}\nwords=(${words.join(' ')}); CURRENT=${current}; _tmux-team; print -l -- $reply`,
+        ],
+        shellRunOptions
+      );
+    for (const testCase of completionCases) {
+      const result = runZshCompletion(testCase.words, 4);
+      const label = `zsh ${testCase.label}`;
+      expect(result.error, label).toBeUndefined();
+      expect(result.status, label).toBe(0);
+      expect(result.stderr, label).toBe('');
+      for (const token of testCase.required) expect(result.stdout, label).toContain(token);
+      for (const token of testCase.absent) expect(result.stdout, label).not.toContain(token);
+    }
 
     logSpy.mockClear();
     cmdCompletion();
@@ -651,8 +745,17 @@ describe('basic commands', () => {
     cmdLearn();
     const output = logSpy.mock.calls.join('\n');
     expect(output).toContain('add <pane-target> <global-name>');
-    expect(output).toContain('this <global-name>');
-    expect(output).toContain('name <global-name>');
+    expect(output).toContain('this <name>');
+    expect(output).toContain('name <name>');
+    expect(output).toContain('list [target] (alias: ls)');
+    expect(output).toContain('role <show|set|clear>');
+    expect(output).toContain('config [show|set|clear]');
+    expect(output).toContain('preamble [show|set|clear]');
+    expect(output).toContain('tmt role show [--identity <name>]');
+    expect(output).toContain('tmt role set [content] [--identity <name>] [--file <path>]');
+    expect(output).toContain('tmt role clear [--identity <name>]');
+    expect(output).not.toContain('  team');
+    expect(output).toContain('text-only commands');
     expect(output).toContain('whoami');
     expect(output).toContain('unbind');
   });

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -2,33 +2,202 @@
 // completion command - shell completion scripts
 // ─────────────────────────────────────────────────────────────
 
+import { getCliCommandMetadata, type CliCommandMetadata } from '../cli/parser.js';
 import { colors } from '../ui.js';
 
-const zshCompletion = `#compdef tmux-team
+// Provider names are intentionally a separate feature inventory. TMT29 owns
+// provider/skill discovery; command grammar owns the command and option list.
+const INSTALL_TARGETS = ['claude', 'codex', 'gemini', 'all'];
+const COMPLETION_SHELLS = ['zsh', 'bash'];
+const IDENTITY_COMMANDS = new Set(['talk', 'send', 'check', 'read']);
+
+function visibleCommands(root: CliCommandMetadata): readonly CliCommandMetadata[] {
+  return root.commands.filter((command) => !command.hidden);
+}
+
+function visibleOptions(command: CliCommandMetadata, rootOnly = false): string[] {
+  const words: string[] = [];
+  const seen = new Set<string>();
+  for (const option of command.options) {
+    if (option.hidden) {
+      continue;
+    }
+    if (rootOnly && !option.rootAllowed) continue;
+    for (const word of [option.short, option.long]) {
+      if (word && !seen.has(word)) {
+        seen.add(word);
+        words.push(word);
+      }
+    }
+  }
+  return words;
+}
+
+function commandWords(command: CliCommandMetadata): string[] {
+  return [command.name, ...command.aliases];
+}
+
+function casePattern(command: CliCommandMetadata): string {
+  return commandWords(command).join('|');
+}
+
+function shellWordList(words: readonly string[]): string {
+  return words.join(' ');
+}
+
+function zshCommandRows(commands: readonly CliCommandMetadata[]): string {
+  return commands
+    .flatMap((command) =>
+      commandWords(command).map((name) => {
+        const description = command.description ? `:${command.description}` : '';
+        return `    '${name}${description}'`;
+      })
+    )
+    .join('\n');
+}
+
+function zshSubcommandWords(command: CliCommandMetadata): string {
+  return command.commands
+    .filter((child) => !child.hidden)
+    .map((child) => child.name)
+    .join(' ');
+}
+
+// Keep the existing fixed-position completion model; metadata supplies the
+// registered words and options without introducing a second argv parser.
+function zshCaseAtThirdWord(root: CliCommandMetadata): string {
+  return visibleCommands(root)
+    .flatMap((command) => {
+      const options = visibleOptions(command);
+      const words =
+        command.commands.length > 0
+          ? [zshSubcommandWords(command), ...options].filter(Boolean)
+          : options;
+      if (IDENTITY_COMMANDS.has(command.name)) {
+        return `      ${casePattern(command)})
+        _get_agents
+        if [[ -n "$agents" ]]; then
+          _describe -t agents 'agents' agents
+        fi
+        compadd -- ${options.join(' ')}
+        ;;`;
+      }
+      if (command.name === 'completion') {
+        return `      completion)
+        compadd -- ${[...COMPLETION_SHELLS, ...options].join(' ')}
+        ;;`;
+      }
+      if (command.name === 'install') {
+        return `      install)
+        compadd -- ${[...INSTALL_TARGETS, ...options].join(' ')}
+        ;;`;
+      }
+      if (words.length === 0) return '';
+      return `      ${casePattern(command)})
+        compadd -- ${words.join(' ')}
+        ;;`;
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function zshCaseAtFourthWord(root: CliCommandMetadata): string {
+  return visibleCommands(root)
+    .flatMap((command) => {
+      const parentOptions = visibleOptions(command);
+      const childCases = command.commands
+        .filter((child) => !child.hidden)
+        .map((child) => {
+          const options = visibleOptions(child);
+          if (options.length === 0) return '';
+          return `          ${child.name}) compadd -- ${options.join(' ')} ;;`;
+        })
+        .filter(Boolean);
+      if (childCases.length > 0) {
+        return `      ${casePattern(command)})
+        case "\${words[3]}" in
+${childCases.join('\n')}
+        esac
+        ;;`;
+      }
+      if (parentOptions.length === 0) return [];
+      return [
+        `      ${casePattern(command)})
+        compadd -- ${parentOptions.join(' ')}
+        ;;`,
+      ];
+    })
+    .join('\n');
+}
+
+function bashCaseAtSecondWord(root: CliCommandMetadata): string {
+  return visibleCommands(root)
+    .map((command) => {
+      const options = visibleOptions(command);
+      if (IDENTITY_COMMANDS.has(command.name)) {
+        return `      ${[command.name, ...command.aliases].join('|')})
+        agents=$(tmux-team list --json 2>/dev/null | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>{try{const j=JSON.parse(s); console.log((j.identities||[]).map(a=>a.name).join(" "))}catch{}})')
+        COMPREPLY=( $(compgen -W "\${agents} ${shellWordList(options)}" -- \${cur}) )
+        ;;`;
+      }
+      const words =
+        command.commands.length > 0
+          ? [
+              ...command.commands.filter((child) => !child.hidden).map((child) => child.name),
+              ...options,
+            ]
+          : options;
+      if (command.name === 'completion') words.push(...COMPLETION_SHELLS);
+      if (command.name === 'install') words.push(...INSTALL_TARGETS);
+      if (words.length === 0) return '';
+      return `      ${casePattern(command)})
+        COMPREPLY=( $(compgen -W "${shellWordList(words)}" -- \${cur}) )
+        ;;`;
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function bashCaseAtThirdWord(root: CliCommandMetadata): string {
+  return visibleCommands(root)
+    .map((command) => {
+      const childCases = command.commands
+        .filter((child) => !child.hidden)
+        .map((child) => {
+          const options = visibleOptions(child);
+          if (options.length === 0) return '';
+          return `          ${child.name})
+            COMPREPLY=( $(compgen -W "${shellWordList(options)}" -- \${cur}) )
+            ;;`;
+        })
+        .filter(Boolean);
+      if (childCases.length > 0) {
+        return `      ${casePattern(command)})
+        case "\${COMP_WORDS[2]}" in
+${childCases.join('\n')}
+        esac
+        ;;`;
+      }
+      const options = visibleOptions(command);
+      if (options.length === 0) return [];
+      return [
+        `      ${casePattern(command)})
+        COMPREPLY=( $(compgen -W "${shellWordList(options)}" -- \${cur}) )
+        ;;`,
+      ];
+    })
+    .join('\n');
+}
+
+function renderZshCompletion(root: CliCommandMetadata): string {
+  const rootOptions = visibleOptions(root, true);
+  return `#compdef tmux-team
 
 _tmux-team() {
   local -a commands agents
 
   commands=(
-    'talk:Send message to an agent'
-    'check:Capture output from agent pane'
-    'reply:Submit a complete result with a receipt'
-    'result:Retrieve a retained result'
-    'list:List active identities or pane status'
-    'add:Add a new agent'
-    'name:Bind the current pane identity'
-    'this:Bind the current pane identity'
-    'whoami:Show the current pane identity'
-    'unbind:Remove the current pane identity'
-    'install:Install agent skills'
-    'upgrade:Upgrade tmux-team and refresh skills'
-    'init:Create empty tmux-team.json'
-    'completion:Output shell completion script'
-    'config:View or modify settings'
-    'preamble:Manage identity preambles'
-    'role:Manage durable identity role profiles'
-    'learn:Show the learning guide'
-    'help:Show help message'
+${zshCommandRows(visibleCommands(root))}
   )
 
   _get_agents() {
@@ -37,118 +206,54 @@ _tmux-team() {
 
   if (( CURRENT == 2 )); then
     _describe -t commands 'tmux-team commands' commands
+    compadd -- ${rootOptions.join(' ')}
   elif (( CURRENT == 3 )); then
     case \${words[2]} in
-      talk|check)
-        _get_agents
-        if [[ -n "$agents" ]]; then
-          _describe -t agents 'agents' agents
-        fi
-        ;;
-      reply)
-        compadd -- "--receipt" "--message" "--file" "--stdin" "--json"
-        ;;
-      result)
-        compadd -- "--json"
-        ;;
-      completion)
-        compadd "zsh" "bash"
-        ;;
-      install)
-        compadd -- "claude" "codex" "gemini" "all" "--dir"
-        ;;
-      learn)
-        compadd -- "--skill"
-        ;;
-      role)
-        compadd "show" "set" "clear"
-        ;;
+${zshCaseAtThirdWord(root)}
     esac
   elif (( CURRENT == 4 )); then
     case \${words[2]} in
-      talk)
-        compadd -- "--delay" "--detach" "--timeout"
-        ;;
-      reply)
-        compadd -- "--receipt" "--message" "--file" "--stdin" "--json"
-        ;;
-      result)
-        compadd -- "--json"
-        ;;
-      role)
-        compadd -- "--identity"
-        if [[ "\${words[3]}" == "set" ]]; then compadd -- "--file"; fi
-        ;;
+${zshCaseAtFourthWord(root)}
     esac
   fi
 }
 
 _tmux-team "$@"`;
+}
 
-const bashCompletion = `_tmux_team() {
+function renderBashCompletion(root: CliCommandMetadata): string {
+  const commandWordsList = visibleCommands(root).flatMap(commandWords);
+  const rootOptions = visibleOptions(root, true);
+  return `_tmux_team() {
   local cur prev commands agents
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
-  commands="talk check reply result list add init completion help name this whoami unbind install upgrade config preamble role learn"
+  commands="${shellWordList(commandWordsList)}"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
-    COMPREPLY=( $(compgen -W "\${commands}" -- \${cur}) )
+    COMPREPLY=( $(compgen -W "\${commands} ${shellWordList(rootOptions)}" -- \${cur}) )
   elif [[ \${COMP_CWORD} -eq 2 ]]; then
     case "\${prev}" in
-      talk|check)
-        agents=$(tmux-team list --json 2>/dev/null | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>{try{const j=JSON.parse(s); console.log((j.identities||[]).map(a=>a.name).join(" "))}catch{}})')
-        COMPREPLY=( $(compgen -W "\${agents}" -- \${cur}) )
-        ;;
-      reply)
-        COMPREPLY=( $(compgen -W "--receipt --message --file --stdin --json" -- \${cur}) )
-        ;;
-      result)
-        COMPREPLY=( $(compgen -W "--json" -- \${cur}) )
-        ;;
-      completion)
-        COMPREPLY=( $(compgen -W "zsh bash" -- \${cur}) )
-        ;;
-      install)
-        COMPREPLY=( $(compgen -W "claude codex gemini all --dir" -- \${cur}) )
-        ;;
-      learn)
-        COMPREPLY=( $(compgen -W "--skill" -- \${cur}) )
-        ;;
-      role)
-        COMPREPLY=( $(compgen -W "show set clear" -- \${cur}) )
-        ;;
+${bashCaseAtSecondWord(root)}
     esac
   elif [[ \${COMP_CWORD} -eq 3 ]]; then
     case "\${COMP_WORDS[1]}" in
-      talk)
-        COMPREPLY=( $(compgen -W "--delay --detach --timeout" -- \${cur}) )
-        ;;
-      reply)
-        COMPREPLY=( $(compgen -W "--receipt --message --file --stdin --json" -- \${cur}) )
-        ;;
-      result)
-        COMPREPLY=( $(compgen -W "--json" -- \${cur}) )
-        ;;
-      role)
-        if [[ "\${COMP_WORDS[2]}" == "set" ]]; then
-          COMPREPLY=( $(compgen -W "--identity --file" -- \${cur}) )
-        else
-          COMPREPLY=( $(compgen -W "--identity" -- \${cur}) )
-        fi
-        ;;
+${bashCaseAtThirdWord(root)}
     esac
   fi
 }
 
 complete -F _tmux_team tmux-team`;
+}
 
 export function cmdCompletion(shell?: string): void {
+  const metadata = getCliCommandMetadata();
   if (shell === 'bash') {
-    console.log(bashCompletion);
+    console.log(renderBashCompletion(metadata));
   } else if (shell === 'zsh') {
-    console.log(zshCompletion);
+    console.log(renderZshCompletion(metadata));
   } else {
     console.log(`
 ${colors.cyan('Shell Completion Setup')}

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -5,14 +5,83 @@
 import { colors } from '../ui.js';
 import { VERSION } from '../version.js';
 import { MAX_CAPTURE_LINES, MAX_TIMER_DELAY_MS } from '../domain/interaction-limits.js';
+import {
+  getCliCommandMetadata,
+  type CliCommandMetadata,
+  type CliCommandOptionMetadata,
+} from '../cli/parser.js';
 
 export interface HelpConfig {
   timeout?: number;
   showIntro?: boolean;
 }
 
+function commandUsage(command: CliCommandMetadata): string {
+  const usage = command.usage.replace(/^\[options\]\s*/, '').trim();
+  const childNames = command.commands.map((child) => child.name).join('|');
+  const childUsage = childNames ? `[${childNames}]` : '';
+  const argumentsUsage =
+    usage
+      .replace('[command]', childUsage)
+      .replace('<command>', childNames ? `<${childNames}>` : '') || childUsage;
+  const aliases = command.aliases.length > 0 ? ` (alias: ${command.aliases.join(', ')})` : '';
+  return `${command.name}${argumentsUsage ? ` ${argumentsUsage}` : ''}${aliases}`;
+}
+
+function findCommand(root: CliCommandMetadata, name: string): CliCommandMetadata | undefined {
+  return root.commands.find((command) => command.name === name);
+}
+
+function requiredCommand(root: CliCommandMetadata, name: string): CliCommandMetadata {
+  const command = findCommand(root, name);
+  if (!command) throw new Error(`CLI metadata is missing command: ${name}`);
+  return command;
+}
+
+function formatOption(option: CliCommandOptionMetadata): string {
+  const description = option.description ? ` ${option.description}` : '';
+  return `  ${colors.green(option.flags)}${description}`;
+}
+
+function commandOptions(command: CliCommandMetadata): readonly CliCommandOptionMetadata[] {
+  return command.options.filter((option) => !option.hidden && !option.rootAllowed);
+}
+
+function commandRows(root: CliCommandMetadata): string {
+  return root.commands
+    .filter((command) => !command.hidden)
+    .map((command) => {
+      const description = command.description ? ` ${command.description}` : '';
+      return `  ${colors.green(commandUsage(command))}${description}`;
+    })
+    .join('\n');
+}
+
+function childRows(parent: CliCommandMetadata): string {
+  return parent.commands
+    .filter((child) => !child.hidden)
+    .map((child) => {
+      const options = commandOptions(child)
+        .map((option) => `[${option.flags}]`)
+        .join(' ');
+      const suffix = options ? ` ${options}` : '';
+      return `  tmt ${colors.green(`${parent.name} ${commandUsage(child)}${suffix}`)}`;
+    })
+    .join('\n');
+}
+
 export function cmdHelp(config?: HelpConfig): void {
   const timeout = config?.timeout ?? 180;
+  const metadata = getCliCommandMetadata();
+  const rootOptions = metadata.options.filter((option) => !option.hidden && option.rootAllowed);
+  const talk = requiredCommand(metadata, 'talk');
+  const check = requiredCommand(metadata, 'check');
+  const reply = requiredCommand(metadata, 'reply');
+  const result = requiredCommand(metadata, 'result');
+  const role = requiredCommand(metadata, 'role');
+  const learn = requiredCommand(metadata, 'learn');
+  const learnSkill = learn.options.find((option) => option.name === 'skill');
+  if (!learnSkill) throw new Error('CLI metadata is missing learn --skill');
 
   // Show intro highlight when running just `tmux-team` with no args
   if (config?.showIntro) {
@@ -34,26 +103,8 @@ ${colors.yellow('USAGE')}
   tmt <command> [arguments]
 
 ${colors.yellow('COMMANDS')}
-  ${colors.green('talk')} <target> <message>     Send message to an identity or pane
-  ${colors.green('check')} <target> [lines]      Capture output from agent's pane
-  ${colors.green('reply')} <request-id>         Submit a complete result with a receipt
-  ${colors.green('result')} <request-id>        Retrieve a retained result
-  ${colors.green('list')} [target]                List active identities or pane status
-  ${colors.green('add')} <pane-target> <global-name> Bind an explicit pane identity
-  ${colors.green('this')} <global-name>       Bind the current pane (alias of name)
-  ${colors.green('name')} <global-name>       Bind the current pane identity
-  ${colors.green('whoami')}                   Show the current pane identity
-  ${colors.green('unbind')}                   Remove the current pane identity
-  ${colors.green('install')} [claude|codex|gemini|all] Install/refresh agent skills
-  ${colors.green('upgrade')}                     Upgrade tmux-team (links update automatically)
-  ${colors.green('init')}                        Create empty tmux-team.json
-  ${colors.green('config')} [show|set|clear]     View/modify settings
-  ${colors.green('preamble')} [show|set|clear]   Manage durable identity preambles
-  ${colors.green('role')} <show|set|clear>      Manage durable identity role profiles
-  ${colors.green('completion')}                  Output shell completion script
-  ${colors.green('learn')}                       Show educational guide
-  ${colors.green('learn --skill')}               Print the exact bundled universal skill
-  ${colors.green('help')}                        Show this help message
+${commandRows(metadata)}
+  ${colors.green(`learn ${learnSkill.flags}`)} Print the exact bundled universal skill
 
 ${colors.yellow('SKILL INSTALLATION')}
   tmt install --dir <skills-root> [--force] [--json]
@@ -63,16 +114,14 @@ ${colors.yellow('SKILL INSTALLATION')}
   Automatic drift reminders cover default paths, not custom folders.
 
 ${colors.yellow('OPTIONS')}
-  ${colors.green('--json')}                      Output in JSON format
-  ${colors.green('--verbose')}                   Show detailed output
-  ${colors.green('--force')}                     Skip warnings
+${rootOptions.map(formatOption).join('\n')}
+  JSON is available only for commands with a JSON result; text-only commands
+  such as help, completion and learn do not provide a universal JSON form.
 
 ${colors.yellow('ROLE USAGE')}
-  tmt role show [--identity <name>]
-  tmt role set <profile> [--identity <name>]
-  tmt role set --file <path> [--identity <name>]
-  tmt role clear [--identity <name>]
+${childRows(role)}
   Omit --identity only in a verified bound pane; explicit offline identities are supported.
+  role set accepts either inline content or --file, never both; --identity selects the durable identity.
 
 ${colors.yellow('CALLER CONTEXT')}
   name, this, whoami and unbind require matching live TMUX/TMUX_PANE context.
@@ -80,19 +129,19 @@ ${colors.yellow('CALLER CONTEXT')}
   Outside tmux, use explicit add/talk/check targets or role --identity <name>.
 
 ${colors.yellow('TALK OPTIONS')}
-  ${colors.green('--delay')} <seconds>           Wait before sending (0 through ${MAX_TIMER_DELAY_MS}ms)
-  ${colors.green('--timeout')} <time>            Observer bound (current: ${timeout}s; positive, at most 24h)
-  ${colors.green('--detach')}                    Return request ID after sending; no explicit --timeout
-  ${colors.green('--no-preamble')}               Skip agent preamble for this message
-  ${colors.green('--debug')}                     Show debug output
+${commandOptions(talk).map(formatOption).join('\n')}
+  Delay is bounded to 0 through ${MAX_TIMER_DELAY_MS}ms; timeout is positive and at most 24h.
+  --detach returns a request ID after sending; --no-preamble skips the agent preamble.
+  --debug shows diagnostic output.
 
 ${colors.yellow('CHECK OPTIONS')}
-  check/read <target> [lines] or --lines <count>: integer 0 through ${MAX_CAPTURE_LINES}.
+  ${commandUsage(check)}; --lines accepts an integer 0 through ${MAX_CAPTURE_LINES}.
+  ${commandOptions(check).map(formatOption).join('\n')}
   Zero captures the visible pane. Invalid CLI/configured counts are rejected.
 
 ${colors.yellow('REPLY / RESULT')}
-  tmt reply <request-id> --receipt <receipt> (--message <text> | --file <path> | --stdin) [--json]
-  tmt result <request-id> [--json]
+  tmt ${commandUsage(reply)} --receipt <receipt> (--message <text> | --file <path> | --stdin) [--json]
+  tmt ${commandUsage(result)} [--json]
   Use exactly one input source and the request ID/receipt from the talk instruction.
   Quote short inline text; use --message='-text' for a leading hyphen.
   Use file/stdin for large bodies or NUL; operating-system argv limits apply.

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,6 @@ export interface Flags {
   json: boolean;
   verbose: boolean;
   debug?: boolean;
-  config?: string;
   force?: boolean;
   delay?: number; // seconds
   detach?: boolean;

--- a/test/e2e/command-options.e2e.test.ts
+++ b/test/e2e/command-options.e2e.test.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture } from './harness.js';
+
+describe.sequential('command option ownership', () => {
+  it('rejects an irrelevant delivery flag without binding a pane or opening storage', async () => {
+    await withE2EFixture(async (fixture) => {
+      const metadata = fixture.paneMetadata(fixture.pane);
+      const result = await fixture.runJsonCli(['name', 'NeverBound', '--timeout', '2'], {
+        withoutTmux: true,
+      });
+      expect(result).toMatchObject({ code: 1, json: { error: { code: 'USAGE_ERROR' } } });
+      expect(result.stderr).toBe('');
+      expect(fs.existsSync(path.join(fixture.globalDir, 'tmux-team.db'))).toBe(false);
+      expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+      expect(fixture.paneMetadata(fixture.pane)).toBe(metadata);
+    });
+  });
+
+  it('preserves root options and literal payloads through send, reply, and read', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect((await fixture.runJsonCli(['this', 'GrammarPeer'])).code).toBe(0);
+      expect(
+        (await fixture.runJsonCli(['preamble', 'set', 'GrammarPeer', 'MUST NOT BE INJECTED'])).code
+      ).toBe(0);
+      const metadata = fixture.paneMetadata(fixture.pane);
+      const message = '--json --timeout=0 literal payload';
+      const sent = await fixture.runJsonCli<{ requestId: string; response: string }>([
+        '--timeout=10',
+        '--delay=0',
+        '--no-preamble',
+        'send',
+        'GrammarPeer',
+        '--',
+        message,
+      ]);
+      expect(sent.code, sent.stderr || sent.stdout).toBe(0);
+      expect(sent.json?.response).toBe(`mock-agent response: ${message}`);
+      const requestId = sent.json?.requestId;
+      expect(requestId).toMatch(/^req_[0-9a-f-]+$/);
+      const request = await fixture.waitForEvent(
+        (event) => event.event === 'request' && event.requestId === requestId
+      );
+      expect(request.message).toBe(message);
+      await fixture.waitForEvent(
+        (event) => event.event === 'summary' && event.requestId === requestId
+      );
+      const captured = await fixture.runJsonCli<{ lines: number; output: string }>([
+        '--lines=0',
+        'read',
+        'GrammarPeer',
+      ]);
+      expect(captured.code).toBe(0);
+      expect(captured.json?.lines).toBe(0);
+      expect(captured.json?.output).toContain(`mock-agent summary: ${message}`);
+      expect(fixture.paneMetadata(fixture.pane)).toBe(metadata);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes TMT-22. Commander registrations now own command-specific option acceptance and the inventory projected by help and Bash/Zsh completion.

- Reject ignored `--config` and unrelated options before Context, storage, or tmux effects.
- Preserve meaningful root placement, aliases, equals values, negated options, role parent/leaf identity selection, and literal payloads after `--`.
- Derive diagnostic flags from parsed option sources. Validate root help/version options before text-only JSON rejection. Preserve strict reply/result contracts and retired-command diagnostics.
- Update shipped guidance and architecture. Declare Zsh in the unit-test job for real bounded shell probes.

## Verification

- `pnpm check`: passed.
- `pnpm test:run`: 51 files, 701 tests passed; 95.43% statement and 89.13% branch coverage, thresholds passed.
- `pnpm test:e2e`: 18 files, 77 tests passed in Docker with real CLI/tmux and deterministic mock agents. New scenarios verify rejected options have no state effects and root flags/literal bodies survive send/reply/read.
- Packed native/skill install verifier: passed on macOS arm64 using an isolated temporary install. Subsequent changes were help usage metadata, shell test organization, and the CI prerequisite; no package/install implementation changed.
- Explicit formatting checks passed for all six shipped guidance files and the workflow. Skill frontmatter and links checked manually; optional Python skill validator was unavailable because PyYAML is not installed.
- Negative baseline probes reproduced acceptance of irrelevant role timeout, ignored config, and invalid root help options on main 6924622.

## Primary architecture review

Reviewed all changed production, test, workflow, and documentation diffs plus runner/dispatcher and integration callers. Command registrations remain the sole option authority; no second argv parser or per-command allowlist is added. Shared operational numeric rules remain owned by TMT-47. Required role-child usage is declared in Commander, not a renderer name exception.

Review corrected root negated-option precedence, unknown-option diagnostic classification, optional role flags, shell false-positive risks, duplicated shell scenarios, and a misplaced CI prerequisite before push. Supplementary review's proposal to rewrite retired-command errors as unknown-option errors was rejected to preserve existing retired-command contracts.

Architecture documentation now describes registration ownership and source-aware diagnostics. Completion retains its existing fixed-position model; provider inventories and canonical skill derivation remain TMT-29, settings consolidation remains TMT-46. No daemon, MCP, memory, remote authorization, publishing, or user-file migration is included.

Required CI must pass on this exact reviewed head before merge. This PR does not close the TMT-18 foundation gate.
