### PR TITLE
TMT-48: Share legacy skill directory candidates and preserve backup failures

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -441,14 +441,17 @@ Before mutation, source/destination overlap is rejected, including destination
 parents that alias the bundled source through symlinks. Force is not permission
 to move the installed package source or create a recursive self-link.
 
-`src/skill-installation.ts` owns shared package-root, bundled-source, target and
-link knowledge used by install, the viewer and local drift inspection. The
-installer owns provider detection/presentation and optional legacy backup;
-the update checker owns reminder policy. No custom-install registry, arbitrary
-folder scan, provider plugin update or agent reload is implied. Links follow
-source updates at the same package path; reinstall explicitly after relocation.
-Automatic drift inspection covers known defaults only, and npm version checking
-is not an alpha-channel skill version tracker.
+`src/skill-installation.ts` owns shared package-root, bundled-source, managed-target,
+and legacy directory candidate resolution used by install, the viewer and local
+drift inspection. Candidate resolution operates without package-root discovery,
+preserves installer preference order, deduplicates equivalent paths, and excludes
+the active `.agents` target. The installer owns provider detection/presentation and
+optional legacy backup; the update checker owns reminder policy and reports legacy
+directory paths directly, detecting incomplete directories and broken links. No
+custom-install registry, arbitrary folder scan, provider plugin update or agent
+reload is implied. Links follow source updates at the same package path; reinstall
+explicitly after relocation. Automatic drift inspection covers known defaults only,
+and npm version checking is not an alpha-channel skill version tracker.
 
 The existing packed native verifier also invokes the packed viewer and default
 and custom installation in an isolated home. It verifies actual link contents,

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import fs from 'fs';
+import * as fs from 'node:fs';
 import os from 'os';
 import path from 'path';
 import type { Context, Flags, Paths, ResolvedConfig, Tmux, UI } from '../types.js';
@@ -92,6 +92,7 @@ describe('cmdInstall', () => {
     fs.rmSync(testDir, { recursive: true, force: true });
     fs.rmSync(homeDir, { recursive: true, force: true });
     vi.doUnmock('../skill-installation.js');
+    vi.doUnmock('node:fs');
     vi.restoreAllMocks();
   });
 
@@ -475,6 +476,111 @@ describe('cmdInstall', () => {
       'legacy'
     );
     expect(ctx.ui.info).toHaveBeenCalledWith(expect.stringContaining('recoverable backup'));
+  });
+
+  it('migrates an incomplete legacy Codex directory lacking SKILL.md with force', async () => {
+    vi.resetModules();
+    vi.doMock('node:os', () => ({
+      default: { homedir: () => homeDir },
+      homedir: () => homeDir,
+    }));
+    const legacy = path.join(homeDir, '.codex', 'skills', 'tmux-team');
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.writeFileSync(path.join(legacy, 'custom-data.json'), '{"partial":true}');
+
+    const { inspectLocalDrift } = await import('../update-check.js');
+    const { packageRoot } = await import('../skill-installation.js');
+    const driftBefore = inspectLocalDrift({
+      home: homeDir,
+      root: packageRoot(),
+      codexHome: path.join(homeDir, '.codex'),
+    });
+    expect(driftBefore).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'legacy',
+          path: legacy,
+        }),
+      ])
+    );
+
+    const { cmdInstall } = await import('./install.js');
+    const ctxWithoutForce = createCtx(testDir);
+    await cmdInstall(ctxWithoutForce, 'codex');
+    expect(fs.existsSync(path.join(legacy, 'custom-data.json'))).toBe(true);
+    expect(ctxWithoutForce.ui.warn).toHaveBeenCalledWith(expect.stringContaining('--force'));
+
+    const ctxWithForce = createCtx(testDir, { flags: { force: true } });
+    await cmdInstall(ctxWithForce, 'codex');
+    expect(fs.existsSync(legacy)).toBe(false);
+    const backup = fs
+      .readdirSync(path.dirname(legacy))
+      .find((entry) => entry.startsWith('tmux-team.backup-'));
+    expect(backup).toBeDefined();
+    expect(
+      fs.readFileSync(path.join(path.dirname(legacy), backup!, 'custom-data.json'), 'utf8')
+    ).toBe('{"partial":true}');
+
+    const driftAfter = inspectLocalDrift({
+      home: homeDir,
+      root: packageRoot(),
+      codexHome: path.join(homeDir, '.codex'),
+    });
+    expect(driftAfter).toEqual([]);
+  });
+
+  it('honestly surfaces rename failures when backing up legacy copies', async () => {
+    vi.resetModules();
+    vi.doMock('node:os', () => ({
+      default: { homedir: () => homeDir },
+      homedir: () => homeDir,
+    }));
+    const legacy = path.join(homeDir, '.codex', 'skills', 'tmux-team');
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.writeFileSync(path.join(legacy, 'SKILL.md'), 'legacy');
+
+    const renameSpy = vi.fn((_oldPath: string, _newPath: string) => {
+      const error = new Error('EACCES: permission denied') as Error & { code: string };
+      error.code = 'EACCES';
+      throw error;
+    });
+
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+      return {
+        ...actual,
+        default: {
+          ...actual,
+          renameSync: renameSpy,
+        },
+        renameSync: renameSpy,
+      };
+    });
+
+    const { cmdInstall } = await import('./install.js');
+    const ctx = createCtx(testDir, { flags: { force: true } });
+    await expect(cmdInstall(ctx, 'codex')).rejects.toThrow(`exit(${ExitCodes.ERROR})`);
+
+    expect(renameSpy).toHaveBeenCalledTimes(1);
+    const [source, destination] = renameSpy.mock.calls[0];
+    expect(source).toBe(legacy);
+    expect(path.dirname(destination)).toBe(path.dirname(legacy));
+    expect(path.basename(destination)).toMatch(/^tmux-team\.backup-\d+$/);
+
+    // Original contents preserved
+    expect(fs.existsSync(path.join(legacy, 'SKILL.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(legacy, 'SKILL.md'), 'utf8')).toBe('legacy');
+
+    // No backup directory created
+    const backups = fs
+      .readdirSync(path.dirname(legacy))
+      .filter((entry) => entry.startsWith('tmux-team.backup-'));
+    expect(backups).toHaveLength(0);
+
+    // No success or backup announcement
+    expect(ctx.ui.success).not.toHaveBeenCalled();
+    expect(ctx.ui.info).not.toHaveBeenCalled();
+    expect(ctx.ui.error).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
   });
 
   it('reports unsupported platforms before touching the filesystem', async () => {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -14,6 +14,7 @@ import {
   ensureManagedLink,
   getCodexHome,
   getCustomSkillConfig,
+  getLegacyCodexDirectories,
   getSkillConfigs,
   hasBundledSkillSource,
   isCorrectLink,
@@ -62,24 +63,12 @@ export function detectEnvironment(): SkillAgent[] {
   return detected;
 }
 
-function legacyCodexDirectories(): string[] {
-  const home = os.homedir();
-  const candidates = [
-    path.join(getCodexHome(), 'skills', 'tmux-team'),
-    path.join(home, '.codex', 'skills', 'tmux-team'),
-  ];
-  const managedTarget = path.resolve(getSkillConfigs().codex.target);
-  return candidates.filter(
-    (candidate, index) =>
-      path.resolve(candidate) !== managedTarget &&
-      candidates.findIndex((other) => path.resolve(other) === path.resolve(candidate)) === index
-  );
-}
-
 /** Migrate pre-4.3 copied Codex skills without deleting user data. */
 export function migrateLegacyCodex(ctx: Context): string[] {
+  const home = os.homedir();
+  const codexHome = getCodexHome(home);
   const backups: string[] = [];
-  for (const legacy of legacyCodexDirectories()) {
+  for (const legacy of getLegacyCodexDirectories(home, codexHome)) {
     if (!targetExists(legacy)) continue;
     if (!ctx.flags.force) {
       ctx.ui.warn(

--- a/src/skill-installation.test.ts
+++ b/src/skill-installation.test.ts
@@ -1,0 +1,49 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getLegacyCodexDirectories } from './skill-installation.js';
+
+describe('skill-installation legacy candidate resolution', () => {
+  it('deduplicates equivalent paths in candidate order when CODEX_HOME matches default .codex', () => {
+    const home = '/test/user/home';
+    const codexHome = path.join(home, '.codex');
+    const candidates = getLegacyCodexDirectories(home, codexHome);
+    expect(candidates).toEqual([path.join(home, '.codex', 'skills', 'tmux-team')]);
+  });
+
+  it('deduplicates equivalent unnormalized candidate paths without pre-normalizing input', () => {
+    const home = '/test/user/home';
+    // Raw unnormalized candidate path containing redundant relative and dot segments
+    const codexHome = `${home}/nested/../.codex/.`;
+    const candidates = getLegacyCodexDirectories(home, codexHome);
+    expect(candidates).toHaveLength(1);
+    expect(path.resolve(candidates[0])).toBe(
+      path.resolve(path.join(home, '.codex', 'skills', 'tmux-team'))
+    );
+  });
+
+  it('preserves installer preference order for a distinct custom CODEX_HOME', () => {
+    const home = '/test/user/home';
+    const customCodexHome = '/opt/custom/codex';
+    const candidates = getLegacyCodexDirectories(home, customCodexHome);
+    expect(candidates).toEqual([
+      path.join(customCodexHome, 'skills', 'tmux-team'),
+      path.join(home, '.codex', 'skills', 'tmux-team'),
+    ]);
+  });
+
+  it('excludes active managed .agents target when CODEX_HOME is configured to .agents', () => {
+    const home = '/test/user/home';
+    const codexHome = path.join(home, '.agents');
+    const candidates = getLegacyCodexDirectories(home, codexHome);
+    expect(candidates).toEqual([path.join(home, '.codex', 'skills', 'tmux-team')]);
+  });
+
+  it('resolves expected paths for nonexistent paths without requiring disk entries', () => {
+    const home = '/virtual/nonexistent/home';
+    const codexHome = '/virtual/nonexistent/codex';
+    const candidates = getLegacyCodexDirectories(home, codexHome);
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]).toBe(path.join(codexHome, 'skills', 'tmux-team'));
+    expect(candidates[1]).toBe(path.join(home, '.codex', 'skills', 'tmux-team'));
+  });
+});

--- a/src/skill-installation.ts
+++ b/src/skill-installation.ts
@@ -46,19 +46,37 @@ export function hasBundledSkillSource(source: string): boolean {
   }
 }
 
+function getManagedSkillTarget(home: string): string {
+  return path.join(home, '.agents', 'skills', 'tmux-team');
+}
+
+export function getLegacyCodexDirectories(home: string, codexHome: string): string[] {
+  const managedTarget = path.resolve(getManagedSkillTarget(home));
+  const candidates = [
+    path.join(codexHome, 'skills', 'tmux-team'),
+    path.join(home, '.codex', 'skills', 'tmux-team'),
+  ];
+  return candidates.filter(
+    (candidate, index) =>
+      path.resolve(candidate) !== managedTarget &&
+      candidates.findIndex((other) => path.resolve(other) === path.resolve(candidate)) === index
+  );
+}
+
 export function getSkillConfigs(
   root = packageRoot(),
   home = os.homedir()
 ): Record<SkillAgent, SkillConfig> {
   const universal = getUniversalSkillSource(root);
+  const agentTarget = getManagedSkillTarget(home);
   return {
     claude: {
       source: path.join(root, 'skills', 'claude', 'team.md'),
       target: path.join(home, '.claude', 'commands', 'team.md'),
     },
     // Codex and Gemini intentionally share one official user-global location.
-    codex: { source: universal, target: path.join(home, '.agents', 'skills', 'tmux-team') },
-    gemini: { source: universal, target: path.join(home, '.agents', 'skills', 'tmux-team') },
+    codex: { source: universal, target: agentTarget },
+    gemini: { source: universal, target: agentTarget },
   };
 }
 

--- a/src/update-check.test.ts
+++ b/src/update-check.test.ts
@@ -53,9 +53,71 @@ describe('local installation drift', () => {
     fs.writeFileSync(path.join(customCodexHome, 'skills', 'tmux-team', 'SKILL.md'), 'old');
     expect(inspectLocalDrift({ home, root, codexHome: customCodexHome })).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ kind: 'legacy', path: expect.stringContaining('custom-codex') }),
+        expect.objectContaining({
+          kind: 'legacy',
+          path: path.join(customCodexHome, 'skills', 'tmux-team'),
+        }),
       ])
     );
+  });
+
+  it('detects incomplete legacy directories and broken symlinks as legacy directory paths', () => {
+    temp = fs.mkdtempSync(path.join(os.tmpdir(), 'tmux-team-drift-incomplete-'));
+    const root = path.join(temp, 'package');
+    const home = path.join(temp, 'home');
+    const defaultCodexHome = path.join(home, '.codex');
+    fs.mkdirSync(path.join(root, 'skills', 'tmux-team'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'skills', 'tmux-team', 'SKILL.md'), 'canonical');
+
+    // Incomplete directory (no SKILL.md)
+    const incompleteLegacy = path.join(defaultCodexHome, 'skills', 'tmux-team');
+    fs.mkdirSync(incompleteLegacy, { recursive: true });
+    fs.writeFileSync(path.join(incompleteLegacy, 'stray.txt'), 'stray');
+
+    const issues = inspectLocalDrift({ home, root, codexHome: defaultCodexHome });
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'legacy',
+          path: incompleteLegacy,
+          message: `Legacy copied Codex skill found at ${incompleteLegacy}`,
+        }),
+      ])
+    );
+
+    // Broken symlink at legacy location
+    const customCodexHome = path.join(temp, 'broken-codex');
+    const brokenLinkLegacy = path.join(customCodexHome, 'skills', 'tmux-team');
+    fs.mkdirSync(path.dirname(brokenLinkLegacy), { recursive: true });
+    fs.symlinkSync(path.join(temp, 'nonexistent-target'), brokenLinkLegacy);
+
+    const issuesWithBroken = inspectLocalDrift({ home, root, codexHome: customCodexHome });
+    expect(issuesWithBroken).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'legacy',
+          path: brokenLinkLegacy,
+        }),
+      ])
+    );
+  });
+
+  it('excludes the active managed .agents target when CODEX_HOME points to .agents', () => {
+    temp = fs.mkdtempSync(path.join(os.tmpdir(), 'tmux-team-drift-exclusion-'));
+    const root = path.join(temp, 'package');
+    const home = path.join(temp, 'home');
+    const canonicalSource = path.join(root, 'skills', 'tmux-team');
+    fs.mkdirSync(canonicalSource, { recursive: true });
+    fs.writeFileSync(path.join(canonicalSource, 'SKILL.md'), 'canonical');
+
+    // Create a real valid managed symlink pointing to the canonical bundled source
+    const managedTarget = path.join(home, '.agents', 'skills', 'tmux-team');
+    fs.mkdirSync(path.dirname(managedTarget), { recursive: true });
+    fs.symlinkSync(canonicalSource, managedTarget);
+
+    // When CODEX_HOME points to ~/.agents, the managed target is excluded and no drift is reported
+    const issues = inspectLocalDrift({ home, root, codexHome: path.join(home, '.agents') });
+    expect(issues).toEqual([]);
   });
 
   it('detects a Claude copied command only when its content differs', () => {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   getCodexHome,
+  getLegacyCodexDirectories,
   getSkillConfigs,
   isCorrectLink,
   packageRoot,
@@ -64,11 +65,8 @@ export function inspectLocalDrift(options: DriftOptions = {}): DriftIssue[] {
   const claudeTarget = configs.claude.target;
   const issues: DriftIssue[] = [];
 
-  for (const legacy of [
-    path.join(home, '.codex', 'skills', 'tmux-team', 'SKILL.md'),
-    path.join(codexHome, 'skills', 'tmux-team', 'SKILL.md'),
-  ]) {
-    if (targetExists(legacy) && !issues.some((issue) => issue.path === legacy)) {
+  for (const legacy of getLegacyCodexDirectories(home, codexHome)) {
+    if (targetExists(legacy)) {
       issues.push({
         kind: 'legacy',
         path: legacy,


### PR DESCRIPTION
## Summary

Closes TMT-48, a bounded child of TMT-29.

- Share one ordered, normalized, deduplicated legacy Codex directory candidate resolver between installation and drift inspection.
- Keep home/CODEX_HOME defaults in consumers and managed-target knowledge in the existing skill-installation module.
- Detect incomplete directories and broken legacy links without treating the active shared `.agents` target as legacy.
- Preserve unforced copies, recoverable forced backups, and honest rename failures. Custom-directory installation remains independent.

## Verification

- Integrated onto main c6488b0 after TMT-22 merged. `git range-diff` confirms the reviewed issue patch was unchanged by rebase.
- `pnpm check`: passed.
- `pnpm test:run`: 52 files, 710 tests passed; 95.44% statement and 89.19% branch coverage, thresholds passed.
- macOS arm64 packed native/skill installation verifier: passed in an isolated temporary install before rebase; no dependency or installer changes were introduced by rebase.
- `pnpm test:e2e`: all 77 scenarios across 18 files passed on the integrated head in a network-isolated Docker container with real CLI/tmux and deterministic mock agents.

Regression assertions cover default/custom/unnormalized paths, deduplication, managed-link exclusion, incomplete directories, broken links, exact preserved backup contents, drift before/after migration, and rename failure preserving source without a backup or success announcement. Existing custom-target isolation tests remain in the full suite.

## Primary architecture review

Primary personally reviewed every changed source/test/document diff, installer and startup-check callers, and the shared link/backup implementation. Gemini implemented the bounded change in its own worktree following the accepted Luna high pattern audit. Primary requested and reviewed stronger failure-state oracles and explicit isolated path inputs, removed unnecessary export/redundant consumer deduplication, and simplified mocked rename assertions before rerunning checks.

Architecture documentation now identifies the existing skill-installation module as the shared candidate owner. No parallel provider registry, parser, storage model, broad path scan, or package-root filesystem discovery is added to candidate construction. Existing inaccessible-lstat behavior is unchanged; this does not claim every unreadable path is detected. There is no user-file deletion, host skill installation, namespace change, MCP, daemon, or publishing.

Required CI must pass on reviewed head d0c3b67c657e56095abaf92da0aa5906452c6316 before merge. This closes only TMT-48, not the remaining TMT-29/TMT-18 foundation gate.
