### PR TITLE
fix(config): centralize setting validation and safe repairs (TMT-46)

### DIFF
--- a/.agents/skills/tmt-dev/SKILL.md
+++ b/.agents/skills/tmt-dev/SKILL.md
@@ -10,7 +10,7 @@ workflow, not end-user documentation for the `tmt` CLI.
 
 Read the repository guidance before planning work:
 
-- [`AGENTS.md`](../../../AGENTS.md) — mandatory audit, ownership, and lifecycle policy.
+- [`AGENTS.md`](../../../AGENTS.md) — pattern inspection, discretionary delegation, ownership, and lifecycle policy.
 - [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) — current and target boundaries, legacy debt, and architecture change triggers.
 - [`CONVENTIONS.md`](../../../CONVENTIONS.md) — code and test style.
 - [`DEVELOPMENT.md`](../../../DEVELOPMENT.md) — commands and the focused verification matrix.
@@ -22,15 +22,19 @@ Read the repository guidance before planning work:
 1. Start from a tracked issue whose outcome, scope, acceptance criteria,
    dependencies, and project relationship are clear. Create its dedicated branch
    and worktree before implementation; follow AGENTS for state and commit attribution.
-2. Before editing, perform the required read-only repository pattern audit with
-   the delegated Luna reviewer at high reasoning effort. The primary reviewer
-   must accept or reject its findings before implementation starts and record
-   the disposition.
+2. Before editing, inspect relevant existing patterns locally or delegate a
+   read-only audit when it is worth the coordination and review effort. Keep
+   inspection proportional to the change; record material findings and their
+   disposition. Delegation is not mandatory. Prefer Luna for simple, bounded
+   tasks and large-scale detection or scanning.
 3. The primary reviewer owns the architecture design: define the affected
    boundary, inputs and outputs, risks, and reuse of existing ports/helpers
-   before assigning implementation.
-4. Assign bounded implementation work with explicit file ownership. Do not let
-   concurrent agents edit overlapping files.
+   before implementation.
+4. Implement directly or delegate according to total effort and coupling, not
+   a requirement to assign work. When delegating, set explicit file ownership,
+   constraints, and verification requirements. Do not let concurrent agents
+   edit overlapping files. Keep architectural and integration decisions with
+   the primary agent.
 5. The primary reviewer reviews every changed file and the relevant callers,
    fixtures, and tests. Passing reports or green CI are evidence, not a
    substitute for that review. Record findings, dispositions, and the reviewed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,13 +34,13 @@ follow-up is not permission to ship inaccurate descriptions of current behavior.
 
 ## Pattern audit before changes
 
-Before editing code, tests, documentation, configuration, or repository skills, the primary agent must delegate a read-only repository pattern audit to a `gpt-5.6-luna` agent with high reasoning effort.
+Before editing code, tests, documentation, configuration, or repository skills, inspect the relevant existing patterns. The primary agent decides whether to inspect locally or delegate, based on the total implementation, coordination, and review effort. Delegation is optional, not a prerequisite for making changes.
 
-The audit must inspect the relevant architecture, helpers, fixtures, scripts, naming conventions, tests, documentation, and skills. It must identify reusable patterns, duplicated behavior, and conflicts with established conventions. The delegated agent must not edit files, mutate external systems, or broaden the requested scope during this audit.
+Keep the inspection proportional to the change. Inspect relevant architecture, helpers, fixtures, scripts, naming conventions, tests, documentation, and skills to identify reusable patterns, duplicated behavior, and conflicts. Prefer `gpt-5.6-luna` for simple, bounded tasks and large-scale detection or scanning. A delegated read-only audit must not edit files, mutate external systems, or broaden the requested scope.
 
-The primary agent must review the findings before any edits begin, record which findings are accepted or rejected and why, and reuse or extend established abstractions where practical. If the audit finds unnecessary duplication or an inconsistent implementation within scope, correct it before continuing. When this rule is introduced after work has started, pause new edits, run the audit, and apply the same review.
+The primary agent reviews findings before editing, records material findings and their disposition, and reuses or extends established abstractions where practical. Correct unnecessary duplication or inconsistent implementation within scope before continuing.
 
-If delegation is unavailable, document that limitation and perform the same read-only audit locally before editing. Delegation never expands the user's authorization.
+Do not split tightly coupled architecture or integration work merely to use another agent. Direct implementation requires no delegation exception. Delegation never expands the user's authorization.
 
 ## Repository content language
 
@@ -56,9 +56,11 @@ in English.
   dedicated branch/worktree, and one reviewable PR. Confirm outcome, scope,
   acceptance criteria, dependencies and project relationship before editing;
   mark the issue started when implementation begins. Split oversized work first.
-- Delegate bounded implementation to `gpt-5.6-luna` by default when available.
-  Give explicit file ownership, constraints and verification requirements;
-  prevent overlapping edits. The primary retains design and acceptance authority.
+- Delegate only when it reduces total effort or provides useful independent coverage.
+  Prefer `gpt-5.6-luna` for simple, bounded work and large-scale detection or scanning.
+  When delegating, give explicit file ownership, constraints and verification
+  requirements; prevent overlapping edits. The primary retains design,
+  integration, and acceptance authority.
 - Keep decisions, progress, blockers, deferred work, branch/PR links and evidence
   synchronized in Linear. Do not mark work done before its delivery state supports it.
 - Every Codex-created commit includes `Co-authored-by: Codex <codex@openai.com>`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -258,8 +258,9 @@ Check validates its effective capture count before target lookup: integers
 0 through 2,147,483,647 are accepted, with zero preserving visible-pane capture.
 Invalid runtime counts return `INVALID_CAPTURE_LINES` (exit 1), without capture
 or reconciliation. These argument limits do not replace tmux's existing
-one-second timeout and 4 MiB output bound. Config loading/writing consolidation
-remains TMT-46 work.
+one-second timeout and 4 MiB output bound. Loaded-setting failures are rejected
+earlier by the shared configuration boundary described below; direct runtime
+command inputs retain their feature-specific validation and errors.
 
 The parser rejects retired `--wait`, talk `--lines`, and explicit
 `--timeout`/`--detach` combinations before Context effects. `send` follows the
@@ -283,6 +284,37 @@ not automatically rewritten. Explicit local `config clear mode` may remove
 that key; config set mode and global clear remain unsupported. captureLines
 still controls check diagnostics. Historical migrations/nonce columns stay
 unchanged; new talk attempts do not create a nonce.
+
+## Configuration policy and raw-file preservation
+
+`src/config.ts` owns path resolution and raw-file loading/writing;
+`src/config-settings.ts` owns fresh canonical defaults, known-setting validation
+and runtime projection. This focused policy reuses the pure
+capture/timing predicates in `domain/interaction-limits.ts`; commands do not
+copy default objects or use permissive `parseInt` conversion. CLI setter syntax
+is decimal integer text for its supported numeric keys, while loaded JSON
+paste delay retains the runtime's finite fractional-millisecond support.
+
+Global/local roots and supplied `defaults`/`$config` containers must be non-null
+objects, not arrays. Every supplied known value is validated before merging,
+including lower-tier values that would be overridden. Missing values use fresh
+defaults; nulls, strings and invalid enums are not coerced. Unknown and retired
+fields remain raw data and do not enter resolved runtime settings. Existing
+global/local precedence and path selection remain unchanged.
+
+Raw edit reads validate container shapes without first rejecting the value
+being repaired. Save validates the complete resulting destination before
+directory creation or writing; unrelated invalid known values still reject.
+Rejected updates preserve file bytes, while successful writes preserve unknown
+fields. This does not supply crash-atomic or concurrent JSON-file updates.
+Loaded shape/value errors join JSON errors at `CONFIG_ERROR` (exit 1), with
+file/field context; invalid setter arguments retain their existing command error.
+
+Context keeps settings lazy for storage-only capabilities. `reply`, `result`
+and explicit role access do not acquire a dependency on unrelated malformed
+configuration. Config-consuming talk/check fail before tmux or request storage;
+help retains its safe default fallback. Exchange retention configuration remains
+future TMT-50 work and must extend this owner instead of creating another loader.
 
 ## Caller context
 
@@ -574,7 +606,6 @@ a gap is resolved; do not leave a permanent exception or label a proposal as shi
 
 | Gap                                                                                                      | Owning issue                                                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Configuration defaults and loaded-setting validation remain split.                                       | [TMT-46](https://linear.app/tigerpig-dev/issue/TMT-46)                                                                                                                 |
 | Shipped skill/provider inventories drift; packed verification does not yet prove application migrations. | [TMT-29](https://linear.app/tigerpig-dev/issue/TMT-29)                                                                                                                 |
 | Non-tmux identity management, memory and durable inbox are future capabilities, not installed APIs.      | [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -142,6 +142,16 @@ Use the E2E skill for integration/lifecycle changes, including its twice-run
 cleanup gate. Keep the existing CI jobs required even when a local check is not
 applicable; do not use this matrix to bypass branch protection.
 
+## Configuration verification
+
+Configuration changes use policy tables for known-field/type/range rules and
+real-file tests for rejected-update byte preservation and targeted repair.
+The CLI contract suite verifies complete JSON/exit behavior and storage-only
+reply/result independence from malformed settings. Docker scenarios preserve
+the no-tmux/no-storage assertions for invalid loaded configuration and exercise
+valid overrides through the public CLI and deterministic peer. A loader-level
+`CONFIG_ERROR` must not weaken the independent runtime capture/timing tests.
+
 ## Packed native-install verification
 
 The packed native-install check verifies release artifacts. It installs the actual

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -151,6 +151,10 @@ reply/result independence from malformed settings. Docker scenarios preserve
 the no-tmux/no-storage assertions for invalid loaded configuration and exercise
 valid overrides through the public CLI and deterministic peer. A loader-level
 `CONFIG_ERROR` must not weaken the independent runtime capture/timing tests.
+Real CLI process tests must declare a bounded process-test timeout, following
+the existing CLI contract suites, rather than inheriting the one-second unit
+default. Keep child-process termination bounds and behavioral assertions intact;
+test-runner budgets are not production timeout policy.
 
 ## Packed native-install verification
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,34 @@ provider-specific cleanup. `check` is a diagnostic snapshot, not durable result
 retrieval. Same-pane input serialization is not guaranteed. See the
 [channel research and implementation plan](REQUEST-RESPONSE.md).
 
+## Configuration validation
+
+`tmt config show --json` reports the resolved values and selected config paths.
+The existing global `config.json` and local `tmux-team.json` `$config` retain
+their precedence; no new settings file is required.
+
+`config set` supports `preambleMode`, `preambleEvery`, and `pasteEnterDelayMs`.
+Use `--global` to write the global file; otherwise it writes a local override.
+Numeric setter input must contain decimal digits only, without suffixes,
+fractions, signs or whitespace. Zero disables preamble injection or the
+paste-to-Enter delay. Preamble frequency must be a safe integer; paste delay
+is bounded to 2,147,483,647 milliseconds.
+
+Loaded configuration validates each supplied known field before merging:
+timeout must be positive and at most 86,400 seconds, poll interval positive
+and finite, capture count an integer from zero through 2,147,483,647, and
+preamble mode either `always` or `disabled`. Loaded JSON paste delay may be
+fractional within its finite non-negative bound. Nulls and numeric strings
+are not defaults. Invalid settings return `CONFIG_ERROR` (exit 1), even if a
+higher tier would override them. Unknown/retired fields stay opaque in raw
+files and are excluded from runtime settings.
+
+Rejected updates preserve the original file; setting a bad field to a valid
+value can repair it, but another invalid known field still prevents saving.
+This is validation before writing, not a concurrent-write or crash-atomic
+guarantee. Storage-only `reply` and `result` remain independent of malformed
+settings. Fix the reported field rather than deleting unrelated configuration.
+
 ## Local SQLite storage
 
 TMT owns its local SQLite database. The database is deliberately local-file

--- a/plugins/tmux-team/commands/learn.md
+++ b/plugins/tmux-team/commands/learn.md
@@ -155,6 +155,24 @@ managed skill links then use the new bundled files automatically. Sending pane
 input is an external action and must be authorized by the user; preserve
 multiline text.
 
+## Configuration safety
+
+Use `tmt config show --json` to inspect resolved settings and file paths.
+`config set` supports `preambleMode`, `preambleEvery`, and
+`pasteEnterDelayMs`; add `--global` for the global file, otherwise it writes
+a local override. Numeric writes require decimal digits only: no suffixes,
+fractions, signs, or whitespace. Zero disables preamble injection or removes
+the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
+paste delay is at most 2147483647 milliseconds.
+
+Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
+talk/check effects, even when another layer would override them. Unknown and
+retired fields remain opaque and are not migrated. A rejected settings update
+leaves the file unchanged. Correct the reported field; do not delete the whole
+configuration as a workaround. Storage-only `reply` and `result` do not load
+unrelated settings, so malformed config does not prevent durable submission
+or retrieval.
+
 ## Command option scope
 
 Options apply only to commands that use them. `--timeout`, `--delay`,

--- a/plugins/tmux-team/commands/team.md
+++ b/plugins/tmux-team/commands/team.md
@@ -123,6 +123,24 @@ do not complete a request. Same-pane input serialization is not guaranteed.
 - Preserve multiline messages and do not send pane input without authorization
 - After receiving a response, summarize it for the user
 
+## Configuration safety
+
+Use `tmt config show --json` to inspect resolved settings and file paths.
+`config set` supports `preambleMode`, `preambleEvery`, and
+`pasteEnterDelayMs`; add `--global` for the global file, otherwise it writes
+a local override. Numeric writes require decimal digits only: no suffixes,
+fractions, signs, or whitespace. Zero disables preamble injection or removes
+the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
+paste delay is at most 2147483647 milliseconds.
+
+Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
+talk/check effects, even when another layer would override them. Unknown and
+retired fields remain opaque and are not migrated. A rejected settings update
+leaves the file unchanged. Correct the reported field; do not delete the whole
+configuration as a workaround. Storage-only `reply` and `result` do not load
+unrelated settings, so malformed config does not prevent durable submission
+or retrieval.
+
 ## Command option scope
 
 Options apply only to commands that use them. `--timeout`, `--delay`,

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -244,6 +244,24 @@ tmux-team talk codex "Review this authentication code" --json
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.
 
+## Configuration safety
+
+Use `tmt config show --json` to inspect resolved settings and file paths.
+`config set` supports `preambleMode`, `preambleEvery`, and
+`pasteEnterDelayMs`; add `--global` for the global file, otherwise it writes
+a local override. Numeric writes require decimal digits only: no suffixes,
+fractions, signs, or whitespace. Zero disables preamble injection or removes
+the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
+paste delay is at most 2147483647 milliseconds.
+
+Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
+talk/check effects, even when another layer would override them. Unknown and
+retired fields remain opaque and are not migrated. A rejected settings update
+leaves the file unchanged. Correct the reported field; do not delete the whole
+configuration as a workaround. Storage-only `reply` and `result` do not load
+unrelated settings, so malformed config does not prevent durable submission
+or retrieval.
+
 ## Command option scope
 
 Options apply only to commands that use them. `--timeout`, `--delay`,

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -266,6 +266,24 @@ identity/profile. Do not delete old user files as a migration workaround.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.
 
+## Configuration safety
+
+Use `tmt config show --json` to inspect resolved settings and file paths.
+`config set` supports `preambleMode`, `preambleEvery`, and
+`pasteEnterDelayMs`; add `--global` for the global file, otherwise it writes
+a local override. Numeric writes require decimal digits only: no suffixes,
+fractions, signs, or whitespace. Zero disables preamble injection or removes
+the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
+paste delay is at most 2147483647 milliseconds.
+
+Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
+talk/check effects, even when another layer would override them. Unknown and
+retired fields remain opaque and are not migrated. A rejected settings update
+leaves the file unchanged. Correct the reported field; do not delete the whole
+configuration as a workaround. Storage-only `reply` and `result` do not load
+unrelated settings, so malformed config does not prevent durable submission
+or retrieval.
+
 ## Command option scope
 
 Options apply only to commands that use them. `--timeout`, `--delay`,

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -267,6 +267,24 @@ identity/profile. Do not delete old user files as a migration workaround.
 - Install integrations with `tmt install`. `tmt upgrade` updates the package;
   managed skill links then use the new bundled files automatically.
 
+## Configuration safety
+
+Use `tmt config show --json` to inspect resolved settings and file paths.
+`config set` supports `preambleMode`, `preambleEvery`, and
+`pasteEnterDelayMs`; add `--global` for the global file, otherwise it writes
+a local override. Numeric writes require decimal digits only: no suffixes,
+fractions, signs, or whitespace. Zero disables preamble injection or removes
+the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
+paste delay is at most 2147483647 milliseconds.
+
+Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
+talk/check effects, even when another layer would override them. Unknown and
+retired fields remain opaque and are not migrated. A rejected settings update
+leaves the file unchanged. Correct the reported field; do not delete the whole
+configuration as a workaround. Storage-only `reply` and `result` do not load
+unrelated settings, so malformed config does not prevent durable submission
+or retrieval.
+
 ## Command option scope
 
 Options apply only to commands that use them. `--timeout`, `--delay`,

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -242,6 +242,24 @@ after sending, and `--delay <seconds>` to delay sending.
 
 Install integrations with `tmt install` (auto-detects supported agents) or `tmt install all --force` to refresh managed links. Upgrade the CLI with `tmt upgrade`; managed links automatically use the updated bundled skill. Run install when an integration is missing or has drifted.
 
+## Configuration safety
+
+Use `tmt config show --json` to inspect resolved settings and file paths.
+`config set` supports `preambleMode`, `preambleEvery`, and
+`pasteEnterDelayMs`; add `--global` for the global file, otherwise it writes
+a local override. Numeric writes require decimal digits only: no suffixes,
+fractions, signs, or whitespace. Zero disables preamble injection or removes
+the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
+paste delay is at most 2147483647 milliseconds.
+
+Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
+talk/check effects, even when another layer would override them. Unknown and
+retired fields remain opaque and are not migrated. A rejected settings update
+leaves the file unchanged. Correct the reported field; do not delete the whole
+configuration as a workaround. Storage-only `reply` and `result` do not load
+unrelated settings, so malformed config does not prevent durable submission
+or retrieval.
+
 ## Command option scope
 
 Options apply only to commands that use them. `--timeout`, `--delay`,

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -1,4 +1,4 @@
-import { ConfigParseError } from './config.js';
+import { ConfigParseError, ConfigValidationError } from './config.js';
 import { createContext, ExitCodes } from './context.js';
 import { cmdHelp, type HelpConfig } from './commands/help.js';
 import { cmdCompletion } from './commands/completion.js';
@@ -30,6 +30,9 @@ function errorMessage(error: unknown): string {
 
 function publicError(error: unknown): { code: string; message: string } {
   if (error instanceof ConfigParseError) {
+    return { code: 'CONFIG_ERROR', message: error.message };
+  }
+  if (error instanceof ConfigValidationError) {
     return { code: 'CONFIG_ERROR', message: error.message };
   }
   return { code: 'INTERNAL_ERROR', message: errorMessage(error) };

--- a/src/commands/config-command.test.ts
+++ b/src/commands/config-command.test.ts
@@ -239,4 +239,46 @@ describe('cmdConfig', () => {
     ).toThrow(`exit(${ExitCodes.ERROR})`);
     expect(fs.existsSync(ctx.paths.globalConfig)).toBe(false);
   });
+
+  it('uses strict integer syntax and preserves partial global defaults', () => {
+    const ctx = createCtx(testDir);
+    fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
+    fs.writeFileSync(
+      ctx.paths.globalConfig,
+      JSON.stringify({ keep: true, defaults: { timeout: 120, future: { enabled: true } } })
+    );
+
+    cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value: '5', global: true }));
+    expect(JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf8'))).toEqual({
+      keep: true,
+      defaults: { timeout: 120, future: { enabled: true }, preambleEvery: 5 },
+    });
+
+    for (const value of ['5.5', '5junk', '5\n', '9007199254740992']) {
+      expect(() =>
+        cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value, global: false }))
+      ).toThrow(`exit(${ExitCodes.ERROR})`);
+    }
+  });
+
+  it('repairs the selected invalid field but rejects an unrelated invalid field before writing', () => {
+    const ctx = createCtx(testDir);
+    fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
+    fs.writeFileSync(
+      ctx.paths.globalConfig,
+      JSON.stringify({ defaults: { preambleEvery: 'bad', captureLines: 100 } })
+    );
+    cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value: '5', global: true }));
+    expect(JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf8')).defaults).toEqual({
+      preambleEvery: 5,
+      captureLines: 100,
+    });
+
+    const original = JSON.stringify({ defaults: { preambleEvery: 3, captureLines: 'bad' } });
+    fs.writeFileSync(ctx.paths.globalConfig, original);
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value: '5', global: true }))
+    ).toThrow(/Invalid configuration/);
+    expect(fs.readFileSync(ctx.paths.globalConfig, 'utf8')).toBe(original);
+  });
 });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -13,6 +13,7 @@ import {
   updateLocalSettings,
   clearLocalSettings,
 } from '../config.js';
+import { createDefaultGlobalDefaults, isValidConfigSettingValue } from '../config-settings.js';
 
 type EnumConfigKey = 'preambleMode';
 type NumericConfigKey = 'preambleEvery' | 'pasteEnterDelayMs';
@@ -22,24 +23,31 @@ const ENUM_KEYS: EnumConfigKey[] = ['preambleMode'];
 const NUMERIC_KEYS: NumericConfigKey[] = ['preambleEvery', 'pasteEnterDelayMs'];
 const VALID_KEYS: ConfigKey[] = [...ENUM_KEYS, ...NUMERIC_KEYS];
 
-const VALID_VALUES: Record<EnumConfigKey, string[]> = {
-  preambleMode: ['always', 'disabled'],
-};
-
 function isValidKey(key: string): key is ConfigKey {
   return VALID_KEYS.includes(key as ConfigKey);
 }
 
-function isEnumKey(key: ConfigKey): key is EnumConfigKey {
-  return ENUM_KEYS.includes(key as EnumConfigKey);
-}
+type ParsedSetting =
+  | { readonly key: EnumConfigKey; readonly value: 'always' | 'disabled' }
+  | { readonly key: NumericConfigKey; readonly value: number };
 
-function isNumericKey(key: ConfigKey): key is NumericConfigKey {
-  return NUMERIC_KEYS.includes(key as NumericConfigKey);
-}
-
-function isValidValue(key: EnumConfigKey, value: string): boolean {
-  return VALID_VALUES[key].includes(value);
+function parseSetting(key: ConfigKey, value: string): ParsedSetting {
+  if (key === 'preambleMode') {
+    if (!isValidConfigSettingValue(key, value)) {
+      throw new Error(`Invalid value for ${key}: ${value}. Valid values: always, disabled`);
+    }
+    return { key, value: value as 'always' | 'disabled' };
+  }
+  if (value.length === 0 || /\D/u.test(value)) {
+    throw new Error(`Invalid value for ${key}: ${value}. Must be a non-negative integer.`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || !isValidConfigSettingValue(key, parsed)) {
+    throw new Error(
+      `Invalid value for ${key}: ${value}. Must be a supported non-negative integer.`
+    );
+  }
+  return { key, value: parsed };
 }
 
 /**
@@ -133,65 +141,40 @@ function setConfig(ctx: Context, key: string, value: string, global: boolean): v
 
   const validKey = key as ConfigKey;
 
-  // Validate enum keys
-  if (isEnumKey(validKey)) {
-    if (!isValidValue(validKey, value)) {
-      ctx.ui.error(
-        `Invalid value for ${key}: ${value}. Valid values: ${VALID_VALUES[validKey].join(', ')}`
-      );
-      ctx.exit(ExitCodes.ERROR);
-    }
-  }
-
-  // Validate numeric keys
-  if (isNumericKey(validKey)) {
-    const numValue = parseInt(value, 10);
-    if (isNaN(numValue) || numValue < 0) {
-      ctx.ui.error(`Invalid value for ${key}: ${value}. Must be a non-negative integer.`);
-      ctx.exit(ExitCodes.ERROR);
-    }
+  let parsed: ParsedSetting;
+  try {
+    parsed = parseSetting(validKey, value);
+  } catch (error) {
+    ctx.ui.error(error instanceof Error ? error.message : String(error));
+    ctx.exit(ExitCodes.ERROR);
   }
 
   if (global) {
     // Set in global config
     const globalConfig = loadGlobalConfig(ctx.paths);
-    if (key === 'preambleMode') {
-      globalConfig.preambleMode = value as 'always' | 'disabled';
-    } else if (key === 'preambleEvery') {
+    if (parsed.key === 'preambleMode') {
+      globalConfig.preambleMode = parsed.value;
+    } else if (parsed.key === 'preambleEvery') {
       if (!globalConfig.defaults) {
-        globalConfig.defaults = {
-          timeout: 180,
-          pollInterval: 1,
-          captureLines: 100,
-          preambleEvery: parseInt(value, 10),
-          pasteEnterDelayMs: 500,
-        };
-      } else {
-        globalConfig.defaults.preambleEvery = parseInt(value, 10);
+        globalConfig.defaults = createDefaultGlobalDefaults();
       }
-    } else if (key === 'pasteEnterDelayMs') {
+      globalConfig.defaults.preambleEvery = parsed.value;
+    } else if (parsed.key === 'pasteEnterDelayMs') {
       if (!globalConfig.defaults) {
-        globalConfig.defaults = {
-          timeout: 180,
-          pollInterval: 1,
-          captureLines: 100,
-          preambleEvery: 3,
-          pasteEnterDelayMs: parseInt(value, 10),
-        };
-      } else {
-        globalConfig.defaults.pasteEnterDelayMs = parseInt(value, 10);
+        globalConfig.defaults = createDefaultGlobalDefaults();
       }
+      globalConfig.defaults.pasteEnterDelayMs = parsed.value;
     }
     saveGlobalConfig(ctx.paths, globalConfig);
     ctx.ui.success(`Set ${key}=${value} in global config`);
   } else {
     // Set in local config
-    if (key === 'preambleMode') {
-      updateLocalSettings(ctx.paths, { preambleMode: value as 'always' | 'disabled' });
-    } else if (key === 'preambleEvery') {
-      updateLocalSettings(ctx.paths, { preambleEvery: parseInt(value, 10) });
-    } else if (key === 'pasteEnterDelayMs') {
-      updateLocalSettings(ctx.paths, { pasteEnterDelayMs: parseInt(value, 10) });
+    if (parsed.key === 'preambleMode') {
+      updateLocalSettings(ctx.paths, { preambleMode: parsed.value });
+    } else if (parsed.key === 'preambleEvery') {
+      updateLocalSettings(ctx.paths, { preambleEvery: parsed.value });
+    } else if (parsed.key === 'pasteEnterDelayMs') {
+      updateLocalSettings(ctx.paths, { pasteEnterDelayMs: parsed.value });
     }
     ctx.ui.success(`Set ${key}=${value} in local config (repo override)`);
   }

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -97,6 +97,15 @@ ${colors.yellow('GLOBAL IDENTITIES')}
   ${colors.dim('Legacy registry commands are retired; local settings and durable identity preambles remain.')}
   ${colors.dim('tmux-team is CLI-only; there is no daemon to run.')}
 
+${colors.yellow('CONFIGURATION SAFETY')}
+
+  Use tmt config show --json for resolved settings and config paths.
+  config set supports preambleMode, preambleEvery and pasteEnterDelayMs;
+  add --global for the global file. Numeric writes require decimal digits,
+  not fractions or suffixes. Invalid loaded settings return CONFIG_ERROR
+  before talk/check effects. Fix the reported field, not the whole file.
+  Storage-only reply/result remain usable with malformed configuration.
+
 ${colors.yellow('BEST PRACTICES')}
 
   1. ${colors.green('Submit a full reply before summarizing')} - terminal text is not completion

--- a/src/config-cli-contract.test.ts
+++ b/src/config-cli-contract.test.ts
@@ -142,110 +142,126 @@ describe('real CLI configuration contract', () => {
     }
   }, 30_000);
 
-  it('rejects null known values even when another config tier overrides them', async () => {
-    for (const [globalValue, localValue] of [
-      [{ defaults: { pasteEnterDelayMs: null } }, { $config: { pasteEnterDelayMs: 0 } }],
-      [{ defaults: { preambleEvery: 3 } }, { $config: { preambleEvery: null } }],
-    ] as const) {
-      await withSandbox(async (sandbox) => {
-        const globalBytes = writeGlobal(sandbox, globalValue);
-        const localBytes = writeLocal(sandbox, localValue);
-        const before = fileSnapshot(sandbox.root);
-        const result = await runCli(sandbox, ['list', '--json']);
+  it(
+    'rejects null known values even when another config tier overrides them',
+    { timeout: 10_000 },
+    async () => {
+      for (const [globalValue, localValue] of [
+        [{ defaults: { pasteEnterDelayMs: null } }, { $config: { pasteEnterDelayMs: 0 } }],
+        [{ defaults: { preambleEvery: 3 } }, { $config: { preambleEvery: null } }],
+      ] as const) {
+        await withSandbox(async (sandbox) => {
+          const globalBytes = writeGlobal(sandbox, globalValue);
+          const localBytes = writeLocal(sandbox, localValue);
+          const before = fileSnapshot(sandbox.root);
+          const result = await runCli(sandbox, ['list', '--json']);
 
-        expect(result.status).toBe(1);
-        expectError(result, 'CONFIG_ERROR');
-        expect(fileSnapshot(sandbox.root)).toEqual(before);
-        expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalBytes);
-        expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(localBytes);
-        expect(fs.existsSync(sandbox.database)).toBe(false);
+          expect(result.status).toBe(1);
+          expectError(result, 'CONFIG_ERROR');
+          expect(fileSnapshot(sandbox.root)).toEqual(before);
+          expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalBytes);
+          expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(localBytes);
+          expect(fs.existsSync(sandbox.database)).toBe(false);
+        });
+      }
+    }
+  );
+
+  it(
+    'accepts omitted defaults and local settings while retaining built-in defaults',
+    { timeout: 10_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        writeGlobal(sandbox, { futureGlobal: { keep: true } });
+        writeLocal(sandbox, { keep: true });
+        const result = await runCli(sandbox, ['config', 'show', '--json']);
+
+        expect(result.status).toBe(0);
+        expect(parseWholeStdout(result)).toMatchObject({
+          resolved: {
+            preambleMode: 'always',
+            preambleEvery: 3,
+            pasteEnterDelayMs: 500,
+            defaults: { timeout: 180, pollInterval: 1, captureLines: 100 },
+          },
+        });
       });
     }
-  });
+  );
 
-  it('accepts omitted defaults and local settings while retaining built-in defaults', async () => {
-    await withSandbox(async (sandbox) => {
-      writeGlobal(sandbox, { futureGlobal: { keep: true } });
-      writeLocal(sandbox, { keep: true });
-      const result = await runCli(sandbox, ['config', 'show', '--json']);
+  it(
+    'accepts safe preamble frequencies above the timer delay bound',
+    { timeout: 10_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        writeGlobal(sandbox, { defaults: { preambleEvery: 2_147_483_648 } });
+        const result = await runCli(sandbox, ['config', 'show', '--json']);
 
-      expect(result.status).toBe(0);
-      expect(parseWholeStdout(result)).toMatchObject({
-        resolved: {
-          preambleMode: 'always',
-          preambleEvery: 3,
-          pasteEnterDelayMs: 500,
-          defaults: { timeout: 180, pollInterval: 1, captureLines: 100 },
-        },
+        expect(result.status).toBe(0);
+        expect(parseWholeStdout(result)).toMatchObject({
+          resolved: { preambleEvery: 2_147_483_648 },
+        });
       });
-    });
-  });
+    }
+  );
 
-  it('accepts safe preamble frequencies above the timer delay bound', async () => {
-    await withSandbox(async (sandbox) => {
-      writeGlobal(sandbox, { defaults: { preambleEvery: 2_147_483_648 } });
-      const result = await runCli(sandbox, ['config', 'show', '--json']);
+  it(
+    'keeps unknown and retired keys opaque while applying valid precedence and zero values',
+    { timeout: 10_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const globalBytes = writeGlobal(sandbox, {
+          preambleMode: 'disabled',
+          mode: 'retired-global-mode',
+          futureGlobal: { keep: true },
+          defaults: {
+            timeout: 86_400,
+            pollInterval: 0.25,
+            captureLines: 0,
+            preambleEvery: 7,
+            pasteEnterDelayMs: 1.5,
+            maxCaptureLines: 999,
+            futureDefault: 'opaque',
+          },
+        });
+        const localBytes = writeLocal(sandbox, {
+          keep: { value: true },
+          $config: {
+            mode: 'retired-local-mode',
+            preambleMode: 'always',
+            preambleEvery: 0,
+            futureLocal: ['opaque'],
+          },
+        });
 
-      expect(result.status).toBe(0);
-      expect(parseWholeStdout(result)).toMatchObject({
-        resolved: { preambleEvery: 2_147_483_648 },
-      });
-    });
-  });
-
-  it('keeps unknown and retired keys opaque while applying valid precedence and zero values', async () => {
-    await withSandbox(async (sandbox) => {
-      const globalBytes = writeGlobal(sandbox, {
-        preambleMode: 'disabled',
-        mode: 'retired-global-mode',
-        futureGlobal: { keep: true },
-        defaults: {
-          timeout: 86_400,
-          pollInterval: 0.25,
-          captureLines: 0,
-          preambleEvery: 7,
-          pasteEnterDelayMs: 1.5,
-          maxCaptureLines: 999,
-          futureDefault: 'opaque',
-        },
-      });
-      const localBytes = writeLocal(sandbox, {
-        keep: { value: true },
-        $config: {
-          mode: 'retired-local-mode',
+        const result = await runCli(sandbox, ['config', 'show', '--json']);
+        expect(result.status).toBe(0);
+        const document = parseWholeStdout(result) as {
+          resolved: {
+            preambleMode: string;
+            preambleEvery: number;
+            pasteEnterDelayMs: number;
+            defaults: Record<string, unknown>;
+          };
+        };
+        expect(document.resolved).toMatchObject({
           preambleMode: 'always',
           preambleEvery: 0,
-          futureLocal: ['opaque'],
-        },
+          pasteEnterDelayMs: 1.5,
+          defaults: {
+            timeout: 86_400,
+            pollInterval: 0.25,
+            captureLines: 0,
+          },
+        });
+        expect(document.resolved.defaults).not.toHaveProperty('maxCaptureLines');
+        expect(document.resolved.defaults).not.toHaveProperty('futureDefault');
+        expect(document.resolved).not.toHaveProperty('mode');
+        expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalBytes);
+        expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(localBytes);
       });
-
-      const result = await runCli(sandbox, ['config', 'show', '--json']);
-      expect(result.status).toBe(0);
-      const document = parseWholeStdout(result) as {
-        resolved: {
-          preambleMode: string;
-          preambleEvery: number;
-          pasteEnterDelayMs: number;
-          defaults: Record<string, unknown>;
-        };
-      };
-      expect(document.resolved).toMatchObject({
-        preambleMode: 'always',
-        preambleEvery: 0,
-        pasteEnterDelayMs: 1.5,
-        defaults: {
-          timeout: 86_400,
-          pollInterval: 0.25,
-          captureLines: 0,
-        },
-      });
-      expect(document.resolved.defaults).not.toHaveProperty('maxCaptureLines');
-      expect(document.resolved.defaults).not.toHaveProperty('futureDefault');
-      expect(document.resolved).not.toHaveProperty('mode');
-      expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalBytes);
-      expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(localBytes);
-    });
-  });
+    }
+  );
 
   it('rejects decimal, out-of-range, and unknown setters without writing files', async () => {
     await withSandbox(async (sandbox) => {
@@ -278,125 +294,141 @@ describe('real CLI configuration contract', () => {
     });
   }, 30_000);
 
-  it('repairs a targeted invalid setting while preserving partial global defaults and opaque siblings', async () => {
-    await withSandbox(async (sandbox) => {
-      writeGlobal(sandbox, {
-        defaults: { timeout: 240, futureDefault: { keep: true } },
-      });
-      writeLocal(sandbox, {
-        keep: 'opaque',
-        $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 500 },
-      });
+  it(
+    'repairs a targeted invalid setting while preserving partial global defaults and opaque siblings',
+    { timeout: 10_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        writeGlobal(sandbox, {
+          defaults: { timeout: 240, futureDefault: { keep: true } },
+        });
+        writeLocal(sandbox, {
+          keep: 'opaque',
+          $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 500 },
+        });
 
-      const repaired = await runCli(sandbox, ['config', 'set', 'preambleEvery', '4', '--json']);
-      expect(repaired.status).toBe(0);
-      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
-        keep: 'opaque',
-        $config: { preambleEvery: 4, pasteEnterDelayMs: 500 },
-      });
+        const repaired = await runCli(sandbox, ['config', 'set', 'preambleEvery', '4', '--json']);
+        expect(repaired.status).toBe(0);
+        expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+          keep: 'opaque',
+          $config: { preambleEvery: 4, pasteEnterDelayMs: 500 },
+        });
 
-      const globalSet = await runCli(sandbox, [
-        'config',
-        'set',
-        'preambleEvery',
-        '0',
-        '--global',
-        '--json',
-      ]);
-      expect(globalSet.status).toBe(0);
-      expect(JSON.parse(fs.readFileSync(sandbox.globalConfig, 'utf8'))).toEqual({
-        defaults: {
-          timeout: 240,
-          preambleEvery: 0,
-          futureDefault: { keep: true },
-        },
+        const globalSet = await runCli(sandbox, [
+          'config',
+          'set',
+          'preambleEvery',
+          '0',
+          '--global',
+          '--json',
+        ]);
+        expect(globalSet.status).toBe(0);
+        expect(JSON.parse(fs.readFileSync(sandbox.globalConfig, 'utf8'))).toEqual({
+          defaults: {
+            timeout: 240,
+            preambleEvery: 0,
+            futureDefault: { keep: true },
+          },
+        });
       });
-    });
-  });
+    }
+  );
 
-  it('allows zero setters and repairs only the targeted invalid local setting', async () => {
-    await withSandbox(async (sandbox) => {
-      writeLocal(sandbox, {
-        keep: 'opaque',
-        $config: { preambleEvery: 3, pasteEnterDelayMs: 500 },
-      });
-      expect(
-        (await runCli(sandbox, ['config', 'set', 'preambleEvery', '0', '--json'])).status
-      ).toBe(0);
-      expect(
-        (await runCli(sandbox, ['config', 'set', 'pasteEnterDelayMs', '0', '--json'])).status
-      ).toBe(0);
-      const shown = await runCli(sandbox, ['config', 'show', '--json']);
-      expect(shown.status).toBe(0);
-      expect(parseWholeStdout(shown)).toMatchObject({
-        resolved: { preambleEvery: 0, pasteEnterDelayMs: 0 },
-      });
+  it(
+    'allows zero setters and repairs only the targeted invalid local setting',
+    { timeout: 10_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        writeLocal(sandbox, {
+          keep: 'opaque',
+          $config: { preambleEvery: 3, pasteEnterDelayMs: 500 },
+        });
+        expect(
+          (await runCli(sandbox, ['config', 'set', 'preambleEvery', '0', '--json'])).status
+        ).toBe(0);
+        expect(
+          (await runCli(sandbox, ['config', 'set', 'pasteEnterDelayMs', '0', '--json'])).status
+        ).toBe(0);
+        const shown = await runCli(sandbox, ['config', 'show', '--json']);
+        expect(shown.status).toBe(0);
+        expect(parseWholeStdout(shown)).toMatchObject({
+          resolved: { preambleEvery: 0, pasteEnterDelayMs: 0 },
+        });
 
-      writeLocal(sandbox, {
-        keep: 'opaque',
-        $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 0 },
-      });
-      const repaired = await runCli(sandbox, ['config', 'clear', 'preambleEvery', '--json']);
-      expect(repaired.status).toBe(0);
-      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
-        keep: 'opaque',
-        $config: { pasteEnterDelayMs: 0 },
-      });
+        writeLocal(sandbox, {
+          keep: 'opaque',
+          $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 0 },
+        });
+        const repaired = await runCli(sandbox, ['config', 'clear', 'preambleEvery', '--json']);
+        expect(repaired.status).toBe(0);
+        expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+          keep: 'opaque',
+          $config: { pasteEnterDelayMs: 0 },
+        });
 
-      const invalidRemainder = JSON.stringify({
-        keep: 'opaque',
-        $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 'invalid' },
+        const invalidRemainder = JSON.stringify({
+          keep: 'opaque',
+          $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 'invalid' },
+        });
+        fs.writeFileSync(sandbox.localConfig, invalidRemainder);
+        const rejected = await runCli(sandbox, ['config', 'clear', 'preambleEvery', '--json']);
+        expect(rejected.status).toBe(1);
+        expectError(rejected, 'CONFIG_ERROR');
+        expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(invalidRemainder);
       });
-      fs.writeFileSync(sandbox.localConfig, invalidRemainder);
-      const rejected = await runCli(sandbox, ['config', 'clear', 'preambleEvery', '--json']);
-      expect(rejected.status).toBe(1);
-      expectError(rejected, 'CONFIG_ERROR');
-      expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(invalidRemainder);
-    });
-  });
+    }
+  );
 
-  it('keeps storage-only reply and result usable with malformed configuration', async () => {
-    await withSandbox(async (sandbox) => {
-      const requestId = 'config-independent-response';
-      const receipt = seedReply(sandbox, requestId);
-      writeGlobal(sandbox, { defaults: { captureLines: 'invalid' } });
-      const body = 'storage-only despite malformed config';
+  it(
+    'keeps storage-only reply and result usable with malformed configuration',
+    { timeout: 10_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const requestId = 'config-independent-response';
+        const receipt = seedReply(sandbox, requestId);
+        writeGlobal(sandbox, { defaults: { captureLines: 'invalid' } });
+        const body = 'storage-only despite malformed config';
 
-      const submitted = await runCli(sandbox, [
-        'reply',
-        requestId,
-        '--receipt',
-        receipt,
-        '--message',
-        body,
-        '--json',
-      ]);
-      expect(submitted.status).toBe(0);
-      expect(parseWholeStdout(submitted)).toMatchObject({
-        status: 'submitted',
-        requestId,
-        bodyBytes: Buffer.byteLength(body),
+        const submitted = await runCli(sandbox, [
+          'reply',
+          requestId,
+          '--receipt',
+          receipt,
+          '--message',
+          body,
+          '--json',
+        ]);
+        expect(submitted.status).toBe(0);
+        expect(parseWholeStdout(submitted)).toMatchObject({
+          status: 'submitted',
+          requestId,
+          bodyBytes: Buffer.byteLength(body),
+        });
+
+        const retrieved = await runCli(sandbox, ['result', requestId, '--json']);
+        expect(retrieved.status).toBe(0);
+        expect(parseWholeStdout(retrieved)).toMatchObject({
+          status: 'completed',
+          requestId,
+          response: body,
+        });
+        expect(fs.existsSync(sandbox.database)).toBe(true);
       });
+    }
+  );
 
-      const retrieved = await runCli(sandbox, ['result', requestId, '--json']);
-      expect(retrieved.status).toBe(0);
-      expect(parseWholeStdout(retrieved)).toMatchObject({
-        status: 'completed',
-        requestId,
-        response: body,
+  it(
+    'does not let malformed unrelated local settings affect a public result lookup',
+    { timeout: 10_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const requestId = 'config-independent-missing-result';
+        seedReply(sandbox, requestId);
+        writeLocal(sandbox, { $config: { preambleEvery: 'invalid' } });
+        const result = await runCli(sandbox, ['result', 'missing-result', '--json']);
+        expect(result.status).toBe(3);
+        expectError(result, 'RESPONSE_NOT_AVAILABLE');
       });
-      expect(fs.existsSync(sandbox.database)).toBe(true);
-    });
-  });
-
-  it('does not let malformed unrelated local settings affect a public result lookup', async () => {
-    await withSandbox(async (sandbox) => {
-      const requestId = 'config-independent-missing-result';
-      seedReply(sandbox, requestId);
-      writeLocal(sandbox, { $config: { preambleEvery: 'invalid' } });
-      const result = await runCli(sandbox, ['result', 'missing-result', '--json']);
-      expect(result.status).toBe(3);
-      expectError(result, 'RESPONSE_NOT_AVAILABLE');
-    });
-  });
+    }
+  );
 });

--- a/src/config-cli-contract.test.ts
+++ b/src/config-cli-contract.test.ts
@@ -1,0 +1,402 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { encodeReplyReceipt } from './reply-receipt.js';
+import { createRequestService } from './request-service.js';
+import { openIdentityRepository } from './storage/identity-repository.js';
+import {
+  expectError,
+  fileSnapshot,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+  type Sandbox,
+} from './test-support/cli-process.js';
+
+const endpoint = {
+  serverId: 'config-contract-server',
+  socketPath: '/tmp/config-contract.sock',
+  serverPid: 1234,
+  serverStartTime: 'config-contract-start',
+  paneId: '%1',
+  panePid: 5678,
+} as const;
+
+function seedReply(sandbox: Sandbox, requestId: string): string {
+  const repository = openIdentityRepository(sandbox.database);
+  try {
+    const service = createRequestService({ repository, now: () => Date.now() });
+    const prepared = service.prepare({
+      requestId,
+      endpoint,
+      wait: false,
+      expiresAtMs: Date.now() + 60 * 60 * 1000,
+    });
+    service.beginSend(prepared.attemptId);
+    service.settle(prepared.attemptId, 'sent');
+    return encodeReplyReceipt({
+      version: 1,
+      requestId,
+      attemptId: prepared.attemptId,
+      endpoint,
+    });
+  } finally {
+    repository.close();
+  }
+}
+
+function writeGlobal(sandbox: Sandbox, value: unknown): string {
+  const bytes = JSON.stringify(value);
+  if (bytes === undefined) throw new Error('Expected a JSON value for the global config fixture.');
+  fs.mkdirSync(sandbox.globalDir, { recursive: true });
+  fs.writeFileSync(sandbox.globalConfig, bytes);
+  return bytes;
+}
+
+function writeLocal(sandbox: Sandbox, value: unknown): string {
+  const bytes = JSON.stringify(value);
+  if (bytes === undefined) throw new Error('Expected a JSON value for the local config fixture.');
+  fs.writeFileSync(sandbox.localConfig, bytes);
+  return bytes;
+}
+
+describe('real CLI configuration contract', () => {
+  it('rejects invalid loaded shapes and numeric policies without rewriting files', async () => {
+    const invalidCases: Array<{ label: string; scope: 'global' | 'local'; value: unknown }> = [
+      { label: 'global null root', scope: 'global', value: null },
+      { label: 'global array root', scope: 'global', value: [] },
+      { label: 'global null defaults', scope: 'global', value: { defaults: null } },
+      { label: 'global array defaults', scope: 'global', value: { defaults: [] } },
+      {
+        label: 'null known global value',
+        scope: 'global',
+        value: { defaults: { pasteEnterDelayMs: null } },
+      },
+      { label: 'unknown preamble mode', scope: 'global', value: { preambleMode: 'poll' } },
+      { label: 'zero timeout', scope: 'global', value: { defaults: { timeout: 0 } } },
+      {
+        label: 'timeout over one day',
+        scope: 'global',
+        value: { defaults: { timeout: 86_400.001 } },
+      },
+      { label: 'zero poll interval', scope: 'global', value: { defaults: { pollInterval: 0 } } },
+      {
+        label: 'fractional capture lines',
+        scope: 'global',
+        value: { defaults: { captureLines: 1.5 } },
+      },
+      {
+        label: 'preamble frequency beyond safe integer',
+        scope: 'global',
+        value: { defaults: { preambleEvery: 9_007_199_254_740_992 } },
+      },
+      {
+        label: 'negative preamble frequency',
+        scope: 'local',
+        value: { $config: { preambleEvery: -1 } },
+      },
+      {
+        label: 'fractional preamble frequency',
+        scope: 'local',
+        value: { $config: { preambleEvery: 1.5 } },
+      },
+      {
+        label: 'string paste delay',
+        scope: 'local',
+        value: { $config: { pasteEnterDelayMs: '1.5' } },
+      },
+      {
+        label: 'negative paste delay',
+        scope: 'local',
+        value: { $config: { pasteEnterDelayMs: -1 } },
+      },
+      {
+        label: 'null known local value',
+        scope: 'local',
+        value: { $config: { preambleEvery: null } },
+      },
+      { label: 'local null root', scope: 'local', value: null },
+      { label: 'local array root', scope: 'local', value: [] },
+      { label: 'local array settings', scope: 'local', value: { $config: [] } },
+    ];
+
+    for (const invalid of invalidCases) {
+      await withSandbox(async (sandbox) => {
+        const bytes =
+          invalid.scope === 'global'
+            ? writeGlobal(sandbox, invalid.value)
+            : writeLocal(sandbox, invalid.value);
+        const before = fileSnapshot(sandbox.root);
+        const result = await runCli(sandbox, ['list', '--json']);
+
+        expect(result.status, invalid.label).toBe(1);
+        expectError(result, 'CONFIG_ERROR');
+        expect(fileSnapshot(sandbox.root), invalid.label).toEqual(before);
+        expect(
+          fs.readFileSync(
+            invalid.scope === 'global' ? sandbox.globalConfig : sandbox.localConfig,
+            'utf8'
+          )
+        ).toBe(bytes);
+        expect(fs.existsSync(sandbox.database), invalid.label).toBe(false);
+      });
+    }
+  }, 30_000);
+
+  it('rejects null known values even when another config tier overrides them', async () => {
+    for (const [globalValue, localValue] of [
+      [{ defaults: { pasteEnterDelayMs: null } }, { $config: { pasteEnterDelayMs: 0 } }],
+      [{ defaults: { preambleEvery: 3 } }, { $config: { preambleEvery: null } }],
+    ] as const) {
+      await withSandbox(async (sandbox) => {
+        const globalBytes = writeGlobal(sandbox, globalValue);
+        const localBytes = writeLocal(sandbox, localValue);
+        const before = fileSnapshot(sandbox.root);
+        const result = await runCli(sandbox, ['list', '--json']);
+
+        expect(result.status).toBe(1);
+        expectError(result, 'CONFIG_ERROR');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+        expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalBytes);
+        expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(localBytes);
+        expect(fs.existsSync(sandbox.database)).toBe(false);
+      });
+    }
+  });
+
+  it('accepts omitted defaults and local settings while retaining built-in defaults', async () => {
+    await withSandbox(async (sandbox) => {
+      writeGlobal(sandbox, { futureGlobal: { keep: true } });
+      writeLocal(sandbox, { keep: true });
+      const result = await runCli(sandbox, ['config', 'show', '--json']);
+
+      expect(result.status).toBe(0);
+      expect(parseWholeStdout(result)).toMatchObject({
+        resolved: {
+          preambleMode: 'always',
+          preambleEvery: 3,
+          pasteEnterDelayMs: 500,
+          defaults: { timeout: 180, pollInterval: 1, captureLines: 100 },
+        },
+      });
+    });
+  });
+
+  it('accepts safe preamble frequencies above the timer delay bound', async () => {
+    await withSandbox(async (sandbox) => {
+      writeGlobal(sandbox, { defaults: { preambleEvery: 2_147_483_648 } });
+      const result = await runCli(sandbox, ['config', 'show', '--json']);
+
+      expect(result.status).toBe(0);
+      expect(parseWholeStdout(result)).toMatchObject({
+        resolved: { preambleEvery: 2_147_483_648 },
+      });
+    });
+  });
+
+  it('keeps unknown and retired keys opaque while applying valid precedence and zero values', async () => {
+    await withSandbox(async (sandbox) => {
+      const globalBytes = writeGlobal(sandbox, {
+        preambleMode: 'disabled',
+        mode: 'retired-global-mode',
+        futureGlobal: { keep: true },
+        defaults: {
+          timeout: 86_400,
+          pollInterval: 0.25,
+          captureLines: 0,
+          preambleEvery: 7,
+          pasteEnterDelayMs: 1.5,
+          maxCaptureLines: 999,
+          futureDefault: 'opaque',
+        },
+      });
+      const localBytes = writeLocal(sandbox, {
+        keep: { value: true },
+        $config: {
+          mode: 'retired-local-mode',
+          preambleMode: 'always',
+          preambleEvery: 0,
+          futureLocal: ['opaque'],
+        },
+      });
+
+      const result = await runCli(sandbox, ['config', 'show', '--json']);
+      expect(result.status).toBe(0);
+      const document = parseWholeStdout(result) as {
+        resolved: {
+          preambleMode: string;
+          preambleEvery: number;
+          pasteEnterDelayMs: number;
+          defaults: Record<string, unknown>;
+        };
+      };
+      expect(document.resolved).toMatchObject({
+        preambleMode: 'always',
+        preambleEvery: 0,
+        pasteEnterDelayMs: 1.5,
+        defaults: {
+          timeout: 86_400,
+          pollInterval: 0.25,
+          captureLines: 0,
+        },
+      });
+      expect(document.resolved.defaults).not.toHaveProperty('maxCaptureLines');
+      expect(document.resolved.defaults).not.toHaveProperty('futureDefault');
+      expect(document.resolved).not.toHaveProperty('mode');
+      expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalBytes);
+      expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(localBytes);
+    });
+  });
+
+  it('rejects decimal, out-of-range, and unknown setters without writing files', async () => {
+    await withSandbox(async (sandbox) => {
+      writeLocal(sandbox, {
+        keep: true,
+        $config: { preambleEvery: 3, pasteEnterDelayMs: 500 },
+      });
+      const before = fileSnapshot(sandbox.root);
+      for (const [key, value] of [
+        ['preambleEvery', '1.5'],
+        ['preambleEvery', '12junk'],
+        ['preambleEvery', ' 12'],
+        ['preambleEvery', '+12'],
+        ['preambleEvery', '9007199254740992'],
+        ['preambleEvery', '-1'],
+        ['pasteEnterDelayMs', '1.5'],
+        ['pasteEnterDelayMs', '12junk'],
+        ['pasteEnterDelayMs', '12\n'],
+        ['pasteEnterDelayMs', ' 12'],
+        ['pasteEnterDelayMs', '+12'],
+        ['pasteEnterDelayMs', '2147483648'],
+        ['pasteEnterDelayMs', '-1'],
+        ['futureKey', '1'],
+      ]) {
+        const result = await runCli(sandbox, ['config', 'set', key, value, '--json']);
+        expect(result.status, `${key}=${value}`).toBe(1);
+        expectError(result, 'ERROR');
+        expect(fileSnapshot(sandbox.root), `${key}=${value}`).toEqual(before);
+      }
+    });
+  }, 30_000);
+
+  it('repairs a targeted invalid setting while preserving partial global defaults and opaque siblings', async () => {
+    await withSandbox(async (sandbox) => {
+      writeGlobal(sandbox, {
+        defaults: { timeout: 240, futureDefault: { keep: true } },
+      });
+      writeLocal(sandbox, {
+        keep: 'opaque',
+        $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 500 },
+      });
+
+      const repaired = await runCli(sandbox, ['config', 'set', 'preambleEvery', '4', '--json']);
+      expect(repaired.status).toBe(0);
+      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+        keep: 'opaque',
+        $config: { preambleEvery: 4, pasteEnterDelayMs: 500 },
+      });
+
+      const globalSet = await runCli(sandbox, [
+        'config',
+        'set',
+        'preambleEvery',
+        '0',
+        '--global',
+        '--json',
+      ]);
+      expect(globalSet.status).toBe(0);
+      expect(JSON.parse(fs.readFileSync(sandbox.globalConfig, 'utf8'))).toEqual({
+        defaults: {
+          timeout: 240,
+          preambleEvery: 0,
+          futureDefault: { keep: true },
+        },
+      });
+    });
+  });
+
+  it('allows zero setters and repairs only the targeted invalid local setting', async () => {
+    await withSandbox(async (sandbox) => {
+      writeLocal(sandbox, {
+        keep: 'opaque',
+        $config: { preambleEvery: 3, pasteEnterDelayMs: 500 },
+      });
+      expect(
+        (await runCli(sandbox, ['config', 'set', 'preambleEvery', '0', '--json'])).status
+      ).toBe(0);
+      expect(
+        (await runCli(sandbox, ['config', 'set', 'pasteEnterDelayMs', '0', '--json'])).status
+      ).toBe(0);
+      const shown = await runCli(sandbox, ['config', 'show', '--json']);
+      expect(shown.status).toBe(0);
+      expect(parseWholeStdout(shown)).toMatchObject({
+        resolved: { preambleEvery: 0, pasteEnterDelayMs: 0 },
+      });
+
+      writeLocal(sandbox, {
+        keep: 'opaque',
+        $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 0 },
+      });
+      const repaired = await runCli(sandbox, ['config', 'clear', 'preambleEvery', '--json']);
+      expect(repaired.status).toBe(0);
+      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+        keep: 'opaque',
+        $config: { pasteEnterDelayMs: 0 },
+      });
+
+      const invalidRemainder = JSON.stringify({
+        keep: 'opaque',
+        $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 'invalid' },
+      });
+      fs.writeFileSync(sandbox.localConfig, invalidRemainder);
+      const rejected = await runCli(sandbox, ['config', 'clear', 'preambleEvery', '--json']);
+      expect(rejected.status).toBe(1);
+      expectError(rejected, 'CONFIG_ERROR');
+      expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(invalidRemainder);
+    });
+  });
+
+  it('keeps storage-only reply and result usable with malformed configuration', async () => {
+    await withSandbox(async (sandbox) => {
+      const requestId = 'config-independent-response';
+      const receipt = seedReply(sandbox, requestId);
+      writeGlobal(sandbox, { defaults: { captureLines: 'invalid' } });
+      const body = 'storage-only despite malformed config';
+
+      const submitted = await runCli(sandbox, [
+        'reply',
+        requestId,
+        '--receipt',
+        receipt,
+        '--message',
+        body,
+        '--json',
+      ]);
+      expect(submitted.status).toBe(0);
+      expect(parseWholeStdout(submitted)).toMatchObject({
+        status: 'submitted',
+        requestId,
+        bodyBytes: Buffer.byteLength(body),
+      });
+
+      const retrieved = await runCli(sandbox, ['result', requestId, '--json']);
+      expect(retrieved.status).toBe(0);
+      expect(parseWholeStdout(retrieved)).toMatchObject({
+        status: 'completed',
+        requestId,
+        response: body,
+      });
+      expect(fs.existsSync(sandbox.database)).toBe(true);
+    });
+  });
+
+  it('does not let malformed unrelated local settings affect a public result lookup', async () => {
+    await withSandbox(async (sandbox) => {
+      const requestId = 'config-independent-missing-result';
+      seedReply(sandbox, requestId);
+      writeLocal(sandbox, { $config: { preambleEvery: 'invalid' } });
+      const result = await runCli(sandbox, ['result', 'missing-result', '--json']);
+      expect(result.status).toBe(3);
+      expectError(result, 'RESPONSE_NOT_AVAILABLE');
+    });
+  });
+});

--- a/src/config-settings.test.ts
+++ b/src/config-settings.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultConfig,
+  createDefaultGlobalDefaults,
+  ConfigValidationError,
+  isValidConfigSettingValue,
+  validateAndProjectGlobalConfig,
+  validateAndProjectLocalSettings,
+  validateGlobalConfigShape,
+  validateLocalConfigShape,
+} from './config-settings.js';
+
+const file = '/tmp/tmux-team-config.json';
+
+describe('config settings policy', () => {
+  it('returns isolated canonical defaults', () => {
+    const first = createDefaultConfig();
+    const second = createDefaultConfig();
+    first.defaults.timeout = 42;
+    expect(second).toEqual({
+      preambleMode: 'always',
+      defaults: {
+        timeout: 180,
+        pollInterval: 1,
+        captureLines: 100,
+        preambleEvery: 3,
+        pasteEnterDelayMs: 500,
+      },
+    });
+    expect(createDefaultGlobalDefaults()).toEqual(second.defaults);
+  });
+
+  it.each([
+    ['preambleEvery', 0],
+    ['preambleEvery', Number.MAX_SAFE_INTEGER],
+    ['timeout', 1],
+    ['timeout', 86_400],
+    ['pollInterval', Number.MIN_VALUE],
+    ['captureLines', 0],
+    ['captureLines', 2_147_483_647],
+    ['pasteEnterDelayMs', 0],
+    ['pasteEnterDelayMs', 0.5],
+    ['pasteEnterDelayMs', 2_147_483_647],
+  ] as const)('accepts %s=%s', (key, value) => {
+    expect(isValidConfigSettingValue(key, value)).toBe(true);
+  });
+
+  it.each([
+    ['preambleEvery', -1],
+    ['preambleEvery', Number.MAX_SAFE_INTEGER + 1],
+    ['preambleEvery', 1.5],
+    ['timeout', 0],
+    ['timeout', 86_401],
+    ['pollInterval', 0],
+    ['pollInterval', Infinity],
+    ['captureLines', -1],
+    ['captureLines', 2_147_483_648],
+    ['captureLines', 1.5],
+    ['pasteEnterDelayMs', -1],
+    ['pasteEnterDelayMs', 2_147_483_648],
+  ] as const)('rejects %s=%s', (key, value) => {
+    expect(isValidConfigSettingValue(key, value)).toBe(false);
+  });
+
+  it('validates known values in global and local layers, including overridden values', () => {
+    expect(() =>
+      validateAndProjectGlobalConfig(
+        { defaults: { timeout: 86_401 }, unrelated: { preserve: true } },
+        file
+      )
+    ).toThrowError(ConfigValidationError);
+    expect(() =>
+      validateAndProjectLocalSettings({ $config: { preambleEvery: null } }, file)
+    ).toThrowError(ConfigValidationError);
+  });
+
+  it('projects known fields without importing unknown or retired fields', () => {
+    expect(
+      validateAndProjectGlobalConfig(
+        {
+          preambleMode: 'disabled',
+          mode: 'wait',
+          defaults: { timeout: 120, maxCaptureLines: 999, future: true },
+        },
+        file
+      )
+    ).toEqual({ preambleMode: 'disabled', defaults: { timeout: 120 } });
+    expect(
+      validateAndProjectLocalSettings(
+        { $config: { preambleMode: 'disabled', mode: 'wait', future: true } },
+        file
+      )
+    ).toEqual({ $config: { preambleMode: 'disabled' } });
+  });
+
+  it('rejects a null or array global root', () => {
+    const validate = validateGlobalConfigShape;
+    expect(() => validate(null, file)).toThrowError(ConfigValidationError);
+    expect(() => validate([], file)).toThrowError(ConfigValidationError);
+  });
+
+  it('rejects a null or array local root', () => {
+    const validate = validateLocalConfigShape;
+    expect(() => validate(null, file)).toThrowError(ConfigValidationError);
+    expect(() => validate([], file)).toThrowError(ConfigValidationError);
+  });
+
+  it('rejects malformed known containers while allowing unknown fields', () => {
+    expect(() => validateGlobalConfigShape({ defaults: null }, file)).toThrowError(
+      ConfigValidationError
+    );
+    expect(() => validateLocalConfigShape({ $config: [] }, file)).toThrowError(
+      ConfigValidationError
+    );
+    expect(() => validateAndProjectGlobalConfig({ future: ['kept'] }, file)).not.toThrow();
+  });
+});

--- a/src/config-settings.ts
+++ b/src/config-settings.ts
@@ -1,0 +1,242 @@
+import type { ConfigDefaults, GlobalConfig, LocalSettings, ResolvedConfig } from './types.js';
+import {
+  isValidCaptureLines,
+  isValidObserverTimeoutSeconds,
+  isValidPollIntervalSeconds,
+  isValidTimerDelayMs,
+} from './domain/interaction-limits.js';
+
+const DEFAULT_CONFIG = {
+  preambleMode: 'always',
+  defaults: {
+    timeout: 180,
+    pollInterval: 1,
+    captureLines: 100,
+    preambleEvery: 3,
+    pasteEnterDelayMs: 500,
+  },
+} as const;
+
+type JsonObject = Record<string, unknown>;
+export type ConfigSettingKey =
+  | 'preambleMode'
+  | 'timeout'
+  | 'pollInterval'
+  | 'captureLines'
+  | 'preambleEvery'
+  | 'pasteEnterDelayMs';
+
+export class ConfigValidationError extends Error {
+  constructor(
+    public readonly filePath: string,
+    public readonly field: string,
+    message: string
+  ) {
+    super(`Invalid configuration in ${filePath} (${field}): ${message}`);
+    this.name = 'ConfigValidationError';
+  }
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(value: JsonObject, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function invalidShape(filePath: string, field: string, expected: string): never {
+  throw new ConfigValidationError(filePath, field, `must be ${expected}.`);
+}
+
+function validateObject(value: unknown, filePath: string, field: string): JsonObject {
+  if (!isJsonObject(value)) invalidShape(filePath, field, 'a non-null object');
+  return value;
+}
+
+function validateKnownField(
+  value: unknown,
+  filePath: string,
+  field: string,
+  valid: (candidate: unknown) => boolean,
+  expected: string
+): void {
+  if (!valid(value)) throw new ConfigValidationError(filePath, field, `must be ${expected}.`);
+}
+
+function isValidPreambleEvery(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isValidPreambleMode(value: unknown): value is 'always' | 'disabled' {
+  return value === 'always' || value === 'disabled';
+}
+
+interface SettingRule {
+  readonly valid: (value: unknown) => boolean;
+  readonly expected: string;
+}
+
+const SETTING_RULES: Record<ConfigSettingKey, SettingRule> = {
+  preambleMode: { valid: isValidPreambleMode, expected: "'always' or 'disabled'" },
+  timeout: {
+    valid: isValidObserverTimeoutSeconds,
+    expected: 'a finite positive number no greater than 86400',
+  },
+  pollInterval: { valid: isValidPollIntervalSeconds, expected: 'a finite positive number' },
+  captureLines: {
+    valid: isValidCaptureLines,
+    expected: 'an integer from 0 through 2147483647',
+  },
+  preambleEvery: { valid: isValidPreambleEvery, expected: 'a safe non-negative integer' },
+  pasteEnterDelayMs: {
+    valid: isValidTimerDelayMs,
+    expected: 'a finite number from 0 through 2147483647',
+  },
+};
+
+export function isValidConfigSettingValue(key: ConfigSettingKey, value: unknown): boolean {
+  return SETTING_RULES[key].valid(value);
+}
+
+function validateKnownSettings(
+  settings: JsonObject,
+  filePath: string,
+  prefix: string,
+  names: readonly ConfigSettingKey[]
+): void {
+  for (const name of names) {
+    if (!hasOwn(settings, name)) continue;
+    const rule = SETTING_RULES[name];
+    validateKnownField(settings[name], filePath, `${prefix}${name}`, rule.valid, rule.expected);
+  }
+}
+
+/** Validate only the JSON container shape so a targeted config repair is possible. */
+export function validateGlobalConfigShape(
+  value: unknown,
+  filePath: string
+): asserts value is JsonObject {
+  const root = validateObject(value, filePath, '<root>');
+  if (hasOwn(root, 'defaults')) validateObject(root.defaults, filePath, 'defaults');
+}
+
+/** Validate only the JSON container shape so a targeted config repair is possible. */
+export function validateLocalConfigShape(
+  value: unknown,
+  filePath: string
+): asserts value is JsonObject {
+  const root = validateObject(value, filePath, '<root>');
+  if (hasOwn(root, '$config')) validateObject(root.$config, filePath, '$config');
+}
+
+export function validateGlobalConfig(
+  value: unknown,
+  filePath: string
+): asserts value is JsonObject {
+  validateGlobalConfigShape(value, filePath);
+  const root = value;
+  validateKnownSettings(root, filePath, '', ['preambleMode']);
+  if (!hasOwn(root, 'defaults')) return;
+  const defaults = root.defaults as JsonObject;
+  validateKnownSettings(defaults, filePath, 'defaults.', [
+    'timeout',
+    'pollInterval',
+    'captureLines',
+    'preambleEvery',
+    'pasteEnterDelayMs',
+  ]);
+}
+
+export function validateLocalConfig(value: unknown, filePath: string): asserts value is JsonObject {
+  validateLocalConfigShape(value, filePath);
+  const root = value;
+  if (!hasOwn(root, '$config')) return;
+  const settings = root.$config as JsonObject;
+  validateKnownSettings(settings, filePath, '$config.', [
+    'preambleMode',
+    'preambleEvery',
+    'pasteEnterDelayMs',
+  ]);
+}
+
+export interface ValidatedGlobalConfig {
+  readonly preambleMode?: GlobalConfig['preambleMode'];
+  readonly defaults?: Partial<ConfigDefaults>;
+}
+
+export interface ValidatedLocalSettings {
+  readonly $config?: LocalSettings;
+}
+
+function projectGlobalConfig(value: JsonObject): ValidatedGlobalConfig {
+  const rawDefaults = isJsonObject(value.defaults) ? value.defaults : undefined;
+  return {
+    ...(value.preambleMode !== undefined && {
+      preambleMode: value.preambleMode as GlobalConfig['preambleMode'],
+    }),
+    ...(rawDefaults && {
+      defaults: {
+        ...(rawDefaults.timeout !== undefined && { timeout: rawDefaults.timeout as number }),
+        ...(rawDefaults.pollInterval !== undefined && {
+          pollInterval: rawDefaults.pollInterval as number,
+        }),
+        ...(rawDefaults.captureLines !== undefined && {
+          captureLines: rawDefaults.captureLines as number,
+        }),
+        ...(rawDefaults.preambleEvery !== undefined && {
+          preambleEvery: rawDefaults.preambleEvery as number,
+        }),
+        ...(rawDefaults.pasteEnterDelayMs !== undefined && {
+          pasteEnterDelayMs: rawDefaults.pasteEnterDelayMs as number,
+        }),
+      },
+    }),
+  };
+}
+
+function projectLocalSettings(value: JsonObject): ValidatedLocalSettings {
+  const rawSettings = isJsonObject(value.$config) ? value.$config : undefined;
+  return {
+    ...(rawSettings && {
+      $config: {
+        ...(rawSettings.preambleMode !== undefined && {
+          preambleMode: rawSettings.preambleMode as LocalSettings['preambleMode'],
+        }),
+        ...(rawSettings.preambleEvery !== undefined && {
+          preambleEvery: rawSettings.preambleEvery as number,
+        }),
+        ...(rawSettings.pasteEnterDelayMs !== undefined && {
+          pasteEnterDelayMs: rawSettings.pasteEnterDelayMs as number,
+        }),
+      },
+    }),
+  };
+}
+
+export function validateAndProjectGlobalConfig(
+  value: unknown,
+  filePath: string
+): ValidatedGlobalConfig {
+  validateGlobalConfig(value, filePath);
+  return projectGlobalConfig(value);
+}
+
+export function validateAndProjectLocalSettings(
+  value: unknown,
+  filePath: string
+): ValidatedLocalSettings {
+  validateLocalConfig(value, filePath);
+  return projectLocalSettings(value);
+}
+
+export function createDefaultConfig(): ResolvedConfig {
+  return {
+    preambleMode: DEFAULT_CONFIG.preambleMode,
+    defaults: { ...DEFAULT_CONFIG.defaults },
+  };
+}
+
+export function createDefaultGlobalDefaults(): ConfigDefaults {
+  return { ...DEFAULT_CONFIG.defaults };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,30 +6,28 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import type {
-  ConfigDefaults,
   GlobalConfig,
   LocalConfigFile,
   LocalSettings,
   ResolvedConfig,
   Paths,
 } from './types.js';
+import {
+  createDefaultConfig,
+  validateGlobalConfig,
+  validateLocalConfig,
+  validateGlobalConfigShape,
+  validateLocalConfigShape,
+  validateAndProjectGlobalConfig,
+  validateAndProjectLocalSettings,
+} from './config-settings.js';
+
+export { ConfigValidationError } from './config-settings.js';
 
 const CONFIG_FILENAME = 'config.json';
 const LOCAL_CONFIG_FILENAME = 'tmux-team.json';
 const STATE_FILENAME = 'state.json';
 const DATABASE_FILENAME = 'tmux-team.db';
-
-// Default configuration values
-const DEFAULT_CONFIG: GlobalConfig = {
-  preambleMode: 'always',
-  defaults: {
-    timeout: 180,
-    pollInterval: 1,
-    captureLines: 100,
-    preambleEvery: 3, // inject preamble every N messages
-    pasteEnterDelayMs: 500, // delay after paste before Enter
-  },
-};
 
 /**
  * Resolve the global config directory path using XDG spec with smart detection.
@@ -127,9 +125,9 @@ export class ConfigParseError extends Error {
   }
 }
 
-function loadJsonFile<T>(filePath: string): T | null {
+function loadJsonFile<T>(filePath: string): T | undefined {
   if (!fs.existsSync(filePath)) {
-    return null;
+    return undefined;
   }
   try {
     const content = fs.readFileSync(filePath, 'utf-8');
@@ -149,38 +147,35 @@ function loadJsonFile<T>(filePath: string): T | null {
  * Note: CLI flags are applied by the caller after this function returns.
  */
 export function loadConfig(paths: Paths): ResolvedConfig {
-  // Start with defaults
-  const config: ResolvedConfig = {
-    ...DEFAULT_CONFIG,
-    defaults: { ...DEFAULT_CONFIG.defaults },
-  };
+  const config = createDefaultConfig();
 
   // Merge global config. Legacy mode and extraction-only maxCaptureLines are
   // intentionally ignored while remaining opaque in the raw file.
-  const globalConfig = loadJsonFile<Partial<GlobalConfig>>(paths.globalConfig);
-  if (globalConfig) {
-    if (globalConfig.preambleMode) config.preambleMode = globalConfig.preambleMode;
-    if (globalConfig.defaults) {
-      const rawDefaults = globalConfig.defaults as ConfigDefaults & {
-        readonly maxCaptureLines?: unknown;
-      };
-      const { maxCaptureLines: _obsoleteMaxCaptureLines, ...runtimeDefaults } = rawDefaults;
-      config.defaults = {
-        ...config.defaults,
-        ...(runtimeDefaults as Partial<ResolvedConfig['defaults']>),
-      };
+  const globalConfig = loadJsonFile<unknown>(paths.globalConfig);
+  if (globalConfig !== undefined) {
+    const knownGlobal = validateAndProjectGlobalConfig(globalConfig, paths.globalConfig);
+    if (knownGlobal.preambleMode !== undefined) {
+      config.preambleMode = knownGlobal.preambleMode;
+    }
+    if (knownGlobal.defaults) {
+      Object.assign(config.defaults, knownGlobal.defaults);
     }
   }
 
   // Load local settings. Other local JSON fields remain opaque and are never
   // imported into runtime identity or preamble state.
-  const localConfigFile = loadJsonFile<LocalConfigFile>(paths.localConfig);
-  if (localConfigFile) {
-    const localSettings = localConfigFile.$config;
+  const localConfigFile = loadJsonFile<unknown>(paths.localConfig);
+  if (localConfigFile !== undefined) {
+    const localSettings = validateAndProjectLocalSettings(
+      localConfigFile,
+      paths.localConfig
+    ).$config;
 
     // Merge local settings (override global)
     if (localSettings) {
-      if (localSettings.preambleMode) config.preambleMode = localSettings.preambleMode;
+      if (localSettings.preambleMode !== undefined) {
+        config.preambleMode = localSettings.preambleMode;
+      }
       if (localSettings.preambleEvery !== undefined) {
         config.defaults.preambleEvery = localSettings.preambleEvery;
       }
@@ -203,13 +198,17 @@ export function ensureGlobalDir(paths: Paths): void {
  * Load raw global config file (for editing).
  */
 export function loadGlobalConfig(paths: Paths): Partial<GlobalConfig> {
-  return loadJsonFile<Partial<GlobalConfig>>(paths.globalConfig) ?? {};
+  const config = loadJsonFile<unknown>(paths.globalConfig);
+  if (config === undefined) return {};
+  validateGlobalConfigShape(config, paths.globalConfig);
+  return config as Partial<GlobalConfig>;
 }
 
 /**
  * Save global config file.
  */
 export function saveGlobalConfig(paths: Paths, config: Partial<GlobalConfig>): void {
+  validateGlobalConfig(config, paths.globalConfig);
   ensureGlobalDir(paths);
   fs.writeFileSync(paths.globalConfig, JSON.stringify(config, null, 2) + '\n');
 }
@@ -218,13 +217,17 @@ export function saveGlobalConfig(paths: Paths, config: Partial<GlobalConfig>): v
  * Load raw local config file (for editing).
  */
 export function loadLocalConfigFile(paths: Paths): LocalConfigFile {
-  return loadJsonFile<LocalConfigFile>(paths.localConfig) ?? {};
+  const config = loadJsonFile<unknown>(paths.localConfig);
+  if (config === undefined) return {};
+  validateLocalConfigShape(config, paths.localConfig);
+  return config as LocalConfigFile;
 }
 
 /**
  * Save local config file (preserves both $config and pane entries).
  */
 export function saveLocalConfigFile(paths: Paths, configFile: LocalConfigFile): void {
+  validateLocalConfig(configFile, paths.localConfig);
   fs.writeFileSync(paths.localConfig, JSON.stringify(configFile, null, 2) + '\n');
 }
 

--- a/test/e2e/capture-limits.e2e.test.ts
+++ b/test/e2e/capture-limits.e2e.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { withE2EFixture } from './harness.js';
 
 describe.sequential('capture numeric contract', () => {
-  it('rejects an invalid loaded count without touching tmux or rewriting its config', async () => {
+  it('reports invalid loaded config without touching tmux or rewriting its config', async () => {
     await withE2EFixture(async (fixture) => {
       const configFile = path.join(fixture.globalDir, 'config.json');
       const configBytes = JSON.stringify({ defaults: { captureLines: '12junk' }, unrelated: true });
@@ -14,7 +14,7 @@ describe.sequential('capture numeric contract', () => {
       });
       expect(result).toMatchObject({
         code: 1,
-        json: { error: { code: 'INVALID_CAPTURE_LINES' } },
+        json: { error: { code: 'CONFIG_ERROR' } },
       });
       expect(fs.readFileSync(configFile, 'utf8')).toBe(configBytes);
       expect(fs.existsSync(path.join(fixture.globalDir, 'tmux-team.db'))).toBe(false);
@@ -52,6 +52,10 @@ describe.sequential('capture numeric contract', () => {
       ).toBe(0);
       await fixture.waitForEvent((event) => event.event === 'summary' && event.message === message);
       const metadata = fixture.paneMetadata(fixture.pane);
+      fs.writeFileSync(
+        path.join(fixture.globalDir, 'config.json'),
+        JSON.stringify({ defaults: { captureLines: 0 } })
+      );
       for (const [command, value] of [
         ['check', '0'],
         ['read', '2147483647'],
@@ -59,7 +63,7 @@ describe.sequential('capture numeric contract', () => {
         const result = await fixture.runJsonCli<{ lines: number; output: string }>([
           command,
           'CapturePeer',
-          `--lines=${value}`,
+          ...(value === '0' ? [] : [`--lines=${value}`]),
         ]);
         expect(result.code).toBe(0);
         expect(result.json?.lines).toBe(Number(value));

--- a/test/e2e/preamble-lifecycle.e2e.test.ts
+++ b/test/e2e/preamble-lifecycle.e2e.test.ts
@@ -274,6 +274,12 @@ describe.sequential('durable identity preambles', () => {
       const statePath = path.join(fixture.globalDir, 'state.json');
       fs.writeFileSync(statePath, '{"requests":{},"preambleCounters":{"Peer":99}}\n');
 
+      expect((await fixture.runJsonCli(['config', 'set', 'preambleEvery', '0'])).code).toBe(0);
+      const countersBeforeOverride = preambleCounters(fixture);
+      await causalTalk(fixture, 'Peer', peer.pid, 'local zero overrides global frequency');
+      expect(preambleCounters(fixture)).toEqual(countersBeforeOverride);
+      expect((await fixture.runJsonCli(['config', 'clear', 'preambleEvery'])).code).toBe(0);
+
       await causalTalk(fixture, 'Peer', peer.pid, 'first', preamble);
       expect(preambleCounters(fixture)).toEqual({ [peerIdentityId]: 1 });
       await causalTalk(fixture, 'Peer', peer.pid, 'explicitly raw', undefined, ['--no-preamble']);


### PR DESCRIPTION
## Scope

- Issue: [TMT-46](https://linear.app/tigerpig-dev/issue/TMT-46)
- Centralize fresh configuration defaults and known-setting validation, reuse existing interaction limits, and reject malformed settings before config-consuming effects.
- Preserve raw unknown fields and partial defaults; allow targeted repairs while validating the complete destination before writes.
- Synchronize README, architecture, installed provider guidance, and the developer workflow. Delegation is discretionary; pattern inspection and primary architectural review remain required.
- No Exchange retention, identity/memory, daemon, new dependencies, release, or migration changes.

## Architecture and review

- `config-settings.ts` owns pure defaults, validation and projection; `config.ts` retains paths and file I/O. Existing interaction-limit predicates remain the common runtime numeric owner.
- Reviewed Context laziness, runner error mapping, config command and raw-save callers, configuration tests, causal Docker helpers and affected documentation.
- Loaded shape/value failures use `CONFIG_ERROR`; invalid setter text retains `ERROR`. Every supplied known field is validated before merge, including overridden values. Unknown/retired keys remain raw-only. Storage-only reply/result do not load unrelated settings.
- Primary reviewer: Codex. Supplementary review: Luna pattern/coverage scans and Gemini via TMT. Primary rejected unsupported exhaustive-coverage claims and independently verified contracts.
- Findings corrected: exposed mutable defaults, duplicated rules/default expansion, repeated setter parsing, unvalidated projection, newline numeric parsing, wrong preamble bound in a test, incomplete partial-default assertions, and missing Docker local-override coverage.
- Reviewed commit: 6057964 (full hash recorded in Linear); follow-up changes only bounded test-runner budgets and developer verification guidance.
- Validation-before-write is not a crash-atomic or concurrent-writer guarantee.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact local commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge: all 10 checks passed in run 34020734034 on 60579640dc6523354e372a4061491ff24e6cff5e.

Commands and results:

- `pnpm check`: passed, including types, lint, source/E2E/developer-document formatting.
- `pnpm test:run`: 750 tests / 54 files passed; 95.54% statements/lines, 89.16% branches; coverage gates passed.
- `pnpm exec vitest run src/config-cli-contract.test.ts`: 10 passed after strengthening exact partial-default preservation.
- `pnpm test:e2e`: both runs passed 77 tests / 18 files; final committed-tree run includes configured capture zero and causal local preamble override/clear coverage.
- `pnpm pack --pack-destination .tmp/tmt-pack` and `node scripts/verify-packed-native-install.mjs --package-tarball .tmp/tmt-pack/tmux-team-5.0.0-alpha.1.tgz --expected-arch arm64 --expected-libc none`: passed on darwin arm64, including packed CLI/skill viewing and default/custom installs.
- Skill authoring validation: universal, Codex, plugin and developer skills passed; validator dependency was isolated outside the repository.
- `git diff --check`: passed.

## Project lifecycle

- Architecture and developer/installed guidance updated in this PR.
- Linear contains scope, exact limits, review dispositions, local evidence and deferred Exchange work.
- Dedicated branch/worktree: `codex/tmt-46-config-policy` / `tmt-46-config-policy`.
- Initial CI exposed an omitted process-test timeout convention (one new multi-process scenario inherited the 1-second unit default). All assertions and child termination bounds are unchanged; explicit 10-second budgets now match existing CLI contract suites. Host checks/full tests and the full offline Linux two-CPU suite passed (750 tests, coverage gates) before the corrective push. The temporary Linux unit image required zsh for existing completion tests; no repository dependency changed.
- Merge only after required checks pass on the corrected reviewed head. Worktree cleanup follows safe merge/handoff verification.
