### PR TITLE
feat: freeze exchange retention and bound cleanup (TMT-54)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,10 +101,11 @@ Timeout remains observer-only; offline queues, leases, memory, and MCP state are
 separate future work. SQLite supplies no autonomous TTL scheduler, so this does
 not promise punctual physical deletion or database-file shrinkage. Keep this
 current map and the linked section in sync as each bounded future slice is
-implemented. The proposed future default is a unified 90-day X retention
-horizon via the existing global config's `exchange.retentionDays`; this is
-unshipped. Current seven-day final-body retention remains unchanged until an
-explicit migration policy lands. The default 180-second talk observer timeout
+implemented. TMT-54 supplies the retention foundation through the existing
+global config's `exchange.retentionDays`, default 90 days. Each new request
+freezes its policy; the migration preserves seven-day retention for existing
+requests and bodies. Provenance, original prompts and attention remain unshipped.
+The default 180-second talk observer timeout
 and the reply submission window are distinct from data retention.
 
 ## Message delivery and uncertainty
@@ -158,8 +159,9 @@ settlement/refund is idempotent and cannot mutate another request.
 
 Wait release does not cancel recipient work or alter delivery outcome. Expiry is
 at least one hour and extends for configured send/wait budgets. Opportunistic
-cleanup prunes terminal metadata only after both 24 hours from settlement and the
-response submission deadline, while keeping cadence totals. A failure before reservation
+cleanup prunes metadata only after its stored horizon, protecting the settlement
+floor, response acceptance deadline and retained final, while keeping cadence
+totals. A failure before reservation
 or begin-send stops input; a post-send persistence failure cannot safely imply
 non-delivery. Commands report `REQUEST_STATE_ERROR` with inspection guidance
 when appropriate. There is no automatic retry, daemon or inbox in this slice.
@@ -185,14 +187,62 @@ delivery outcomes cannot be rewritten by contradictory settlement. Completion
 means a submitted result, not successful task execution or authenticated delivery.
 
 Submission remains eligible until the later of attempt expiry and seven days from
-preparation. Wait release does not close this window. Final bodies expire seven
-days after submission: reads hide them at that boundary; opportunistic cleanup
+preparation. Wait release does not close this window. Final bodies expire after
+the duration frozen on their request, anchored at submission: reads hide them
+at that boundary; opportunistic cleanup
 physically removes them. Independent endpoint snapshots and no cascading foreign
-keys let a final outlive its attempt or identity binding. The bounded attempt
+keys preserve finals across identity rebinding and support already-orphaned
+historical finals; current cleanup retains matching metadata through final expiry. The bounded attempt
 completion marker prevents recreation and false refunds after body deletion when
 a long attempt deadline is still open. Preparation rejects IDs still owned by a
 retained final. After all retained metadata is gone, unknown and previously expired
 requests are indistinguishable; there is no permanent tombstone store.
+
+### Frozen retention and bounded housekeeping
+
+TMT-54 appends persisted retention to the existing request/response schema.
+`domain/exchange-retention.ts` owns numeric validity and deadline calculations;
+the request service owns lifecycle policy and the request adapter owns indexed
+candidate selection and mutation. Configuration consumes that same policy.
+Context supplies a lazy policy callback used only by new preparation, before
+the reservation transaction. Reply, result and cleanup use stored deadlines
+without opening current configuration or tmux.
+
+`exchange.retentionDays` is global-only, an integer from 1 through 3650 with a
+90-day default. Policy changes affect new requests only. The forward migration
+stamps existing requests/bodies with seven days and preserves original time
+anchors; it does not rebase on migration time, resurrect missing data or retain
+a second legacy service implementation. New arithmetic is checked; historical
+deadline calculations remain within the supported integer range.
+
+The original request horizon starts at preparation; final-body retention starts
+at first accepted submission. Metadata protects both, the unchanged reply
+acceptance window and the existing 24-hour settlement floor. An accepted late
+final may extend metadata through its own expiry; reads, duplicate replies,
+housekeeping and waiter release do not renew it. Synthetic cleanup settlement
+can delay physical deletion for 24 hours without restoring logically expired
+metadata. A short configured horizon may
+leave metadata eligible for a late reply after request content would expire.
+This is a per-content duration, not a hard limit from first creation.
+
+Logical reads hide expired records at deadline equality even before physical
+cleanup. Housekeeping uses one short immediate transaction, bounded to 100
+expired-attempt transitions, 100 final-body deletions and 100 metadata deletions,
+ordered by expiry and stable ID. It runs through existing request operations;
+repeated calls drain backlog without a daemon or a physical-deletion SLA.
+Metadata selection pins its horizon index so a fresh database without planner
+statistics cannot sort all terminal candidates before applying the batch limit.
+The limit bounds mutations, not a universal maximum on examined index entries.
+Failure rolls back the batch and propagates through existing command errors.
+No transaction spans tmux, polling or external work. Conditional state changes
+preserve exactly-once cadence refunds and completion fences.
+
+Deadlines use UTC wall time, not a sliding timer. Clock rollback does not change
+stored deadlines but can delay logical expiry while data is still physically
+present. Deletion is not file shrinkage or secure erasure; no per-call VACUUM
+or automatic clock-repair mechanism is provided. Identity/profile/cadence data
+are outside Exchange content cleanup. Prompts and attention remain separate
+future slices consuming this owner rather than copying its policy.
 
 Typed response errors distinguish invalid/oversized input, unknown request, wrong
 attempt/recipient, ineligible state, expiry and conflict. Rejections preserve

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,6 +113,18 @@ submission/retention boundaries, plus independent processes for writer races.
 The live CLI consumes this same service; Docker/mock-agent scenarios verify
 request correlation and exact-body retrieval across the real CLI/tmux boundary.
 
+Retention tests distinguish the frozen policy from current configuration and
+logical expiry from physical deletion. Use injected clocks and independent SQL
+oracles for exact boundaries, migration anchors and bounded batch draining;
+never wait real days or only assert that cleanup was called. Check metadata
+cleanup query plans without `ANALYZE`: exercise the actual adapter SQL and
+prove ordered index selection without a temporary full candidate sort.
+Cover retained finals beyond preparation horizons, unchanged idempotency timestamps, no
+metadata renewal from housekeeping, and cleanup/submission transaction races.
+Docker scenarios verify real config-to-preparation wiring and storage-only
+reply/result behavior after current configuration becomes invalid. Prompt and
+attention tests belong to their delivering slices, not this retention baseline.
+
 Reply adapter verification additionally exercises the real CLI in an isolated
 home and SQLite database, including inline text and file/stdin decoding, exact result text,
 idempotent retry across invocations and rejection without partial finalization.

--- a/README.md
+++ b/README.md
@@ -230,8 +230,10 @@ Retrying the identical body for the same request and attempt is idempotent and
 keeps the original `submittedAtMs`. A different body is a conflict; the
 stored response and timestamp remain unchanged.
 
-The receipt is local correlation, not remote authentication. Accepted bodies
-are retained for seven days from submission; identical retry is safe only
+The receipt is local correlation, not remote authentication. New requests freeze
+the global retention duration at preparation (90 days by default); accepted
+bodies use that duration from submission. Existing requests and bodies migrated
+from the earlier schema keep seven days. Identical retry is safe only
 while retained with the same receipt and body, not indefinitely. A missing
 result does not cancel the work. Surface failed submission without a success
 summary, and do not resubmit if final summarization fails after acceptance.
@@ -331,6 +333,26 @@ Numeric setter input must contain decimal digits only, without suffixes,
 fractions, signs or whitespace. Zero disables preamble injection or the
 paste-to-Enter delay. Preamble frequency must be a safe integer; paste delay
 is bounded to 2,147,483,647 milliseconds.
+
+Exchange retention is global-only:
+
+```bash
+tmt config set exchange.retentionDays 90 --global
+```
+
+The same global file stores `{"exchange":{"retentionDays":90}}`; valid values
+are integer days from 1 through 3650. `config show` reports the resolved duration
+and global/default source. Local fields do not override it; a local setter or
+`config clear exchange.retentionDays` is rejected. Changes affect newly prepared
+requests only, not existing records, reply eligibility or observer timeouts.
+
+Stored UTC deadlines determine logical expiry. Bounded cleanup runs during
+request/result operations, not on a background schedule. A final's retention
+starts at submission, so a late accepted reply can keep metadata longer than
+the original request horizon. Reads/retries do not renew retention or acknowledge
+results. Unread records do not live forever. Physical deletion may occur later;
+it does not promise database-file shrinkage or secure erasure. Wall-clock
+rollback can delay logical expiry while data remains physically stored.
 
 Loaded configuration validates each supplied known field before merging:
 timeout must be positive and at most 86,400 seconds, poll interval positive

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -49,9 +49,36 @@ The submission deadline is the later of attempt expiry and seven days after
 preparation. Equality is expired. Wait release and the existing one-hour minimum
 attempt expiry do not end that window. Cleanup preserves terminal attempt metadata
 through both this deadline and the existing 24-hour settlement retention floor.
-Final bodies have independent seven-day retention after submission; expired bodies
+Final bodies have independent retention after submission, using the duration
+frozen on their request (90 days by default for new requests); expired bodies
 are hidden by reads and deleted by opportunistic cleanup. This is not a scheduled
 physical-deletion SLA. Retained retries remain idempotent past submission expiry.
+
+TMT-54 persists retention through a forward migration. Existing requests and
+bodies retain a concrete seven-day duration, preserving submission timestamps;
+new global policy never extends those old bodies. The global config's
+`exchange.retentionDays` accepts integer days 1 through 3650, default 90.
+`config set exchange.retentionDays <days> --global` changes future preparation
+only; local override/clear is rejected. Reply/result use stored deadlines and
+do not load current configuration. No permanent alternate legacy runtime path
+or migration-time rebasing is introduced.
+
+Initial metadata expiry protects the preparation content horizon, reply
+acceptance deadline and attempt-expiry-plus-24-hour settlement floor. An actual
+nonexpired settlement protects its own floor; first final submission extends
+metadata through that body's expiry. Reads, housekeeping, waiter release and
+identical retries do not renew retention. Metadata cannot be pruned ahead of a
+retained final or still-eligible reply. No prompts or attention are stored yet.
+
+Service-owned request/result reads apply logical expiry independently of physical
+cleanup. Opportunistic cleanup uses deterministic limited batches in a short
+transaction: up to 100 expired-attempt transitions, 100 final deletions and 100
+metadata deletions. Batch failure rolls back and propagates through the existing
+error boundary. Repeated invocations drain backlog; no invocation means no
+scheduled deletion. Deadlines are fixed UTC wall-clock values. Clock rollback
+can delay logical expiry while content is physically present, but never changes
+the stored deadline or restores deleted data. Cleanup is not secure erasure,
+file shrinkage, acknowledgement, cancellation or a change to reply eligibility.
 
 Migration 5 adds independent `request_responses` rows, with complete endpoint
 snapshots and no cascading foreign keys to attempts or identities. It also adds
@@ -155,12 +182,15 @@ a truthful work/tests/blockers summary; failed submission is never success.
 ## Future TMT Exchange direction (unshipped)
 
 This section is the canonical future design direction for a TMT Exchange (X).
-It is not an implementation contract or a claim that the commands, schema, or
-state below exist. The current `talk`, `reply`, `result`, and diagnostic `check`
+TMT-54's retention foundation is implemented as described above; provenance,
+prompt storage and attention below remain unshipped. The current `talk`,
+`reply`, `result`, and diagnostic `check`
 contracts above remain authoritative until bounded implementation issues land.
 
 Planning and bounded follow-up ownership are tracked by [TMT-49](https://linear.app/tigerpig-dev/issue/TMT-49),
-[TMT-50](https://linear.app/tigerpig-dev/issue/TMT-50) (provenance/context),
+[TMT-50](https://linear.app/tigerpig-dev/issue/TMT-50), with retention in
+[TMT-54](https://linear.app/tigerpig-dev/issue/TMT-54) and provenance/context in
+[TMT-55](https://linear.app/tigerpig-dev/issue/TMT-55),
 [TMT-51](https://linear.app/tigerpig-dev/issue/TMT-51) (attention), and
 [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30) (identity bootstrap).
 
@@ -228,15 +258,12 @@ memory feature, or MCP state machine is implied. An eventual minimal MCP
 client may use live tmux delivery and the same SQLite-backed reply path without
 requiring caller identity or an inbox; authenticated remote access is separate.
 
-Prompt, request metadata, final-body, attention, acknowledgement, and
-unavailable-versus-pending retention semantics must be specified before code.
-TMT-owned automatic expiry is part of the direction: every service-owned read
-must apply logical expiry at the current clock, and the same shared service may
-perform bounded opportunistic physical cleanup in a short SQLite transaction.
-SQLite has no autonomous TTL scheduler, so no daemon, cron, network service, or
-punctual physical-deletion promise is introduced; without a TMT invocation,
-cleanup waits. The existing seven-day final-body expiry is the current baseline
-to extend or reconcile, not a parallel cleanup subsystem.
+TMT-54 owns the shared frozen policy, metadata/final horizons and bounded
+housekeeping. TMT-55 must specify prompt privacy and validation and consume the
+preparation-anchored horizon; TMT-51 must define attention/ack and
+unavailable-versus-pending projections through that same owner. Do not add a
+parallel cleanup subsystem. SQLite has no autonomous TTL scheduler, so no daemon,
+cron, network service or punctual physical-deletion promise is introduced.
 
 Acknowledgement is not deletion, and unread records are not retained
 indefinitely. An expired result is unavailable, not pending. A hard metadata
@@ -248,16 +275,14 @@ shrinkage or secure erasure: do not run `VACUUM` on every command or treat
 `auto_vacuum` as a TTL mechanism ([SQLite `auto_vacuum`](https://sqlite.org/pragma.html#pragma_auto_vacuum),
 [SQLite serverless operation](https://www.sqlite.org/zeroconf.html)).
 
-Beyond the proposed default below, exact clock boundaries, configuration
-validation, cleanup batch bounds, restart behavior, and cleanup/read races are
-pre-code gates. The design must say which prompt, metadata, body, attention,
-and acknowledgement state survives expiry, when an expired revision can no
-longer reopen attention, and how identity rebinding affects a view. These are
-not fixed invented policy values in this document.
+Attention design must say which visible state survives prompt/body expiry,
+when an expired revision can no longer reopen, and how identity rebinding
+affects a view. It consumes the stored metadata horizon; reads/ack must never
+silently renew it. TMT-54's exact boundaries and bounded cleanup are not new
+policy knobs for the attention adapter to reinterpret.
 
-The proposed interpretation of three months is exactly 90 days for retained X
-content/metadata/attention horizon. It should reuse the existing global config
-file, with the proposed key and default visible as:
+The implemented interpretation of the default duration is exactly 90 days,
+using the existing global config file:
 
 ```json
 {
@@ -267,15 +292,13 @@ file, with the proposed key and default visible as:
 }
 ```
 
-This is an unshipped config contract, not a new configuration system. The
-current seven-day final-body retention remains current until the X migration;
-TMT-50 must define how existing seven-day data transitions to the unified
-policy, without resurrecting expired or deleted bodies. Whether retention is
-anchored at creation, final submission, or another recorded event; the allowed
-range; whether a setting change affects existing records or only new ones; and
-the cleanup batch bound remain pre-code decisions. Ack and reads do not renew
-retention. The 180-second `talk` observer timeout and the reply acceptance
-window remain separate lifetimes.
+This applies to newly prepared requests only. Older migrated records retain
+seven days, without resurrecting expired or deleted bodies. Request content
+uses preparation time; final content uses submission time; metadata protects
+both plus settlement/acceptance obligations. A late final can therefore keep
+metadata longer than 90 days from creation. Ack and reads do not renew
+retention. The 180-second `talk` observer timeout and the unchanged reply
+acceptance window remain separate lifetimes.
 
 The following semantic scenarios are illustrative only, not final JSON schemas:
 
@@ -291,8 +314,8 @@ multi-process races for single ack and `ack --all`, real Docker/mock-agent
 scenarios for talk/reply/result correlation and late replies, and packed-skill
 verification when any shipped command guidance changes. Reuse the existing
 request worker harness and E2E fixture; do not add tests for unshipped commands
-to the installed skill. The intended sequence is foundation/configuration
-work (TMT-46/TMT-29), bounded metadata/identity and attention slices, minimal
+to the installed skill. Foundation/configuration work (TMT-46/TMT-29) is complete.
+The remaining sequence is bounded provenance/context, identity and attention slices, minimal
 MCP, then memory. Offline queue/lease work remains a separate future track.
 If pursued, an offline queue or lease is separate from X and is not an MCP
 prerequisite.

--- a/plugins/tmux-team/commands/learn.md
+++ b/plugins/tmux-team/commands/learn.md
@@ -97,10 +97,12 @@ An identical retry for the same request and attempt keeps the original
 `submittedAtMs`; a different body is a conflict and cannot replace the stored
 response.
 
-The receipt is local correlation, not remote authentication. Accepted bodies
-are retained for seven days from submission; an identical retry is safe only
-while that body is retained and with the same receipt and body, not
-indefinitely. A missing result does not cancel the work. Surface a failed
+The receipt is local correlation, not remote authentication. New requests freeze
+the global retention policy at preparation (90 days by default). Accepted bodies
+use that duration from submission; pre-retention-migration requests and bodies
+keep seven days. Identical retries are safe only while the body is retained,
+with the same receipt and body; retries and reads never renew expiry.
+A missing result does not cancel the work. Surface a failed
 submission without a success summary; if final summarization fails after
 acceptance, do not resubmit.
 
@@ -288,6 +290,20 @@ the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
 paste delay is at most 2147483647 milliseconds.
 The default paste-to-Enter delay is 500 milliseconds; `config show` reports
 the effective value after global and local overrides.
+
+`tmt config set exchange.retentionDays 90 --global` sets the duration for new
+requests only, from 1 through 3650 integer days. It uses `exchange.retentionDays`
+in the same global config file. Local overrides and local `config clear` are
+not supported for this key. Changing it never extends existing data or changes
+the reply acceptance window or observer timeout. Results remain available
+without reading current configuration.
+
+Expired content is unavailable at its stored UTC deadline. Request/result
+operations perform bounded opportunistic cleanup; without an invocation there
+is no punctual physical deletion. A late accepted final has its own duration
+from submission, so metadata can outlive the original request horizon. Reads
+never acknowledge a result. Cleanup is not file shrinkage or secure erasure;
+wall-clock rollback can delay logical expiry while data remains stored.
 
 Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
 talk/check effects, even when another layer would override them. Unknown and

--- a/plugins/tmux-team/commands/team.md
+++ b/plugins/tmux-team/commands/team.md
@@ -99,10 +99,12 @@ An identical retry for the same request and attempt keeps the original
 `submittedAtMs`; a different body is a conflict and cannot replace the stored
 response.
 
-The receipt is local correlation, not remote authentication. Accepted bodies
-are retained for seven days from submission; an identical retry is safe only
-while that body is retained and with the same receipt and body, not
-indefinitely. A missing result does not cancel the work. Surface a failed
+The receipt is local correlation, not remote authentication. New requests freeze
+the global retention policy at preparation (90 days by default). Accepted bodies
+use that duration from submission; pre-retention-migration requests and bodies
+keep seven days. Identical retries are safe only while the body is retained,
+with the same receipt and body; retries and reads never renew expiry.
+A missing result does not cancel the work. Surface a failed
 submission without a success summary; if final summarization fails after
 acceptance, do not resubmit.
 
@@ -290,6 +292,20 @@ the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
 paste delay is at most 2147483647 milliseconds.
 The default paste-to-Enter delay is 500 milliseconds; `config show` reports
 the effective value after global and local overrides.
+
+`tmt config set exchange.retentionDays 90 --global` sets the duration for new
+requests only, from 1 through 3650 integer days. It uses `exchange.retentionDays`
+in the same global config file. Local overrides and local `config clear` are
+not supported for this key. Changing it never extends existing data or changes
+the reply acceptance window or observer timeout. Results remain available
+without reading current configuration.
+
+Expired content is unavailable at its stored UTC deadline. Request/result
+operations perform bounded opportunistic cleanup; without an invocation there
+is no punctual physical deletion. A late accepted final has its own duration
+from submission, so metadata can outlive the original request horizon. Reads
+never acknowledge a result. Cleanup is not file shrinkage or secure erasure;
+wall-clock rollback can delay logical expiry while data remains stored.
 
 Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
 talk/check effects, even when another layer would override them. Unknown and

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -104,10 +104,12 @@ An identical retry for the same request and attempt keeps the original
 `submittedAtMs`; a different body is a conflict and cannot replace the stored
 response.
 
-The receipt is local correlation, not remote authentication. Accepted bodies
-are retained for seven days from submission; an identical retry is safe only
-while that body is retained and with the same receipt and body, not
-indefinitely. A missing result does not cancel the work. Surface a failed
+The receipt is local correlation, not remote authentication. New requests freeze
+the global retention policy at preparation (90 days by default). Accepted bodies
+use that duration from submission; pre-retention-migration requests and bodies
+keep seven days. Identical retries are safe only while the body is retained,
+with the same receipt and body; retries and reads never renew expiry.
+A missing result does not cancel the work. Surface a failed
 submission without a success summary; if final summarization fails after
 acceptance, do not resubmit.
 
@@ -295,6 +297,20 @@ the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
 paste delay is at most 2147483647 milliseconds.
 The default paste-to-Enter delay is 500 milliseconds; `config show` reports
 the effective value after global and local overrides.
+
+`tmt config set exchange.retentionDays 90 --global` sets the duration for new
+requests only, from 1 through 3650 integer days. It uses `exchange.retentionDays`
+in the same global config file. Local overrides and local `config clear` are
+not supported for this key. Changing it never extends existing data or changes
+the reply acceptance window or observer timeout. Results remain available
+without reading current configuration.
+
+Expired content is unavailable at its stored UTC deadline. Request/result
+operations perform bounded opportunistic cleanup; without an invocation there
+is no punctual physical deletion. A late accepted final has its own duration
+from submission, so metadata can outlive the original request horizon. Reads
+never acknowledge a result. Cleanup is not file shrinkage or secure erasure;
+wall-clock rollback can delay logical expiry while data remains stored.
 
 Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
 talk/check effects, even when another layer would override them. Unknown and

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -95,10 +95,12 @@ An identical retry for the same request and attempt keeps the original
 `submittedAtMs`; a different body is a conflict and cannot replace the stored
 response.
 
-The receipt is local correlation, not remote authentication. Accepted bodies
-are retained for seven days from submission; an identical retry is safe only
-while that body is retained and with the same receipt and body, not
-indefinitely. A missing result does not cancel the work. Surface a failed
+The receipt is local correlation, not remote authentication. New requests freeze
+the global retention policy at preparation (90 days by default). Accepted bodies
+use that duration from submission; pre-retention-migration requests and bodies
+keep seven days. Identical retries are safe only while the body is retained,
+with the same receipt and body; retries and reads never renew expiry.
+A missing result does not cancel the work. Surface a failed
 submission without a success summary; if final summarization fails after
 acceptance, do not resubmit.
 
@@ -286,6 +288,20 @@ the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
 paste delay is at most 2147483647 milliseconds.
 The default paste-to-Enter delay is 500 milliseconds; `config show` reports
 the effective value after global and local overrides.
+
+`tmt config set exchange.retentionDays 90 --global` sets the duration for new
+requests only, from 1 through 3650 integer days. It uses `exchange.retentionDays`
+in the same global config file. Local overrides and local `config clear` are
+not supported for this key. Changing it never extends existing data or changes
+the reply acceptance window or observer timeout. Results remain available
+without reading current configuration.
+
+Expired content is unavailable at its stored UTC deadline. Request/result
+operations perform bounded opportunistic cleanup; without an invocation there
+is no punctual physical deletion. A late accepted final has its own duration
+from submission, so metadata can outlive the original request horizon. Reads
+never acknowledge a result. Cleanup is not file shrinkage or secure erasure;
+wall-clock rollback can delay logical expiry while data remains stored.
 
 Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
 talk/check effects, even when another layer would override them. Unknown and

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -98,10 +98,12 @@ An identical retry for the same request and attempt keeps the original
 `submittedAtMs`; a different body is a conflict and cannot replace the stored
 response.
 
-The receipt is local correlation, not remote authentication. Accepted bodies
-are retained for seven days from submission; an identical retry is safe only
-while that body is retained and with the same receipt and body, not
-indefinitely. A missing result does not cancel the work. Surface a failed
+The receipt is local correlation, not remote authentication. New requests freeze
+the global retention policy at preparation (90 days by default). Accepted bodies
+use that duration from submission; pre-retention-migration requests and bodies
+keep seven days. Identical retries are safe only while the body is retained,
+with the same receipt and body; retries and reads never renew expiry.
+A missing result does not cancel the work. Surface a failed
 submission without a success summary; if final summarization fails after
 acceptance, do not resubmit.
 
@@ -289,6 +291,20 @@ the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
 paste delay is at most 2147483647 milliseconds.
 The default paste-to-Enter delay is 500 milliseconds; `config show` reports
 the effective value after global and local overrides.
+
+`tmt config set exchange.retentionDays 90 --global` sets the duration for new
+requests only, from 1 through 3650 integer days. It uses `exchange.retentionDays`
+in the same global config file. Local overrides and local `config clear` are
+not supported for this key. Changing it never extends existing data or changes
+the reply acceptance window or observer timeout. Results remain available
+without reading current configuration.
+
+Expired content is unavailable at its stored UTC deadline. Request/result
+operations perform bounded opportunistic cleanup; without an invocation there
+is no punctual physical deletion. A late accepted final has its own duration
+from submission, so metadata can outlive the original request horizon. Reads
+never acknowledge a result. Cleanup is not file shrinkage or secure erasure;
+wall-clock rollback can delay logical expiry while data remains stored.
 
 Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
 talk/check effects, even when another layer would override them. Unknown and

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -93,10 +93,12 @@ An identical retry for the same request and attempt keeps the original
 `submittedAtMs`; a different body is a conflict and cannot replace the stored
 response.
 
-The receipt is local correlation, not remote authentication. Accepted bodies
-are retained for seven days from submission; an identical retry is safe only
-while that body is retained and with the same receipt and body, not
-indefinitely. A missing result does not cancel the work. Surface a failed
+The receipt is local correlation, not remote authentication. New requests freeze
+the global retention policy at preparation (90 days by default). Accepted bodies
+use that duration from submission; pre-retention-migration requests and bodies
+keep seven days. Identical retries are safe only while the body is retained,
+with the same receipt and body; retries and reads never renew expiry.
+A missing result does not cancel the work. Surface a failed
 submission without a success summary; if final summarization fails after
 acceptance, do not resubmit.
 
@@ -284,6 +286,20 @@ the paste-to-Enter delay. Preamble frequency is bounded to a safe integer;
 paste delay is at most 2147483647 milliseconds.
 The default paste-to-Enter delay is 500 milliseconds; `config show` reports
 the effective value after global and local overrides.
+
+`tmt config set exchange.retentionDays 90 --global` sets the duration for new
+requests only, from 1 through 3650 integer days. It uses `exchange.retentionDays`
+in the same global config file. Local overrides and local `config clear` are
+not supported for this key. Changing it never extends existing data or changes
+the reply acceptance window or observer timeout. Results remain available
+without reading current configuration.
+
+Expired content is unavailable at its stored UTC deadline. Request/result
+operations perform bounded opportunistic cleanup; without an invocation there
+is no punctual physical deletion. A late accepted final has its own duration
+from submission, so metadata can outlive the original request horizon. Reads
+never acknowledge a result. Cleanup is not file shrinkage or secure erasure;
+wall-clock rollback can delay logical expiry while data remains stored.
 
 Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
 talk/check effects, even when another layer would override them. Unknown and

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Context } from './types.js';
+import { createDefaultConfig } from './config-settings.js';
 
 const unusedRequestService: Context['requestService'] = {
   prepare() {
@@ -43,16 +44,7 @@ function makeStubContext(): Context {
       table: vi.fn(),
       json: vi.fn(),
     },
-    config: {
-      preambleMode: 'always',
-      defaults: {
-        timeout: 180,
-        pollInterval: 1,
-        captureLines: 100,
-        preambleEvery: 3,
-        pasteEnterDelayMs: 500,
-      },
-    },
+    config: createDefaultConfig(),
     tmux: {
       send: vi.fn(),
       capture: vi.fn(),

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -9,6 +9,7 @@ import { IdentityServiceError } from '../identity-service.js';
 import { ExitCodes } from '../exits.js';
 import { IdentitySelectionError } from '../identity-context.js';
 import { MAX_CAPTURE_LINES } from '../domain/interaction-limits.js';
+import { createDefaultConfig } from '../config-settings.js';
 
 import { cmdInit } from './init.js';
 import { cmdAdd } from './add.js';
@@ -100,14 +101,7 @@ function createCtx(
     databaseFile: path.join(testDir, 'tmux-team.db'),
   };
   const baseConfig: ResolvedConfig = {
-    preambleMode: 'always',
-    defaults: {
-      timeout: 180,
-      pollInterval: 1,
-      captureLines: 100,
-      preambleEvery: 3,
-      pasteEnterDelayMs: 500,
-    },
+    ...createDefaultConfig(),
     ...overrides?.config,
   };
   const flags: Flags = { json: false, verbose: false, ...overrides?.flags } as Flags;
@@ -621,7 +615,7 @@ describe('basic commands', () => {
       cmdConfig(ctx, configRequest('clear', { key: 'invalidkey', global: false }))
     ).toThrow(`exit(${ExitCodes.ERROR})`);
     expect(ctx.ui.error).toHaveBeenCalledWith(
-      'Invalid key: invalidkey. Valid keys: preambleMode, preambleEvery, pasteEnterDelayMs'
+      'Invalid key: invalidkey. Valid keys: preambleMode, preambleEvery, pasteEnterDelayMs, exchange.retentionDays'
     );
   });
 

--- a/src/commands/config-command.test.ts
+++ b/src/commands/config-command.test.ts
@@ -47,6 +47,7 @@ function createCtx(
       preambleEvery: 3,
       pasteEnterDelayMs: 500,
     },
+    exchange: { retentionDays: 90 },
     ...configOverrides,
   };
   const tmux: Tmux = {
@@ -103,12 +104,16 @@ describe('cmdConfig', () => {
     expect(out.resolved).toBeTruthy();
     expect(out.sources).toBeTruthy();
     expect(out.paths).toBeTruthy();
+    expect(out.resolved.exchange.retentionDays).toBe(90);
+    expect(out.sources.exchange.retentionDays).toBe('default');
   });
 
   it('shows config as table in human mode', () => {
     const ctx = createCtx(testDir);
     cmdConfig(ctx, configRequest('show'));
     expect(ctx.ui.table).toHaveBeenCalled();
+    const tableCall = (ctx.ui.table as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(tableCall[1]).toContainEqual(['exchange.retentionDays', '90', '(default)']);
   });
 
   it('rejects invalid keys and values', () => {
@@ -155,6 +160,44 @@ describe('cmdConfig', () => {
     expect(saved.defaults.preambleEvery).toBe(5);
   });
 
+  it('sets global exchange retention and preserves unknown siblings', () => {
+    const ctx = createCtx(testDir);
+    fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
+    fs.writeFileSync(
+      ctx.paths.globalConfig,
+      JSON.stringify({ keep: true, exchange: { future: { enabled: true } } })
+    );
+
+    cmdConfig(
+      ctx,
+      configRequest('set', { key: 'exchange.retentionDays', value: '3650', global: true })
+    );
+
+    expect(JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf8'))).toEqual({
+      keep: true,
+      exchange: { future: { enabled: true }, retentionDays: 3650 },
+    });
+  });
+
+  it('rejects local exchange retention writes and clears before changing bytes', () => {
+    const ctx = createCtx(testDir);
+    const original = JSON.stringify({ keep: true, $config: { exchange: { retentionDays: 1 } } });
+    fs.writeFileSync(ctx.paths.localConfig, original);
+
+    expect(() =>
+      cmdConfig(
+        ctx,
+        configRequest('set', { key: 'exchange.retentionDays', value: '90', global: false })
+      )
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(fs.readFileSync(ctx.paths.localConfig, 'utf8')).toBe(original);
+
+    expect(() =>
+      cmdConfig(ctx, configRequest('clear', { key: 'exchange.retentionDays', global: false }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(fs.readFileSync(ctx.paths.localConfig, 'utf8')).toBe(original);
+  });
+
   it('preserves an opaque global mode key during unrelated settings writes', () => {
     const ctx = createCtx(testDir);
     fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
@@ -181,10 +224,12 @@ describe('cmdConfig', () => {
     expect(out.resolved).not.toHaveProperty('mode');
     expect(out.sources.preambleMode).toBe('local');
     expect(out.sources.preambleEvery).toBe('local');
+    expect(out.resolved.exchange.retentionDays).toBe(90);
+    expect(out.sources.exchange.retentionDays).toBe('default');
   });
 
   it('shows global source when only global config has settings', () => {
-    const ctx = createCtx(testDir, { json: true });
+    const ctx = createCtx(testDir, { json: true }, { exchange: { retentionDays: 30 } });
     // Create global config with settings
     fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
     fs.writeFileSync(
@@ -193,12 +238,15 @@ describe('cmdConfig', () => {
         mode: 'wait',
         preambleMode: 'disabled',
         defaults: { preambleEvery: 7 },
+        exchange: { retentionDays: 30 },
       })
     );
     cmdConfig(ctx, configRequest('show'));
     const out = (ctx.ui as any).jsonCalls[0] as any;
     expect(out.sources.preambleMode).toBe('global');
     expect(out.sources.preambleEvery).toBe('global');
+    expect(out.resolved.exchange.retentionDays).toBe(30);
+    expect(out.sources.exchange.retentionDays).toBe('global');
   });
 
   it('shows default source when no config has settings', () => {
@@ -207,6 +255,25 @@ describe('cmdConfig', () => {
     const out = (ctx.ui as any).jsonCalls[0] as any;
     expect(out.sources.preambleMode).toBe('default');
     expect(out.sources.preambleEvery).toBe('default');
+    expect(out.resolved.exchange.retentionDays).toBe(90);
+    expect(out.sources.exchange.retentionDays).toBe('default');
+  });
+
+  it('does not project an opaque local exchange setting', () => {
+    const ctx = createCtx(testDir, { json: true });
+    fs.writeFileSync(
+      ctx.paths.localConfig,
+      JSON.stringify({
+        exchange: { retentionDays: 1 },
+        $config: { exchange: { retentionDays: 1 } },
+      })
+    );
+
+    cmdConfig(ctx, configRequest('show'));
+
+    const out = (ctx.ui as any).jsonCalls[0] as any;
+    expect(out.resolved.exchange.retentionDays).toBe(90);
+    expect(out.sources.exchange.retentionDays).toBe('default');
   });
 
   it('shows sources in table mode with local settings', () => {
@@ -236,6 +303,14 @@ describe('cmdConfig', () => {
     const ctx = createCtx(testDir);
     expect(() =>
       cmdConfig(ctx, configRequest('set', { key: 'mode', value: 'wait', global: true }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(fs.existsSync(ctx.paths.globalConfig)).toBe(false);
+  });
+
+  it.each(['0', '3651', '1.5', '1\n'])('rejects invalid exchange retention %j', (value) => {
+    const ctx = createCtx(testDir);
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'exchange.retentionDays', value, global: true }))
     ).toThrow(`exit(${ExitCodes.ERROR})`);
     expect(fs.existsSync(ctx.paths.globalConfig)).toBe(false);
   });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -16,15 +16,23 @@ import {
 import { createDefaultGlobalDefaults, isValidConfigSettingValue } from '../config-settings.js';
 
 type EnumConfigKey = 'preambleMode';
-type NumericConfigKey = 'preambleEvery' | 'pasteEnterDelayMs';
+type NumericConfigKey = 'preambleEvery' | 'pasteEnterDelayMs' | 'exchange.retentionDays';
 type ConfigKey = EnumConfigKey | NumericConfigKey;
 
 const ENUM_KEYS: EnumConfigKey[] = ['preambleMode'];
-const NUMERIC_KEYS: NumericConfigKey[] = ['preambleEvery', 'pasteEnterDelayMs'];
+const NUMERIC_KEYS: NumericConfigKey[] = [
+  'preambleEvery',
+  'pasteEnterDelayMs',
+  'exchange.retentionDays',
+];
 const VALID_KEYS: ConfigKey[] = [...ENUM_KEYS, ...NUMERIC_KEYS];
 
 function isValidKey(key: string): key is ConfigKey {
   return VALID_KEYS.includes(key as ConfigKey);
+}
+
+function isGlobalOnlyKey(key: ConfigKey): key is 'exchange.retentionDays' {
+  return key === 'exchange.retentionDays';
 }
 
 type ParsedSetting =
@@ -65,6 +73,9 @@ function showConfig(ctx: Context): void {
         preambleEvery: ctx.config.defaults.preambleEvery,
         pasteEnterDelayMs: ctx.config.defaults.pasteEnterDelayMs,
         defaults: ctx.config.defaults,
+        exchange: {
+          retentionDays: ctx.config.exchange.retentionDays,
+        },
       },
       sources: {
         preambleMode: localSettings?.preambleMode
@@ -84,6 +95,9 @@ function showConfig(ctx: Context): void {
             : globalConfig.defaults?.pasteEnterDelayMs !== undefined
               ? 'global'
               : 'default',
+        exchange: {
+          retentionDays: globalConfig.exchange?.retentionDays !== undefined ? 'global' : 'default',
+        },
       },
       paths: {
         global: ctx.paths.globalConfig,
@@ -111,6 +125,8 @@ function showConfig(ctx: Context): void {
       : globalConfig.defaults?.pasteEnterDelayMs !== undefined
         ? '(global)'
         : '(default)';
+  const exchangeRetentionSource =
+    globalConfig.exchange?.retentionDays !== undefined ? '(global)' : '(default)';
 
   ctx.ui.info('Current configuration:\n');
   ctx.ui.table(
@@ -122,6 +138,11 @@ function showConfig(ctx: Context): void {
       ['defaults.timeout', String(ctx.config.defaults.timeout), '(global)'],
       ['defaults.pollInterval', String(ctx.config.defaults.pollInterval), '(global)'],
       ['defaults.captureLines', String(ctx.config.defaults.captureLines), '(global)'],
+      [
+        'exchange.retentionDays',
+        String(ctx.config.exchange.retentionDays),
+        exchangeRetentionSource,
+      ],
     ]
   );
 
@@ -140,6 +161,11 @@ function setConfig(ctx: Context, key: string, value: string, global: boolean): v
   }
 
   const validKey = key as ConfigKey;
+
+  if (!global && isGlobalOnlyKey(validKey)) {
+    ctx.ui.error(`${validKey} can only be set in global config with --global.`);
+    ctx.exit(ExitCodes.ERROR);
+  }
 
   let parsed: ParsedSetting;
   try {
@@ -164,6 +190,8 @@ function setConfig(ctx: Context, key: string, value: string, global: boolean): v
         globalConfig.defaults = createDefaultGlobalDefaults();
       }
       globalConfig.defaults.pasteEnterDelayMs = parsed.value;
+    } else if (parsed.key === 'exchange.retentionDays') {
+      globalConfig.exchange = { ...globalConfig.exchange, retentionDays: parsed.value };
     }
     saveGlobalConfig(ctx.paths, globalConfig);
     ctx.ui.success(`Set ${key}=${value} in global config`);
@@ -190,6 +218,11 @@ function clearConfig(ctx: Context, key?: string): void {
     const isObsoleteMode = key === 'mode';
     if (!isObsoleteMode && !isValidKey(key)) {
       ctx.ui.error(`Invalid key: ${key}. Valid keys: ${VALID_KEYS.join(', ')}`);
+      ctx.exit(ExitCodes.ERROR);
+    }
+
+    if (isValidKey(key) && isGlobalOnlyKey(key)) {
+      ctx.ui.error(`${key} is global-only and has no local override to clear.`);
       ctx.exit(ExitCodes.ERROR);
     }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -156,7 +156,8 @@ ${colors.yellow('REPLY / RESULT')}
   keep the original submittedAtMs; conflicting bodies cannot replace results.
   JSON unavailable is {status:"unavailable",requestId,error:{code:"RESPONSE_NOT_AVAILABLE",message}}.
   Receipts are local correlation, not remote authentication. Bodies are
-  retained seven days; retry only with the same receipt/body while retained.
+  retained for the request's frozen duration (90 days by default, seven for
+  pre-migration requests). Retry only with the same receipt/body while retained.
   Missing results do not cancel work. Surface failed submission without a
   success summary, and never resubmit after accepted delivery.
 
@@ -180,6 +181,9 @@ ${colors.yellow('CONFIG')}
 ${colors.yellow('SETTINGS')}
   tmux-team config set preambleMode disabled ${colors.dim('Disable preambles (local)')}
   tmux-team config set preambleEvery 5      ${colors.dim('Inject preamble every 5 messages')}
+  tmux-team config set exchange.retentionDays 90 --global
+  Retention accepts integer days 1..3650, global-only, for new requests only.
+  Reads/retries do not renew expiry; cleanup is bounded and opportunistic.
   --wait is retired; --lines is only for check, not talk.
   Stored mode/maxCaptureLines settings are inert and preserved, not migrated.
   config clear mode removes only the obsolete local mode key.

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import type { Context, Flags, Paths, ResolvedConfig, Tmux, UI } from '../types.js';
 import { ExitCodes } from '../exits.js';
 import { ALL_SKILL_TARGET, SKILL_AGENTS } from '../skill-installation.js';
+import { createDefaultConfig } from '../config-settings.js';
 
 function createMockUI(): UI {
   return {
@@ -25,16 +26,7 @@ function createCtx(testDir: string, overrides?: Partial<{ flags: Partial<Flags> 
     stateFile: path.join(testDir, 'state.json'),
     databaseFile: path.join(testDir, 'tmux-team.db'),
   };
-  const config: ResolvedConfig = {
-    preambleMode: 'always',
-    defaults: {
-      timeout: 180,
-      pollInterval: 1,
-      captureLines: 100,
-      preambleEvery: 3,
-      pasteEnterDelayMs: 500,
-    },
-  };
+  const config: ResolvedConfig = createDefaultConfig();
   const flags: Flags = { json: false, verbose: false, ...overrides?.flags } as Flags;
   const tmux: Tmux = {
     send: vi.fn(),

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -59,7 +59,8 @@ ${colors.yellow('DURABLE REPLIES AND RESULTS')}
   Identical retries keep the original submission timestamp; conflicting bodies
   cannot replace stored results.
   Receipts are local correlation, not remote authentication. Bodies are
-  retained seven days; retry only with the same receipt/body while retained.
+  retained for the request's frozen duration (90 days by default, seven for
+  pre-migration requests). Retry only with the same receipt/body while retained.
   Missing results do not cancel work. Surface failed submission without a
   success summary, and never resubmit after accepted delivery.
 
@@ -105,6 +106,11 @@ ${colors.yellow('CONFIGURATION SAFETY')}
   not fractions or suffixes. Invalid loaded settings return CONFIG_ERROR
   before talk/check effects. Fix the reported field, not the whole file.
   Storage-only reply/result remain usable with malformed configuration.
+  tmt config set exchange.retentionDays 90 --global sets 1..3650 integer days
+  for new requests only. Existing deadlines, reply eligibility and observer
+  timeouts are unchanged. Local overrides/clear are not supported for this key.
+  Final retention starts at submission. Reads/retries do not renew expiry;
+  cleanup is bounded and opportunistic, not scheduled or secure erasure.
 
 ${colors.yellow('BEST PRACTICES')}
 

--- a/src/commands/name.test.ts
+++ b/src/commands/name.test.ts
@@ -4,6 +4,7 @@ import { cmdThis } from './this.js';
 import { cmdAdd } from './add.js';
 import { IdentityServiceError } from '../identity-service.js';
 import type { Context, IdentityService } from '../types.js';
+import { createDefaultConfig } from '../config-settings.js';
 
 function identity(name: string = 'Backend') {
   return {
@@ -33,6 +34,14 @@ function context(json = false): Context {
     resolveActive: vi.fn(),
     reconcile: vi.fn(),
   };
+  const config = createDefaultConfig();
+  config.defaults = {
+    ...config.defaults,
+    timeout: 1,
+    captureLines: 1,
+    preambleEvery: 1,
+    pasteEnterDelayMs: 0,
+  };
   return {
     argv: [],
     flags: { json, verbose: false },
@@ -44,16 +53,7 @@ function context(json = false): Context {
       table: vi.fn(),
       json: vi.fn(),
     },
-    config: {
-      preambleMode: 'always',
-      defaults: {
-        timeout: 1,
-        pollInterval: 1,
-        captureLines: 1,
-        preambleEvery: 1,
-        pasteEnterDelayMs: 0,
-      },
-    },
+    config,
     tmux,
     identityService,
     get requestService(): Context['requestService'] {

--- a/src/commands/preamble.test.ts
+++ b/src/commands/preamble.test.ts
@@ -12,6 +12,7 @@ import { PreambleContentError } from '../domain/preamble.js';
 import { ExitCodes } from '../exits.js';
 import { cmdPreamble } from './preamble.js';
 import type { PreambleRequest } from '../cli/requests.js';
+import { createDefaultConfig } from '../config-settings.js';
 
 const identity: DurableIdentity = {
   id: 'identity-alice',
@@ -45,16 +46,7 @@ function createContext(service: PreambleService, flags: Partial<Context['flags']
     argv: [],
     flags: { json: false, verbose: false, ...flags },
     ui,
-    config: {
-      preambleMode: 'always',
-      defaults: {
-        timeout: 180,
-        pollInterval: 1,
-        captureLines: 100,
-        preambleEvery: 3,
-        pasteEnterDelayMs: 500,
-      },
-    },
+    config: createDefaultConfig(),
     tmux: {
       send: vi.fn(),
       capture: vi.fn(),

--- a/src/commands/reply-result.test.ts
+++ b/src/commands/reply-result.test.ts
@@ -93,6 +93,7 @@ describe('reply and result command adapters', () => {
       body,
       bodyBytes: Buffer.byteLength(body),
       submittedAtMs: 99,
+      responseExpiresAtMs: 1_000,
     }));
     const ctx = createContext({ submitResponse });
 
@@ -122,6 +123,7 @@ describe('reply and result command adapters', () => {
       body,
       bodyBytes: Buffer.byteLength(body),
       submittedAtMs: 99,
+      responseExpiresAtMs: 1_000,
     }));
     const ctx = createContext({ submitResponse });
 
@@ -230,6 +232,7 @@ describe('reply and result command adapters', () => {
       body: '\ufeffbody\r\n日本語\u0000',
       bodyBytes: Buffer.byteLength('\ufeffbody\r\n日本語\u0000'),
       submittedAtMs: 123,
+      responseExpiresAtMs: 1_000,
     };
     const ctx = createContext({ getResponse: vi.fn(() => response) });
 

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -17,6 +17,7 @@ import { ExitCodes } from '../exits.js';
 import { TmuxDeliveryError } from '../message-delivery.js';
 import { decodeReplyReceipt } from '../reply-receipt.js';
 import { MAX_OBSERVER_TIMEOUT_SECONDS, MAX_TIMER_DELAY_MS } from '../domain/interaction-limits.js';
+import { createDefaultConfig } from '../config-settings.js';
 import { cmdTalk } from './talk.js';
 
 const ENDPOINT = {
@@ -177,17 +178,14 @@ function createPaths(root: string): Paths {
 }
 
 function createConfig(overrides: Partial<ResolvedConfig['defaults']> = {}): ResolvedConfig {
-  return {
-    preambleMode: 'always',
-    defaults: {
-      timeout: 180,
-      pollInterval: 0.001,
-      captureLines: 100,
-      preambleEvery: 3,
-      pasteEnterDelayMs: 0,
-      ...overrides,
-    },
+  const config = createDefaultConfig();
+  config.defaults = {
+    ...config.defaults,
+    pollInterval: 0.001,
+    pasteEnterDelayMs: 0,
+    ...overrides,
   };
+  return config;
 }
 
 function createPreambleService(content = 'Be concise'): NonNullable<Context['preambleService']> {

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { cmdWhoami } from './whoami.js';
 import { cmdUnbind } from './unbind.js';
 import type { Context, IdentityService } from '../types.js';
+import { createDefaultConfig } from '../config-settings.js';
 
 function identity(name = 'alice') {
   return {
@@ -39,6 +40,14 @@ function context(json = false): Context {
     resolveActive: vi.fn(),
     reconcile: vi.fn(),
   };
+  const config = createDefaultConfig();
+  config.defaults = {
+    ...config.defaults,
+    timeout: 1,
+    captureLines: 1,
+    preambleEvery: 1,
+    pasteEnterDelayMs: 0,
+  };
   return {
     argv: [],
     flags: { json, verbose: false },
@@ -50,16 +59,7 @@ function context(json = false): Context {
       table: vi.fn(),
       json: vi.fn(),
     },
-    config: {
-      preambleMode: 'always',
-      defaults: {
-        timeout: 1,
-        pollInterval: 1,
-        captureLines: 1,
-        preambleEvery: 1,
-        pasteEnterDelayMs: 0,
-      },
-    },
+    config,
     tmux: {
       send: vi.fn(),
       capture: vi.fn(),

--- a/src/config-cli-contract.test.ts
+++ b/src/config-cli-contract.test.ts
@@ -66,6 +66,17 @@ describe('real CLI configuration contract', () => {
       { label: 'global array root', scope: 'global', value: [] },
       { label: 'global null defaults', scope: 'global', value: { defaults: null } },
       { label: 'global array defaults', scope: 'global', value: { defaults: [] } },
+      { label: 'global null exchange', scope: 'global', value: { exchange: null } },
+      {
+        label: 'numeric-string exchange retention',
+        scope: 'global',
+        value: { exchange: { retentionDays: '90' } },
+      },
+      {
+        label: 'zero exchange retention',
+        scope: 'global',
+        value: { exchange: { retentionDays: 0 } },
+      },
       {
         label: 'null known global value',
         scope: 'global',

--- a/src/config-settings.test.ts
+++ b/src/config-settings.test.ts
@@ -17,6 +17,7 @@ describe('config settings policy', () => {
     const first = createDefaultConfig();
     const second = createDefaultConfig();
     first.defaults.timeout = 42;
+    first.exchange.retentionDays = 1;
     expect(second).toEqual({
       preambleMode: 'always',
       defaults: {
@@ -26,6 +27,7 @@ describe('config settings policy', () => {
         preambleEvery: 3,
         pasteEnterDelayMs: 500,
       },
+      exchange: { retentionDays: 90 },
     });
     expect(createDefaultGlobalDefaults()).toEqual(second.defaults);
   });
@@ -41,6 +43,8 @@ describe('config settings policy', () => {
     ['pasteEnterDelayMs', 0],
     ['pasteEnterDelayMs', 0.5],
     ['pasteEnterDelayMs', 2_147_483_647],
+    ['exchange.retentionDays', 1],
+    ['exchange.retentionDays', 3650],
   ] as const)('accepts %s=%s', (key, value) => {
     expect(isValidConfigSettingValue(key, value)).toBe(true);
   });
@@ -58,8 +62,26 @@ describe('config settings policy', () => {
     ['captureLines', 1.5],
     ['pasteEnterDelayMs', -1],
     ['pasteEnterDelayMs', 2_147_483_648],
+    ['exchange.retentionDays', 0],
+    ['exchange.retentionDays', 3651],
+    ['exchange.retentionDays', 1.5],
   ] as const)('rejects %s=%s', (key, value) => {
     expect(isValidConfigSettingValue(key, value)).toBe(false);
+  });
+
+  it.each([null, '90', -1, 0, 1.5, Infinity, NaN, Number.MAX_SAFE_INTEGER])(
+    'rejects malformed global retention without treating %j as a default',
+    (retentionDays) => {
+      expect(() =>
+        validateAndProjectGlobalConfig({ exchange: { retentionDays } }, file)
+      ).toThrowError(ConfigValidationError);
+    }
+  );
+
+  it.each([null, [], '90', 90])('rejects the invalid exchange container %j', (exchange) => {
+    expect(() => validateAndProjectGlobalConfig({ exchange }, file)).toThrowError(
+      ConfigValidationError
+    );
   });
 
   it('validates known values in global and local layers, including overridden values', () => {
@@ -68,6 +90,9 @@ describe('config settings policy', () => {
         { defaults: { timeout: 86_401 }, unrelated: { preserve: true } },
         file
       )
+    ).toThrowError(ConfigValidationError);
+    expect(() =>
+      validateAndProjectGlobalConfig({ exchange: { retentionDays: 3651 } }, file)
     ).toThrowError(ConfigValidationError);
     expect(() =>
       validateAndProjectLocalSettings({ $config: { preambleEvery: null } }, file)
@@ -81,13 +106,25 @@ describe('config settings policy', () => {
           preambleMode: 'disabled',
           mode: 'wait',
           defaults: { timeout: 120, maxCaptureLines: 999, future: true },
+          exchange: { retentionDays: 90, future: true },
         },
         file
       )
-    ).toEqual({ preambleMode: 'disabled', defaults: { timeout: 120 } });
+    ).toEqual({
+      preambleMode: 'disabled',
+      defaults: { timeout: 120 },
+      exchange: { retentionDays: 90 },
+    });
     expect(
       validateAndProjectLocalSettings(
-        { $config: { preambleMode: 'disabled', mode: 'wait', future: true } },
+        {
+          $config: {
+            preambleMode: 'disabled',
+            mode: 'wait',
+            future: true,
+            exchange: { retentionDays: 1 },
+          },
+        },
         file
       )
     ).toEqual({ $config: { preambleMode: 'disabled' } });
@@ -107,6 +144,9 @@ describe('config settings policy', () => {
 
   it('rejects malformed known containers while allowing unknown fields', () => {
     expect(() => validateGlobalConfigShape({ defaults: null }, file)).toThrowError(
+      ConfigValidationError
+    );
+    expect(() => validateGlobalConfigShape({ exchange: [] }, file)).toThrowError(
       ConfigValidationError
     );
     expect(() => validateLocalConfigShape({ $config: [] }, file)).toThrowError(

--- a/src/config-settings.ts
+++ b/src/config-settings.ts
@@ -1,10 +1,22 @@
-import type { ConfigDefaults, GlobalConfig, LocalSettings, ResolvedConfig } from './types.js';
+import type {
+  ConfigDefaults,
+  GlobalConfig,
+  GlobalExchangeSettings,
+  LocalSettings,
+  ResolvedConfig,
+} from './types.js';
 import {
   isValidCaptureLines,
   isValidObserverTimeoutSeconds,
   isValidPollIntervalSeconds,
   isValidTimerDelayMs,
 } from './domain/interaction-limits.js';
+import {
+  DEFAULT_EXCHANGE_RETENTION_DAYS,
+  MAX_EXCHANGE_RETENTION_DAYS,
+  MIN_EXCHANGE_RETENTION_DAYS,
+  isValidExchangeRetentionDays,
+} from './domain/exchange-retention.js';
 
 const DEFAULT_CONFIG = {
   preambleMode: 'always',
@@ -15,6 +27,9 @@ const DEFAULT_CONFIG = {
     preambleEvery: 3,
     pasteEnterDelayMs: 500,
   },
+  exchange: {
+    retentionDays: DEFAULT_EXCHANGE_RETENTION_DAYS,
+  },
 } as const;
 
 type JsonObject = Record<string, unknown>;
@@ -24,7 +39,8 @@ export type ConfigSettingKey =
   | 'pollInterval'
   | 'captureLines'
   | 'preambleEvery'
-  | 'pasteEnterDelayMs';
+  | 'pasteEnterDelayMs'
+  | 'exchange.retentionDays';
 
 export class ConfigValidationError extends Error {
   constructor(
@@ -93,6 +109,10 @@ const SETTING_RULES: Record<ConfigSettingKey, SettingRule> = {
     valid: isValidTimerDelayMs,
     expected: 'a finite number from 0 through 2147483647',
   },
+  'exchange.retentionDays': {
+    valid: isValidExchangeRetentionDays,
+    expected: `an integer from ${MIN_EXCHANGE_RETENTION_DAYS} through ${MAX_EXCHANGE_RETENTION_DAYS}`,
+  },
 };
 
 export function isValidConfigSettingValue(key: ConfigSettingKey, value: unknown): boolean {
@@ -119,6 +139,7 @@ export function validateGlobalConfigShape(
 ): asserts value is JsonObject {
   const root = validateObject(value, filePath, '<root>');
   if (hasOwn(root, 'defaults')) validateObject(root.defaults, filePath, 'defaults');
+  if (hasOwn(root, 'exchange')) validateObject(root.exchange, filePath, 'exchange');
 }
 
 /** Validate only the JSON container shape so a targeted config repair is possible. */
@@ -137,6 +158,19 @@ export function validateGlobalConfig(
   validateGlobalConfigShape(value, filePath);
   const root = value;
   validateKnownSettings(root, filePath, '', ['preambleMode']);
+  if (hasOwn(root, 'exchange')) {
+    const exchange = root.exchange as JsonObject;
+    if (hasOwn(exchange, 'retentionDays')) {
+      const rule = SETTING_RULES['exchange.retentionDays'];
+      validateKnownField(
+        exchange.retentionDays,
+        filePath,
+        'exchange.retentionDays',
+        rule.valid,
+        rule.expected
+      );
+    }
+  }
   if (!hasOwn(root, 'defaults')) return;
   const defaults = root.defaults as JsonObject;
   validateKnownSettings(defaults, filePath, 'defaults.', [
@@ -163,6 +197,7 @@ export function validateLocalConfig(value: unknown, filePath: string): asserts v
 export interface ValidatedGlobalConfig {
   readonly preambleMode?: GlobalConfig['preambleMode'];
   readonly defaults?: Partial<ConfigDefaults>;
+  readonly exchange?: Pick<GlobalExchangeSettings, 'retentionDays'>;
 }
 
 export interface ValidatedLocalSettings {
@@ -171,6 +206,7 @@ export interface ValidatedLocalSettings {
 
 function projectGlobalConfig(value: JsonObject): ValidatedGlobalConfig {
   const rawDefaults = isJsonObject(value.defaults) ? value.defaults : undefined;
+  const rawExchange = isJsonObject(value.exchange) ? value.exchange : undefined;
   return {
     ...(value.preambleMode !== undefined && {
       preambleMode: value.preambleMode as GlobalConfig['preambleMode'],
@@ -191,6 +227,9 @@ function projectGlobalConfig(value: JsonObject): ValidatedGlobalConfig {
           pasteEnterDelayMs: rawDefaults.pasteEnterDelayMs as number,
         }),
       },
+    }),
+    ...(rawExchange?.retentionDays !== undefined && {
+      exchange: { retentionDays: rawExchange.retentionDays as number },
     }),
   };
 }
@@ -234,6 +273,7 @@ export function createDefaultConfig(): ResolvedConfig {
   return {
     preambleMode: DEFAULT_CONFIG.preambleMode,
     defaults: { ...DEFAULT_CONFIG.defaults },
+    exchange: { ...DEFAULT_CONFIG.exchange },
   };
 }
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -207,6 +207,23 @@ describe('loadConfig', () => {
     expect(config.defaults.pollInterval).toBe(1);
     expect(config.defaults.captureLines).toBe(100);
     expect(config.defaults.pasteEnterDelayMs).toBe(500);
+    expect(config.exchange.retentionDays).toBe(90);
+  });
+
+  it('loads global exchange retention but ignores local exchange data', () => {
+    const globalConfig = { exchange: { retentionDays: 30 } };
+    const localConfig = { $config: { exchange: { retentionDays: 1 } } };
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p === mockPaths.globalConfig) return JSON.stringify(globalConfig);
+      if (p === mockPaths.localConfig) return JSON.stringify(localConfig);
+      return '';
+    });
+
+    const config = loadConfig(mockPaths);
+
+    expect(config.exchange.retentionDays).toBe(30);
   });
 
   it('loads runtime settings while leaving obsolete mode and extraction keys opaque', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -160,6 +160,9 @@ export function loadConfig(paths: Paths): ResolvedConfig {
     if (knownGlobal.defaults) {
       Object.assign(config.defaults, knownGlobal.defaults);
     }
+    if (knownGlobal.exchange?.retentionDays !== undefined) {
+      config.exchange.retentionDays = knownGlobal.exchange.retentionDays;
+    }
   }
 
   // Load local settings. Other local JSON fields remain opaque and are never

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Paths, ResolvedConfig, UI, Tmux } from './types.js';
+import { createDefaultConfig } from './config-settings.js';
 
 describe('createContext', () => {
   afterEach(() => {
@@ -19,16 +20,7 @@ describe('createContext', () => {
       stateFile: '/g/state.json',
       databaseFile: '/g/tmux-team.db',
     };
-    const config: ResolvedConfig = {
-      preambleMode: 'always',
-      defaults: {
-        timeout: 180,
-        pollInterval: 1,
-        captureLines: 100,
-        preambleEvery: 3,
-        pasteEnterDelayMs: 500,
-      },
-    };
+    const config: ResolvedConfig = createDefaultConfig();
     const ui: UI = {
       info: vi.fn(),
       success: vi.fn(),
@@ -76,16 +68,7 @@ describe('createContext', () => {
       stateFile: '/g/state.json',
       databaseFile: '/g/tmux-team.db',
     };
-    const config: ResolvedConfig = {
-      preambleMode: 'always',
-      defaults: {
-        timeout: 180,
-        pollInterval: 1,
-        captureLines: 100,
-        preambleEvery: 3,
-        pasteEnterDelayMs: 500,
-      },
-    };
+    const config: ResolvedConfig = createDefaultConfig();
     const tmux: Tmux = {
       send: vi.fn(),
       capture: vi.fn(),
@@ -218,7 +201,18 @@ describe('createContext', () => {
       submitResponse: vi.fn(),
       getResponse: vi.fn(),
     };
-    const createRequestService = vi.fn(() => requestService);
+    let retentionPolicy: (() => number) | undefined;
+    const createRequestService = vi.fn(
+      (options: { repository: unknown; getRetentionDays: () => number }) => {
+        retentionPolicy = options.getRetentionDays;
+        return requestService;
+      }
+    );
+    const loadConfig = vi.fn(() => ({ ...createDefaultConfig(), exchange: { retentionDays: 17 } }));
+    vi.doMock('./config.js', () => ({
+      resolvePaths: () => ({ databaseFile: '/isolated/tmux-team.db' }),
+      loadConfig,
+    }));
     vi.doMock('./storage/identity-repository.js', () => ({ openIdentityRepository }));
     vi.doMock('./request-service.js', () => ({ createRequestService }));
 
@@ -231,7 +225,13 @@ describe('createContext', () => {
 
     expect(createRequestService).not.toHaveBeenCalled();
     expect(ctx.requestService).toBe(requestService);
-    expect(createRequestService).toHaveBeenCalledWith({ repository });
+    expect(createRequestService).toHaveBeenCalledWith({
+      repository,
+      getRetentionDays: expect.any(Function),
+    });
+    expect(loadConfig).not.toHaveBeenCalled();
+    expect(retentionPolicy?.()).toBe(17);
+    expect(loadConfig).toHaveBeenCalledOnce();
     expect(openIdentityRepository).toHaveBeenCalledOnce();
     ctx.dispose?.();
     expect(repository.close).toHaveBeenCalledOnce();

--- a/src/context.ts
+++ b/src/context.ts
@@ -94,7 +94,12 @@ export function createContext(options: CreateContextOptions): Context {
   };
   const getRequestService = (): NonNullable<Context['requestService']> => {
     assertActive();
-    requestService ??= createRequestService({ repository: getIdentityRepository() });
+    requestService ??= createRequestService({
+      repository: getIdentityRepository(),
+      // Only preparation asks for current policy. Stored replies and results
+      // remain usable without loading unrelated current configuration.
+      getRetentionDays: () => getConfig().exchange.retentionDays,
+    });
     return requestService;
   };
   const dispose = (): void => {

--- a/src/domain/exchange-retention.test.ts
+++ b/src/domain/exchange-retention.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addExchangeRetentionMs,
+  DEFAULT_EXCHANGE_RETENTION_DAYS,
+  isValidExchangeRetentionDays,
+  MAX_EXCHANGE_RETENTION_DAYS,
+  MIN_EXCHANGE_RETENTION_DAYS,
+  RETENTION_DAY_MS,
+} from './exchange-retention.js';
+
+describe('exchange retention policy', () => {
+  it('accepts only bounded safe integer day counts', () => {
+    expect(isValidExchangeRetentionDays(MIN_EXCHANGE_RETENTION_DAYS)).toBe(true);
+    expect(isValidExchangeRetentionDays(DEFAULT_EXCHANGE_RETENTION_DAYS)).toBe(true);
+    expect(isValidExchangeRetentionDays(MAX_EXCHANGE_RETENTION_DAYS)).toBe(true);
+    for (const value of [0, -1, 1.5, '90', null, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(isValidExchangeRetentionDays(value)).toBe(false);
+    }
+  });
+
+  it('checks the persisted expiry arithmetic instead of wrapping', () => {
+    expect(addExchangeRetentionMs(1_700_000_000_000, 1)).toBe(1_700_000_000_000 + RETENTION_DAY_MS);
+    expect(addExchangeRetentionMs(Number.MAX_SAFE_INTEGER - RETENTION_DAY_MS, 1)).toBe(
+      Number.MAX_SAFE_INTEGER
+    );
+    expect(() => addExchangeRetentionMs(Number.MAX_SAFE_INTEGER - RETENTION_DAY_MS + 1, 1)).toThrow(
+      'outside the supported range'
+    );
+    expect(() => addExchangeRetentionMs(Number.MAX_SAFE_INTEGER, 1)).toThrow(
+      'outside the supported range'
+    );
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects unsupported clock anchor %s',
+    (anchor) => {
+      expect(() => addExchangeRetentionMs(anchor, 1)).toThrow('anchor is outside');
+    }
+  );
+});

--- a/src/domain/exchange-retention.ts
+++ b/src/domain/exchange-retention.ts
@@ -1,0 +1,55 @@
+/** The default lifetime for newly prepared exchange records. */
+export const DEFAULT_EXCHANGE_RETENTION_DAYS = 90;
+
+/** The duration stamped onto records created by the pre-retention schema. */
+export const LEGACY_EXCHANGE_RETENTION_DAYS = 7;
+
+export const MIN_EXCHANGE_RETENTION_DAYS = 1;
+export const MAX_EXCHANGE_RETENTION_DAYS = 3650;
+export const RETENTION_DAY_MS = 24 * 60 * 60 * 1000;
+export const EXCHANGE_RESPONSE_ACCEPTANCE_WINDOW_MS = 7 * RETENTION_DAY_MS;
+export const EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS = RETENTION_DAY_MS;
+
+export function isValidExchangeRetentionDays(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= MIN_EXCHANGE_RETENTION_DAYS &&
+    value <= MAX_EXCHANGE_RETENTION_DAYS
+  );
+}
+
+export function assertExchangeRetentionDays(
+  value: unknown,
+  label = 'retention days'
+): asserts value is number {
+  if (!isValidExchangeRetentionDays(value)) {
+    throw new Error(
+      `${label} must be an integer from ${MIN_EXCHANGE_RETENTION_DAYS} through ${MAX_EXCHANGE_RETENTION_DAYS}.`
+    );
+  }
+}
+
+export function exchangeRetentionMs(retentionDays: number): number {
+  assertExchangeRetentionDays(retentionDays);
+  const duration = retentionDays * RETENTION_DAY_MS;
+  if (!Number.isSafeInteger(duration)) {
+    throw new Error('Exchange retention duration is outside the supported range.');
+  }
+  return duration;
+}
+
+export function addExchangeRetentionMs(
+  anchorMs: number,
+  retentionDays: number,
+  label = 'exchange retention expiry'
+): number {
+  if (!Number.isSafeInteger(anchorMs) || anchorMs <= 0) {
+    throw new Error(`${label} anchor is outside the supported range.`);
+  }
+  const duration = exchangeRetentionMs(retentionDays);
+  if (anchorMs > Number.MAX_SAFE_INTEGER - duration) {
+    throw new Error(`${label} is outside the supported range.`);
+  }
+  return anchorMs + duration;
+}

--- a/src/reply-cli-contract.test.ts
+++ b/src/reply-cli-contract.test.ts
@@ -36,6 +36,7 @@ interface SeedOptions {
   readonly expired?: boolean;
   readonly preparedAtMs?: number;
   readonly reservePreamble?: boolean;
+  readonly retentionDays?: number;
 }
 
 function seedAttempt(sandbox: Sandbox, requestId: string, options: SeedOptions = {}): SeededReply {
@@ -47,7 +48,12 @@ function seedAttempt(sandbox: Sandbox, requestId: string, options: SeedOptions =
       : undefined;
     const now =
       options.preparedAtMs ?? (options.expired ? Date.now() - 2 * 60 * 60 * 1000 : Date.now());
-    const service = createRequestService({ repository, now: () => now });
+    const retentionDays = options.retentionDays;
+    const service = createRequestService({
+      repository,
+      now: () => now,
+      ...(retentionDays !== undefined && { getRetentionDays: () => retentionDays }),
+    });
     const prepared = service.prepare({
       requestId,
       endpoint,
@@ -75,7 +81,7 @@ function seedAttempt(sandbox: Sandbox, requestId: string, options: SeedOptions =
   }
 }
 
-function stateSnapshot(sandbox: Sandbox, requestId: string): unknown {
+function stateSnapshot(sandbox: Sandbox, requestId: string) {
   const database = new Database(sandbox.database, { readonly: true });
   try {
     return {
@@ -557,10 +563,13 @@ describe('real reply/result CLI process contract', () => {
     { timeout: 15_000 },
     () =>
       withSandbox(async (sandbox) => {
-        const preparedAtMs = Date.now() - 8 * 24 * 60 * 60 * 1000;
+        // The one-day body is expired while the seven-day acceptance marker
+        // still prevents resurrection. Public result may physically prune it.
+        const preparedAtMs = Date.now() - 2 * 24 * 60 * 60 * 1000;
         const seeded = seedAttempt(sandbox, 'request-expired-body', {
           preparedAtMs,
           reservePreamble: true,
+          retentionDays: 1,
         });
         const repository = openIdentityRepository(sandbox.database);
         try {
@@ -586,7 +595,10 @@ describe('real reply/result CLI process contract', () => {
         );
         expect(retry.status).toBe(1);
         expectError(retry, 'RESPONSE_EXPIRED');
-        expect(stateSnapshot(sandbox, seeded.requestId)).toEqual(before);
+        expect(stateSnapshot(sandbox, seeded.requestId)).toEqual({
+          ...before,
+          response: undefined,
+        });
       })
   );
 

--- a/src/request-response-concurrency.test.ts
+++ b/src/request-response-concurrency.test.ts
@@ -19,6 +19,8 @@ import {
 
 const directories: string[] = [];
 const repositories: IdentityRepository[] = [];
+const BASE_NOW_MS = 1_700_000_000_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const endpoint: RequestEndpoint = {
   serverId: 'server-1',
@@ -45,6 +47,12 @@ interface WorkerMessage {
   readonly attempt?: {
     readonly status: string;
     readonly cadenceReserved: boolean;
+    readonly waitActive: boolean;
+    readonly responseSubmittedAtMs?: number;
+  };
+  readonly rawResponse?: {
+    readonly body: string;
+    readonly responseExpiresAtMs: number;
   };
   readonly cadence?: boolean;
 }
@@ -58,7 +66,11 @@ function raceFixture(): RaceFixture {
   const repository = openIdentityRepository(database);
   repositories.push(repository);
   const identity = repository.createIdentity('Alice', 'alice');
-  const service = createRequestService({ repository, now: () => 1_700_000_000_000 });
+  const service = createRequestService({
+    repository,
+    now: () => BASE_NOW_MS,
+    getRetentionDays: () => 7,
+  });
   return { database, barrier, identityId: identity.id, repository, service };
 }
 
@@ -100,6 +112,53 @@ function runWorker(
     variant,
     path.dirname(value.barrier)
   );
+}
+
+async function runOrderedRace(
+  value: RaceFixture,
+  schedule: 'late' | 'expiry',
+  finalFirst: boolean
+): Promise<WorkerMessage[]> {
+  const requestId = `request-cleanup-final-${schedule}-${finalFirst ? 'final-first' : 'cleanup-first'}`;
+  const attemptId = prepareSending(value, requestId);
+  const cleanup = runWorker(value, requestId, attemptId, 'cleanup', `cleanup-${schedule}-gated`);
+  const final = runWorker(
+    value,
+    requestId,
+    attemptId,
+    'final',
+    `submit-${schedule}-gated`,
+    `${schedule} final body`
+  );
+  const handles = [cleanup, final];
+  try {
+    await waitForFiles(
+      handles.map((handle) => path.join(value.barrier, `ready-${handle.variant}`)),
+      handles
+    );
+    const submitGate = `go-submit-${schedule}`;
+    const cleanupGate = `go-cleanup-${schedule}`;
+    if (finalFirst) {
+      fs.writeFileSync(path.join(value.barrier, submitGate), 'go');
+      const finalResult = await collectResults([final]);
+      fs.writeFileSync(path.join(value.barrier, cleanupGate), 'go');
+      const cleanupResult = await collectResults([cleanup]);
+      return [
+        workerMessage<WorkerMessage>(finalResult[0]!),
+        workerMessage<WorkerMessage>(cleanupResult[0]!),
+      ];
+    }
+    fs.writeFileSync(path.join(value.barrier, cleanupGate), 'go');
+    const cleanupResult = await collectResults([cleanup]);
+    fs.writeFileSync(path.join(value.barrier, submitGate), 'go');
+    const finalResult = await collectResults([final]);
+    return [
+      workerMessage<WorkerMessage>(cleanupResult[0]!),
+      workerMessage<WorkerMessage>(finalResult[0]!),
+    ];
+  } finally {
+    await stopWorkers(handles);
+  }
 }
 
 afterEach(() => {
@@ -249,5 +308,104 @@ describe('durable response multi-process races', () => {
     } finally {
       await stopWorkers(secondHandles);
     }
+  }, 60_000);
+
+  it('serializes cleanup and a late final in either order without refunding cadence', async () => {
+    const cleanupFirst = raceFixture();
+    const cleanupFirstMessages = await runOrderedRace(cleanupFirst, 'late', false);
+    expect(cleanupFirstMessages[0]).toMatchObject({
+      ok: true,
+      operation: 'cleanup',
+      attempt: { status: 'uncertain', waitActive: false, cadenceReserved: true },
+    });
+    expect(cleanupFirstMessages[1]).toMatchObject({
+      ok: true,
+      operation: 'submit',
+      attempt: {
+        status: 'uncertain',
+        waitActive: false,
+        cadenceReserved: true,
+        responseSubmittedAtMs: BASE_NOW_MS + 6 * DAY_MS,
+      },
+      rawResponse: {
+        body: 'late final body',
+        responseExpiresAtMs: BASE_NOW_MS + 13 * DAY_MS,
+      },
+    });
+    expect(
+      cleanupFirst.service.getResponse('request-cleanup-final-late-cleanup-first')
+    ).toMatchObject({
+      body: 'late final body',
+    });
+    expect(cleanupFirst.repository.getPreambleCount(cleanupFirst.identityId)).toBe(1);
+
+    const finalFirst = raceFixture();
+    const finalFirstMessages = await runOrderedRace(finalFirst, 'late', true);
+    expect(finalFirstMessages[0]).toMatchObject({
+      ok: true,
+      operation: 'submit',
+      attempt: {
+        status: 'sending',
+        waitActive: true,
+        cadenceReserved: true,
+        responseSubmittedAtMs: BASE_NOW_MS + 6 * DAY_MS,
+      },
+      rawResponse: {
+        body: 'late final body',
+        responseExpiresAtMs: BASE_NOW_MS + 13 * DAY_MS,
+      },
+    });
+    expect(finalFirstMessages[1]).toMatchObject({
+      ok: true,
+      operation: 'cleanup',
+      attempt: { status: 'uncertain', waitActive: false, cadenceReserved: true },
+      rawResponse: { body: 'late final body' },
+    });
+    expect(finalFirst.service.getResponse('request-cleanup-final-late-final-first')).toMatchObject({
+      body: 'late final body',
+    });
+    expect(finalFirst.repository.getPreambleCount(finalFirst.identityId)).toBe(1);
+  }, 60_000);
+
+  it('rejects finalization at equal expiry in either order without resurrecting a body or marker', async () => {
+    const cleanupFirst = raceFixture();
+    const cleanupFirstMessages = await runOrderedRace(cleanupFirst, 'expiry', false);
+    expect(cleanupFirstMessages[0]).toMatchObject({
+      ok: true,
+      operation: 'cleanup',
+      attempt: { status: 'uncertain', waitActive: false, cadenceReserved: true },
+      rawResponse: null,
+    });
+    expect(cleanupFirstMessages[1]).toMatchObject({
+      ok: false,
+      code: 'RESPONSE_EXPIRED',
+      attempt: { status: 'uncertain', waitActive: false, cadenceReserved: true },
+      rawResponse: null,
+    });
+    expect(cleanupFirstMessages[1]?.attempt?.responseSubmittedAtMs).toBeUndefined();
+    expect(
+      cleanupFirst.service.getResponse('request-cleanup-final-expiry-cleanup-first')
+    ).toBeUndefined();
+    expect(cleanupFirst.repository.getPreambleCount(cleanupFirst.identityId)).toBe(1);
+
+    const finalFirst = raceFixture();
+    const finalFirstMessages = await runOrderedRace(finalFirst, 'expiry', true);
+    expect(finalFirstMessages[0]).toMatchObject({
+      ok: false,
+      code: 'RESPONSE_EXPIRED',
+      attempt: { status: 'sending', waitActive: true, cadenceReserved: true },
+      rawResponse: null,
+    });
+    expect(finalFirstMessages[0]?.attempt?.responseSubmittedAtMs).toBeUndefined();
+    expect(finalFirstMessages[1]).toMatchObject({
+      ok: true,
+      operation: 'cleanup',
+      attempt: { status: 'uncertain', waitActive: false, cadenceReserved: true },
+      rawResponse: null,
+    });
+    expect(
+      finalFirst.service.getResponse('request-cleanup-final-expiry-final-first')
+    ).toBeUndefined();
+    expect(finalFirst.repository.getPreambleCount(finalFirst.identityId)).toBe(1);
   }, 60_000);
 });

--- a/src/request-response.test.ts
+++ b/src/request-response.test.ts
@@ -42,7 +42,11 @@ function fixture(): Fixture {
   repositories.push(repository);
   const identity = repository.createIdentity('Alice', 'alice');
   const clock = { value: 1_700_000_000_000 };
-  const service = createRequestService({ repository, now: () => clock.value });
+  const service = createRequestService({
+    repository,
+    now: () => clock.value,
+    getRetentionDays: () => 7,
+  });
   return {
     database,
     endpoint,
@@ -153,6 +157,7 @@ describe('durable request responses', () => {
         body,
         bodyBytes: Buffer.byteLength(body, 'utf8'),
         submittedAtMs: value.clock.value,
+        responseExpiresAtMs: value.clock.value + RESPONSE_RETENTION_MS,
       });
       expect(value.service.getResponse(requestId)).toEqual(submitted);
     }
@@ -407,6 +412,70 @@ describe('durable request responses', () => {
     );
   });
 
+  it('freezes retention at preparation and never consults configuration on read or cleanup', () => {
+    const value = fixture();
+    let configuredDays = 1;
+    let reads = 0;
+    const service = createRequestService({
+      repository: value.repository,
+      now: () => value.clock.value,
+      getRetentionDays: () => {
+        reads += 1;
+        return configuredDays;
+      },
+    });
+    const attemptId = service.prepare({
+      requestId: 'request-frozen-retention',
+      endpoint: value.endpoint,
+      wait: true,
+      expiresAtMs: value.clock.value + 60 * 60 * 1000,
+    }).attemptId;
+    expect(reads).toBe(1);
+    expect(service.getAttempt(attemptId)).toMatchObject({ retentionDays: 1 });
+
+    configuredDays = 90;
+    service.beginSend(attemptId);
+    const response = service.submitResponse({
+      requestId: 'request-frozen-retention',
+      attemptId,
+      endpoint: value.endpoint,
+      body: 'frozen',
+    });
+    expect(response.responseExpiresAtMs).toBe(value.clock.value + DAY_MS);
+    service.releaseWait(attemptId);
+    service.settle(attemptId, 'sent');
+    service.getResponse('request-frozen-retention');
+    service.cleanup();
+    expect(reads).toBe(1);
+  });
+
+  it('hides an expired body logically while bounded cleanup leaves later physical rows', () => {
+    const value = fixture();
+    const accepted = Array.from({ length: 101 }, (_, index) => {
+      const requestId = `request-logical-body-${String(index).padStart(3, '0')}`;
+      const attemptId = prepareSending(value, requestId, { wait: false });
+      return submit(value, requestId, attemptId, requestId);
+    });
+    const last = accepted[accepted.length - 1];
+    if (!last) throw new Error('Expected final response.');
+    value.clock.value = last.responseExpiresAtMs;
+
+    expect(value.service.getResponse(last.requestId)).toBeUndefined();
+    expect(value.repository.findResponse(last.requestId)).toEqual(last);
+    expect(
+      accepted.filter((response) => value.repository.findResponse(response.requestId)).length
+    ).toBe(1);
+  });
+
+  it('does not reopen an in-flight attempt after its metadata horizon', () => {
+    const value = fixture();
+    const attemptId = prepareSending(value, 'request-expired-metadata');
+    value.clock.value += 7 * DAY_MS + 1;
+    expect(() => value.service.settle(attemptId, 'sent')).toThrow('metadata has expired');
+    expect(value.service.getAttempt(attemptId)).toBeUndefined();
+    expect(value.repository.findAttempt(attemptId)).toMatchObject({ status: 'uncertain' });
+  });
+
   it('retains a response while attempt metadata reaches ordinary cleanup age, then expires both at seven days', () => {
     const value = fixture();
     const requestId = 'request-retention';
@@ -428,9 +497,9 @@ describe('durable request responses', () => {
     const expiredAttempt = value.service.getAttempt(attemptId);
     expectResponseError(
       () => submit(value, requestId, attemptId, 'retained body'),
-      'RESPONSE_EXPIRED'
+      'RESPONSE_REQUEST_NOT_FOUND'
     );
-    expect(value.repository.findResponse(requestId)).toEqual(accepted);
+    expect(value.repository.findResponse(requestId)).toBeUndefined();
     expect(value.service.getAttempt(attemptId)).toEqual(expiredAttempt);
     value.service.cleanup();
     expect(value.service.getResponse(requestId)).toBeUndefined();
@@ -447,7 +516,8 @@ describe('durable request responses', () => {
     value.clock.value += 8 * DAY_MS;
     const settledAtMs = value.clock.value;
     value.service.cleanup();
-    expect(value.service.getAttempt(attemptId)).toMatchObject({
+    expect(value.service.getAttempt(attemptId)).toBeUndefined();
+    expect(value.repository.findAttempt(attemptId)).toMatchObject({
       status: 'uncertain',
       waitActive: false,
       settledAtMs,
@@ -455,7 +525,8 @@ describe('durable request responses', () => {
     });
     value.clock.value = settledAtMs + DAY_MS - 1;
     value.service.cleanup();
-    expect(value.service.getAttempt(attemptId)).toBeDefined();
+    expect(value.service.getAttempt(attemptId)).toBeUndefined();
+    expect(value.repository.findAttempt(attemptId)).toBeDefined();
     value.clock.value += 1;
     value.service.cleanup();
     expect(value.service.getAttempt(attemptId)).toBeUndefined();
@@ -506,7 +577,7 @@ describe('durable request responses', () => {
     expect(value.repository.getPreambleCount(value.identityId)).toBe(1);
   });
 
-  it('blocks request-id reuse while a retained response outlives its purged attempt metadata', () => {
+  it('blocks request-id reuse while a retained response keeps metadata fenced', () => {
     const value = fixture();
     const requestId = 'request-retained-id';
     const attemptId = prepareSending(value, requestId, {
@@ -519,7 +590,7 @@ describe('durable request responses', () => {
 
     value.clock.value = accepted.submittedAtMs + 2 * DAY_MS;
     value.service.cleanup();
-    expect(value.service.getAttempt(attemptId)).toBeUndefined();
+    expect(value.service.getAttempt(attemptId)).toBeDefined();
     expect(value.service.getResponse(requestId)).toEqual(accepted);
     expect(submit(value, requestId, attemptId, 'retained request id')).toEqual(accepted);
     const attemptsBeforeReuse = value.service.listAttempts();

--- a/src/request-service.test.ts
+++ b/src/request-service.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   createRequestService,
+  REQUEST_RETENTION_MS,
   RESPONSE_ACCEPTANCE_WINDOW_MS,
   type RequestEndpoint,
 } from './request-service.js';
@@ -369,7 +370,11 @@ describe('request service', () => {
     const repository = openIdentityRepository(databaseFile());
     repositories.push(repository);
     let nowMs = 10_000;
-    const service = createRequestService({ repository, now: () => nowMs });
+    const service = createRequestService({
+      repository,
+      now: () => nowMs,
+      getRetentionDays: () => 7,
+    });
     const prepared = service.prepare({
       requestId: 'request-1',
       endpoint,
@@ -388,6 +393,71 @@ describe('request service', () => {
     nowMs += RESPONSE_ACCEPTANCE_WINDOW_MS + 1;
     service.cleanup();
     expect(service.getAttempt(prepared.attemptId)).toBeUndefined();
+  });
+
+  it('hides metadata at its exact logical boundary before physical cleanup removes it', () => {
+    const repository = openIdentityRepository(databaseFile());
+    repositories.push(repository);
+    let nowMs = 10_000;
+    const service = createRequestService({
+      repository,
+      now: () => nowMs,
+      getRetentionDays: () => 1,
+    });
+    const prepared = service.prepare({
+      requestId: 'request-logical-boundary',
+      endpoint,
+      wait: false,
+      expiresAtMs: nowMs + 60 * 60 * 1000,
+    });
+    service.beginSend(prepared.attemptId);
+    const persisted = repository.findAttempt(prepared.attemptId);
+    if (!persisted) throw new Error('Expected persisted attempt.');
+
+    nowMs = persisted.retentionExpiresAtMs - 1;
+    expect(service.getAttempt(prepared.attemptId)).toBeDefined();
+    nowMs = persisted.retentionExpiresAtMs;
+    expect(service.getAttempt(prepared.attemptId)).toBeUndefined();
+    expect(service.listAttempts()).toEqual([]);
+    expect(repository.findAttempt(prepared.attemptId)).toBeDefined();
+  });
+
+  it('extends metadata only for an actual late settlement, never for reads or repeats', () => {
+    const repository = openIdentityRepository(databaseFile());
+    repositories.push(repository);
+    let nowMs = 10_000;
+    const service = createRequestService({
+      repository,
+      now: () => nowMs,
+      getRetentionDays: () => 1,
+    });
+    const prepared = service.prepare({
+      requestId: 'request-late-settlement',
+      endpoint,
+      wait: true,
+      expiresAtMs: nowMs + 60 * 60 * 1000,
+    });
+    service.beginSend(prepared.attemptId);
+    const before = repository.findAttempt(prepared.attemptId);
+    if (!before) throw new Error('Expected persisted attempt.');
+
+    nowMs = before.retentionExpiresAtMs - 1;
+    service.settle(prepared.attemptId, 'sent');
+    const afterSettlement = repository.findAttempt(prepared.attemptId);
+    if (!afterSettlement) throw new Error('Expected settled attempt.');
+    expect(afterSettlement.retentionExpiresAtMs).toBe(nowMs + REQUEST_RETENTION_MS);
+    expect(afterSettlement.retentionExpiresAtMs).toBeGreaterThan(before.retentionExpiresAtMs);
+
+    nowMs += 1_000;
+    service.settle(prepared.attemptId, 'sent');
+    nowMs += 1_000;
+    service.releaseWait(prepared.attemptId);
+    nowMs += 1_000;
+    expect(service.getAttempt(prepared.attemptId)).toBeDefined();
+    expect(service.listAttempts()).toHaveLength(1);
+    expect(repository.findAttempt(prepared.attemptId)?.retentionExpiresAtMs).toBe(
+      afterSettlement.retentionExpiresAtMs
+    );
   });
 
   it('rejects settlement before begin and preserves idempotent terminal settlement', () => {

--- a/src/request-service.ts
+++ b/src/request-service.ts
@@ -4,6 +4,13 @@ import {
   validateResponseBody,
   type ValidatedResponseBody,
 } from './domain/response.js';
+import {
+  addExchangeRetentionMs,
+  assertExchangeRetentionDays,
+  DEFAULT_EXCHANGE_RETENTION_DAYS,
+  EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS,
+  EXCHANGE_RESPONSE_ACCEPTANCE_WINDOW_MS,
+} from './domain/exchange-retention.js';
 import type { TmuxEndpointSnapshot } from './types.js';
 
 export type RequestAttemptStatus =
@@ -45,6 +52,10 @@ export interface RequestAttemptRecord extends RequestEndpoint {
   /** Immutable completion tombstone retained with attempt metadata after body pruning. */
   readonly responseSubmittedAtMs?: number;
   readonly expiresAtMs: number;
+  /** Frozen policy used to retain this attempt and any response it accepts. */
+  readonly retentionDays: number;
+  /** Metadata horizon, extended only by a first explicit settlement or accepted final. */
+  readonly retentionExpiresAtMs: number;
 }
 
 export interface RequestResponseSubmission {
@@ -61,6 +72,8 @@ export interface RequestResponseRecord {
   readonly body: string;
   readonly bodyBytes: number;
   readonly submittedAtMs: number;
+  /** Independent logical/physical body horizon anchored at submission. */
+  readonly responseExpiresAtMs: number;
 }
 
 export interface RequestPreparationInput {
@@ -91,19 +104,21 @@ export interface RequestRepository {
   /** Must run inside the caller's immediate transaction with marker insertion. */
   createResponse(response: RequestResponseRecord): void;
   findActiveRequest(endpoint: RequestEndpoint): string | undefined;
+  /** A supplied horizon extends metadata atomically with an explicit settlement. */
   updateAttemptState(
     attemptId: string,
     expectedStatus: RequestAttemptStatus,
     status: RequestAttemptStatus,
     cadenceReserved: boolean,
-    nowMs: number
+    nowMs: number,
+    retentionExpiresAtMs?: number
   ): boolean;
   releaseWait(attemptId: string, nowMs: number): boolean;
   getPreambleCount(identityId: string): number;
   setPreambleCount(identityId: string, count: number, nowMs: number): void;
-  deleteRetained(nowMs: number, retentionMs: number, responseAcceptanceWindowMs: number): void;
-  deleteRetainedResponses(nowMs: number, retentionMs: number): void;
-  listExpiredAttempts(nowMs: number): RequestAttemptRecord[];
+  deleteRetained(nowMs: number, limit: number): void;
+  deleteRetainedResponses(nowMs: number, limit: number): void;
+  listExpiredAttempts(nowMs: number, limit: number): RequestAttemptRecord[];
   listAttempts(): RequestAttemptRecord[];
 }
 
@@ -119,10 +134,10 @@ export interface RequestService {
   getResponse(requestId: string): RequestResponseRecord | undefined;
 }
 
-export const REQUEST_RETENTION_MS = 24 * 60 * 60 * 1000;
+export const REQUEST_RETENTION_MS = EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS;
 export const REQUEST_MIN_EXPIRY_MS = 60 * 60 * 1000;
-export const RESPONSE_ACCEPTANCE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-export const RESPONSE_BODY_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+export const RESPONSE_ACCEPTANCE_WINDOW_MS = EXCHANGE_RESPONSE_ACCEPTANCE_WINDOW_MS;
+export const CLEANUP_BATCH_SIZE = 100;
 
 function assertString(value: unknown, label: string): asserts value is string {
   if (typeof value !== 'string' || value.length === 0) {
@@ -190,10 +205,7 @@ function validateResponseInput(input: RequestResponseSubmission): ValidatedRespo
 }
 
 function isResponseExpired(response: RequestResponseRecord, currentMs: number): boolean {
-  return (
-    currentMs >= response.submittedAtMs &&
-    currentMs - response.submittedAtMs >= RESPONSE_BODY_RETENTION_MS
-  );
+  return currentMs >= response.responseExpiresAtMs;
 }
 
 function isPastResponseDeadline(attempt: RequestAttemptRecord, currentMs: number): boolean {
@@ -207,6 +219,9 @@ function isPastResponseDeadline(attempt: RequestAttemptRecord, currentMs: number
 }
 
 function addMilliseconds(value: number, delta: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0 || !Number.isSafeInteger(delta) || delta < 0) {
+    throw new Error(`${label} is outside the supported range.`);
+  }
   if (value > Number.MAX_SAFE_INTEGER - delta) {
     throw new Error(`${label} is outside the supported range.`);
   }
@@ -255,10 +270,12 @@ export function endpointFromSnapshot(
 export function createRequestService(options: {
   readonly repository: RequestRepository;
   readonly now?: () => number;
+  readonly getRetentionDays?: () => number;
 }): RequestService {
   const { repository } = options;
   if (!repository) throw new Error('Request repository is required.');
   const now = options.now ?? Date.now;
+  const getRetentionDays = options.getRetentionDays ?? (() => DEFAULT_EXCHANGE_RETENTION_DAYS);
 
   const readNow = (): number => {
     const value = now();
@@ -275,21 +292,23 @@ export function createRequestService(options: {
 
   const transitionDefinitelyFailed = (
     attempt: RequestAttemptRecord,
-    currentMs: number
+    currentMs: number,
+    retentionExpiresAtMs?: number
   ): boolean => {
     const transitioned = repository.updateAttemptState(
       attempt.attemptId,
       attempt.status,
       'definitely_failed',
       false,
-      currentMs
+      currentMs,
+      retentionExpiresAtMs
     );
     if (transitioned) refundAttempt(attempt, currentMs);
     return transitioned;
   };
 
   const cleanupWithinTransaction = (currentMs: number): void => {
-    for (const attempt of repository.listExpiredAttempts(currentMs)) {
+    for (const attempt of repository.listExpiredAttempts(currentMs, CLEANUP_BATCH_SIZE)) {
       if (attempt.waitActive) repository.releaseWait(attempt.attemptId, currentMs);
       if (attempt.status === 'prepared') {
         transitionDefinitelyFailed(attempt, currentMs);
@@ -303,20 +322,33 @@ export function createRequestService(options: {
         );
       }
     }
-    repository.deleteRetainedResponses(currentMs, RESPONSE_BODY_RETENTION_MS);
-    repository.deleteRetained(currentMs, REQUEST_RETENTION_MS, RESPONSE_ACCEPTANCE_WINDOW_MS);
+    repository.deleteRetainedResponses(currentMs, CLEANUP_BATCH_SIZE);
+    repository.deleteRetained(currentMs, CLEANUP_BATCH_SIZE);
   };
+
+  const readWithCleanup = <T>(read: (currentMs: number) => T): T =>
+    repository.withImmediateTransaction(() => {
+      const currentMs = readNow();
+      cleanupWithinTransaction(currentMs);
+      return read(currentMs);
+    });
 
   return {
     prepare(input) {
       validatePreparation(input);
+      const retentionDays = getRetentionDays();
+      assertExchangeRetentionDays(retentionDays);
       const attemptId = makeAttemptId();
 
       return repository.withImmediateTransaction(() => {
         const currentMs = readNow();
         const minimumExpiry = addMilliseconds(currentMs, REQUEST_MIN_EXPIRY_MS, 'minimum expiry');
-        addMilliseconds(currentMs, RESPONSE_ACCEPTANCE_WINDOW_MS, 'response acceptance deadline');
         const expiresAtMs = Math.max(input.expiresAtMs, minimumExpiry);
+        const retentionExpiresAtMs = Math.max(
+          addExchangeRetentionMs(currentMs, retentionDays),
+          addMilliseconds(currentMs, RESPONSE_ACCEPTANCE_WINDOW_MS, 'response acceptance deadline'),
+          addMilliseconds(expiresAtMs, REQUEST_RETENTION_MS, 'settlement retention floor')
+        );
         cleanupWithinTransaction(currentMs);
         if (repository.findResponse(input.requestId)) {
           throw new Error(`Request '${input.requestId}' already has a retained response.`);
@@ -348,6 +380,8 @@ export function createRequestService(options: {
           cadenceReserved,
           preparedAtMs: currentMs,
           expiresAtMs,
+          retentionDays,
+          retentionExpiresAtMs,
         });
 
         return {
@@ -366,6 +400,9 @@ export function createRequestService(options: {
         const currentMs = readNow();
         const attempt = repository.findAttempt(attemptId);
         if (!attempt) throw new Error(`Request attempt '${attemptId}' was not found.`);
+        if (attempt.retentionExpiresAtMs <= currentMs) {
+          throw new Error(`Request attempt '${attemptId}' metadata has expired.`);
+        }
         if (attempt.status !== 'prepared') {
           throw new Error(`Request attempt '${attemptId}' is already ${attempt.status}.`);
         }
@@ -394,6 +431,12 @@ export function createRequestService(options: {
         const currentMs = readNow();
         const attempt = repository.findAttempt(attemptId);
         if (!attempt) throw new Error(`Request attempt '${attemptId}' was not found.`);
+        if (
+          currentMs >= attempt.retentionExpiresAtMs &&
+          (attempt.status === 'prepared' || attempt.status === 'sending')
+        ) {
+          throw new Error(`Request attempt '${attemptId}' metadata has expired.`);
+        }
         // An accepted reply prevents proving that the recipient was not reached;
         // a sending attempt therefore settles conservatively as uncertain.
         const cannotProveUnsent =
@@ -421,8 +464,14 @@ export function createRequestService(options: {
         ) {
           throw new Error(`Request attempt '${attemptId}' is still ${attempt.status}.`);
         }
+        // Only a new, explicit settlement earns this floor. Cleanup and repeat
+        // settlement calls must not renew the frozen metadata deadline.
+        const retentionExpiresAtMs = Math.max(
+          attempt.retentionExpiresAtMs,
+          addMilliseconds(currentMs, REQUEST_RETENTION_MS, 'settlement retention floor')
+        );
         if (effectiveOutcome === 'definitely_failed') {
-          if (!transitionDefinitelyFailed(attempt, currentMs)) {
+          if (!transitionDefinitelyFailed(attempt, currentMs, retentionExpiresAtMs)) {
             throw new Error(`Request attempt '${attemptId}' could not settle.`);
           }
         } else {
@@ -431,7 +480,8 @@ export function createRequestService(options: {
             attempt.status,
             effectiveOutcome,
             attempt.cadenceReserved,
-            currentMs
+            currentMs,
+            retentionExpiresAtMs
           );
           if (!transitioned) {
             throw new Error(`Request attempt '${attemptId}' could not settle.`);
@@ -456,11 +506,16 @@ export function createRequestService(options: {
 
     getAttempt(attemptId) {
       assertString(attemptId, 'attemptId');
-      return repository.findAttempt(attemptId);
+      return readWithCleanup((currentMs) => {
+        const attempt = repository.findAttempt(attemptId);
+        return attempt && currentMs < attempt.retentionExpiresAtMs ? attempt : undefined;
+      });
     },
 
     listAttempts() {
-      return repository.listAttempts();
+      return readWithCleanup((currentMs) =>
+        repository.listAttempts().filter((attempt) => currentMs < attempt.retentionExpiresAtMs)
+      );
     },
 
     submitResponse(input) {
@@ -542,6 +597,7 @@ export function createRequestService(options: {
           body: validated.body,
           bodyBytes: validated.bodyBytes,
           submittedAtMs: currentMs,
+          responseExpiresAtMs: addExchangeRetentionMs(currentMs, attempt.retentionDays),
         };
         repository.createResponse(response);
         return response;
@@ -558,9 +614,10 @@ export function createRequestService(options: {
           { cause: error }
         );
       }
-      const response = repository.findResponse(requestId);
-      if (!response) return undefined;
-      return isResponseExpired(response, readNow()) ? undefined : response;
+      return readWithCleanup((currentMs) => {
+        const response = repository.findResponse(requestId);
+        return response && !isResponseExpired(response, currentMs) ? response : undefined;
+      });
     },
   };
 }

--- a/src/storage/identity-repository.test.ts
+++ b/src/storage/identity-repository.test.ts
@@ -233,7 +233,7 @@ describe('identity repository contract', () => {
     try {
       expect(verification.prepare('SELECT MAX(version) AS version FROM _migrations').get()).toEqual(
         {
-          version: 5,
+          version: CURRENT_MIGRATIONS.length,
         }
       );
       expect(

--- a/src/storage/migrations.ts
+++ b/src/storage/migrations.ts
@@ -1,7 +1,20 @@
 import type Database from 'better-sqlite3';
+import {
+  EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS,
+  EXCHANGE_RESPONSE_ACCEPTANCE_WINDOW_MS,
+  LEGACY_EXCHANGE_RETENTION_DAYS,
+  RETENTION_DAY_MS,
+} from '../domain/exchange-retention.js';
 import { classifyStorageError, incompatibleSchema, StorageError } from './errors.js';
 
 type SqliteDatabase = Database.Database;
+
+function saturatingAddMilliseconds(value: number, delta: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0 || !Number.isSafeInteger(delta) || delta < 0) {
+    throw new Error(`${label} is outside the supported range.`);
+  }
+  return value > Number.MAX_SAFE_INTEGER - delta ? Number.MAX_SAFE_INTEGER : value + delta;
+}
 
 export interface MigrationDefinition {
   readonly version: number;
@@ -133,6 +146,142 @@ export const CURRENT_MIGRATIONS: readonly MigrationDefinition[] = [
         CREATE INDEX request_responses_retention
           ON request_responses (submitted_at_ms);
       `),
+  },
+  {
+    version: 6,
+    name: 'freeze exchange retention and response expiry horizons',
+    up: (database) => {
+      database.exec(`
+        ALTER TABLE request_attempts
+          ADD COLUMN retention_days INTEGER NOT NULL DEFAULT ${LEGACY_EXCHANGE_RETENTION_DAYS};
+        ALTER TABLE request_attempts
+          ADD COLUMN retention_expires_at_ms INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE request_responses
+          ADD COLUMN response_expires_at_ms INTEGER NOT NULL DEFAULT 0;
+      `);
+
+      const selectAttempts = database.prepare(
+        `SELECT attempt_id, prepared_at_ms, expires_at_ms, settled_at_ms
+         FROM request_attempts
+         WHERE attempt_id > ?
+         ORDER BY attempt_id
+         LIMIT 100`
+      );
+      const selectFirstAttempts = database.prepare(
+        `SELECT attempt_id, prepared_at_ms, expires_at_ms, settled_at_ms
+         FROM request_attempts ORDER BY attempt_id LIMIT 100`
+      );
+      const updateAttempt = database.prepare(
+        'UPDATE request_attempts SET retention_expires_at_ms = ? WHERE attempt_id = ?'
+      );
+      let previousAttemptId: string | undefined;
+      while (true) {
+        const attempts = (
+          previousAttemptId === undefined
+            ? selectFirstAttempts.all()
+            : selectAttempts.all(previousAttemptId)
+        ) as Array<{
+          attempt_id: string;
+          prepared_at_ms: number;
+          expires_at_ms: number;
+          settled_at_ms: number | null;
+        }>;
+        if (attempts.length === 0) break;
+        for (const attempt of attempts) {
+          const frozenRetention = saturatingAddMilliseconds(
+            attempt.prepared_at_ms,
+            LEGACY_EXCHANGE_RETENTION_DAYS * RETENTION_DAY_MS,
+            `Attempt '${attempt.attempt_id}' retention expiry`
+          );
+          const responseAcceptance = saturatingAddMilliseconds(
+            attempt.prepared_at_ms,
+            EXCHANGE_RESPONSE_ACCEPTANCE_WINDOW_MS,
+            `Attempt '${attempt.attempt_id}' response acceptance deadline`
+          );
+          const settlementFloor = saturatingAddMilliseconds(
+            attempt.expires_at_ms,
+            EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS,
+            `Attempt '${attempt.attempt_id}' settlement retention floor`
+          );
+          const settledFloor =
+            attempt.settled_at_ms === null
+              ? 0
+              : saturatingAddMilliseconds(
+                  attempt.settled_at_ms,
+                  EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS,
+                  `Attempt '${attempt.attempt_id}' settled retention floor`
+                );
+          updateAttempt.run(
+            Math.max(frozenRetention, responseAcceptance, settlementFloor, settledFloor),
+            attempt.attempt_id
+          );
+          previousAttemptId = attempt.attempt_id;
+        }
+      }
+
+      const selectResponses = database.prepare(
+        `SELECT request_id, submitted_at_ms
+         FROM request_responses
+         WHERE request_id > ?
+         ORDER BY request_id
+         LIMIT 100`
+      );
+      const selectFirstResponses = database.prepare(
+        `SELECT request_id, submitted_at_ms
+         FROM request_responses ORDER BY request_id LIMIT 100`
+      );
+      const updateResponse = database.prepare(
+        'UPDATE request_responses SET response_expires_at_ms = ? WHERE request_id = ?'
+      );
+      let previousRequestId: string | undefined;
+      while (true) {
+        const responses = (
+          previousRequestId === undefined
+            ? selectFirstResponses.all()
+            : selectResponses.all(previousRequestId)
+        ) as Array<{
+          request_id: string;
+          submitted_at_ms: number;
+        }>;
+        if (responses.length === 0) break;
+        for (const response of responses) {
+          updateResponse.run(
+            saturatingAddMilliseconds(
+              response.submitted_at_ms,
+              LEGACY_EXCHANGE_RETENTION_DAYS * RETENTION_DAY_MS,
+              `Response '${response.request_id}' retention expiry`
+            ),
+            response.request_id
+          );
+          previousRequestId = response.request_id;
+        }
+      }
+      database.exec(`
+        UPDATE request_attempts
+        SET retention_expires_at_ms = MAX(
+          retention_expires_at_ms,
+          COALESCE(
+            (SELECT response_expires_at_ms
+             FROM request_responses
+             WHERE request_responses.request_id = request_attempts.request_id
+               AND request_responses.attempt_id = request_attempts.attempt_id),
+            retention_expires_at_ms
+          )
+        )
+      `);
+
+      database.exec(`
+        CREATE INDEX request_attempts_retention_horizon
+          ON request_attempts (retention_expires_at_ms, attempt_id);
+        CREATE INDEX request_attempts_cleanup_expiry
+          ON request_attempts (expires_at_ms, attempt_id)
+          WHERE wait_active = 1 OR status IN ('prepared', 'sending');
+        CREATE INDEX request_responses_expiry
+          ON request_responses (response_expires_at_ms, request_id);
+        CREATE INDEX request_responses_attempt
+          ON request_responses (attempt_id, response_expires_at_ms);
+      `);
+    },
   },
 ];
 

--- a/src/storage/request-repository.test.ts
+++ b/src/storage/request-repository.test.ts
@@ -1,9 +1,17 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import type { RequestAttemptRecord, RequestEndpoint } from '../request-service.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  RequestAttemptRecord,
+  RequestEndpoint,
+  RequestResponseRecord,
+} from '../request-service.js';
+import { createRequestService } from '../request-service.js';
+import { RETENTION_DAY_MS } from '../domain/exchange-retention.js';
 import { openIdentityRepository } from './identity-repository.js';
+import { createRequestRepository } from './request-repository.js';
+import { openStorageWithDatabase } from './sqlite-adapter.js';
 
 const directories: string[] = [];
 const repositories: Array<{ close(): void }> = [];
@@ -34,6 +42,8 @@ function attempt(overrides: Partial<RequestAttemptRecord> = {}): RequestAttemptR
     cadenceReserved: true,
     preparedAtMs: 10,
     expiresAtMs: 100,
+    retentionDays: 7,
+    retentionExpiresAtMs: 10 + 7 * 24 * 60 * 60 * 1000,
     ...overrides,
   };
 }
@@ -103,6 +113,7 @@ describe('request repository', () => {
       cadenceReserved: true,
       settledAtMs: 1,
       waitReleasedAtMs: 1,
+      retentionExpiresAtMs: 1,
     });
     const recent = attempt({
       attemptId: 'recent',
@@ -130,12 +141,267 @@ describe('request repository', () => {
       repository.createAttempt(active);
       repository.createAttempt(prepared);
     });
-    repository.deleteRetained(100, 50, 50);
+    repository.deleteRetained(24 * 60 * 60 * 1000 + 100, 50);
     expect(repository.findAttempt(value.attemptId)).toBeUndefined();
     expect(repository.findAttempt(recent.attemptId)).toBeDefined();
     expect(repository.findAttempt(active.attemptId)).toBeDefined();
     expect(repository.findAttempt(prepared.attemptId)).toBeDefined();
     expect(repository.getPreambleCount(identity.id)).toBe(3);
     repository.close();
+  });
+
+  it('bounds each cleanup candidate phase and orders ties deterministically', () => {
+    const repository = openIdentityRepository(databaseFile());
+    repositories.push(repository);
+    const attempts = Array.from({ length: 101 }, (_, index) =>
+      attempt({
+        attemptId: `attempt-${String(index).padStart(3, '0')}`,
+        requestId: `request-${String(index).padStart(3, '0')}`,
+        status: 'sent',
+        waitActive: false,
+        settledAtMs: 1,
+        waitReleasedAtMs: 1,
+        retentionExpiresAtMs: 1,
+      })
+    );
+    const pending = Array.from({ length: 101 }, (_, index) =>
+      attempt({
+        attemptId: `pending-${String(index).padStart(3, '0')}`,
+        requestId: `pending-request-${String(index).padStart(3, '0')}`,
+        status: 'prepared',
+        waitActive: false,
+        expiresAtMs: 1,
+        retentionExpiresAtMs: 1,
+      })
+    );
+    repository.withImmediateTransaction(() => {
+      for (const value of [...attempts, ...pending]) repository.createAttempt(value);
+    });
+
+    expect(repository.listExpiredAttempts(100, 100).map((value) => value.attemptId)).toEqual(
+      pending.slice(0, 100).map((value) => value.attemptId)
+    );
+
+    const responses: RequestResponseRecord[] = attempts.map((value) => ({
+      requestId: value.requestId,
+      attemptId: value.attemptId,
+      endpoint,
+      body: value.requestId,
+      bodyBytes: value.requestId.length,
+      submittedAtMs: 1,
+      responseExpiresAtMs: 1,
+    }));
+    repository.withImmediateTransaction(() => {
+      for (const response of responses) repository.createResponse(response);
+    });
+    repository.deleteRetainedResponses(100, 100);
+    expect(responses.filter((response) => repository.findResponse(response.requestId)).length).toBe(
+      1
+    );
+    expect(repository.findResponse('request-100')).toBeDefined();
+    expect(repository.findResponse('request-000')).toBeUndefined();
+    repository.deleteRetained(24 * 60 * 60 * 1000 + 100, 100);
+    expect(repository.listAttempts().filter((value) => value.status === 'sent')).toHaveLength(1);
+  });
+
+  it('keeps metadata cleanup on the ordered horizon index without ANALYZE', () => {
+    const file = databaseFile();
+    const storage = openStorageWithDatabase({ globalDir: path.dirname(file), databaseFile: file });
+    repositories.push(storage);
+    const database = storage.database;
+    const seedRepository = createRequestRepository(() => database);
+    const terminalAttempts = Array.from({ length: 2_000 }, (_, index) =>
+      attempt({
+        attemptId: `plan-attempt-${String(index).padStart(4, '0')}`,
+        requestId: `plan-request-${String(index).padStart(4, '0')}`,
+        waitActive: false,
+        status: 'sent',
+        settledAtMs: 1,
+        waitReleasedAtMs: 1,
+        retentionExpiresAtMs: 1,
+      })
+    );
+    database.transaction(() => {
+      for (const value of terminalAttempts) seedRepository.createAttempt(value);
+    })();
+
+    expect(
+      database.prepare("SELECT name FROM sqlite_master WHERE name = 'sqlite_stat1'").all()
+    ).toEqual([]);
+
+    const preparedSql: string[] = [];
+    const observedDatabase = new Proxy(database, {
+      get(target, property, receiver) {
+        if (property === 'prepare') {
+          return (sql: string) => {
+            preparedSql.push(sql);
+            return target.prepare(sql);
+          };
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const repository = createRequestRepository(() => observedDatabase);
+    const nowMs = 10 * RETENTION_DAY_MS;
+    repository.deleteRetained(nowMs, 100);
+
+    const deleteSql = preparedSql.find((sql) => sql.includes('DELETE FROM request_attempts'));
+    if (!deleteSql) throw new Error('Expected production metadata cleanup SQL.');
+    const plan = database
+      .prepare(`EXPLAIN QUERY PLAN ${deleteSql}`)
+      .all(nowMs - RETENTION_DAY_MS, nowMs, nowMs, 100) as Array<{ detail: string }>;
+    const details = plan.map((row) => row.detail);
+    expect(details).toEqual(
+      expect.arrayContaining([expect.stringContaining('request_attempts_retention_horizon')])
+    );
+    expect(details.some((detail) => detail.includes('USE TEMP B-TREE FOR ORDER BY'))).toBe(false);
+
+    const withoutHint = deleteSql.replace(' INDEXED BY request_attempts_retention_horizon', '');
+    expect(withoutHint).not.toBe(deleteSql);
+    const unhintedPlan = database
+      .prepare(`EXPLAIN QUERY PLAN ${withoutHint}`)
+      .all(nowMs - RETENTION_DAY_MS, nowMs, nowMs, 100) as Array<{ detail: string }>;
+    expect(unhintedPlan.map((row) => row.detail)).toContain('USE TEMP B-TREE FOR ORDER BY');
+  });
+
+  it('drains more than one batch of expired transitions, bodies, and metadata in order', () => {
+    const repository = openIdentityRepository(databaseFile());
+    repositories.push(repository);
+    const cleanupNow = 10 * RETENTION_DAY_MS;
+    const pending = Array.from({ length: 205 }, (_, index) =>
+      attempt({
+        attemptId: `pending-${String(index).padStart(3, '0')}`,
+        requestId: `pending-request-${String(index).padStart(3, '0')}`,
+        waitActive: true,
+        status: 'prepared',
+        expiresAtMs: 1,
+        retentionExpiresAtMs: cleanupNow + RETENTION_DAY_MS,
+      })
+    );
+    const retained = Array.from({ length: 205 }, (_, index) =>
+      attempt({
+        attemptId: `retained-${String(index).padStart(3, '0')}`,
+        requestId: `retained-request-${String(index).padStart(3, '0')}`,
+        waitActive: false,
+        status: 'sent',
+        settledAtMs: cleanupNow - 2 * RETENTION_DAY_MS,
+        waitReleasedAtMs: cleanupNow - 2 * RETENTION_DAY_MS,
+        retentionExpiresAtMs: cleanupNow - 1,
+      })
+    );
+    const responses: RequestResponseRecord[] = retained.map((value) => ({
+      requestId: value.requestId,
+      attemptId: value.attemptId,
+      endpoint,
+      body: value.requestId,
+      bodyBytes: value.requestId.length,
+      submittedAtMs: cleanupNow - 2 * RETENTION_DAY_MS,
+      responseExpiresAtMs: cleanupNow - 1,
+    }));
+
+    repository.withImmediateTransaction(() => {
+      for (const value of [...pending, ...retained]) repository.createAttempt(value);
+      for (const response of responses) repository.createResponse(response);
+    });
+
+    const service = createRequestService({ repository, now: () => cleanupNow });
+    service.cleanup();
+    expect(repository.findAttempt(pending[0]!.attemptId)).toMatchObject({
+      status: 'definitely_failed',
+      waitActive: false,
+    });
+    expect(repository.findAttempt(pending[100]!.attemptId)).toMatchObject({
+      status: 'prepared',
+      waitActive: true,
+    });
+    expect(repository.listAttempts().filter((value) => value.status === 'sent')).toHaveLength(105);
+    expect(repository.listAttempts().filter((value) => value.status === 'prepared')).toHaveLength(
+      105
+    );
+    expect(responses.filter((value) => repository.findResponse(value.requestId))).toHaveLength(105);
+    expect(repository.findAttempt(retained[100]!.attemptId)).toBeDefined();
+    expect(repository.findAttempt(retained[0]!.attemptId)).toBeUndefined();
+
+    service.cleanup();
+    expect(repository.listAttempts().filter((value) => value.status === 'sent')).toHaveLength(5);
+    expect(repository.listAttempts().filter((value) => value.status === 'prepared')).toHaveLength(
+      5
+    );
+    expect(responses.filter((value) => repository.findResponse(value.requestId))).toHaveLength(5);
+    expect(repository.findAttempt(retained[199]!.attemptId)).toBeUndefined();
+    expect(repository.findAttempt(retained[200]!.attemptId)).toBeDefined();
+
+    service.cleanup();
+    expect(repository.listAttempts().filter((value) => value.status === 'sent')).toHaveLength(0);
+    expect(repository.listAttempts().filter((value) => value.status === 'prepared')).toHaveLength(
+      0
+    );
+    expect(responses.filter((value) => repository.findResponse(value.requestId))).toHaveLength(0);
+    expect(repository.listAttempts()).toHaveLength(205);
+    expect(repository.listAttempts().every((value) => value.status === 'definitely_failed')).toBe(
+      true
+    );
+  });
+
+  it('rolls back service cleanup after transitions and body deletion fail', () => {
+    const repository = openIdentityRepository(databaseFile());
+    repositories.push(repository);
+    const cleanupNow = 10 * RETENTION_DAY_MS;
+    const identity = repository.createIdentity('Cleanup', 'cleanup');
+    repository.setPreambleCount(identity.id, 5, cleanupNow - 1);
+    const pending = attempt({
+      attemptId: 'rollback-pending',
+      requestId: 'rollback-pending-request',
+      identityId: identity.id,
+      waitActive: true,
+      status: 'prepared',
+      cadenceReserved: true,
+      expiresAtMs: 1,
+      retentionExpiresAtMs: cleanupNow + RETENTION_DAY_MS,
+    });
+    const retained = Array.from({ length: 3 }, (_, index) =>
+      attempt({
+        attemptId: `rollback-${index}`,
+        requestId: `rollback-request-${index}`,
+        waitActive: false,
+        status: 'sent',
+        settledAtMs: cleanupNow - 2 * RETENTION_DAY_MS,
+        waitReleasedAtMs: cleanupNow - 2 * RETENTION_DAY_MS,
+        retentionExpiresAtMs: cleanupNow - 1,
+      })
+    );
+    repository.withImmediateTransaction(() => {
+      repository.createAttempt(pending);
+      for (const value of retained) repository.createAttempt(value);
+      for (const value of retained) {
+        repository.createResponse({
+          requestId: value.requestId,
+          attemptId: value.attemptId,
+          endpoint,
+          body: value.requestId,
+          bodyBytes: value.requestId.length,
+          submittedAtMs: cleanupNow - 2 * RETENTION_DAY_MS,
+          responseExpiresAtMs: cleanupNow - 1,
+        });
+      }
+    });
+    const beforeAttempts = [pending, ...retained].map((value) =>
+      repository.findAttempt(value.attemptId)
+    );
+    const beforeResponses = retained.map((value) => repository.findResponse(value.requestId));
+    const service = createRequestService({ repository, now: () => cleanupNow });
+    const deleteSpy = vi.spyOn(repository, 'deleteRetained').mockImplementation(() => {
+      throw new Error('simulated cleanup failure');
+    });
+
+    expect(() => service.cleanup()).toThrow('simulated cleanup failure');
+    deleteSpy.mockRestore();
+    expect([pending, ...retained].map((value) => repository.findAttempt(value.attemptId))).toEqual(
+      beforeAttempts
+    );
+    expect(retained.map((value) => repository.findResponse(value.requestId))).toEqual(
+      beforeResponses
+    );
+    expect(repository.getPreambleCount(identity.id)).toBe(5);
   });
 });

--- a/src/storage/request-repository.ts
+++ b/src/storage/request-repository.ts
@@ -1,4 +1,5 @@
 import type Database from 'better-sqlite3';
+import { EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS } from '../domain/exchange-retention.js';
 import type {
   RequestAttemptRecord,
   RequestEndpoint,
@@ -30,6 +31,8 @@ type AttemptRow = {
   wait_released_at_ms: number | null;
   response_submitted_at_ms: number | null;
   expires_at_ms: number;
+  retention_days: number;
+  retention_expires_at_ms: number;
 };
 
 type ResponseRow = {
@@ -44,18 +47,20 @@ type ResponseRow = {
   body: string;
   body_bytes: number;
   submitted_at_ms: number;
+  response_expires_at_ms: number;
 };
 
 const ATTEMPT_COLUMNS = `
   attempt_id, request_id, nonce, identity_id, server_id, socket_path, server_pid,
   server_start_time, pane_id, pane_pid, wait_active, status, preamble_every,
   inject_preamble, cadence_reserved, prepared_at_ms, sending_at_ms, settled_at_ms,
-  wait_released_at_ms, response_submitted_at_ms, expires_at_ms
+  wait_released_at_ms, response_submitted_at_ms, expires_at_ms, retention_days,
+  retention_expires_at_ms
 `;
 
 const RESPONSE_COLUMNS = `
   request_id, attempt_id, server_id, socket_path, server_pid, server_start_time,
-  pane_id, pane_pid, body, body_bytes, submitted_at_ms
+  pane_id, pane_pid, body, body_bytes, submitted_at_ms, response_expires_at_ms
 `;
 
 function mapAttempt(row: AttemptRow): RequestAttemptRecord {
@@ -83,6 +88,8 @@ function mapAttempt(row: AttemptRow): RequestAttemptRecord {
       responseSubmittedAtMs: row.response_submitted_at_ms,
     }),
     expiresAtMs: row.expires_at_ms,
+    retentionDays: row.retention_days,
+    retentionExpiresAtMs: row.retention_expires_at_ms,
   };
 }
 
@@ -101,6 +108,7 @@ function mapResponse(row: ResponseRow): RequestResponseRecord {
     body: row.body,
     bodyBytes: row.body_bytes,
     submittedAtMs: row.submitted_at_ms,
+    responseExpiresAtMs: row.response_expires_at_ms,
   };
 }
 
@@ -113,6 +121,25 @@ function endpointArgs(endpoint: RequestEndpoint): readonly unknown[] {
     endpoint.paneId,
     endpoint.panePid,
   ];
+}
+
+function checkedLimit(limit: number): number {
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new Error('Cleanup batch limit must be a positive safe integer.');
+  }
+  return limit;
+}
+
+function checkedCutoff(nowMs: number, durationMs: number, label: string): number {
+  if (
+    !Number.isSafeInteger(nowMs) ||
+    nowMs <= 0 ||
+    !Number.isSafeInteger(durationMs) ||
+    durationMs < 0
+  ) {
+    throw new Error(`${label} is outside the supported range.`);
+  }
+  return nowMs >= durationMs ? nowMs - durationMs : 0;
 }
 
 function getAttempt(database: SqliteDatabase, attemptId: string): AttemptRow | undefined {
@@ -138,8 +165,9 @@ export function createRequestRepository(
              attempt_id, request_id, nonce, identity_id, server_id, socket_path, server_pid,
              server_start_time, pane_id, pane_pid, wait_active, status, preamble_every,
              inject_preamble, cadence_reserved, prepared_at_ms, sending_at_ms, settled_at_ms,
-             wait_released_at_ms, response_submitted_at_ms, expires_at_ms
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+             wait_released_at_ms, response_submitted_at_ms, expires_at_ms, retention_days,
+             retention_expires_at_ms
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           attempt.attemptId,
@@ -162,7 +190,9 @@ export function createRequestRepository(
           attempt.settledAtMs ?? null,
           attempt.waitReleasedAtMs ?? null,
           attempt.responseSubmittedAtMs ?? null,
-          attempt.expiresAtMs
+          attempt.expiresAtMs,
+          attempt.retentionDays,
+          attempt.retentionExpiresAtMs
         );
     },
 
@@ -189,8 +219,8 @@ export function createRequestRepository(
         .prepare(
           `INSERT INTO request_responses (
              request_id, attempt_id, server_id, socket_path, server_pid, server_start_time,
-             pane_id, pane_pid, body, body_bytes, submitted_at_ms
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+             pane_id, pane_pid, body, body_bytes, submitted_at_ms, response_expires_at_ms
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           response.requestId,
@@ -203,15 +233,22 @@ export function createRequestRepository(
           response.endpoint.panePid,
           response.body,
           response.bodyBytes,
-          response.submittedAtMs
+          response.submittedAtMs,
+          response.responseExpiresAtMs
         );
       const marker = database
         .prepare(
           `UPDATE request_attempts
-           SET response_submitted_at_ms = ?
+           SET response_submitted_at_ms = ?,
+               retention_expires_at_ms = MAX(retention_expires_at_ms, ?)
            WHERE attempt_id = ? AND request_id = ? AND response_submitted_at_ms IS NULL`
         )
-        .run(response.submittedAtMs, response.attemptId, response.requestId);
+        .run(
+          response.submittedAtMs,
+          response.responseExpiresAtMs,
+          response.attemptId,
+          response.requestId
+        );
       if (marker.changes !== 1) {
         throw new Error(
           `Request attempt '${response.attemptId}' could not record response completion.`
@@ -232,7 +269,14 @@ export function createRequestRepository(
       return row?.request_id;
     },
 
-    updateAttemptState(attemptId, expectedStatus, status, cadenceReserved, nowMs) {
+    updateAttemptState(
+      attemptId,
+      expectedStatus,
+      status,
+      cadenceReserved,
+      nowMs,
+      retentionExpiresAtMs
+    ) {
       const result = requireOpen()
         .prepare(
           `UPDATE request_attempts
@@ -242,7 +286,8 @@ export function createRequestRepository(
                settled_at_ms = CASE
                  WHEN ? IN ('sent', 'uncertain', 'definitely_failed') THEN ?
                  ELSE settled_at_ms
-               END
+               END,
+               retention_expires_at_ms = MAX(retention_expires_at_ms, COALESCE(?, retention_expires_at_ms))
            WHERE attempt_id = ? AND status = ?`
         )
         .run(
@@ -252,6 +297,7 @@ export function createRequestRepository(
           nowMs,
           status,
           nowMs,
+          retentionExpiresAtMs ?? null,
           attemptId,
           expectedStatus
         );
@@ -288,34 +334,69 @@ export function createRequestRepository(
         .run(identityId, count, nowMs);
     },
 
-    deleteRetained(nowMs, retentionMs, responseAcceptanceWindowMs) {
+    deleteRetained(nowMs, limit) {
       const database = requireOpen();
+      if (!Number.isSafeInteger(nowMs) || nowMs <= 0) {
+        throw new Error('Request retention cutoff is outside the supported range.');
+      }
+      const settledCutoff = checkedCutoff(
+        nowMs,
+        EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS,
+        'settlement retention cutoff'
+      );
+      const checkedBatchLimit = checkedLimit(limit);
+      // Fresh databases lack planner statistics. Pin the ordered horizon index
+      // so the older status index cannot force a full candidate sort before LIMIT.
       database
         .prepare(
           `DELETE FROM request_attempts
-           WHERE wait_active = 0 AND status IN ('sent', 'uncertain', 'definitely_failed')
-             AND settled_at_ms IS NOT NULL
-             AND settled_at_ms <= ?
-             AND expires_at_ms <= ? AND prepared_at_ms <= ?`
+           WHERE attempt_id IN (
+             SELECT attempt_id FROM request_attempts INDEXED BY request_attempts_retention_horizon
+             WHERE wait_active = 0 AND status IN ('sent', 'uncertain', 'definitely_failed')
+               AND settled_at_ms IS NOT NULL
+               AND settled_at_ms <= ?
+               AND retention_expires_at_ms <= ?
+               AND NOT EXISTS (
+                 SELECT 1 FROM request_responses
+                 WHERE request_responses.attempt_id = request_attempts.attempt_id
+                   AND request_responses.response_expires_at_ms > ?
+               )
+             ORDER BY retention_expires_at_ms, attempt_id
+             LIMIT ?
+           )`
         )
-        .run(nowMs - retentionMs, nowMs, nowMs - responseAcceptanceWindowMs);
+        .run(settledCutoff, nowMs, nowMs, checkedBatchLimit);
     },
 
-    deleteRetainedResponses(nowMs, retentionMs) {
+    deleteRetainedResponses(nowMs, limit) {
+      const checkedBatchLimit = checkedLimit(limit);
+      if (!Number.isSafeInteger(nowMs) || nowMs <= 0) {
+        throw new Error('Response retention cutoff is outside the supported range.');
+      }
       requireOpen()
-        .prepare('DELETE FROM request_responses WHERE submitted_at_ms <= ?')
-        .run(nowMs - retentionMs);
+        .prepare(
+          `DELETE FROM request_responses
+           WHERE request_id IN (
+             SELECT request_id FROM request_responses
+             WHERE response_expires_at_ms <= ?
+             ORDER BY response_expires_at_ms, request_id
+             LIMIT ?
+           )`
+        )
+        .run(nowMs, checkedBatchLimit);
     },
 
-    listExpiredAttempts(nowMs) {
+    listExpiredAttempts(nowMs, limit) {
+      const checkedBatchLimit = checkedLimit(limit);
       const rows = requireOpen()
         .prepare(
           `SELECT ${ATTEMPT_COLUMNS} FROM request_attempts
            WHERE expires_at_ms <= ?
              AND (wait_active = 1 OR status IN ('prepared', 'sending'))
-           ORDER BY expires_at_ms, attempt_id`
+           ORDER BY expires_at_ms, attempt_id
+           LIMIT ?`
         )
-        .all(nowMs) as AttemptRow[];
+        .all(nowMs, checkedBatchLimit) as AttemptRow[];
       return rows.map(mapAttempt);
     },
 

--- a/src/storage/request-response-migration.test.ts
+++ b/src/storage/request-response-migration.test.ts
@@ -3,7 +3,14 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
+import {
+  EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS,
+  EXCHANGE_RESPONSE_ACCEPTANCE_WINDOW_MS,
+  LEGACY_EXCHANGE_RETENTION_DAYS,
+  RETENTION_DAY_MS,
+} from '../domain/exchange-retention.js';
 import { createRequestService, type RequestEndpoint } from '../request-service.js';
+import { StorageError } from './errors.js';
 import { openIdentityRepository } from './identity-repository.js';
 import { CURRENT_MIGRATIONS } from './migrations.js';
 import { openStorageWithMigrations } from './sqlite-adapter.js';
@@ -123,6 +130,76 @@ function seedSchema4Database(file: string): void {
   }
 }
 
+type HistoricalRequestRow = {
+  attemptId: string;
+  requestId: string;
+  preparedAtMs: number;
+  expiresAtMs: number;
+  settledAtMs: number;
+  submittedAtMs?: number;
+};
+
+function seedSchema5Requests(file: string, rows: readonly HistoricalRequestRow[]): void {
+  const initial = openStorageWithMigrations(location(file), CURRENT_MIGRATIONS.slice(0, 5));
+  initial.close();
+
+  const database = new Database(file);
+  try {
+    const insertAttempt = database.prepare(
+      `INSERT INTO request_attempts (
+         attempt_id, request_id, nonce, identity_id, server_id, socket_path, server_pid,
+         server_start_time, pane_id, pane_pid, wait_active, status, preamble_every,
+         inject_preamble, cadence_reserved, prepared_at_ms, sending_at_ms, settled_at_ms,
+         wait_released_at_ms, response_submitted_at_ms, expires_at_ms
+       ) VALUES (?, ?, NULL, NULL, ?, ?, ?, ?, ?, ?, 0, 'sent', NULL, 0, 0, ?, ?, ?, ?, ?, ?)`
+    );
+    const insertResponse = database.prepare(
+      `INSERT INTO request_responses (
+         request_id, attempt_id, server_id, socket_path, server_pid, server_start_time,
+         pane_id, pane_pid, body, body_bytes, submitted_at_ms
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    database.transaction(() => {
+      for (const row of rows) {
+        insertAttempt.run(
+          row.attemptId,
+          row.requestId,
+          endpoint.serverId,
+          endpoint.socketPath,
+          endpoint.serverPid,
+          endpoint.serverStartTime,
+          endpoint.paneId,
+          endpoint.panePid,
+          row.preparedAtMs,
+          row.preparedAtMs,
+          row.settledAtMs,
+          null,
+          row.submittedAtMs ?? null,
+          row.expiresAtMs
+        );
+        if (row.submittedAtMs !== undefined) {
+          const body = `body-${row.requestId}`;
+          insertResponse.run(
+            row.requestId,
+            row.attemptId,
+            endpoint.serverId,
+            endpoint.socketPath,
+            endpoint.serverPid,
+            endpoint.serverStartTime,
+            endpoint.paneId,
+            endpoint.panePid,
+            body,
+            Buffer.byteLength(body, 'utf8'),
+            row.submittedAtMs
+          );
+        }
+      }
+    })();
+  } finally {
+    database.close();
+  }
+}
+
 afterEach(() => {
   for (const repository of repositories.splice(0)) repository.close();
   for (const directory of directories.splice(0)) {
@@ -177,6 +254,8 @@ describe('request response migrations', () => {
       settledAtMs: preparedAtMs + 20,
       waitReleasedAtMs: preparedAtMs + 30,
       expiresAtMs: preparedAtMs + 60 * 60 * 1000,
+      retentionDays: 7,
+      retentionExpiresAtMs: preparedAtMs + 7 * 24 * 60 * 60 * 1000,
     });
 
     const beforeResponse = new Database(file, { readonly: true });
@@ -203,6 +282,7 @@ describe('request response migrations', () => {
       body: responseBody,
       bodyBytes: Buffer.byteLength(responseBody, 'utf8'),
       submittedAtMs: nowMs,
+      responseExpiresAtMs: nowMs + 7 * 24 * 60 * 60 * 1000,
     });
     expect(service.getResponse('request-1')).toEqual(response);
     expect(repository.findAttempt('attempt-1')).toMatchObject({
@@ -250,5 +330,158 @@ describe('request response migrations', () => {
     } finally {
       verification.close();
     }
+  });
+
+  it('backfills multiple keyset pages from original request and response anchors', () => {
+    const file = databaseFile();
+    const rows = Array.from({ length: 205 }, (_, index) => {
+      const anchor = preparedAtMs + index * 10_000;
+      return {
+        attemptId: `attempt-${String(index).padStart(3, '0')}`,
+        requestId: `request-${String(index).padStart(3, '0')}`,
+        preparedAtMs: anchor,
+        expiresAtMs: anchor + 10,
+        settledAtMs: anchor + 20,
+        submittedAtMs: anchor + 30,
+      };
+    });
+    const unansweredAttempt = {
+      attemptId: 'attempt-no-response',
+      requestId: 'request-no-response',
+      preparedAtMs: preparedAtMs + 3_000_000,
+      expiresAtMs: preparedAtMs + 3_000_010,
+      settledAtMs: preparedAtMs + 3_000_020,
+    };
+    seedSchema5Requests(file, [...rows, unansweredAttempt]);
+
+    const repository = openIdentityRepository(file);
+    repositories.push(repository);
+    const expected = (row: HistoricalRequestRow): number => {
+      const frozen = row.preparedAtMs + LEGACY_EXCHANGE_RETENTION_DAYS * RETENTION_DAY_MS;
+      const acceptance = row.preparedAtMs + EXCHANGE_RESPONSE_ACCEPTANCE_WINDOW_MS;
+      const settlement = row.expiresAtMs + EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS;
+      const settled = row.settledAtMs + EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS;
+      const response =
+        row.submittedAtMs === undefined
+          ? 0
+          : row.submittedAtMs + LEGACY_EXCHANGE_RETENTION_DAYS * RETENTION_DAY_MS;
+      return Math.max(frozen, acceptance, settlement, settled, response);
+    };
+
+    const verification = new Database(file, { readonly: true });
+    try {
+      expect(verification.prepare('SELECT COUNT(*) AS count FROM request_attempts').get()).toEqual({
+        count: 206,
+      });
+      expect(verification.prepare('SELECT COUNT(*) AS count FROM request_responses').get()).toEqual(
+        {
+          count: 205,
+        }
+      );
+      expect(
+        verification
+          .prepare('SELECT COUNT(*) AS count FROM request_attempts WHERE retention_days = 7')
+          .get()
+      ).toEqual({ count: 206 });
+    } finally {
+      verification.close();
+    }
+
+    for (const index of [0, 99, 100, 204]) {
+      const row = rows[index]!;
+      expect(repository.findAttempt(row.attemptId)).toMatchObject({
+        retentionDays: LEGACY_EXCHANGE_RETENTION_DAYS,
+        retentionExpiresAtMs: expected(row),
+      });
+      expect(repository.findResponse(row.requestId)).toMatchObject({
+        responseExpiresAtMs: row.submittedAtMs! + LEGACY_EXCHANGE_RETENTION_DAYS * RETENTION_DAY_MS,
+      });
+    }
+    expect(repository.findAttempt(unansweredAttempt.attemptId)).toMatchObject({
+      retentionDays: LEGACY_EXCHANGE_RETENTION_DAYS,
+      retentionExpiresAtMs: expected(unansweredAttempt),
+    });
+  });
+
+  it('bounds migration arithmetic for valid historical timestamps near MAX_SAFE_INTEGER', () => {
+    const file = databaseFile();
+    const nearMax = Number.MAX_SAFE_INTEGER - 1;
+    seedSchema5Requests(file, [
+      {
+        attemptId: 'near-max-attempt',
+        requestId: 'near-max-request',
+        preparedAtMs: nearMax,
+        expiresAtMs: nearMax,
+        settledAtMs: nearMax,
+        submittedAtMs: nearMax,
+      },
+    ]);
+
+    const repository = openIdentityRepository(file);
+    repositories.push(repository);
+    expect(repository.findAttempt('near-max-attempt')).toMatchObject({
+      retentionDays: 7,
+      retentionExpiresAtMs: Number.MAX_SAFE_INTEGER,
+    });
+    expect(repository.findResponse('near-max-request')).toMatchObject({
+      responseExpiresAtMs: Number.MAX_SAFE_INTEGER,
+    });
+  });
+
+  it('rolls back invalid historical retention values without partial schema changes', () => {
+    const file = databaseFile();
+    seedSchema5Requests(file, [
+      {
+        attemptId: 'invalid-attempt',
+        requestId: 'invalid-request',
+        preparedAtMs: 0,
+        expiresAtMs: preparedAtMs,
+        settledAtMs: preparedAtMs,
+      },
+    ]);
+
+    expect(() => openIdentityRepository(file)).toThrow(StorageError);
+    try {
+      openIdentityRepository(file);
+      expect.fail('expected migration 6 to reject the invalid historical anchor');
+    } catch (error) {
+      expect(error).toMatchObject({ code: 'migration', migrationVersion: 6 });
+    }
+
+    const failed = new Database(file, { readonly: true });
+    try {
+      expect(failed.prepare('SELECT MAX(version) AS version FROM _migrations').get()).toEqual({
+        version: 5,
+      });
+      expect(failed.pragma('table_info(request_attempts)')).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'retention_days' })])
+      );
+      expect(
+        failed
+          .prepare('SELECT prepared_at_ms FROM request_attempts WHERE attempt_id = ?')
+          .get('invalid-attempt')
+      ).toEqual({ prepared_at_ms: 0 });
+    } finally {
+      failed.close();
+    }
+
+    const repair = new Database(file);
+    try {
+      repair
+        .prepare('UPDATE request_attempts SET prepared_at_ms = ? WHERE attempt_id = ?')
+        .run(preparedAtMs, 'invalid-attempt');
+    } finally {
+      repair.close();
+    }
+    const recovered = openIdentityRepository(file);
+    repositories.push(recovered);
+    expect(recovered.findAttempt('invalid-attempt')).toMatchObject({
+      retentionDays: LEGACY_EXCHANGE_RETENTION_DAYS,
+      retentionExpiresAtMs: Math.max(
+        preparedAtMs + LEGACY_EXCHANGE_RETENTION_DAYS * RETENTION_DAY_MS,
+        preparedAtMs + EXCHANGE_RESPONSE_ACCEPTANCE_WINDOW_MS,
+        preparedAtMs + EXCHANGE_METADATA_SETTLEMENT_FLOOR_MS
+      ),
+    });
   });
 });

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -34,7 +34,7 @@ describe('SQLite storage adapter', () => {
 
     expect(storage.health()).toMatchObject({
       open: true,
-      schemaVersion: 5,
+      schemaVersion: CURRENT_MIGRATIONS.length,
       journalMode: 'wal',
       foreignKeys: true,
       busyTimeoutMs: 5000,
@@ -143,7 +143,7 @@ describe('SQLite storage adapter', () => {
     seeded.close();
 
     const upgraded = openStorage(location(directory));
-    expect(upgraded.health().schemaVersion).toBe(5);
+    expect(upgraded.health().schemaVersion).toBe(CURRENT_MIGRATIONS.length);
     upgraded.close();
 
     const verification = new Database(path.join(directory, 'tmux-team.db'), { readonly: true });
@@ -259,16 +259,12 @@ describe('SQLite storage adapter', () => {
         }
         return statement;
       });
-      expect(applyMigrations(first)).toBe(5);
+      expect(applyMigrations(first)).toBe(CURRENT_MIGRATIONS.length);
       spy.mockRestore();
       expect(interleave).toBe(false);
-      expect(first.prepare('SELECT version FROM _migrations ORDER BY version').all()).toEqual([
-        { version: 1 },
-        { version: 2 },
-        { version: 3 },
-        { version: 4 },
-        { version: 5 },
-      ]);
+      expect(first.prepare('SELECT version FROM _migrations ORDER BY version').all()).toEqual(
+        CURRENT_MIGRATIONS.map((migration) => ({ version: migration.version }))
+      );
       expect(
         first.prepare("SELECT name FROM sqlite_master WHERE name = 'role_profiles'").all()
       ).toEqual([{ name: 'role_profiles' }]);

--- a/src/test-support/workers/request-response-concurrency-worker.ts
+++ b/src/test-support/workers/request-response-concurrency-worker.ts
@@ -7,7 +7,6 @@ const [, , database, barrier, requestId, attemptId, variant, mode, body] = proce
 if (!database || !barrier || !requestId || !attemptId || !variant || !mode) {
   throw new Error('Usage: database barrier requestId attemptId variant mode [body]');
 }
-
 const endpoint: RequestEndpoint = {
   serverId: 'server-1',
   socketPath: '/tmp/tmt-server-1',
@@ -16,13 +15,45 @@ const endpoint: RequestEndpoint = {
   paneId: '%7',
   panePid: 99,
 };
-const nowMs = 1_700_000_000_000;
+const baseNowMs = 1_700_000_000_000;
+const scenarios: Record<
+  string,
+  {
+    readonly operation: 'submit' | 'settle' | 'cleanup';
+    readonly gate: string;
+    readonly nowMs: number;
+  }
+> = {
+  submit: { operation: 'submit', gate: 'go', nowMs: baseNowMs },
+  'submit-gated': { operation: 'submit', gate: 'go-submit', nowMs: baseNowMs },
+  'submit-late-gated': {
+    operation: 'submit',
+    gate: 'go-submit-late',
+    nowMs: baseNowMs + 6 * 24 * 60 * 60 * 1000,
+  },
+  'submit-expiry-gated': {
+    operation: 'submit',
+    gate: 'go-submit-expiry',
+    nowMs: baseNowMs + 7 * 24 * 60 * 60 * 1000,
+  },
+  fail: { operation: 'settle', gate: 'go', nowMs: baseNowMs },
+  'fail-gated': { operation: 'settle', gate: 'go-fail', nowMs: baseNowMs },
+  'cleanup-late-gated': {
+    operation: 'cleanup',
+    gate: 'go-cleanup-late',
+    nowMs: baseNowMs + 6 * 24 * 60 * 60 * 1000,
+  },
+  'cleanup-expiry-gated': {
+    operation: 'cleanup',
+    gate: 'go-cleanup-expiry',
+    nowMs: baseNowMs + 7 * 24 * 60 * 60 * 1000,
+  },
+};
+const scenario = scenarios[mode];
+if (!scenario) throw new Error(`Unknown response race mode '${mode}'.`);
+const nowMs = scenario.nowMs;
 const repository = openIdentityRepository(database);
 const service = createRequestService({ repository, now: () => nowMs });
-if (!['submit', 'submit-gated', 'fail', 'fail-gated'].includes(mode)) {
-  repository.close();
-  throw new Error(`Unknown response race mode '${mode}'.`);
-}
 
 function output(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value)}\n`);
@@ -30,12 +61,21 @@ function output(value: unknown): void {
 
 try {
   fs.writeFileSync(`${barrier}/ready-${variant}`, 'ready');
-  const gate = mode === 'submit-gated' ? 'go-submit' : mode === 'fail-gated' ? 'go-fail' : 'go';
-  waitForBarrier(`${barrier}/${gate}`, 15_000);
+  waitForBarrier(`${barrier}/${scenario.gate}`, 15_000);
 
-  if (mode === 'fail' || mode === 'fail-gated') {
+  if (scenario.operation === 'cleanup') {
+    service.cleanup();
+    const attempt = repository.findAttempt(attemptId);
+    output({
+      ok: true,
+      operation: 'cleanup',
+      attempt: attempt ?? null,
+      rawResponse: repository.findResponse(requestId) ?? null,
+      cadence: attempt?.cadenceReserved,
+    });
+  } else if (scenario.operation === 'settle') {
     service.settle(attemptId, 'definitely_failed');
-    const attempt = service.getAttempt(attemptId);
+    const attempt = repository.findAttempt(attemptId);
     output({
       ok: true,
       operation: 'settle',
@@ -49,23 +89,26 @@ try {
       endpoint,
       body: body ?? '',
     });
-    const attempt = service.getAttempt(attemptId);
+    const attempt = repository.findAttempt(attemptId);
     output({
       ok: true,
       operation: 'submit',
       response,
       attempt,
       cadence: attempt?.cadenceReserved,
+      rawResponse: repository.findResponse(requestId) ?? null,
     });
   }
 } catch (error) {
   const typed = error as { code?: string; message?: string };
+  const attempt = repository.findAttempt(attemptId);
   output({
     ok: false,
     code: typed.code,
     message: typed.message ?? String(error),
-    attempt: service.getAttempt(attemptId),
-    cadence: service.getAttempt(attemptId)?.cadenceReserved,
+    attempt: attempt ?? null,
+    cadence: attempt?.cadenceReserved,
+    rawResponse: repository.findResponse(requestId) ?? null,
   });
   process.exitCode = 0;
 } finally {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,9 +27,19 @@ export interface ConfigDefaults {
   pasteEnterDelayMs: number; // delay after paste before Enter (default: 500)
 }
 
+export interface ExchangeConfig {
+  retentionDays: number;
+}
+
+export interface GlobalExchangeSettings {
+  retentionDays?: number;
+  [key: string]: unknown;
+}
+
 export interface GlobalConfig {
   preambleMode: 'always' | 'disabled';
   defaults: ConfigDefaults;
+  exchange?: GlobalExchangeSettings;
 }
 
 export interface LocalSettings {
@@ -46,6 +56,7 @@ export interface LocalConfigFile {
 export interface ResolvedConfig {
   preambleMode: 'always' | 'disabled';
   defaults: ConfigDefaults;
+  exchange: ExchangeConfig;
 }
 
 export interface Flags {

--- a/test/e2e/exchange-retention.e2e.test.ts
+++ b/test/e2e/exchange-retention.e2e.test.ts
@@ -1,0 +1,148 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture } from './harness.js';
+import { requestAttempts, requestResponses } from './request-state-oracle.js';
+
+interface TalkOutput {
+  status: string;
+  requestId: string;
+  response?: string;
+  submittedAtMs?: number;
+}
+
+describe.sequential('frozen Exchange retention through the public CLI', () => {
+  it('freezes preparation policy and accepts a gated final despite invalid current config', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const globalFile = path.join(fixture.globalDir, 'config.json');
+        const localFile = path.join(fixture.workspace, 'tmux-team.json');
+        const defaults = await fixture.runJsonCli(['config', 'show'], { withoutTmux: true });
+        expect(defaults).toMatchObject({
+          code: 0,
+          json: {
+            resolved: { exchange: { retentionDays: 90 } },
+            sources: { exchange: { retentionDays: 'default' } },
+          },
+        });
+        expect(
+          (
+            await fixture.runJsonCli(['config', 'set', 'exchange.retentionDays', '1', '--global'], {
+              withoutTmux: true,
+            })
+          ).code
+        ).toBe(0);
+        const beforeRejectedWrite = fs.readFileSync(globalFile, 'utf8');
+        const localBefore = fs.existsSync(localFile) ? fs.readFileSync(localFile, 'utf8') : null;
+        const localWrite = await fixture.runJsonCli([
+          'config',
+          'set',
+          'exchange.retentionDays',
+          '2',
+        ]);
+        expect(localWrite.code).toBe(1);
+        expect(fs.readFileSync(globalFile, 'utf8')).toBe(beforeRejectedWrite);
+        expect(fs.existsSync(localFile) ? fs.readFileSync(localFile, 'utf8') : null).toBe(
+          localBefore
+        );
+
+        const first = await fixture.runJsonCli<TalkOutput>([
+          'talk',
+          fixture.pane,
+          'one day frozen',
+          '--no-preamble',
+          '--detach',
+        ]);
+        expect(first.code, first.stderr || first.stdout).toBe(0);
+        const firstId = first.json?.requestId ?? '';
+        await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.requestId === firstId
+        );
+        expect(
+          requestAttempts(fixture).find((row) => row.request_id === firstId)?.retention_days
+        ).toBe(1);
+
+        expect(
+          (await fixture.runJsonCli(['config', 'set', 'exchange.retentionDays', '90', '--global']))
+            .code
+        ).toBe(0);
+        fixture.releaseReplyGate(firstId);
+        await fixture.waitForEvent(
+          (event) => event.event === 'submitted' && event.requestId === firstId
+        );
+        const firstBody = requestResponses(fixture).find((row) => row.request_id === firstId);
+        expect(firstBody).toBeDefined();
+        expect(firstBody!.response_expires_at_ms - firstBody!.submitted_at_ms).toBe(86_400_000);
+        expect(firstBody!.body).toBe('mock-agent response: one day frozen');
+        const firstMetadata = requestAttempts(fixture).find((row) => row.request_id === firstId);
+        expect(firstMetadata?.retention_days).toBe(1);
+
+        const second = await fixture.runJsonCli<TalkOutput>([
+          'talk',
+          fixture.pane,
+          'ninety days frozen',
+          '--no-preamble',
+          '--detach',
+        ]);
+        expect(second.code, second.stderr || second.stdout).toBe(0);
+        const secondId = second.json?.requestId ?? '';
+        await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.requestId === secondId
+        );
+        expect(
+          requestAttempts(fixture).find((row) => row.request_id === secondId)?.retention_days
+        ).toBe(90);
+
+        // Only the disposable fixture config is invalidated after preparation.
+        // The real mock peer must still submit through the public reply adapter.
+        fs.writeFileSync(globalFile, '{"exchange":{"retentionDays":0}}\n');
+        fixture.releaseReplyGate(secondId);
+        const submitted = await fixture.waitForEvent(
+          (event) => event.event === 'submitted' && event.requestId === secondId
+        );
+        const secondBody = requestResponses(fixture).find((row) => row.request_id === secondId);
+        expect(secondBody).toBeDefined();
+        expect(secondBody!.response_expires_at_ms - secondBody!.submitted_at_ms).toBe(
+          90 * 86_400_000
+        );
+        expect(secondBody!.body).toBe('mock-agent response: ninety days frozen');
+        expect(submitted.body).toBe(secondBody!.body);
+        const secondMetadata = requestAttempts(fixture).find((row) => row.request_id === secondId);
+        expect(secondMetadata?.retention_days).toBe(90);
+        const result = await fixture.runJsonCli<TalkOutput>(['result', secondId], {
+          withoutTmux: true,
+        });
+        expect(result).toMatchObject({
+          code: 0,
+          stderr: '',
+          json: {
+            status: 'completed',
+            requestId: secondId,
+            response: secondBody!.body,
+            submittedAtMs: secondBody!.submitted_at_ms,
+          },
+        });
+        expect(requestResponses(fixture).find((row) => row.request_id === firstId)).toEqual(
+          firstBody
+        );
+        expect(requestResponses(fixture).find((row) => row.request_id === secondId)).toEqual(
+          secondBody
+        );
+        expect(requestAttempts(fixture).find((row) => row.request_id === firstId)).toEqual(
+          firstMetadata
+        );
+        expect(requestAttempts(fixture).find((row) => row.request_id === secondId)).toEqual(
+          secondMetadata
+        );
+        for (const row of requestAttempts(fixture)) {
+          const body = requestResponses(fixture).find(
+            (response) => response.request_id === row.request_id
+          );
+          expect(row.retention_expires_at_ms).toBeGreaterThanOrEqual(body!.response_expires_at_ms);
+        }
+        expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+      },
+      { replyGate: true }
+    );
+  });
+});

--- a/test/e2e/request-state-oracle.ts
+++ b/test/e2e/request-state-oracle.ts
@@ -15,6 +15,15 @@ export interface AttemptRow {
   wait_active: number;
   status: string;
   inject_preamble: number;
+  retention_days: number;
+  retention_expires_at_ms: number;
+}
+
+export interface ResponseRow {
+  request_id: string;
+  body: string;
+  submitted_at_ms: number;
+  response_expires_at_ms: number;
 }
 
 /** Read committed state independently of the CLI's service and connection. */
@@ -41,4 +50,11 @@ export function preambleCounters(fixture: E2EFixture): Record<string, number> {
       .all() as Array<{ identity_id: string; reserved_count: number }>;
     return Object.fromEntries(rows.map((row) => [row.identity_id, row.reserved_count]));
   });
+}
+
+export function requestResponses(fixture: E2EFixture): ResponseRow[] {
+  return read(
+    fixture,
+    (database) => database.prepare('SELECT * FROM request_responses').all() as ResponseRow[]
+  );
 }


### PR DESCRIPTION
## Scope

- Issue: [TMT-54](https://linear.app/tigerpig-dev/issue/TMT-54)
- Freeze `exchange.retentionDays` at request preparation, with a global-only 90-day default and integer range 1–3650.
- Preserve seven-day original anchors for existing SQLite records through migration 6. Retain each accepted final from its original submission, with coordinated metadata horizons.
- Apply logical expiry independently of bounded opportunistic cleanup. No prompts, provenance, identity creation, attention, daemon, memory or MCP implementation.

## Architecture and review

- Reuses RequestService, RequestRepository and the existing Context SQLite connection. A focused domain policy supplies shared range validation and retention arithmetic; no parallel retention service or legacy runtime fallback.
- Configuration is consulted only for preparation. Storage-only reply/result continue to work with invalid current configuration; public response envelopes and receipt/endpoint fences are unchanged.
- First explicit settlement and accepted final may extend metadata for their obligations. Reads, retries, waiter release and synthetic cleanup never renew logical expiry. Synthetic settlement can delay physical deletion without restoring visibility.
- Cleanup uses one short immediate transaction with at most 100 transitions, 100 body deletions and 100 metadata deletions. Expired prepared reservations refund once; expired sending remains uncertain without refund. No transaction spans tmux or polling.
- Primary reviewer: Codex; personally reviewed every changed file, caller boundaries, schema, tests and generated guidance. Bounded Luna implementation/testing and Gemini's correlated read-only review were supplementary.
- Findings resolved: missing read-side cleanup/logical filtering; missing explicit-settlement floor; migration backfill full-scan risks; stale fixed-seven-day test assumptions; worker observation triggering the competing cleanup operation; duplicate test snapshots and historical seeding SQL.
- Gemini review: `req_3cf74026-b69a-4d77-a3a5-121e20a02b81`, no actionable findings. Its descriptions were corrected: logical filtering is in service `getResponse`, and repeated terminal settlement returns before SQL update.
- Reviewed commit: `0260004b61bc7fec115d7015fad204b7174aceac`.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge.

Commands and results:

- `pnpm check`: passed TypeScript, E2E types, Oxlint, formatting and all five skill projections.
- `pnpm test:run`: 814 tests across 58 files passed; 95.52% lines/statements, 89.12% branches; coverage gates passed. One concurrent verification attempt hit existing one-second dynamic-import test budgets; the unchanged full rerun passed without weakening timeouts or coverage.
- `pnpm test:e2e`: three local Docker passes, each 78 tests across 19 files, including a full rerun after the final ordered-index correction. Real mock-agent gates verify frozen one-day versus ninety-day requests and reply/result independence from malformed current configuration.
- Real SQLite tests cover 205-row batch draining, independent logical expiry, schema-5 multi-page migration, original anchors, integer saturation, rollback and marker preservation.
- A no-ANALYZE query-plan regression captures actual production SQL, proves ordered horizon-index selection without a temporary candidate sort, and reproduces the old planner regression by removing only the index hint. Limits bound mutations, not a universal maximum on examined index entries.
- Independent-process barriers cover cleanup-first/final-first schedules both before and at acceptance expiry; observation uses non-mutating repository snapshots.
- Packed native application install on macOS arm64 passed using `pnpm pack` and `scripts/verify-packed-native-install.mjs`; bundled skill validation passed.
- No dependency changes or GitHub CI runs were needed during local iteration. Single candidate CI run [34029085614](https://github.com/wkh237/tmux-team/actions/runs/34029085614) passed all 10 checks on reviewed head `0260004b61bc7fec115d7015fad204b7174aceac`; merge readiness was CLEAN before normal protected merge.

## Project lifecycle

- Updated ARCHITECTURE, REQUEST-RESPONSE, DEVELOPMENT, README, help/learn, canonical installed skill and generated projections in this PR.
- Linear contains bounded scope, implementation refinements, review dispositions and verification evidence. TMT-55 follows only after this retention foundation is delivered.
- Dedicated branch/worktree: `codex/tmt-54-exchange-retention`, `/Users/benhsieh/dev/tmt-54-exchange-retention`. Preserve verification artifacts externally and remove the clean, pushed worktree after delivery.
- Fixed UTC deadlines can be delayed by clock rollback while data remains physically present. Cleanup is not a background deletion SLA, secure erasure, acknowledgement or database-file shrinkage. Existing storage-initialization retry latency remains separate documented debt.
