### PR TITLE
feat: add standalone durable identity commands (TMT-30)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -440,6 +440,29 @@ choose a target or data owner. Talk's explicit originator selects local attribut
 without binding the caller. No listener, non-tmux
 identity binding, memory or inbox is implied by this boundary.
 
+## Standalone durable identity operations
+
+TMT-30 exposes explicit `identity create <name>`, `identity show <name>` and
+`identity list` through the existing IdentityService and SQLite repository.
+They use storage-only parser capabilities and never probe tmux, reconcile
+bindings, load unrelated configuration or infer an omitted name. Ordinary
+`list` keeps its verified active-presence contract.
+
+Standalone creation and binding reuse the same validated canonical creation
+primitive. An immediate transaction makes the standalone `created` result
+truthful under concurrent canonical collisions; repeated creation preserves
+the original UUID, display name, timestamps, profiles and binding. Binding
+retains its separate durable-identity and endpoint-publication commit points.
+Show validates names and uses the shared durable selector; ordered listing
+uses the existing repository query. No schema or dependency is added.
+
+The pure public identity projection in `domain/identity.ts` is shared with role
+results and exposes only UUID/name/canonical name, not timestamps or endpoint
+evidence. It is distinct from active-pane presentation. Creation/discovery is
+not login, exclusive caller ownership, authentication, an endpoint or a listener.
+Anonymous talk and request-ID results remain available; identity-scoped attention
+is still a separate future slice.
+
 ## Binding publication and recovery
 
 Identity creation and binding publication are distinct commit points. Invalid
@@ -631,7 +654,7 @@ not replace the storage/concurrency suites.
 The packed verifier additionally checks the actual installed inventory and runs
 an isolated storage probe using the installed TypeScript loader and runtime
 modules. Public role commands initialize storage and prove cross-process profile
-persistence; only identity seeding uses the existing repository API. Exact
+persistence; standalone identity creation/show/list use the public CLI as well. Exact
 installed migration-manifest comparison is paired with repository/schema reads,
 and incompatible history must fail without resetting data. This is verification
 infrastructure, not another migration runner or application service. Test files
@@ -647,7 +670,7 @@ standalone skills remain distributed. Plugin projections remain repository-based
 | [src/context.ts](src/context.ts), [src/types.ts](src/types.ts)                                                                                                             | Composition and lazy resource lifetime; shared UI, adapter, service and configuration contracts. The shared types module is not a dumping ground for new domain models. |
 | [src/commands/](src/commands/)                                                                                                                                             | CLI orchestration, error mapping and presentation. Some delivery policy still lives in commands; they are effectful adapters, not pure functions.                       |
 | [src/domain/](src/domain/)                                                                                                                                                 | Pure name validation, bounded text normalization, feature-specific errors and identity models; no alternate in-memory binding model.                                    |
-| [src/identity-service.ts](src/identity-service.ts)                                                                                                                         | Durable binding, presence, reconciliation and an application-owned identity repository port; supplies verified identities to the target resolver.                       |
+| [src/identity-service.ts](src/identity-service.ts)                                                                                                                         | Durable identity creation/discovery, binding, presence and reconciliation through one repository port; supplies verified identities to the target resolver.             |
 | [src/role-service.ts](src/role-service.ts), [src/identity-context.ts](src/identity-context.ts)                                                                             | Role use cases with an application-owned repository port and shared durable explicit/implicit identity selection.                                                       |
 | [src/target-resolver.ts](src/target-resolver.ts)                                                                                                                           | Shared name/pane resolution; pane-shaped arguments are resolved before names.                                                                                           |
 | [src/storage/](src/storage/)                                                                                                                                               | SQLite lifecycle, migrations, errors and SQL implementing composed application-owned repository ports; Context owns the CLI handle.                                     |
@@ -733,9 +756,9 @@ These links identify owners of unresolved work, not permission to widen an
 unrelated PR. Update this section and the current map in the delivering PR when
 a gap is resolved; do not leave a permanent exception or label a proposal as shipped.
 
-| Gap                                                                                                 | Owning issue                                                                                                                                                           |
-| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Non-tmux identity management, memory and durable inbox are future capabilities, not installed APIs. | [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
+| Gap                                                                                       | Owning issue                                                                                                                                                           |
+| ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Identity attention, memory and durable inbox are future capabilities, not installed APIs. | [TMT-51](https://linear.app/tigerpig-dev/issue/TMT-51), [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
 
 ## Maintenance contract
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -98,6 +98,12 @@ tests forbidden examples as well as repository files. It does not prove semantic
 architecture correctness; primary review and the architecture-impact record
 remain required.
 
+Runner routing tests keep one module import and reset stable context/handler
+mocks between cases. Do not rebuild the full dependency graph for each argument
+case with module-cache resets; reserve those for tests of module initialization
+itself. Keep parser and runner behavior real, and retain separate public CLI
+subprocess coverage rather than treating mocked routing as end-to-end evidence.
+
 Identity, request and response concurrency suites share bounded worker startup, barriers,
 result collection and termination in `src/test-support/request-workers.ts`.
 Scenario assertions stay in their owning test modules; process entrypoints live
@@ -108,6 +114,9 @@ forced termination through observable process absence, and exercise an unrelated
 working directory without adding dependencies to the fixture.
 Test-support infrastructure is excluded from production coverage, like worker
 fixtures; this does not exclude the request service, domain rules or SQL adapter.
+Identity E2E scenarios share `test/e2e/identity-state-oracle.ts` for read-only
+identity/binding/profile snapshots; request state has its separate existing
+oracle. Do not copy a snapshot implementation into each new lifecycle scenario.
 Final-response tests use real temporary SQLite and an injected clock for exact
 submission/retention boundaries, plus independent processes for writer races.
 The live CLI consumes this same service; Docker/mock-agent scenarios verify
@@ -216,8 +225,8 @@ is followed by application storage verification through the same packed CLI.
 `scripts/packed-storage-probe.mjs` runs with the installed package's TypeScript
 loader and imports only that package's runtime owners. Its first storage action
 is a missing-name role read through the public CLI. It compares the resulting
-migration history with the installed migration manifest, seeds only an identity
-through the existing repository, and verifies role writes/reads/clear across
+migration history with the installed migration manifest, creates and discovers
+an identity through the public identity CLI (including canonical idempotence), and verifies role writes/reads/clear across
 CLI processes. Repository read paths also exercise the remaining current tables.
 An incompatible future history must fail without erasing history or role data.
 Manifest equality alone does not prove schema behavior, nor does this smoke

--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ Find the current pane ID with:
 tmux display-message -p '#{pane_id}'
 ```
 
+## Durable identities without a pane
+
+The same commands work inside and outside tmux:
+
+```bash
+tmt identity create coordinator --json
+tmt identity show coordinator --json
+tmt identity list --json
+```
+
+Creation returns `{identity:{id,name,canonicalName},created}`. Repeating a
+canonical-equivalent name returns the same UUID and original display name with
+`created:false`, without changing a pane binding or profile. Show returns
+`{identity:{id,name,canonicalName}}`; list returns `{identities:[...]}` in
+canonical-name order, including unbound identities. These storage-only commands
+work even with no tmux server or malformed unrelated configuration.
+
+This does not log in or bind the caller. Use `talk --identity coordinator` to
+attribute a request; a recipient still needs a live bound pane. `tmt list`
+continues to show active destinations, not every stored identity. Create/show
+require a name: invalid names return `INVALID_NAME` (exit 1), while a valid
+missing show name returns `NAME_NOT_FOUND` (exit 3). No identity deletion,
+rename, attention view or listener is added.
+
 ## Commands
 
 View the exact bundled universal skill with `tmt learn --skill`; plain

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -184,7 +184,8 @@ a truthful work/tests/blockers summary; failed submission is never success.
 
 This section is the canonical future design direction for a TMT Exchange (X).
 TMT-54's retention foundation and TMT-55's provenance/original context are
-implemented; identity-scoped attention below remains unshipped. The current `talk`,
+implemented. TMT-30 also supplies explicit storage-only identity create/show/list;
+identity-scoped attention below remains unshipped. The current `talk`,
 `reply`, `result`, and diagnostic `check`
 contracts above remain authoritative until bounded implementation issues land.
 
@@ -193,7 +194,10 @@ Planning and bounded follow-up ownership are tracked by [TMT-49](https://linear.
 [TMT-54](https://linear.app/tigerpig-dev/issue/TMT-54) and provenance/context in
 [TMT-55](https://linear.app/tigerpig-dev/issue/TMT-55),
 [TMT-51](https://linear.app/tigerpig-dev/issue/TMT-51) (attention), and
-[TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30) (identity bootstrap).
+[TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30) (implemented identity bootstrap).
+The same identity commands work inside and outside tmux, without implicit
+selection or automatic binding. Explicit talk attribution may use an existing
+identity even while another pane is bound to it; this is not authentication.
 
 X is a logical collaboration record that relates an originator's request, its
 delivery attempts, the recipient's one immutable final reply, and per-identity
@@ -347,7 +351,7 @@ scenarios for talk/reply/result correlation and late replies, and packed-skill
 verification when any shipped command guidance changes. Reuse the existing
 request worker harness and E2E fixture; do not add tests for unshipped commands
 to the installed skill. Foundation/configuration work (TMT-46/TMT-29) is complete.
-The remaining sequence is bounded identity and attention slices, minimal
+The remaining sequence is bounded attention, minimal
 MCP, then memory. Offline queue/lease work remains a separate future track.
 If pursued, an offline queue or lease is separate from X and is not an MCP
 prerequisite.

--- a/plugins/tmux-team/commands/learn.md
+++ b/plugins/tmux-team/commands/learn.md
@@ -166,6 +166,33 @@ Do not resend simply because a caller timed out or was interrupted.
 Craft clear, specific requests. After receiving a durable response, summarize
 the result for the user without treating submission alone as task success.
 
+## Durable identity creation and discovery
+
+Use the same explicit commands inside or outside tmux:
+
+```bash
+tmt identity create coordinator --json
+tmt identity show coordinator --json
+tmt identity list --json
+```
+
+These commands use only local storage, without tmux or unrelated configuration.
+Create is idempotent for canonical-equivalent names: it preserves the existing
+UUID, original display name, profiles and any pane binding. It never logs in,
+binds a pane or takes over another caller's identity. Multiple local callers
+may explicitly select the same identity; this is not authentication.
+
+Create returns `{identity:{id,name,canonicalName},created}`; show returns
+`{identity:{id,name,canonicalName}}`; list returns `{identities:[...]}` in
+canonical-name order, including unbound identities. It does not report presence.
+Use ordinary `tmt list` for verified active destinations. A new identity alone
+cannot receive talk: bind a live pane with `add`, `name` or `this` first.
+
+Names are required for create/show; omission never selects the current pane.
+Invalid names return `INVALID_NAME` (exit 1); valid missing show names return
+`NAME_NOT_FOUND` (exit 3). Creation does not alter anonymous talk or request-ID
+result access. There is no identity rename/delete, listener or attention command.
+
 ## Role profiles
 
 Roles are stored profiles, not automatically injected instructions. Select an
@@ -199,8 +226,8 @@ tmt preamble clear reviewer
 ```
 
 Names are explicit; omitting the name lists preambles, not the caller's data.
-Unknown identities fail with `NAME_NOT_FOUND`; bind the intended identity
-explicitly rather than treating a pane ID or an old registration as its name.
+Unknown identities fail with `NAME_NOT_FOUND`; create the intended identity
+with `identity create` rather than treating a pane ID or an old registration as its name.
 Use `clear`, not blank `set`. Content is limited to 65,536 UTF-8 bytes.
 
 `talk` uses the resolved identity's preamble for both names and bound pane

--- a/plugins/tmux-team/commands/team.md
+++ b/plugins/tmux-team/commands/team.md
@@ -168,6 +168,33 @@ Do not resend simply because a caller timed out or was interrupted.
 Craft clear, specific requests. After receiving a durable response, summarize
 the result for the user without treating submission alone as task success.
 
+## Durable identity creation and discovery
+
+Use the same explicit commands inside or outside tmux:
+
+```bash
+tmt identity create coordinator --json
+tmt identity show coordinator --json
+tmt identity list --json
+```
+
+These commands use only local storage, without tmux or unrelated configuration.
+Create is idempotent for canonical-equivalent names: it preserves the existing
+UUID, original display name, profiles and any pane binding. It never logs in,
+binds a pane or takes over another caller's identity. Multiple local callers
+may explicitly select the same identity; this is not authentication.
+
+Create returns `{identity:{id,name,canonicalName},created}`; show returns
+`{identity:{id,name,canonicalName}}`; list returns `{identities:[...]}` in
+canonical-name order, including unbound identities. It does not report presence.
+Use ordinary `tmt list` for verified active destinations. A new identity alone
+cannot receive talk: bind a live pane with `add`, `name` or `this` first.
+
+Names are required for create/show; omission never selects the current pane.
+Invalid names return `INVALID_NAME` (exit 1); valid missing show names return
+`NAME_NOT_FOUND` (exit 3). Creation does not alter anonymous talk or request-ID
+result access. There is no identity rename/delete, listener or attention command.
+
 ## Role profiles
 
 Roles are stored profiles, not automatically injected instructions. Select an
@@ -201,8 +228,8 @@ tmt preamble clear reviewer
 ```
 
 Names are explicit; omitting the name lists preambles, not the caller's data.
-Unknown identities fail with `NAME_NOT_FOUND`; bind the intended identity
-explicitly rather than treating a pane ID or an old registration as its name.
+Unknown identities fail with `NAME_NOT_FOUND`; create the intended identity
+with `identity create` rather than treating a pane ID or an old registration as its name.
 Use `clear`, not blank `set`. Content is limited to 65,536 UTF-8 bytes.
 
 `talk` uses the resolved identity's preamble for both names and bound pane

--- a/plugins/tmux-team/skills/tmux-team/SKILL.md
+++ b/plugins/tmux-team/skills/tmux-team/SKILL.md
@@ -173,6 +173,33 @@ Do not resend simply because a caller timed out or was interrupted.
 Craft clear, specific requests. After receiving a durable response, summarize
 the result for the user without treating submission alone as task success.
 
+## Durable identity creation and discovery
+
+Use the same explicit commands inside or outside tmux:
+
+```bash
+tmt identity create coordinator --json
+tmt identity show coordinator --json
+tmt identity list --json
+```
+
+These commands use only local storage, without tmux or unrelated configuration.
+Create is idempotent for canonical-equivalent names: it preserves the existing
+UUID, original display name, profiles and any pane binding. It never logs in,
+binds a pane or takes over another caller's identity. Multiple local callers
+may explicitly select the same identity; this is not authentication.
+
+Create returns `{identity:{id,name,canonicalName},created}`; show returns
+`{identity:{id,name,canonicalName}}`; list returns `{identities:[...]}` in
+canonical-name order, including unbound identities. It does not report presence.
+Use ordinary `tmt list` for verified active destinations. A new identity alone
+cannot receive talk: bind a live pane with `add`, `name` or `this` first.
+
+Names are required for create/show; omission never selects the current pane.
+Invalid names return `INVALID_NAME` (exit 1); valid missing show names return
+`NAME_NOT_FOUND` (exit 3). Creation does not alter anonymous talk or request-ID
+result access. There is no identity rename/delete, listener or attention command.
+
 ## Role profiles
 
 Roles are stored profiles, not automatically injected instructions. Select an
@@ -206,8 +233,8 @@ tmt preamble clear reviewer
 ```
 
 Names are explicit; omitting the name lists preambles, not the caller's data.
-Unknown identities fail with `NAME_NOT_FOUND`; bind the intended identity
-explicitly rather than treating a pane ID or an old registration as its name.
+Unknown identities fail with `NAME_NOT_FOUND`; create the intended identity
+with `identity create` rather than treating a pane ID or an old registration as its name.
 Use `clear`, not blank `set`. Content is limited to 65,536 UTF-8 bytes.
 
 `talk` uses the resolved identity's preamble for both names and bound pane

--- a/scripts/packed-storage-probe.mjs
+++ b/scripts/packed-storage-probe.mjs
@@ -154,13 +154,35 @@ async function main() {
 
   assertSchema(Database, paths.databaseFile, CURRENT_MIGRATIONS);
 
-  let identity;
-  const seedRepository = openIdentityRepository(paths.databaseFile);
-  try {
-    identity = seedRepository.createIdentity(IDENTITY_NAME, IDENTITY_CANONICAL_NAME);
-  } finally {
-    seedRepository.close();
-  }
+  const created = await runJson(
+    executable,
+    ['identity', 'create', IDENTITY_NAME, '--json'],
+    environment
+  );
+  assert.equal(created.created, true);
+  assert.equal(typeof created.identity.id, 'string');
+  assert.ok(created.identity.id.length > 0);
+  const identity = {
+    id: created.identity.id,
+    name: IDENTITY_NAME,
+    canonicalName: IDENTITY_CANONICAL_NAME,
+  };
+  assert.deepEqual(created, { identity, created: true });
+  assert.deepEqual(
+    await runJson(
+      executable,
+      ['identity', 'create', IDENTITY_CANONICAL_NAME, '--json'],
+      environment
+    ),
+    { identity, created: false }
+  );
+  assert.deepEqual(
+    await runJson(executable, ['identity', 'show', IDENTITY_CANONICAL_NAME, '--json'], environment),
+    { identity }
+  );
+  assert.deepEqual(await runJson(executable, ['identity', 'list', '--json'], environment), {
+    identities: [identity],
+  });
 
   const seededSnapshot = nativeSnapshot(Database, paths.databaseFile);
   assert.equal(seededSnapshot.identities.length, 1);
@@ -213,7 +235,13 @@ async function main() {
   assertRoleResult(roleAfterClear, identity, null);
   const reopenedRepository = openIdentityRepository(paths.databaseFile);
   try {
-    assert.deepEqual(reopenedRepository.listIdentities(), [identity]);
+    const storedIdentities = reopenedRepository.listIdentities();
+    assert.equal(storedIdentities.length, 1);
+    assert.deepEqual(storedIdentities[0], {
+      ...identity,
+      createdAt: seededSnapshot.identities[0].created_at,
+      updatedAt: seededSnapshot.identities[0].updated_at,
+    });
     assert.equal(reopenedRepository.findRole(identity.id), undefined);
   } finally {
     reopenedRepository.close();

--- a/skills/claude/team.md
+++ b/skills/claude/team.md
@@ -164,6 +164,33 @@ Do not resend simply because a caller timed out or was interrupted.
 Craft clear, specific requests. After receiving a durable response, summarize
 the result for the user without treating submission alone as task success.
 
+## Durable identity creation and discovery
+
+Use the same explicit commands inside or outside tmux:
+
+```bash
+tmt identity create coordinator --json
+tmt identity show coordinator --json
+tmt identity list --json
+```
+
+These commands use only local storage, without tmux or unrelated configuration.
+Create is idempotent for canonical-equivalent names: it preserves the existing
+UUID, original display name, profiles and any pane binding. It never logs in,
+binds a pane or takes over another caller's identity. Multiple local callers
+may explicitly select the same identity; this is not authentication.
+
+Create returns `{identity:{id,name,canonicalName},created}`; show returns
+`{identity:{id,name,canonicalName}}`; list returns `{identities:[...]}` in
+canonical-name order, including unbound identities. It does not report presence.
+Use ordinary `tmt list` for verified active destinations. A new identity alone
+cannot receive talk: bind a live pane with `add`, `name` or `this` first.
+
+Names are required for create/show; omission never selects the current pane.
+Invalid names return `INVALID_NAME` (exit 1); valid missing show names return
+`NAME_NOT_FOUND` (exit 3). Creation does not alter anonymous talk or request-ID
+result access. There is no identity rename/delete, listener or attention command.
+
 ## Role profiles
 
 Roles are stored profiles, not automatically injected instructions. Select an
@@ -197,8 +224,8 @@ tmt preamble clear reviewer
 ```
 
 Names are explicit; omitting the name lists preambles, not the caller's data.
-Unknown identities fail with `NAME_NOT_FOUND`; bind the intended identity
-explicitly rather than treating a pane ID or an old registration as its name.
+Unknown identities fail with `NAME_NOT_FOUND`; create the intended identity
+with `identity create` rather than treating a pane ID or an old registration as its name.
 Use `clear`, not blank `set`. Content is limited to 65,536 UTF-8 bytes.
 
 `talk` uses the resolved identity's preamble for both names and bound pane

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -167,6 +167,33 @@ Do not resend simply because a caller timed out or was interrupted.
 Craft clear, specific requests. After receiving a durable response, summarize
 the result for the user without treating submission alone as task success.
 
+## Durable identity creation and discovery
+
+Use the same explicit commands inside or outside tmux:
+
+```bash
+tmt identity create coordinator --json
+tmt identity show coordinator --json
+tmt identity list --json
+```
+
+These commands use only local storage, without tmux or unrelated configuration.
+Create is idempotent for canonical-equivalent names: it preserves the existing
+UUID, original display name, profiles and any pane binding. It never logs in,
+binds a pane or takes over another caller's identity. Multiple local callers
+may explicitly select the same identity; this is not authentication.
+
+Create returns `{identity:{id,name,canonicalName},created}`; show returns
+`{identity:{id,name,canonicalName}}`; list returns `{identities:[...]}` in
+canonical-name order, including unbound identities. It does not report presence.
+Use ordinary `tmt list` for verified active destinations. A new identity alone
+cannot receive talk: bind a live pane with `add`, `name` or `this` first.
+
+Names are required for create/show; omission never selects the current pane.
+Invalid names return `INVALID_NAME` (exit 1); valid missing show names return
+`NAME_NOT_FOUND` (exit 3). Creation does not alter anonymous talk or request-ID
+result access. There is no identity rename/delete, listener or attention command.
+
 ## Role profiles
 
 Roles are stored profiles, not automatically injected instructions. Select an
@@ -200,8 +227,8 @@ tmt preamble clear reviewer
 ```
 
 Names are explicit; omitting the name lists preambles, not the caller's data.
-Unknown identities fail with `NAME_NOT_FOUND`; bind the intended identity
-explicitly rather than treating a pane ID or an old registration as its name.
+Unknown identities fail with `NAME_NOT_FOUND`; create the intended identity
+with `identity create` rather than treating a pane ID or an old registration as its name.
 Use `clear`, not blank `set`. Content is limited to 65,536 UTF-8 bytes.
 
 `talk` uses the resolved identity's preamble for both names and bound pane

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -162,6 +162,33 @@ Do not resend simply because a caller timed out or was interrupted.
 Craft clear, specific requests. After receiving a durable response, summarize
 the result for the user without treating submission alone as task success.
 
+## Durable identity creation and discovery
+
+Use the same explicit commands inside or outside tmux:
+
+```bash
+tmt identity create coordinator --json
+tmt identity show coordinator --json
+tmt identity list --json
+```
+
+These commands use only local storage, without tmux or unrelated configuration.
+Create is idempotent for canonical-equivalent names: it preserves the existing
+UUID, original display name, profiles and any pane binding. It never logs in,
+binds a pane or takes over another caller's identity. Multiple local callers
+may explicitly select the same identity; this is not authentication.
+
+Create returns `{identity:{id,name,canonicalName},created}`; show returns
+`{identity:{id,name,canonicalName}}`; list returns `{identities:[...]}` in
+canonical-name order, including unbound identities. It does not report presence.
+Use ordinary `tmt list` for verified active destinations. A new identity alone
+cannot receive talk: bind a live pane with `add`, `name` or `this` first.
+
+Names are required for create/show; omission never selects the current pane.
+Invalid names return `INVALID_NAME` (exit 1); valid missing show names return
+`NAME_NOT_FOUND` (exit 3). Creation does not alter anonymous talk or request-ID
+result access. There is no identity rename/delete, listener or attention command.
+
 ## Role profiles
 
 Roles are stored profiles, not automatically injected instructions. Select an
@@ -195,8 +222,8 @@ tmt preamble clear reviewer
 ```
 
 Names are explicit; omitting the name lists preambles, not the caller's data.
-Unknown identities fail with `NAME_NOT_FOUND`; bind the intended identity
-explicitly rather than treating a pane ID or an old registration as its name.
+Unknown identities fail with `NAME_NOT_FOUND`; create the intended identity
+with `identity create` rather than treating a pane ID or an old registration as its name.
 Use `clear`, not blank `set`. Content is limited to 65,536 UTF-8 bytes.
 
 `talk` uses the resolved identity's preamble for both names and bound pane

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Context } from './types.js';
+import type { CreateContextOptions } from './context.js';
 import { createDefaultConfig } from './config-settings.js';
 
 const unusedRequestService: Context['requestService'] = {
@@ -57,6 +58,15 @@ function makeStubContext(): Context {
       setPaneTitle: vi.fn(),
     },
     identityService: {
+      createIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity creation.');
+      }),
+      showIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity lookup.');
+      }),
+      listIdentities: vi.fn(() => {
+        throw new Error('Unexpected durable identity listing.');
+      }),
       bindCurrent: vi.fn(),
       bindPane: vi.fn(),
       unbindCurrent: vi.fn(),
@@ -82,9 +92,62 @@ function makeStubContext(): Context {
   };
 }
 
+const handlers = {
+  cmdHelp: vi.fn(),
+  cmdCompletion: vi.fn(),
+  cmdLearn: vi.fn(),
+  cmdInit: vi.fn(),
+  cmdList: vi.fn(),
+  cmdAdd: vi.fn(),
+  cmdTalk: vi.fn(),
+  cmdCheck: vi.fn(),
+  cmdConfig: vi.fn(),
+  cmdPreamble: vi.fn(),
+  cmdInstall: vi.fn(),
+  cmdThis: vi.fn(),
+  cmdName: vi.fn(),
+  cmdUpgrade: vi.fn(),
+  cmdWhoami: vi.fn(),
+  cmdUnbind: vi.fn(),
+  cmdRole: vi.fn(),
+  cmdIdentity: vi.fn(),
+  cmdReply: vi.fn(),
+  cmdResult: vi.fn(),
+};
+
+const contextFactory = vi.fn((_options: CreateContextOptions) => makeStubContext());
+
+vi.mock('./context.js', () => ({
+  createContext: (options: CreateContextOptions) => contextFactory(options),
+  ExitCodes: { SUCCESS: 0, ERROR: 1, UNSUPPORTED_TEAM: 1 },
+}));
+vi.mock('./commands/help.js', () => ({ cmdHelp: handlers.cmdHelp }));
+vi.mock('./commands/completion.js', () => ({ cmdCompletion: handlers.cmdCompletion }));
+vi.mock('./commands/learn.js', () => ({ cmdLearn: handlers.cmdLearn }));
+vi.mock('./commands/init.js', () => ({ cmdInit: handlers.cmdInit }));
+vi.mock('./commands/list.js', () => ({ cmdList: handlers.cmdList }));
+vi.mock('./commands/add.js', () => ({ cmdAdd: handlers.cmdAdd }));
+vi.mock('./commands/talk.js', () => ({ cmdTalk: handlers.cmdTalk }));
+vi.mock('./commands/check.js', () => ({ cmdCheck: handlers.cmdCheck }));
+vi.mock('./commands/config.js', () => ({ cmdConfig: handlers.cmdConfig }));
+vi.mock('./commands/preamble.js', () => ({ cmdPreamble: handlers.cmdPreamble }));
+vi.mock('./commands/install.js', () => ({ cmdInstall: handlers.cmdInstall }));
+vi.mock('./commands/this.js', () => ({ cmdThis: handlers.cmdThis }));
+vi.mock('./commands/name.js', () => ({ cmdName: handlers.cmdName }));
+vi.mock('./commands/upgrade.js', () => ({ cmdUpgrade: handlers.cmdUpgrade }));
+vi.mock('./commands/whoami.js', () => ({ cmdWhoami: handlers.cmdWhoami }));
+vi.mock('./commands/unbind.js', () => ({ cmdUnbind: handlers.cmdUnbind }));
+vi.mock('./commands/role.js', () => ({ cmdRole: handlers.cmdRole }));
+vi.mock('./commands/identity.js', () => ({ cmdIdentity: handlers.cmdIdentity }));
+vi.mock('./commands/reply.js', () => ({ cmdReply: handlers.cmdReply }));
+vi.mock('./commands/result.js', () => ({ cmdResult: handlers.cmdResult }));
+
+const { runCli } = await import('./cli-runner.js');
+
 describe('cli', () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
+    vi.resetAllMocks();
+    contextFactory.mockImplementation(() => makeStubContext());
   });
 
   afterEach(() => {
@@ -96,14 +159,8 @@ describe('cli', () => {
     ['--team value', ['node', 'cli', 'list', '--team', 'legacy']],
     ['--team=value', ['node', 'cli', 'list', '--team=legacy']],
   ])('rejects %s before creating command context', async (_label, argv) => {
-    vi.resetModules();
-    const createContext = vi.fn(() => makeStubContext());
-    vi.doMock('./context.js', () => ({
-      createContext,
-      ExitCodes: { SUCCESS: 0, ERROR: 1, UNSUPPORTED_TEAM: 1 },
-    }));
+    const createContext = contextFactory;
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(argv.slice(2))).toBe(1);
     expect(createContext).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith(
@@ -112,29 +169,18 @@ describe('cli', () => {
   });
 
   it('prints completion for bash', async () => {
-    vi.resetModules();
-
-    vi.doMock('./context.js', () => ({
-      createContext: () => makeStubContext(),
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/completion.js', () => ({
-      cmdCompletion: (shell?: string) => {
-        console.log(`completion:${shell}`);
-      },
-    }));
+    handlers.cmdCompletion.mockImplementation((shell?: string) => {
+      console.log(`completion:${shell}`);
+    });
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(['completion', 'bash'])).toBe(0);
     expect(logSpy).toHaveBeenCalledWith('completion:bash');
   });
 
   it('errors on invalid time format', async () => {
-    vi.resetModules();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(['talk', 'codex', 'hi', '--delay', 'abc'])).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith(
       '✗ Invalid time format: abc. Use number (seconds) or number with ms/s suffix.'
@@ -142,62 +188,40 @@ describe('cli', () => {
   });
 
   it('reports an unknown command without creating a Context', async () => {
-    vi.resetModules();
-    const createContext = vi.fn(() => makeStubContext());
-    vi.doMock('./context.js', () => ({
-      createContext,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
+    const createContext = contextFactory;
 
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(['nope'])).toBe(1);
     expect(createContext).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown command'));
   });
 
   it('handles --version by printing VERSION', async () => {
-    vi.resetModules();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(['--version'])).toBe(0);
     expect(logSpy).toHaveBeenCalled();
   });
 
   it('routes learn command and does not exit', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const learnSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/learn.js', () => ({ cmdLearn: learnSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const learnSpy = handlers.cmdLearn;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['learn'])).toBe(0);
     expect(learnSpy).toHaveBeenCalled();
   });
 
   it('prints JSON error when --json and a command throws', async () => {
-    vi.resetModules();
     // The mocked command throws through the shared runner boundary.
 
     const ctx = makeStubContext();
     ctx.flags.json = true;
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/role.js', () => ({
-      cmdRole: () => {
-        throw new Error('boom');
-      },
-    }));
+    contextFactory.mockImplementation(() => ctx);
+    handlers.cmdRole.mockImplementation(() => {
+      throw new Error('boom');
+    });
 
     const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(['role', 'show', '--json'])).toBe(1);
     expect(JSON.parse(String(writeSpy.mock.calls[0]?.[0]))).toEqual({
       error: { code: 'INTERNAL_ERROR', message: 'boom' },
@@ -205,32 +229,18 @@ describe('cli', () => {
   });
 
   it('routes install command', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const installSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/install.js', () => ({ cmdInstall: installSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const installSpy = handlers.cmdInstall;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['install', 'claude'])).toBe(0);
 
     expect(installSpy).toHaveBeenCalledWith(ctx, 'claude', undefined);
   });
 
   it('routes preamble command', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const preambleSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/preamble.js', () => ({ cmdPreamble: preambleSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const preambleSpy = handlers.cmdPreamble;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['preamble', 'show'])).toBe(0);
 
     expect(preambleSpy).toHaveBeenCalledWith(ctx, {
@@ -241,205 +251,119 @@ describe('cli', () => {
   });
 
   it('routes this command', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const thisSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/this.js', () => ({ cmdThis: thisSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const thisSpy = handlers.cmdThis;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['this', 'myagent'])).toBe(0);
 
     expect(thisSpy).toHaveBeenCalledWith(ctx, 'myagent');
   });
 
   it('routes name command as a current-pane identity binding', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const nameSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/name.js', () => ({ cmdName: nameSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const nameSpy = handlers.cmdName;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['name', 'backend'])).toBe(0);
 
     expect(nameSpy).toHaveBeenCalledWith(ctx, 'backend');
   });
 
   it('errors when name command has missing or extra arguments', async () => {
-    vi.resetModules();
     const argv = ['name', 'backend', 'main:1.2', 'extra'];
 
     const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/name.js', () => ({ cmdName: vi.fn() }));
+    contextFactory.mockImplementation(() => ctx);
 
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(argv)).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team name <global-name>');
   });
 
   it('errors when name command has no name', async () => {
-    vi.resetModules();
     const argv = ['name'];
     const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/name.js', () => ({ cmdName: vi.fn() }));
+    contextFactory.mockImplementation(() => ctx);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(argv)).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team name <global-name>');
   });
 
   it('errors when this command is missing name', async () => {
-    vi.resetModules();
     const argv = ['this'];
 
     const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/this.js', () => ({ cmdThis: vi.fn() }));
+    contextFactory.mockImplementation(() => ctx);
 
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(argv)).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team this <global-name>');
   });
 
   it('errors when this command has an extra argument', async () => {
-    vi.resetModules();
     const argv = ['this', 'backend', 'extra'];
     const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/this.js', () => ({ cmdThis: vi.fn() }));
+    contextFactory.mockImplementation(() => ctx);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(argv)).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team this <global-name>');
   });
 
   it('routes whoami without arguments', async () => {
-    vi.resetModules();
     const ctx = makeStubContext();
-    const whoamiSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/whoami.js', () => ({ cmdWhoami: whoamiSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const whoamiSpy = handlers.cmdWhoami;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['whoami'])).toBe(0);
     expect(whoamiSpy).toHaveBeenCalledWith(ctx);
   });
 
   it('routes unbind without arguments', async () => {
-    vi.resetModules();
     const ctx = makeStubContext();
-    const unbindSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/unbind.js', () => ({ cmdUnbind: unbindSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const unbindSpy = handlers.cmdUnbind;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['unbind'])).toBe(0);
     expect(unbindSpy).toHaveBeenCalledWith(ctx);
   });
 
   it.each(['whoami', 'unbind'])('rejects arguments for %s', async (command) => {
-    vi.resetModules();
     const argv = [command, 'extra'];
     const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock(`./commands/${command}.js`, () => ({
-      [command === 'whoami' ? 'cmdWhoami' : 'cmdUnbind']: vi.fn(),
-    }));
+    contextFactory.mockImplementation(() => ctx);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(argv)).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith(`✗ Usage: tmux-team ${command}`);
   });
 
   it('routes init command', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const initSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/init.js', () => ({ cmdInit: initSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const initSpy = handlers.cmdInit;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['init'])).toBe(0);
 
     expect(initSpy).toHaveBeenCalledWith(ctx);
   });
 
   it('routes list command', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const listSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/list.js', () => ({ cmdList: listSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const listSpy = handlers.cmdList;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['list'])).toBe(0);
 
     expect(listSpy).toHaveBeenCalledWith(ctx);
   });
 
   it('routes ls alias to list command', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const listSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/list.js', () => ({ cmdList: listSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const listSpy = handlers.cmdList;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['ls'])).toBe(0);
 
     expect(listSpy).toHaveBeenCalledWith(ctx);
   });
 
   it('routes add command', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const addSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/add.js', () => ({ cmdAdd: addSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const addSpy = handlers.cmdAdd;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['add', '1.0', 'myagent'])).toBe(0);
 
     expect(addSpy).toHaveBeenCalledWith(ctx, '1.0', 'myagent');
@@ -449,31 +373,18 @@ describe('cli', () => {
     ['missing', ['node', 'cli', 'add', '1.0']],
     ['extra', ['node', 'cli', 'add', '1.0', 'backend', 'remark']],
   ])('rejects add command with %s arguments', async (_case, argv) => {
-    vi.resetModules();
     const commandArgs = argv.slice(2);
     const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/add.js', () => ({ cmdAdd: vi.fn() }));
+    contextFactory.mockImplementation(() => ctx);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(commandArgs)).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith('✗ Usage: tmux-team add <pane-target> <global-name>');
   });
 
   it('routes config command', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const configSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/config.js', () => ({ cmdConfig: configSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const configSpy = handlers.cmdConfig;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['config', 'show'])).toBe(0);
 
     expect(configSpy).toHaveBeenCalledWith(ctx, {
@@ -484,152 +395,99 @@ describe('cli', () => {
   });
 
   it('parses --timeout flag with seconds', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const talkSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: (opts: any) => {
-        ctx.flags = opts.flags;
-        return ctx;
-      },
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/talk.js', () => ({ cmdTalk: talkSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const talkSpy = handlers.cmdTalk;
+    contextFactory.mockImplementation((opts) => {
+      ctx.flags = opts.flags;
+      return ctx;
+    });
     expect(await runCli(['talk', 'claude', 'hi', '--timeout', '30'])).toBe(0);
 
     expect(ctx.flags.timeout).toBe(30);
+    expect(talkSpy).toHaveBeenCalledOnce();
   });
 
   it('parses --timeout flag with ms suffix', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const talkSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: (opts: any) => {
-        ctx.flags = opts.flags;
-        return ctx;
-      },
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/talk.js', () => ({ cmdTalk: talkSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const talkSpy = handlers.cmdTalk;
+    contextFactory.mockImplementation((opts) => {
+      ctx.flags = opts.flags;
+      return ctx;
+    });
     expect(await runCli(['talk', 'claude', 'hi', '--timeout', '500ms'])).toBe(0);
 
     expect(ctx.flags.timeout).toBe(0.5);
+    expect(talkSpy).toHaveBeenCalledOnce();
   });
 
   it('parses --detach flag', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const talkSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: (opts: any) => {
-        ctx.flags = opts.flags;
-        return ctx;
-      },
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/talk.js', () => ({ cmdTalk: talkSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const talkSpy = handlers.cmdTalk;
+    contextFactory.mockImplementation((opts) => {
+      ctx.flags = opts.flags;
+      return ctx;
+    });
     expect(await runCli(['talk', 'claude', 'hi', '--detach'])).toBe(0);
 
     expect(ctx.flags.detach).toBe(true);
+    expect(talkSpy).toHaveBeenCalledOnce();
   });
 
   it('rejects talk --lines before creating command context', async () => {
-    vi.resetModules();
-    const contextFactory = vi.fn(() => makeStubContext());
-    vi.doMock('./context.js', () => ({
-      createContext: contextFactory,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(['talk', 'claude', 'hi', '--lines', '50'])).toBe(1);
     expect(contextFactory).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalled();
   });
 
   it('parses --no-preamble flag', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const talkSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: (opts: any) => {
-        ctx.flags = opts.flags;
-        return ctx;
-      },
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/talk.js', () => ({ cmdTalk: talkSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const talkSpy = handlers.cmdTalk;
+    contextFactory.mockImplementation((opts) => {
+      ctx.flags = opts.flags;
+      return ctx;
+    });
     expect(await runCli(['talk', 'claude', 'hi', '--no-preamble'])).toBe(0);
 
     expect(ctx.flags.noPreamble).toBe(true);
+    expect(talkSpy).toHaveBeenCalledOnce();
   });
 
   it('routes check command with lines argument', async () => {
-    vi.resetModules();
-
     const ctx = makeStubContext();
-    const checkSpy = vi.fn();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
-    vi.doMock('./commands/check.js', () => ({ cmdCheck: checkSpy }));
-    const { runCli } = await import('./cli-runner.js');
+    const checkSpy = handlers.cmdCheck;
+    contextFactory.mockImplementation(() => ctx);
     expect(await runCli(['check', 'claude', '50'])).toBe(0);
 
     expect(checkSpy).toHaveBeenCalledWith(ctx, 'claude', 50);
   });
 
   it('errors on talk with missing arguments', async () => {
-    vi.resetModules();
     const argv = ['talk', 'claude']; // missing message
 
     const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
+    contextFactory.mockImplementation(() => ctx);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(argv)).toBe(1);
     expect(errorSpy).toHaveBeenCalled();
   });
 
   it('errors on add with missing arguments', async () => {
-    vi.resetModules();
-    const argv = ['add', 'claude']; // missing pane
+    const argv = ['add', 'claude']; // missing global name
 
     const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
+    contextFactory.mockImplementation(() => ctx);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(argv)).toBe(1);
     expect(errorSpy).toHaveBeenCalled();
   });
 
   it('errors on check with missing arguments', async () => {
-    vi.resetModules();
     const argv = ['check']; // missing target
 
     const ctx = makeStubContext();
-    vi.doMock('./context.js', () => ({
-      createContext: () => ctx,
-      ExitCodes: { SUCCESS: 0, ERROR: 1 },
-    }));
+    contextFactory.mockImplementation(() => ctx);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { runCli } = await import('./cli-runner.js');
     expect(await runCli(argv)).toBe(1);
     expect(errorSpy).toHaveBeenCalled();
   });

--- a/src/cli/application.test.ts
+++ b/src/cli/application.test.ts
@@ -17,6 +17,7 @@ const handlers = {
   cmdWhoami: vi.fn(),
   cmdUnbind: vi.fn(),
   cmdRole: vi.fn(),
+  cmdIdentity: vi.fn(),
   cmdReply: vi.fn(),
   cmdResult: vi.fn(),
 };
@@ -36,6 +37,7 @@ vi.mock('../commands/upgrade.js', () => ({ cmdUpgrade: handlers.cmdUpgrade }));
 vi.mock('../commands/whoami.js', () => ({ cmdWhoami: handlers.cmdWhoami }));
 vi.mock('../commands/unbind.js', () => ({ cmdUnbind: handlers.cmdUnbind }));
 vi.mock('../commands/role.js', () => ({ cmdRole: handlers.cmdRole }));
+vi.mock('../commands/identity.js', () => ({ cmdIdentity: handlers.cmdIdentity }));
 vi.mock('../commands/reply.js', () => ({ cmdReply: handlers.cmdReply }));
 vi.mock('../commands/result.js', () => ({ cmdResult: handlers.cmdResult }));
 
@@ -67,6 +69,7 @@ describe('application dispatcher', () => {
       ['config', { operation: 'show', global: false }],
       ['preamble', { operation: 'show' }],
       ['role', { operation: 'show' }],
+      ['identity', { operation: 'create', name: 'Alice' }],
       ['reply', { requestId: 'request-1', receipt: 'receipt', file: '/tmp/reply.txt' }],
       ['result', { requestId: 'request-1' }],
       ['install', { target: 'codex' }],
@@ -95,6 +98,11 @@ describe('application dispatcher', () => {
       ctx,
       expect.objectContaining({ operation: 'show' })
     );
+    expect(handlers.cmdIdentity).toHaveBeenCalledWith(ctx, {
+      kind: 'identity',
+      operation: 'create',
+      name: 'Alice',
+    });
     expect(handlers.cmdReply).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({ kind: 'reply', requestId: 'request-1', file: '/tmp/reply.txt' })

--- a/src/cli/application.ts
+++ b/src/cli/application.ts
@@ -14,6 +14,7 @@ import { cmdUpgrade } from '../commands/upgrade.js';
 import { cmdWhoami } from '../commands/whoami.js';
 import { cmdUnbind } from '../commands/unbind.js';
 import { cmdRole } from '../commands/role.js';
+import { cmdIdentity } from '../commands/identity.js';
 import { cmdReply } from '../commands/reply.js';
 import { cmdResult } from '../commands/result.js';
 import type { ParsedArgs, ParsedInvocation } from './parser.js';
@@ -53,6 +54,8 @@ export async function dispatchCommand(ctx: Context, parsed: ParsedArgs): Promise
       return cmdPreamble(ctx, request);
     case 'role':
       return cmdRole(ctx, request);
+    case 'identity':
+      return cmdIdentity(ctx, request);
     case 'reply':
       return cmdReply(ctx, request);
     case 'result':

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -22,6 +22,38 @@ const receipt = encodeReplyReceipt({
 });
 
 describe('declarative CLI parser', () => {
+  it('parses explicit durable identity operations as storage-only requests', () => {
+    for (const operation of ['create', 'show'] as const) {
+      const parsed = parseArgs(['identity', operation, 'Alice', '--json']);
+      expect(parsed.invocation).toEqual({ kind: 'identity', operation, name: 'Alice' });
+      expect(parsed.metadata.capability).toBe('storage');
+      expect(parsed.flags.json).toBe(true);
+    }
+    expect(parseArgs(['identity', 'list']).invocation).toEqual({
+      kind: 'identity',
+      operation: 'list',
+    });
+    expect(parseArgs(['identity', 'create', '--', '--json']).invocation).toEqual({
+      kind: 'identity',
+      operation: 'create',
+      name: '--json',
+    });
+  });
+
+  it.each([
+    ['identity'],
+    ['identity', 'create'],
+    ['identity', 'show'],
+    ['identity', 'list', 'Alice'],
+    ['identity', 'create', 'Alice', 'Bob'],
+    ['identity', 'list', '--identity', 'Alice'],
+    ['identity', 'create', 'Alice', '--force'],
+    ['--verbose', 'identity', 'list'],
+    ['identity', 'list', '--timeout', '1'],
+  ])('rejects incomplete or unrelated identity arguments: %j', (...args) => {
+    expect(() => parseArgs(args)).toThrow(CliParseError);
+  });
+
   it('parses global options independently of command position', () => {
     const parsed = parseArgs(['talk', 'claude', 'hello', '--timeout', '500ms']);
     expect(parsed.flags).toMatchObject({ timeout: 0.5 });

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -4,6 +4,7 @@ import type { Flags } from '../types.js';
 import type { IdentitySelector } from '../identity-context.js';
 import type {
   ConfigRequest,
+  IdentityRequest,
   PreambleRequest,
   ReplyRequest,
   ResultRequest,
@@ -32,6 +33,7 @@ export type ParsedInvocation =
   | TalkRequest
   | { readonly kind: 'check'; readonly target: IdentitySelector; readonly lines?: number }
   | ConfigRequest
+  | IdentityRequest
   | PreambleRequest
   | ReplyRequest
   | ResultRequest
@@ -338,6 +340,7 @@ function capabilityFor(invocation: ParsedInvocation): ParsedMetadata['capability
     case 'learn':
       return 'none';
     case 'config':
+    case 'identity':
     case 'install':
       return 'storage';
     case 'preamble':
@@ -695,6 +698,28 @@ function setupProgram(capture: Capture): Command {
   preambleClear.action(function (agent: string) {
     action(this, { kind: 'preamble', operation: 'clear', agent });
   });
+  const identity = storageOnly(
+    program.command('identity').description('Create and discover durable identities')
+  );
+  identity.action(function () {
+    throw new CliParseError('Choose identity create, show, or list.');
+  });
+  for (const operation of ['create', 'show'] as const) {
+    const command = storageOnly(
+      identity
+        .command(operation)
+        .description(`${operation === 'create' ? 'Create' : 'Show'} a durable identity`)
+        .argument('<name>')
+    );
+    command.action(function (name: string) {
+      action(this, { kind: 'identity', operation, name });
+    });
+  }
+  storageOnly(identity.command('list').description('List all durable identities')).action(
+    function () {
+      action(this, { kind: 'identity', operation: 'list' });
+    }
+  );
   const role = register(
     program
       .command('role')

--- a/src/cli/requests.ts
+++ b/src/cli/requests.ts
@@ -1,5 +1,10 @@
 import type { IdentitySelector } from '../identity-context.js';
 
+export type IdentityRequest = { readonly kind: 'identity' } & (
+  | { readonly operation: 'create' | 'show'; readonly name: string }
+  | { readonly operation: 'list' }
+);
+
 export interface ConfigRequest {
   readonly kind: 'config';
   readonly operation: 'show' | 'set' | 'clear';

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -109,6 +109,15 @@ function createCtx(
   const tmux = createMockTmux();
   const registrations = overrides?.identities ?? [];
   const identityService: IdentityService = {
+    createIdentity: vi.fn(() => {
+      throw new Error('Unexpected durable identity creation.');
+    }),
+    showIdentity: vi.fn(() => {
+      throw new Error('Unexpected durable identity lookup.');
+    }),
+    listIdentities: vi.fn(() => {
+      throw new Error('Unexpected durable identity listing.');
+    }),
     bindCurrent: vi.fn((name: string) => ({
       id: 'identity-id',
       name,

--- a/src/commands/config-command.test.ts
+++ b/src/commands/config-command.test.ts
@@ -65,6 +65,15 @@ function createCtx(
     config,
     tmux,
     identityService: {
+      createIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity creation.');
+      }),
+      showIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity lookup.');
+      }),
+      listIdentities: vi.fn(() => {
+        throw new Error('Unexpected durable identity listing.');
+      }),
       bindCurrent: vi.fn(),
       bindPane: vi.fn(),
       unbindCurrent: vi.fn(),

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -79,6 +79,7 @@ export function cmdHelp(config?: HelpConfig): void {
   const reply = requiredCommand(metadata, 'reply');
   const result = requiredCommand(metadata, 'result');
   const role = requiredCommand(metadata, 'role');
+  const identity = requiredCommand(metadata, 'identity');
   const learn = requiredCommand(metadata, 'learn');
   const learnSkill = learn.options.find((option) => option.name === 'skill');
   if (!learnSkill) throw new Error('CLI metadata is missing learn --skill');
@@ -117,6 +118,13 @@ ${colors.yellow('OPTIONS')}
 ${rootOptions.map(formatOption).join('\n')}
   JSON is available only for commands with a JSON result; text-only commands
   such as help, completion and learn do not provide a universal JSON form.
+
+${colors.yellow('DURABLE IDENTITY USAGE')}
+${childRows(identity)}
+  Storage-only; works inside or outside tmux without loading unrelated configuration.
+  Create preserves an existing canonical name, UUID, profile and pane binding.
+  Identity list includes unbound identities; ordinary list shows active destinations.
+  No login, automatic binding, presence claim or authentication is implied.
 
 ${colors.yellow('ROLE USAGE')}
 ${childRows(role)}

--- a/src/commands/identity.test.ts
+++ b/src/commands/identity.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import { IdentitySelectionError } from '../identity-context.js';
+import { IdentityServiceError } from '../identity-service.js';
+import type { DurableIdentity } from '../domain/identity.js';
+import type { Context, IdentityService, UI } from '../types.js';
+import { cmdIdentity } from './identity.js';
+
+type MockUI = UI & { jsonCalls: unknown[] };
+
+function identity(name = 'Alice'): DurableIdentity {
+  return {
+    id: 'identity-alice',
+    name,
+    canonicalName: name.toLowerCase(),
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function context(json = true): {
+  ctx: Context;
+  ui: MockUI;
+  identityService: IdentityService;
+  exit: (code: number) => never;
+} {
+  const jsonCalls: unknown[] = [];
+  const ui = {
+    jsonCalls,
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    table: vi.fn(),
+    json(value: unknown) {
+      jsonCalls.push(value);
+    },
+  } as unknown as MockUI;
+  const identityService = {
+    bindCurrent: vi.fn(),
+    bindPane: vi.fn(),
+    unbindCurrent: vi.fn(),
+    currentIdentity: vi.fn(),
+    resolveIdentity: vi.fn(),
+    activeIdentities: vi.fn(() => []),
+    resolveActive: vi.fn(),
+    reconcile: vi.fn(),
+    createIdentity: vi.fn(() => ({ identity: identity(), created: true })),
+    showIdentity: vi.fn(() => identity()),
+    listIdentities: vi.fn(() => [identity()]),
+  } satisfies IdentityService;
+  const exit = ((code: number): never => {
+    throw new Error(`exit(${code})`);
+  }) as (code: number) => never;
+  const ctx = {
+    argv: [],
+    flags: { json, verbose: false },
+    ui,
+    identityService,
+    exit,
+    get config(): never {
+      throw new Error('config must not be accessed');
+    },
+    get tmux(): never {
+      throw new Error('tmux must not be accessed');
+    },
+  } as unknown as Context;
+  return { ctx, ui, identityService, exit };
+}
+
+describe('cmdIdentity', () => {
+  it('creates through the service and publishes only the public JSON DTO', () => {
+    const { ctx, ui, identityService } = context();
+    cmdIdentity(ctx, { kind: 'identity', operation: 'create', name: ' Alice ' });
+
+    expect(identityService.createIdentity).toHaveBeenCalledWith(' Alice ');
+    expect(ui.jsonCalls).toEqual([
+      {
+        identity: { id: 'identity-alice', name: 'Alice', canonicalName: 'alice' },
+        created: true,
+      },
+    ]);
+  });
+
+  it('shows and lists explicit identities without consulting config or tmux', () => {
+    const shown = context();
+    cmdIdentity(shown.ctx, { kind: 'identity', operation: 'show', name: 'alice' });
+    expect(shown.identityService.showIdentity).toHaveBeenCalledWith('alice');
+    expect(shown.ui.jsonCalls).toEqual([
+      { identity: { id: 'identity-alice', name: 'Alice', canonicalName: 'alice' } },
+    ]);
+
+    const listed = context();
+    cmdIdentity(listed.ctx, { kind: 'identity', operation: 'list' });
+    expect(listed.identityService.listIdentities).toHaveBeenCalledOnce();
+    expect(listed.ui.jsonCalls).toEqual([
+      { identities: [{ id: 'identity-alice', name: 'Alice', canonicalName: 'alice' }] },
+    ]);
+  });
+
+  it('keeps human output semantic and concise', () => {
+    const create = context(false);
+    cmdIdentity(create.ctx, { kind: 'identity', operation: 'create', name: 'Alice' });
+    const createdMessage = vi.mocked(create.ui.success).mock.calls[0]?.[0];
+    expect(createdMessage).toMatch(/created/i);
+    expect(createdMessage).toContain('Alice');
+    expect(createdMessage).toContain('identity-alice');
+
+    const existing = context(false);
+    vi.mocked(existing.identityService.createIdentity).mockReturnValue({
+      identity: identity(),
+      created: false,
+    });
+    cmdIdentity(existing.ctx, { kind: 'identity', operation: 'create', name: 'Alice' });
+    const existingMessage = vi.mocked(existing.ui.success).mock.calls[0]?.[0];
+    expect(existingMessage).toMatch(/already exists/i);
+    expect(existingMessage).toContain('Alice');
+    expect(existingMessage).toContain('identity-alice');
+
+    const show = context(false);
+    cmdIdentity(show.ctx, { kind: 'identity', operation: 'show', name: 'Alice' });
+    expect(show.ui.table).toHaveBeenCalledWith(
+      ['NAME', 'CANONICAL NAME', 'ID'],
+      [['Alice', 'alice', 'identity-alice']]
+    );
+
+    const list = context(false);
+    cmdIdentity(list.ctx, { kind: 'identity', operation: 'list' });
+    expect(list.ui.table).toHaveBeenCalledWith(['NAME', 'ID'], [['Alice', 'identity-alice']]);
+
+    const empty = context(false);
+    vi.mocked(empty.identityService.listIdentities).mockReturnValue([]);
+    cmdIdentity(empty.ctx, { kind: 'identity', operation: 'list' });
+    expect(empty.ui.info).toHaveBeenCalledWith('No durable identities found.');
+  });
+
+  it.each([
+    [new IdentityServiceError('INVALID_NAME', 'Identity name is invalid.'), 'INVALID_NAME', 1],
+    [
+      new IdentitySelectionError('NAME_NOT_FOUND', "Identity 'missing' was not found."),
+      'NAME_NOT_FOUND',
+      3,
+    ],
+  ] as const)('maps expected error %s to JSON and exit %i', (error, code, exitCode) => {
+    const { ctx, ui, identityService } = context();
+    vi.mocked(identityService.showIdentity).mockImplementation(() => {
+      throw error;
+    });
+
+    expect(() =>
+      cmdIdentity(ctx, { kind: 'identity', operation: 'show', name: 'missing' })
+    ).toThrow(`exit(${exitCode})`);
+    expect(ui.jsonCalls).toEqual([{ error: { code, message: error.message } }]);
+  });
+
+  it('sanitizes unexpected service failures while preserving the public error code', () => {
+    const { ctx, ui, identityService } = context();
+    vi.mocked(identityService.listIdentities).mockImplementation(() => {
+      throw new Error('SQLITE_BUSY: /private/secret/database.db');
+    });
+
+    expect(() => cmdIdentity(ctx, { kind: 'identity', operation: 'list' })).toThrow('exit(1)');
+    expect(ui.jsonCalls).toEqual([
+      { error: { code: 'IDENTITY_ERROR', message: 'Could not complete the identity operation.' } },
+    ]);
+    expect(JSON.stringify(ui.jsonCalls)).not.toContain('secret');
+  });
+
+  it('sanitizes unexpected human failures without ANSI-sensitive snapshots', () => {
+    const { ctx, ui, identityService } = context(false);
+    vi.mocked(identityService.createIdentity).mockImplementation(() => {
+      throw new Error('database secret leaked');
+    });
+
+    expect(() =>
+      cmdIdentity(ctx, { kind: 'identity', operation: 'create', name: 'Alice' })
+    ).toThrow('exit(1)');
+    expect(ui.error).toHaveBeenCalledWith('Could not complete the identity operation.');
+    expect(JSON.stringify(vi.mocked(ui.error).mock.calls)).not.toContain('secret');
+  });
+});

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -1,0 +1,49 @@
+import type { Context } from '../types.js';
+import type { IdentityRequest } from '../cli/requests.js';
+import { publicIdentity } from '../domain/identity.js';
+import { IdentityServiceError } from '../identity-service.js';
+import { IdentitySelectionError } from '../identity-context.js';
+import { ExitCodes } from '../exits.js';
+
+/** Storage-only identity operations; presence remains owned by the list command. */
+export function cmdIdentity(ctx: Context, request: IdentityRequest): void {
+  try {
+    const service = ctx.identityService;
+    if (request.operation === 'list') {
+      const identities = service.listIdentities().map(publicIdentity);
+      if (ctx.flags.json) ctx.ui.json({ identities });
+      else if (identities.length === 0) ctx.ui.info('No durable identities found.');
+      else
+        ctx.ui.table(
+          ['NAME', 'ID'],
+          identities.map((identity) => [identity.name, identity.id])
+        );
+      return;
+    }
+    if (request.operation === 'create') {
+      const result = service.createIdentity(request.name);
+      const identity = publicIdentity(result.identity);
+      if (ctx.flags.json) ctx.ui.json({ identity, created: result.created });
+      else
+        ctx.ui.success(
+          `${result.created ? 'Created' : 'Already exists:'} identity '${identity.name}' (${identity.id}).`
+        );
+      return;
+    }
+    const identity = publicIdentity(service.showIdentity(request.name));
+    if (ctx.flags.json) ctx.ui.json({ identity });
+    else
+      ctx.ui.table(
+        ['NAME', 'CANONICAL NAME', 'ID'],
+        [[identity.name, identity.canonicalName, identity.id]]
+      );
+  } catch (error) {
+    const expected =
+      error instanceof IdentityServiceError || error instanceof IdentitySelectionError;
+    const code = expected ? error.code : 'IDENTITY_ERROR';
+    const message = expected ? error.message : 'Could not complete the identity operation.';
+    if (ctx.flags.json) ctx.ui.json({ error: { code, message } });
+    else ctx.ui.error(message);
+    ctx.exit(code === 'NAME_NOT_FOUND' ? ExitCodes.NAME_NOT_FOUND : ExitCodes.ERROR);
+  }
+}

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -43,6 +43,15 @@ function createCtx(testDir: string, overrides?: Partial<{ flags: Partial<Flags> 
     config,
     tmux,
     identityService: {
+      createIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity creation.');
+      }),
+      showIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity lookup.');
+      }),
+      listIdentities: vi.fn(() => {
+        throw new Error('Unexpected durable identity listing.');
+      }),
       bindCurrent: vi.fn(),
       bindPane: vi.fn(),
       unbindCurrent: vi.fn(),

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -21,7 +21,7 @@ ${colors.yellow('WHAT IS TMUX-TEAM?')}
 
 ${colors.yellow('CORE CONCEPT')}
 
-  Each agent runs in its own tmux pane. When you talk to another agent:
+  A recipient runs in a tmux pane; the caller does not have to. When you talk:
   1. Your message is pasted via a tmux buffer
   2. tmux-team waits briefly, then sends Enter to submit
   3. The recipient submits its complete final through tmt reply
@@ -34,6 +34,18 @@ ${colors.yellow('ESSENTIAL COMMANDS')}
   ${colors.green('tmux-team check')} <target> [lines]  Read pane output
   ${colors.green('tmux-team talk')} <target> "<msg>" --detach  Send without waiting
   ${colors.green('tmux-team result')} <request-id> --json      Retrieve a retained final
+
+${colors.yellow('DURABLE IDENTITIES')}
+
+  tmt identity create coordinator --json
+  tmt identity show coordinator --json
+  tmt identity list --json
+
+  These commands work inside or outside tmux. Repeated creation preserves the
+  existing UUID, display name, profiles and pane binding. Nothing logs in or
+  binds automatically. identity list includes unbound identities; ordinary
+  list shows active destinations. Use talk --identity coordinator for explicit
+  local attribution, not authentication. A recipient still needs a live pane.
 
 ${colors.yellow('DURABLE REPLIES AND RESULTS')}
 

--- a/src/commands/name.test.ts
+++ b/src/commands/name.test.ts
@@ -26,6 +26,15 @@ function context(json = false): Context {
     setPaneTitle: vi.fn(),
   };
   const identityService: IdentityService = {
+    createIdentity: vi.fn(() => {
+      throw new Error('Unexpected durable identity creation.');
+    }),
+    showIdentity: vi.fn(() => {
+      throw new Error('Unexpected durable identity lookup.');
+    }),
+    listIdentities: vi.fn(() => {
+      throw new Error('Unexpected durable identity listing.');
+    }),
     bindCurrent: vi.fn(() => identity()),
     bindPane: vi.fn(() => identity()),
     unbindCurrent: vi.fn(),

--- a/src/commands/preamble.test.ts
+++ b/src/commands/preamble.test.ts
@@ -57,6 +57,15 @@ function createContext(service: PreambleService, flags: Partial<Context['flags']
     },
     preambleService: service,
     identityService: {
+      createIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity creation.');
+      }),
+      showIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity lookup.');
+      }),
+      listIdentities: vi.fn(() => {
+        throw new Error('Unexpected durable identity listing.');
+      }),
       bindCurrent: vi.fn(),
       bindPane: vi.fn(),
       unbindCurrent: vi.fn(),

--- a/src/commands/role.test.ts
+++ b/src/commands/role.test.ts
@@ -22,6 +22,15 @@ function context(service: RoleService, json = true): Context & { output: unknown
     config: {} as Context['config'],
     tmux: {} as Context['tmux'],
     identityService: {
+      createIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity creation.');
+      }),
+      showIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity lookup.');
+      }),
+      listIdentities: vi.fn(() => {
+        throw new Error('Unexpected durable identity listing.');
+      }),
       bindCurrent: vi.fn(),
       bindPane: vi.fn(),
       unbindCurrent: vi.fn(),

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -272,6 +272,15 @@ function createContext(
     config: overrides.config ?? createConfig(),
     tmux: overrides.tmux ?? createMockTmux(),
     identityService: {
+      createIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity creation.');
+      }),
+      showIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity lookup.');
+      }),
+      listIdentities: vi.fn(() => {
+        throw new Error('Unexpected durable identity listing.');
+      }),
       bindCurrent: vi.fn(),
       bindPane: vi.fn(),
       unbindCurrent: vi.fn(),

--- a/src/commands/unsupported-team.test.ts
+++ b/src/commands/unsupported-team.test.ts
@@ -18,6 +18,15 @@ function context(json: boolean): Context {
     config: {} as Context['config'],
     tmux: {} as Context['tmux'],
     identityService: {
+      createIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity creation.');
+      }),
+      showIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity lookup.');
+      }),
+      listIdentities: vi.fn(() => {
+        throw new Error('Unexpected durable identity listing.');
+      }),
       bindCurrent: vi.fn(),
       bindPane: vi.fn(),
       unbindCurrent: vi.fn(),

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -16,6 +16,15 @@ function context(json = false): Context {
     config: {} as Context['config'],
     tmux: {} as Context['tmux'],
     identityService: {
+      createIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity creation.');
+      }),
+      showIdentity: vi.fn(() => {
+        throw new Error('Unexpected durable identity lookup.');
+      }),
+      listIdentities: vi.fn(() => {
+        throw new Error('Unexpected durable identity listing.');
+      }),
       bindCurrent: vi.fn(),
       bindPane: vi.fn(),
       unbindCurrent: vi.fn(),

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -17,6 +17,15 @@ function identity(name = 'alice') {
 function context(json = false): Context {
   const current = { identity: identity() };
   const identityService: IdentityService = {
+    createIdentity: vi.fn(() => {
+      throw new Error('Unexpected durable identity creation.');
+    }),
+    showIdentity: vi.fn(() => {
+      throw new Error('Unexpected durable identity lookup.');
+    }),
+    listIdentities: vi.fn(() => {
+      throw new Error('Unexpected durable identity listing.');
+    }),
     bindCurrent: vi.fn(),
     bindPane: vi.fn(),
     unbindCurrent: vi.fn(() => identity()),

--- a/src/domain/identity.ts
+++ b/src/domain/identity.ts
@@ -7,6 +7,17 @@ export interface DurableIdentity {
   readonly updatedAt: string;
 }
 
+/** Public identity fields safe to include in command results. */
+export type PublicIdentity = Pick<DurableIdentity, 'id' | 'name' | 'canonicalName'>;
+
+export function publicIdentity(identity: DurableIdentity): PublicIdentity {
+  return {
+    id: identity.id,
+    name: identity.name,
+    canonicalName: identity.canonicalName,
+  };
+}
+
 /** Transient evidence that a durable identity is bound to one tmux pane instance. */
 export interface TmuxBinding {
   readonly id: string;

--- a/src/identity-cli-contract.test.ts
+++ b/src/identity-cli-contract.test.ts
@@ -1,0 +1,220 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  expectJsonSuccess,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+} from './test-support/cli-process.js';
+import type { PublicIdentity } from './domain/identity.js';
+
+function forbidTmux(sandbox: Parameters<typeof runCli>[0]): string {
+  const wrapperDirectory = path.join(sandbox.root, 'forbidden-bin');
+  const logPath = path.join(sandbox.root, 'tmux-invocations.log');
+  mkdirSync(wrapperDirectory);
+  const wrapperPath = path.join(wrapperDirectory, 'tmux');
+  writeFileSync(
+    wrapperPath,
+    '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TMT_IDENTITY_TMUX_LOG"\nexit 97\n'
+  );
+  chmodSync(wrapperPath, 0o755);
+  sandbox.env.PATH = `${wrapperDirectory}${path.delimiter}${process.env.PATH ?? ''}`;
+  sandbox.env.TMT_IDENTITY_TMUX_LOG = logPath;
+  return logPath;
+}
+
+function assertPublicIdentity(value: unknown): asserts value is PublicIdentity {
+  expect(value).toEqual({
+    id: expect.any(String),
+    name: expect.any(String),
+    canonicalName: expect.any(String),
+  });
+  expect(Object.keys(value as object).sort()).toEqual(['canonicalName', 'id', 'name']);
+  expect((value as PublicIdentity).id).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  );
+}
+
+describe('real CLI durable identity contract', () => {
+  it(
+    'creates, shows, and lists storage-only identities with stable canonical rows',
+    { timeout: 10_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        const globalConfig = '{ malformed global config';
+        const localConfig = '{ malformed local config';
+        mkdirSync(sandbox.globalDir, { recursive: true });
+        writeFileSync(sandbox.globalConfig, globalConfig);
+        writeFileSync(sandbox.localConfig, localConfig);
+        const tmuxLog = forbidTmux(sandbox);
+
+        const first = await runCli(sandbox, ['identity', 'create', '  Alice  ', '--json']);
+        expect(first.status).toBe(0);
+        expect(first.stderr).toBe('');
+        const firstDocument = parseWholeStdout(first) as {
+          identity: PublicIdentity;
+          created: boolean;
+        };
+        expect(firstDocument.created).toBe(true);
+        assertPublicIdentity(firstDocument.identity);
+        expect(firstDocument.identity).toEqual({
+          id: firstDocument.identity.id,
+          name: 'Alice',
+          canonicalName: 'alice',
+        });
+        const identityId = firstDocument.identity.id;
+
+        const repeated = await runCli(sandbox, ['identity', 'create', 'ALICE', '--json']);
+        expectJsonSuccess(repeated, {
+          identity: { id: identityId, name: 'Alice', canonicalName: 'alice' },
+          created: false,
+        });
+
+        const shown = await runCli(sandbox, ['identity', 'show', 'alice', '--json']);
+        expectJsonSuccess(shown, {
+          identity: { id: identityId, name: 'Alice', canonicalName: 'alice' },
+        });
+
+        const listed = await runCli(sandbox, ['identity', 'list', '--json']);
+        expectJsonSuccess(listed, {
+          identities: [{ id: identityId, name: 'Alice', canonicalName: 'alice' }],
+        });
+
+        expect(readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalConfig);
+        expect(readFileSync(sandbox.localConfig, 'utf8')).toBe(localConfig);
+        expect(existsSync(tmuxLog)).toBe(false);
+      })
+  );
+
+  it(
+    'calibrates the tmux invocation guard with a command that needs tmux',
+    { timeout: 10_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        const tmuxLog = forbidTmux(sandbox);
+        const activeList = await runCli(sandbox, ['list', '--json']);
+        expect(activeList.status).toBe(1);
+        expect(existsSync(tmuxLog)).toBe(true);
+      })
+  );
+
+  it(
+    'maps invalid names to INVALID_NAME with exit status 1 and no created row',
+    { timeout: 10_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        for (const name of ['%12', '10.3']) {
+          const result = await runCli(sandbox, ['identity', 'create', name, '--json']);
+          expect(result.status, name).toBe(1);
+          expect(result.stderr, name).toBe('');
+          expectError(result, 'INVALID_NAME');
+        }
+
+        const listed = await runCli(sandbox, ['identity', 'list', '--json']);
+        expectJsonSuccess(listed, { identities: [] });
+      })
+  );
+
+  it(
+    'maps a valid but missing show name to NAME_NOT_FOUND with exit status 3',
+    { timeout: 10_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        const result = await runCli(sandbox, ['identity', 'show', 'Missing', '--json']);
+        expect(result.status).toBe(3);
+        expect(result.stderr).toBe('');
+        expect(parseWholeStdout(result)).toEqual({
+          error: { code: 'NAME_NOT_FOUND', message: "Identity 'Missing' was not found." },
+        });
+      })
+  );
+
+  it(
+    'keeps explicit role access storage-only for a durable identity',
+    { timeout: 10_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        mkdirSync(sandbox.globalDir, { recursive: true });
+        writeFileSync(sandbox.globalConfig, '{ malformed');
+        writeFileSync(sandbox.localConfig, '{ malformed');
+        const tmuxLog = forbidTmux(sandbox);
+
+        const created = await runCli(sandbox, ['identity', 'create', 'RoleUser', '--json']);
+        expect(created.status).toBe(0);
+        expect(created.stderr).toBe('');
+        const createdDocument = parseWholeStdout(created) as {
+          identity: PublicIdentity;
+        };
+        assertPublicIdentity(createdDocument.identity);
+
+        const set = await runCli(sandbox, [
+          'role',
+          'set',
+          'durable role content',
+          '--identity',
+          'roleuser',
+          '--json',
+        ]);
+        expect(set.status).toBe(0);
+        expect(set.stderr).toBe('');
+        const setDocument = parseWholeStdout(set) as {
+          identity: PublicIdentity;
+          role: { content: string; updatedAt: string };
+        };
+        expect(setDocument.identity).toEqual(createdDocument.identity);
+        expect(setDocument.role.content).toBe('durable role content');
+        expect(setDocument.role.updatedAt).toEqual(expect.any(String));
+
+        const shown = await runCli(sandbox, ['role', 'show', '--identity', 'ROLEUSER', '--json']);
+        expect(shown.status).toBe(0);
+        expect(shown.stderr).toBe('');
+        expect(parseWholeStdout(shown)).toEqual(setDocument);
+        expect(readFileSync(sandbox.globalConfig, 'utf8')).toBe('{ malformed');
+        expect(readFileSync(sandbox.localConfig, 'utf8')).toBe('{ malformed');
+        expect(existsSync(tmuxLog)).toBe(false);
+      })
+  );
+
+  it(
+    'rejects identity grammar failures before creating storage rows',
+    { timeout: 10_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        for (const args of [
+          ['identity', '--json'],
+          ['identity', 'create', '--json'],
+          ['identity', 'show', '--json'],
+          ['identity', 'create', 'Alice', 'extra', '--json'],
+          ['identity', 'list', 'extra', '--json'],
+        ]) {
+          const result = await runCli(sandbox, args);
+          expect(result.status, args.join(' ')).toBe(1);
+          expect(result.stderr, args.join(' ')).toBe('');
+          expectError(result, 'USAGE_ERROR');
+          expect(existsSync(sandbox.database), args.join(' ')).toBe(false);
+        }
+
+        const created = await runCli(sandbox, ['identity', 'create', 'Alice', '--json']);
+        expectJsonSuccess(created, {
+          identity: expect.objectContaining({ name: 'Alice', canonicalName: 'alice' }),
+          created: true,
+        });
+        const beforeInvalidGrammar = parseWholeStdout(created) as { identity: PublicIdentity };
+        const invalidGrammar = await runCli(sandbox, [
+          'identity',
+          'create',
+          'Alice',
+          'extra',
+          '--json',
+        ]);
+        expect(invalidGrammar.status).toBe(1);
+        expectError(invalidGrammar, 'USAGE_ERROR');
+        const listed = await runCli(sandbox, ['identity', 'list', '--json']);
+        expectJsonSuccess(listed, {
+          identities: [beforeInvalidGrammar.identity],
+        });
+      })
+  );
+});

--- a/src/identity-concurrency.test.ts
+++ b/src/identity-concurrency.test.ts
@@ -18,6 +18,50 @@ afterEach(() => {
 });
 
 describe('identity repository multi-process races', () => {
+  it('creates one durable identity for equivalent names without creating a binding', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-concurrency-'));
+    directories.push(directory);
+    const barrier = path.join(directory, 'barrier');
+    fs.mkdirSync(barrier);
+    const databaseFile = path.join(directory, 'tmux-team.db');
+    const worker = new URL(
+      './test-support/workers/identity-concurrency-worker.ts',
+      import.meta.url
+    );
+    const handles = ['a', 'b'].map((variant) =>
+      spawnWorker(worker, [databaseFile, barrier, variant, 'create'], variant, directory)
+    );
+    try {
+      await waitForFiles(
+        ['a', 'b'].map((variant) => path.join(barrier, `ready-${variant}`)),
+        handles
+      );
+      fs.writeFileSync(path.join(barrier, 'go'), 'go');
+      const results = await collectResults(handles);
+      const messages = results.map((result) =>
+        workerMessage<{ id: string; created: boolean }>(result)
+      );
+      expect(messages.map((message) => message.id)).toEqual([messages[0]?.id, messages[0]?.id]);
+      expect(messages.map((message) => message.created).sort()).toEqual([false, true]);
+
+      const repository = openIdentityRepository(databaseFile);
+      try {
+        const identities = repository.listIdentities();
+        expect(identities).toHaveLength(1);
+        expect(identities[0]).toMatchObject({
+          id: messages[0]?.id,
+          canonicalName: 'alice',
+        });
+        expect(['Ａｌｉｃｅ', 'alice']).toContain(identities[0]?.name);
+        expect(repository.findBindings()).toHaveLength(0);
+      } finally {
+        repository.close();
+      }
+    } finally {
+      await stopWorkers(handles);
+    }
+  }, 30_000);
+
   it('converges equivalent names to one identity and one binding', async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-concurrency-'));
     directories.push(directory);

--- a/src/identity-service.test.ts
+++ b/src/identity-service.test.ts
@@ -130,6 +130,104 @@ describe('durable identity service', () => {
     );
   });
 
+  it('creates standalone identities idempotently without consulting tmux', () => {
+    const test = fixture();
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    repositories.push(repository);
+    const service = createIdentityService({ tmux: test.tmux, repository });
+    const bound = service.bindCurrent('Bound');
+    const role = repository.setRole(bound.id, 'bound profile');
+    const preamble = repository.setPreamble(bound.id, 'bound preamble');
+    const binding = repository.findBindings();
+    const snapshot = vi.spyOn(test.tmux, 'getEndpointSnapshot');
+    const currentPane = vi.spyOn(test.tmux, 'getCurrentPaneId');
+    const transaction = vi.spyOn(repository, 'withImmediateTransaction');
+
+    const first = service.createIdentity('  Standalone  ');
+    const second = service.createIdentity('standalone');
+    expect(service.createIdentity('BOUND')).toEqual({ identity: bound, created: false });
+
+    expect(first.created).toBe(true);
+    expect(first.identity).toMatchObject({
+      name: 'Standalone',
+      canonicalName: 'standalone',
+      id: expect.any(String),
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+    });
+    expect(first.identity.createdAt).toBe(first.identity.updatedAt);
+    expect(second).toEqual({ identity: first.identity, created: false });
+    expect(() => service.createIdentity('%2')).toThrowError(
+      expect.objectContaining({ code: 'INVALID_NAME' })
+    );
+    expect(transaction).toHaveBeenCalledTimes(3);
+    expect(snapshot).not.toHaveBeenCalled();
+    expect(currentPane).not.toHaveBeenCalled();
+    expect(repository.findBindings()).toEqual(binding);
+    expect(repository.findRole(bound.id)).toEqual(role);
+    expect(repository.findPreamble(bound.id)).toEqual(preamble);
+  });
+
+  it('rolls back a standalone identity insert when its immediate transaction fails', () => {
+    const test = fixture();
+    const base = openIdentityRepository(test.paths.databaseFile);
+    const repository = {
+      ...base,
+      withImmediateTransaction<T>(operation: () => T): T {
+        return base.withImmediateTransaction(() => {
+          operation();
+          throw new Error('abort after identity insert');
+        });
+      },
+    };
+    const service = createIdentityService({ tmux: test.tmux, repository });
+
+    try {
+      expect(() => service.createIdentity('rolled-back')).toThrow('abort after identity insert');
+      expect(base.findByCanonicalName('rolled-back')).toBeUndefined();
+    } finally {
+      base.close();
+    }
+  });
+
+  it('shows existing identities, rejects invalid names, and reports missing names', () => {
+    const test = fixture();
+    const service = createTestService(test);
+    // Fullwidth Latin tests canonical normalization without changing display text.
+    const identity = service.createIdentity(' Ａｌｉｃｅ ').identity;
+    const snapshot = vi.spyOn(test.tmux, 'getEndpointSnapshot');
+    const currentPane = vi.spyOn(test.tmux, 'getCurrentPaneId');
+
+    expect(service.showIdentity('alice')).toEqual(identity);
+    expect(() => service.showIdentity('missing')).toThrowError(
+      expect.objectContaining({ code: 'NAME_NOT_FOUND' })
+    );
+    expect(() => service.showIdentity('%1')).toThrowError(
+      expect.objectContaining({ code: 'INVALID_NAME' })
+    );
+    expect(snapshot).not.toHaveBeenCalled();
+    expect(currentPane).not.toHaveBeenCalled();
+  });
+
+  it('lists durable identities in canonical order with profiles and bindings intact', () => {
+    const test = fixture();
+    const service = createTestService(test);
+    const bound = service.bindCurrent('Zulu');
+    const repository = openIdentityRepository(test.paths.databaseFile);
+    repositories.push(repository);
+    repository.setRole(bound.id, 'keep this profile');
+    const snapshot = vi.spyOn(test.tmux, 'getEndpointSnapshot');
+    const currentPane = vi.spyOn(test.tmux, 'getCurrentPaneId');
+    const alpha = service.createIdentity('Alpha').identity;
+    const middle = service.createIdentity('middle').identity;
+
+    expect(service.listIdentities()).toEqual([alpha, middle, bound]);
+    expect(snapshot).not.toHaveBeenCalled();
+    expect(currentPane).not.toHaveBeenCalled();
+    expect(repository.findBindings()).toHaveLength(1);
+    expect(repository.findRole(bound.id)).toMatchObject({ content: 'keep this profile' });
+  });
+
   it('rejects invalid names before creating durable state', () => {
     const test = fixture();
     const service = createTestService(test);
@@ -1043,16 +1141,20 @@ describe('durable identity service', () => {
     const test = fixture();
     const base = openIdentityRepository(test.paths.databaseFile);
     const observer = openIdentityRepository(test.paths.databaseFile);
+    let observedSecondCommit = false;
     const repository = {
       ...base,
-      createIdentity(name: string, canonicalName: string) {
-        const identity = base.createIdentity(name, canonicalName);
-        // Observation alone must preserve the committed UUID; no profile row
-        // exists to trigger the former feature-specific deletion guards.
-        if (canonicalName === 'second') {
-          expect(observer.findByCanonicalName(canonicalName)).toEqual(identity);
+      withImmediateTransaction<T>(operation: () => T): T {
+        const result = base.withImmediateTransaction(operation);
+        if (!observedSecondCommit && observer.findByCanonicalName('second')) {
+          // The second identity transaction has committed before the
+          // separate binding publication transaction starts.
+          expect(observer.findByCanonicalName('second')).toEqual(
+            expect.objectContaining({ canonicalName: 'second' })
+          );
+          observedSecondCommit = true;
         }
-        return identity;
+        return result;
       },
     };
     const service = createIdentityService({ tmux: test.tmux, repository });
@@ -1061,6 +1163,7 @@ describe('durable identity service', () => {
       expect(() => service.bindCurrent('second')).toThrowError(
         new IdentityServiceError('PANE_ALREADY_BOUND', 'Pane is already bound to another name.')
       );
+      expect(observedSecondCommit).toBe(true);
       const identities = observer.listIdentities();
       expect(identities.map(({ canonicalName }) => canonicalName)).toEqual(['first', 'second']);
       expect(observer.findBindings()).toMatchObject([{ identityId: identities[0]?.id }]);

--- a/src/identity-service.ts
+++ b/src/identity-service.ts
@@ -2,6 +2,7 @@ import { performance } from 'node:perf_hooks';
 import { validateName } from './domain/names.js';
 import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
 import {
+  requireDurableIdentity,
   resolveDurableIdentity,
   IdentitySelectionError,
   type IdentitySelector,
@@ -17,6 +18,7 @@ import type {
   TmuxEndpointSnapshot,
   TmuxOperationOptions,
   TmuxServerEvidence,
+  IdentityCreationResult,
 } from './types.js';
 
 const PUBLICATION_TIMEOUT_MS = 3_000;
@@ -199,21 +201,17 @@ function mapActive(
   });
 }
 
-function createOrResolve(repository: IdentityRepository, name: string): DurableIdentity {
+function createOrResolve(repository: IdentityRepository, name: string): IdentityCreationResult {
   const valid = validateName(name);
   if (!valid.ok) throw new IdentityServiceError(valid.error.code, valid.error.message);
-  const existing = repository.findByCanonicalName(valid.value.canonicalName);
-  if (existing) return existing;
-  try {
-    return repository.createIdentity(valid.value.name, valid.value.canonicalName);
-  } catch (error) {
-    // A concurrent creator may win the canonical unique constraint.
-    const raced = repository.findByCanonicalName(valid.value.canonicalName);
-    if (raced) return raced;
-    throw new IdentityServiceError('RECONCILIATION_FAILED', 'Could not create durable identity.', {
-      cause: error,
-    });
-  }
+  return repository.withImmediateTransaction(() => {
+    const existing = repository.findByCanonicalName(valid.value.canonicalName);
+    if (existing) return { identity: existing, created: false };
+    return {
+      identity: repository.createIdentity(valid.value.name, valid.value.canonicalName),
+      created: true,
+    };
+  });
 }
 
 function paneEvidence(snapshot: TmuxEndpointSnapshot, paneId: string): PaneInfo {
@@ -352,7 +350,19 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
     // acquired below; this preflight prevents a missing pane from leaving a
     // newly-created identity behind.
     paneEvidence(endpointSnapshot(tmux), paneId);
-    const identity = createOrResolve(repository, name);
+    let identity: DurableIdentity;
+    try {
+      identity = createOrResolve(repository, name).identity;
+    } catch (error) {
+      if (error instanceof IdentityServiceError) throw error;
+      throw new IdentityServiceError(
+        'RECONCILIATION_FAILED',
+        'Could not create durable identity.',
+        {
+          cause: error,
+        }
+      );
+    }
     return coordinated((options) => {
       const snapshot = endpointSnapshot(tmux, options);
       const pane = paneEvidence(snapshot, paneId);
@@ -447,6 +457,23 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
   };
 
   return {
+    createIdentity(name) {
+      return createOrResolve(repository, name);
+    },
+    showIdentity(name) {
+      const valid = validateName(name);
+      if (!valid.ok) throw new IdentityServiceError(valid.error.code, valid.error.message);
+      return requireDurableIdentity(
+        {
+          findByCanonicalName: (canonicalName) => repository.findByCanonicalName(canonicalName),
+          currentIdentity: () => undefined,
+        },
+        { value: name, kind: 'identity', explicit: true }
+      );
+    },
+    listIdentities() {
+      return repository.listIdentities();
+    },
     bindCurrent(name) {
       const current = tmux.getCurrentPaneId();
       if (!current)

--- a/src/role-service.ts
+++ b/src/role-service.ts
@@ -1,4 +1,4 @@
-import type { DurableIdentity, RoleProfile } from './domain/identity.js';
+import { publicIdentity, type DurableIdentity, type RoleProfile } from './domain/identity.js';
 import {
   requireDurableIdentity,
   type DurableIdentityContext,
@@ -35,7 +35,7 @@ export function createRoleService(options: RoleServiceOptions): RoleService {
   const resolve = (selector?: IdentitySelector): DurableIdentity =>
     resolveIdentity(options.repository, options.currentIdentity, selector);
   const result = (identity: DurableIdentity): RoleResult => ({
-    identity: { id: identity.id, name: identity.name, canonicalName: identity.canonicalName },
+    identity: publicIdentity(identity),
     role: options.repository.findRole(identity.id) ?? null,
   });
   return {
@@ -45,7 +45,7 @@ export function createRoleService(options: RoleServiceOptions): RoleService {
     set(selector, content) {
       const identity = resolve(selector);
       return {
-        identity: { id: identity.id, name: identity.name, canonicalName: identity.canonicalName },
+        identity: publicIdentity(identity),
         role: options.repository.setRole(identity.id, normalizeRoleContent(content)),
       };
     },
@@ -53,7 +53,7 @@ export function createRoleService(options: RoleServiceOptions): RoleService {
       const identity = resolve(selector);
       options.repository.clearRole(identity.id);
       return {
-        identity: { id: identity.id, name: identity.name, canonicalName: identity.canonicalName },
+        identity: publicIdentity(identity),
         role: null,
       };
     },

--- a/src/test-support/workers/identity-concurrency-worker.ts
+++ b/src/test-support/workers/identity-concurrency-worker.ts
@@ -6,8 +6,9 @@ import { openIdentityRepository } from '../../storage/identity-repository.js';
 import type { PaneInfo, Tmux } from '../../types.js';
 import { waitForBarrier } from './barrier.js';
 
-const [databaseFile, barrierDirectory, variant] = process.argv.slice(2);
+const [databaseFile, barrierDirectory, variant, mode = 'bind'] = process.argv.slice(2);
 if (!databaseFile || !barrierDirectory || !variant) throw new Error('Invalid worker arguments.');
+if (mode !== 'bind' && mode !== 'create') throw new Error('Invalid worker mode.');
 
 const BARRIER_TIMEOUT_MS = 30_000;
 
@@ -49,8 +50,17 @@ waitForBarrier(path.join(barrierDirectory, 'go'), BARRIER_TIMEOUT_MS);
 const repository = openIdentityRepository(databaseFile);
 try {
   const service = createIdentityService({ tmux, repository });
-  const identity = service.bindCurrent(variant === 'a' ? 'Ａｌｉｃｅ' : 'alice');
-  process.stdout.write(JSON.stringify({ ok: true, id: identity.id }) + '\n');
+  // The fullwidth spelling and its ASCII equivalent share the NFKC key.
+  const name = variant === 'a' ? 'Ａｌｉｃｅ' : 'alice';
+  if (mode === 'create') {
+    const result = service.createIdentity(name);
+    process.stdout.write(
+      JSON.stringify({ ok: true, id: result.identity.id, created: result.created }) + '\n'
+    );
+  } else {
+    const identity = service.bindCurrent(name);
+    process.stdout.write(JSON.stringify({ ok: true, id: identity.id }) + '\n');
+  }
 } catch (error) {
   process.stdout.write(JSON.stringify({ ok: false, error: String(error) }) + '\n');
   process.exitCode = 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
-import type { DurableIdentity, RoleProfile, TmuxBinding } from './domain/identity.js';
+import type {
+  DurableIdentity,
+  PublicIdentity,
+  RoleProfile,
+  TmuxBinding,
+} from './domain/identity.js';
 import type { DurableIdentityResolution, IdentitySelector } from './identity-context.js';
 import type { PreambleService } from './preamble-service.js';
 import type { RequestService } from './request-service.js';
@@ -150,7 +155,15 @@ export type TmuxEndpointProbe =
   | { readonly status: 'dead' }
   | { readonly status: 'unknown' };
 
+export interface IdentityCreationResult {
+  readonly identity: DurableIdentity;
+  readonly created: boolean;
+}
+
 export interface IdentityService {
+  createIdentity(name: string): IdentityCreationResult;
+  showIdentity(name: string): DurableIdentity;
+  listIdentities(): DurableIdentity[];
   bindCurrent(name: string): DurableIdentity;
   bindPane(pane: string, name: string): DurableIdentity;
   unbindCurrent(): DurableIdentity | undefined;
@@ -173,7 +186,7 @@ export interface RoleService {
 }
 
 export interface RoleResult {
-  readonly identity: Pick<DurableIdentity, 'id' | 'name' | 'canonicalName'>;
+  readonly identity: PublicIdentity;
   readonly role: RoleProfile | null;
 }
 

--- a/test/e2e/durable-identity.e2e.test.ts
+++ b/test/e2e/durable-identity.e2e.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type CliResult, type E2EFixture } from './harness.js';
+import { durableState } from './identity-state-oracle.js';
+
+interface PublicIdentity {
+  id: string;
+  name: string;
+  canonicalName: string;
+}
+
+interface IdentityResult {
+  identity: PublicIdentity;
+  created?: boolean;
+}
+
+function success<T>(result: CliResult<T>): T {
+  expect(result.code, result.stderr || result.stdout).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.json).toBeDefined();
+  return result.json as T;
+}
+
+async function showStoredProfile(fixture: E2EFixture, name: string): Promise<string> {
+  const result = await fixture.runJsonCli<{ identity: PublicIdentity; role: { content: string } }>(
+    ['role', 'show', '--identity', name],
+    { withoutTmux: true }
+  );
+  return success(result).role.content;
+}
+
+describe.sequential('durable identity lifecycle', () => {
+  it('creates offline, binds, restarts, and rebinds one identity without losing its profile', async () => {
+    await withE2EFixture(async (fixture) => {
+      // Fullwidth Latin and ASCII spellings are intentionally equivalent after
+      // Unicode normalization, while the first spelling remains the display name.
+      const name = 'Ａｌｉｃｅ';
+      const equivalentName = 'alice';
+      const profile = 'Keep this profile across a tmux restart: 世界.';
+      const preamble = 'Use the durable profile for this pane.';
+
+      // Creation is deliberately outside tmux: durable identity storage is not
+      // contingent on a currently reachable pane.
+      const created = success(
+        await fixture.runJsonCli<IdentityResult>(['identity', 'create', name], {
+          withoutTmux: true,
+        })
+      );
+      expect(created.created).toBe(true);
+      expect(created.identity).toMatchObject({ name, canonicalName: 'alice' });
+      expect(created.identity.id).toMatch(/^[0-9a-f-]{36}$/);
+
+      expect(
+        success(
+          await fixture.runJsonCli<{ identity: PublicIdentity }>(
+            ['identity', 'show', equivalentName],
+            { withoutTmux: true }
+          )
+        )
+      ).toEqual({ identity: created.identity });
+      expect(
+        success(
+          await fixture.runJsonCli<{ identities: PublicIdentity[] }>(['identity', 'list'], {
+            withoutTmux: true,
+          })
+        )
+      ).toEqual({ identities: [created.identity] });
+
+      expect(
+        success(
+          await fixture.runJsonCli(['role', 'set', profile, '--identity', name], {
+            withoutTmux: true,
+          })
+        )
+      ).toMatchObject({ identity: created.identity, role: { content: profile } });
+      expect(
+        success(
+          await fixture.runJsonCli(['preamble', 'set', name, preamble], { withoutTmux: true })
+        )
+      ).toEqual({ agent: name, preamble, status: 'set' });
+
+      const firstBinding = success<{ bound: true; name: string; pane: string }>(
+        await fixture.runJsonCli(['name', name])
+      );
+      expect(firstBinding).toEqual({ bound: true, name, pane: fixture.pane });
+      const stateBeforeRepeat = durableState(fixture);
+      expect(stateBeforeRepeat.identities).toHaveLength(1);
+      expect(stateBeforeRepeat.identities[0]?.id).toBe(created.identity.id);
+      expect(stateBeforeRepeat.bindings).toHaveLength(1);
+      expect(stateBeforeRepeat.bindings[0]?.identity_id).toBe(created.identity.id);
+      expect(stateBeforeRepeat.profiles).toHaveLength(1);
+
+      const repeated = success(
+        await fixture.runJsonCli<IdentityResult>(['identity', 'create', equivalentName], {
+          withoutTmux: true,
+        })
+      );
+      expect(repeated).toEqual({ identity: created.identity, created: false });
+      expect(durableState(fixture)).toEqual(stateBeforeRepeat);
+      expect(await showStoredProfile(fixture, equivalentName)).toBe(profile);
+      expect(durableState(fixture)).toEqual(stateBeforeRepeat);
+
+      const activeBeforeRestart = success<{
+        identities: Array<Omit<PublicIdentity, 'id'> & { pane: string }>;
+      }>(await fixture.runJsonCli(['list']));
+      expect(activeBeforeRestart.identities).toEqual([
+        expect.objectContaining({ name, canonicalName: 'alice', pane: fixture.pane }),
+      ]);
+
+      const preambleBeforeRestart = success<{ agent: string; preamble: string }>(
+        await fixture.runJsonCli(['preamble', 'show', equivalentName], { withoutTmux: true })
+      );
+      expect(preambleBeforeRestart).toEqual({ agent: name, preamble });
+
+      expect(success(await fixture.runJsonCli(['unbind']))).toEqual({
+        unbound: true,
+        name,
+        pane: fixture.pane,
+      });
+      expect(success(await fixture.runJsonCli(['list']))).toEqual({ identities: [] });
+
+      const restarted = await fixture.restartServer();
+      const rebound = success<{ bound: true; name: string; pane: string }>(
+        await fixture.runJsonCli(['name', equivalentName])
+      );
+      expect(rebound).toEqual({ bound: true, name, pane: restarted.pane });
+      expect(await showStoredProfile(fixture, name)).toBe(profile);
+      expect(
+        success(
+          await fixture.runJsonCli<{ agent: string; preamble: string }>(
+            ['preamble', 'show', name],
+            { withoutTmux: true }
+          )
+        )
+      ).toEqual({ agent: name, preamble });
+      expect(
+        success<{ identities: Array<Omit<PublicIdentity, 'id'> & { pane: string }> }>(
+          await fixture.runJsonCli(['list'])
+        )
+      ).toEqual({
+        identities: [
+          expect.objectContaining({ name, canonicalName: 'alice', pane: restarted.pane }),
+        ],
+      });
+      const finalState = durableState(fixture);
+      expect(finalState.identities).toEqual(stateBeforeRepeat.identities);
+      expect(finalState.profiles).toEqual(stateBeforeRepeat.profiles);
+      expect(finalState.bindings).toHaveLength(1);
+      expect(finalState.bindings[0]).toMatchObject({
+        identity_id: created.identity.id,
+        pane_id: restarted.pane,
+      });
+    });
+  }, 45_000);
+});

--- a/test/e2e/identity-lifecycle.e2e.test.ts
+++ b/test/e2e/identity-lifecycle.e2e.test.ts
@@ -3,6 +3,7 @@ import Database from 'better-sqlite3';
 import fs from 'node:fs';
 import path from 'node:path';
 import { E2EFixture, withE2EFixture, type CliResult, type MockPane } from './harness.js';
+import { durableState } from './identity-state-oracle.js';
 
 interface Identity {
   name: string;
@@ -36,33 +37,6 @@ async function listIdentities(fixture: E2EFixture): Promise<IdentityListItem[]> 
 
 function metadata(fixture: E2EFixture, pane: MockPane): Record<string, unknown> {
   return JSON.parse(fixture.paneMetadata(pane.pane)) as Record<string, unknown>;
-}
-
-interface DurableState {
-  identities: Array<Record<string, unknown>>;
-  bindings: Array<Record<string, unknown>>;
-  profiles: Array<Record<string, unknown>>;
-}
-
-function durableState(fixture: E2EFixture): DurableState {
-  const database = new Database(path.join(fixture.globalDir, 'tmux-team.db'), {
-    readonly: true,
-  });
-  try {
-    return {
-      identities: database
-        .prepare('SELECT * FROM identities ORDER BY canonical_name')
-        .all() as Array<Record<string, unknown>>,
-      bindings: database.prepare('SELECT * FROM bindings ORDER BY identity_id').all() as Array<
-        Record<string, unknown>
-      >,
-      profiles: database.prepare('SELECT * FROM role_profiles ORDER BY identity_id').all() as Array<
-        Record<string, unknown>
-      >,
-    };
-  } finally {
-    database.close();
-  }
 }
 
 function withoutVerificationTimestamp(

--- a/test/e2e/identity-state-oracle.ts
+++ b/test/e2e/identity-state-oracle.ts
@@ -1,0 +1,29 @@
+import Database from 'better-sqlite3';
+import path from 'node:path';
+import type { E2EFixture } from './harness.js';
+
+export interface DurableState {
+  identities: Array<Record<string, unknown>>;
+  bindings: Array<Record<string, unknown>>;
+  profiles: Array<Record<string, unknown>>;
+}
+
+/** Observe committed identity state without service reconciliation or writes. */
+export function durableState(fixture: E2EFixture): DurableState {
+  const database = new Database(path.join(fixture.globalDir, 'tmux-team.db'), { readonly: true });
+  try {
+    return {
+      identities: database
+        .prepare('SELECT * FROM identities ORDER BY canonical_name')
+        .all() as Array<Record<string, unknown>>,
+      bindings: database.prepare('SELECT * FROM bindings ORDER BY identity_id').all() as Array<
+        Record<string, unknown>
+      >,
+      profiles: database.prepare('SELECT * FROM role_profiles ORDER BY identity_id').all() as Array<
+        Record<string, unknown>
+      >,
+    };
+  } finally {
+    database.close();
+  }
+}


### PR DESCRIPTION
## Scope

- Issue: [TMT-30](https://linear.app/tigerpig-dev/issue/TMT-30/add-explicit-non-tmux-identity-creation-and-durable-identity-discovery)
- Add explicit `tmt identity create <name>`, `show <name>` and `list`, identically inside and outside tmux.
- Create returns `{identity:{id,name,canonicalName},created}`; canonical repeats preserve the UUID, original display name, timestamps, profiles and binding. Show/list expose the same narrow identity projection, including unbound identities.
- Existing active `list`, `name`, `this`, `add`, anonymous talk and request-ID results retain their contracts. No schema/dependency, login, authentication, automatic binding, rename/delete, attention, listener, memory or MCP work is included. Pane labels are separately tracked in TMT-56.

## Architecture and review

- Reuse the existing IdentityService/repository and shared name selector. One immediate creation transaction produces truthful concurrent `created` results; binding retains separate durable-creation and endpoint-publication commits.
- Share the pure public identity projection with role results. CLI grammar/dispatch remain typed and storage-only, without SQL in commands or a second service/registry.
- Primary reviewer: Codex. Reviewed every changed file and relevant parser, context, selector, repository, binding and role callers; reviewed commit: `4bead5c2fcf6b0ac84b1559dfe173bfc2999d803`.
- Corrected redundant transactional recovery, an invalid commit-observation assertion, delegated test type errors, an incorrect active-list UUID assumption, duplicate E2E state inspectors, and missing no-tmux guard coverage for explicit role access.
- Replaced repeated runner module-cache resets with stable isolated mocks and one import after two existing argument-validation cases timed out in separate full runs. Preserved all cases and the original timeout; strengthened dispatch assertions. Parser, runner and startup behavior remain real in this suite; real subprocess coverage remains separate.
- Gemini supplied a read-only no-findings review. A focused second review found the role guard gap above; primary fixed it. Independent approval did not replace primary review.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge: all 10 checks passed in [run 34034674716](https://github.com/wkh237/tmux-team/actions/runs/34034674716) on `4bead5c2fcf6b0ac84b1559dfe173bfc2999d803`; merge state CLEAN.

Local Node 24.20.0; Docker uses the repository's pinned Node 22 image and network-isolated real tmux with mock agents:

- `pnpm check`: passed, zero lint warnings/errors, including typechecks, format and five generated skill projections. A later developer-guide addition also passed `pnpm docs:format:check`.
- `pnpm test:run`: 61 files / 889 tests passed; coverage 95.70% lines, 89.42% branches and 97.49% functions, with the original thresholds unchanged. Runner routing: 37 tests, 63 ms in the full run.
- `pnpm test:e2e`: both runs passed 21 files / 81 tests, in 252.32s and 256.14s, with isolated lifecycle cleanup.
- `pnpm pack --pack-destination .tmp/tmt-pack` and `node scripts/verify-packed-native-install.mjs --package-tarball .tmp/tmt-pack/tmux-team-5.0.0-alpha.1.tgz --expected-arch arm64 --expected-libc none`: passed on macOS arm64. Verifies actual installed identity CLI, SQLite/FTS5, migrations, profile persistence and skill installation.
- Negative artifact: a disposable copied identity handler was deliberately broken; the same packed verifier failed with exit 1 at the public identity probe and cleaned its installation root. Valid candidate source/tarball were untouched.
- Canonical installed skill passed the skill validator. All five generated projections passed drift detection.

## Project lifecycle

- Updated README, architecture, request/response design, developer guidance, help, learn and canonical installed skill with its generated projections.
- Linear includes the bounded contract, architectural decisions, review findings, failed-test diagnosis and local evidence. TMT-51 attention is next; TMT-56 pane label is an independent backlog item.
- One issue/branch/worktree/PR. Normal protected merge only after exact-head CI succeeds. Worktree/artifact handoff and cleanup follow delivery; no release, package publication or tags are authorized by this PR.
