### PR TITLE
feat: extend native skill support to agy Pi and OpenCode (TMT-58)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -632,8 +632,11 @@ unwritable output streams are outside the one-document guarantee.
 ## Bundled skill viewing and installation
 
 All providers install the single canonical `skills/tmux-team/SKILL.md` directory.
-Claude links it at `~/.claude/skills/tmux-team`; Codex and Gemini share
-`~/.agents/skills/tmux-team`. There are no generated provider copies, command
+Claude links it at `~/.claude/skills/tmux-team`; Codex, Gemini and OpenCode share
+`~/.agents/skills/tmux-team`. Antigravity CLI uses
+`~/.gemini/config/skills/tmux-team`; Pi uses `~/.pi/agent/skills/tmux-team`,
+respecting `PI_CODING_AGENT_DIR`. Pi's native target supports the verified 0.85.0
+loader without assuming newer shared-directory discovery. There are no generated provider copies, command
 wrappers, marketplace manifests or plugin assets. Native Claude skill invocation
 is `/tmux-team`, not a separately maintained slash-command contract.
 The educational learn guide points to the canonical viewer and grammar-backed
@@ -643,6 +646,13 @@ The ordered provider list and its derived type live in `skill-installation.ts`.
 Installer acceptance, install-all expansion and completion consume that owner;
 provider environment detection and Codex-specific backup rules remain installer
 policies. Command and option grammar still belongs to the parser.
+Detection uses provider-specific directory or executable evidence, not the mere
+presence of the shared `.agents` directory. OpenCode detection respects its explicit
+configuration directory override before the XDG root; its skill link remains shared. No-provider installation
+uses the neutral universal config and omits `agent` from the result instead of
+inventing a Codex installation. Explicit selectors do not require a provider binary.
+All installation modes are non-interactive; none installs provider applications,
+edits provider settings, bypasses permissions, or reloads active conversations.
 
 `learn --skill` emits the exact bundled universal `SKILL.md`, without startup
 checks, ANSI formatting, or an added newline. It is text-only and rejects JSON
@@ -653,7 +663,7 @@ the invocation directory. It is mutually exclusive with an explicit provider
 or `all`; empty directory input is rejected before effects. Custom mode links
 the universal skill and never migrates default-provider paths. Existing managed
 links are no-ops; unmanaged paths are refused unless explicit force requests a
-recoverable adjacent backup. Unrelated siblings remain outside the operation.
+recoverable backup outside the skills root. Unrelated siblings remain outside the operation.
 Before mutation, source/destination overlap is rejected, including destination
 parents that alias the bundled source through symlinks. Force is not permission
 to move the installed package source or create a recursive self-link.
@@ -669,6 +679,8 @@ custom-install registry, arbitrary folder scan, provider plugin update or agent
 reload is implied. Links follow source updates at the same package path; reinstall
 explicitly after relocation. Automatic drift inspection covers known defaults only,
 and npm version checking is not an alpha-channel skill version tracker.
+Managed-target drift inspection enumerates the provider path owner and deduplicates
+shared targets, rather than separately maintaining a Claude/Codex-only path list.
 
 The retired Claude command path is shared by installer and drift inspection.
 Default Claude installation preserves and warns about the old command; explicit

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -197,6 +197,17 @@ Provider names and ordering belong to `src/skill-installation.ts`. Installation
 and completion consume that inventory; provider detection and legacy-backup
 policy remain in their existing adapters. Test derivation with an altered
 inventory, not only matching copies of the current provider names.
+Cover every explicit provider target, directory/executable auto-detection,
+provider overrides and the neutral no-provider fallback with isolated homes.
+Shared `.agents` presence alone must not invent Codex detection. Drift tests
+must catch new provider targets and deduplicate shared paths. Packed verification
+must independently compare expected paths and exact installed contents, including
+fallback JSON without a provider, no-op reinstall and safe conflict handling.
+When claiming provider compatibility, record the actual provider version and
+loader or live discovery evidence separately from TMT's filesystem tests.
+Use provider-native locations when the supported installed baseline does not
+discover newer shared paths; never add a second content source or silently edit
+provider configuration to make a smoke test pass.
 
 ## Packed native-install verification
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the tested `5.0.0-alpha.1` preview directly from this pinned revision.
 Requires macOS or Linux, Node.js >=22.12 (Node 24 recommended), and tmux.
 
 ```bash
-npm install -g https://github.com/wkh237/tmux-team/archive/47eaa363757583b1472b2fbc6bbd3559392afbf8.tar.gz
+npm install -g https://github.com/wkh237/tmux-team/archive/99d4a12bde0e0c63dbb8391a5bb8865c3669b2c1.tar.gz
 tmt install
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tmux-team
 
-Your coding agents, working together. Connect Claude, Codex, and Gemini in
-tmux: delegate by name, collect complete replies, and recover outstanding work
+Your coding agents, working together. Connect terminal agents in tmux:
+delegate by name, collect complete replies, and recover outstanding work
 without digging through terminal history. Local CLI, no daemon required.
 
 ## v5 preview installation
@@ -23,6 +23,10 @@ After `tmt install`, load or reload the installed `tmux-team` skill in each
 agent before sending work. Provider-specific install notes are in
 [`skills/README.md`](skills/README.md); the canonical bundled guidance is
 [`skills/tmux-team/SKILL.md`](skills/tmux-team/SKILL.md).
+
+Upgrading from an older version? Update the CLI, run `tmt install`, then restart
+the agent or ask it to read `tmt learn --skill`. Installation never prompts;
+conflicts are preserved until you explicitly choose `--force`.
 
 ## Quick start
 
@@ -84,7 +88,8 @@ an inbox.
 - Complete final replies through `reply`/`result`, including late replies after
   a pane closes.
 - Local SQLite state with no background service and no network transport.
-- Skills for Claude Code, Codex, and Gemini, installed or repaired by `tmt install`.
+- One skill for Claude Code, Codex, Gemini, agy, Pi and OpenCode, installed or
+  repaired by `tmt install`.
 
 Useful commands:
 
@@ -115,7 +120,8 @@ request/response design is documented in
 
 ## One skill, no plugin
 
-`tmt install` installs the same native skill for Claude Code, Codex, and Gemini.
+`tmt install` detects supported providers and installs the same canonical skill.
+If none is detected, it installs the shared skill without requiring a provider.
 Claude Code can invoke it as `/tmux-team`; no marketplace or separate `/team`
 command is needed. See the [installation guide](skills/README.md) if you have
 an older command or plugin installed.

--- a/scripts/verify-packed-native-install.mjs
+++ b/scripts/verify-packed-native-install.mjs
@@ -134,13 +134,13 @@ function loadAndVerifySqlite(projectDirectory, expectedLibc) {
   }
 }
 
-function isolatedEnvironment(projectDirectory) {
-  const home = path.join(projectDirectory, 'home');
+function createIsolatedHomeEnvironment(projectDirectory, name, baseEnv = process.env) {
+  const home = path.join(projectDirectory, name);
   fs.mkdirSync(home);
   const temporaryDirectory = path.join(home, 'tmp');
   fs.mkdirSync(temporaryDirectory);
   const env = {
-    ...process.env,
+    ...baseEnv,
     HOME: home,
     CODEX_HOME: path.join(home, '.codex'),
     XDG_CONFIG_HOME: path.join(home, '.config'),
@@ -148,7 +148,15 @@ function isolatedEnvironment(projectDirectory) {
     TMUX_TEAM_HOME: path.join(home, 'tmt'),
     TMPDIR: temporaryDirectory,
   };
-  for (const key of ['TMUX', 'TMUX_PANE', 'NODE_OPTIONS', 'NODE_PATH']) delete env[key];
+  for (const key of ['TMUX', 'TMUX_PANE', 'NODE_OPTIONS', 'NODE_PATH', 'OPENCODE_CONFIG_DIR']) {
+    delete env[key];
+  }
+  return { home, env };
+}
+
+function isolatedEnvironment(projectDirectory) {
+  const { home, env } = createIsolatedHomeEnvironment(projectDirectory, 'home');
+  env.PI_CODING_AGENT_DIR = path.join(home, '.pi', 'agent');
   return env;
 }
 
@@ -164,10 +172,10 @@ function verifyPackedCli(projectDirectory, env) {
 function verifyPackedSkills(projectDirectory, env, providers) {
   const executable = path.join(projectDirectory, 'node_modules', '.bin', 'tmt');
   const home = env.HOME;
-  const run = (args, expectedStatus = 0) =>
+  const run = (args, expectedStatus = 0, commandEnv = env) =>
     runPackedCommand(executable, args, {
       cwd: projectDirectory,
-      env,
+      env: commandEnv,
       expectedStatus,
     });
 
@@ -194,23 +202,25 @@ function verifyPackedSkills(projectDirectory, env, providers) {
     installed.installed.map((item) => item.agent),
     providers
   );
+  const providerTargets = {
+    agy: path.join(home, '.gemini', 'config', 'skills', 'tmux-team'),
+    claude: path.join(home, '.claude', 'skills', 'tmux-team'),
+    codex: path.join(home, '.agents', 'skills', 'tmux-team'),
+    gemini: path.join(home, '.agents', 'skills', 'tmux-team'),
+    opencode: path.join(home, '.agents', 'skills', 'tmux-team'),
+    pi: path.join(home, '.pi', 'agent', 'skills', 'tmux-team'),
+  };
   assert.deepEqual(
     Object.fromEntries(installed.installed.map((item) => [item.agent, item.target])),
-    {
-      claude: path.join(home, '.claude', 'skills', 'tmux-team'),
-      codex: path.join(home, '.agents', 'skills', 'tmux-team'),
-      gemini: path.join(home, '.agents', 'skills', 'tmux-team'),
-    },
+    providerTargets,
     'Provider installs must use only the canonical skill targets'
   );
-  const universal = path.join(home, '.agents', 'skills', 'tmux-team');
-  const claude = path.join(home, '.claude', 'skills', 'tmux-team');
-  assert.ok(fs.lstatSync(universal).isSymbolicLink());
-  assert.equal(fs.readFileSync(path.join(universal, 'SKILL.md'), 'utf8'), content);
-  assert.ok(fs.lstatSync(claude).isSymbolicLink());
-  assert.equal(fs.readFileSync(path.join(claude, 'SKILL.md'), 'utf8'), content);
-  assert.equal(fs.realpathSync(universal), fs.realpathSync(path.dirname(source)));
-  assert.equal(fs.realpathSync(claude), fs.realpathSync(path.dirname(source)));
+  for (const target of Object.values(providerTargets)) {
+    assert.ok(fs.lstatSync(target).isSymbolicLink());
+    assert.equal(fs.readFileSync(path.join(target, 'SKILL.md'), 'utf8'), content);
+    assert.equal(fs.realpathSync(target), fs.realpathSync(path.dirname(source)));
+  }
+  const claude = providerTargets.claude;
   assert.ok(fs.existsSync(legacyClaudeCommand), 'The legacy Claude command should be preserved');
   const legacyContent = fs.readFileSync(legacyClaudeCommand, 'utf8');
   assert.equal(legacyContent, 'legacy Claude command\n');
@@ -296,13 +306,68 @@ function verifyPackedSkills(projectDirectory, env, providers) {
   assert.ok(fs.lstatSync(target).isSymbolicLink());
   assert.equal(fs.readFileSync(sibling, 'utf8'), 'preserve this sibling');
 
+  for (const [provider, name] of [
+    ['agy', 'agy-home'],
+    ['opencode', 'opencode-home'],
+  ]) {
+    const { home: providerHome, env: providerEnv } = createIsolatedHomeEnvironment(
+      projectDirectory,
+      name,
+      env
+    );
+    providerEnv.PI_CODING_AGENT_DIR = path.join(providerHome, '.pi', 'agent');
+    const target =
+      provider === 'agy'
+        ? path.join(providerHome, '.gemini', 'config', 'skills', 'tmux-team')
+        : path.join(providerHome, '.agents', 'skills', 'tmux-team');
+    const result = JSON.parse(run(['install', provider, '--json'], 0, providerEnv));
+    assert.deepEqual(result.installed, [{ agent: provider, target, changed: true }]);
+    assert.ok(fs.lstatSync(target).isSymbolicLink());
+    assert.equal(fs.realpathSync(target), fs.realpathSync(path.dirname(source)));
+  }
+  const { home: piHome, env: piEnv } = createIsolatedHomeEnvironment(
+    projectDirectory,
+    'pi-home',
+    env
+  );
+  const piAgentRoot = path.join(piHome, 'custom-pi-agent');
+  piEnv.PI_CODING_AGENT_DIR = piAgentRoot;
+  const piTarget = path.join(piAgentRoot, 'skills', 'tmux-team');
+  const piInstall = JSON.parse(run(['install', 'pi', '--json'], 0, piEnv));
+  assert.deepEqual(piInstall.installed, [{ agent: 'pi', target: piTarget, changed: true }]);
+  assert.ok(fs.lstatSync(piTarget).isSymbolicLink());
+  assert.equal(fs.realpathSync(piTarget), fs.realpathSync(path.dirname(source)));
+  assert.equal(fs.existsSync(path.join(piHome, '.pi')), false);
+
+  const { home: fallbackHome, env: fallbackEnv } = createIsolatedHomeEnvironment(
+    projectDirectory,
+    'fallback-home',
+    env
+  );
+  fallbackEnv.PI_CODING_AGENT_DIR = path.join(fallbackHome, '.pi', 'agent');
+  // Keep the packed executable's shebang working while excluding agent
+  // commands from PATH, so detection has no provider signals to observe.
+  const fallbackBin = path.join(fallbackHome, 'bin');
+  fs.mkdirSync(fallbackBin);
+  fs.symlinkSync(process.execPath, path.join(fallbackBin, 'node'));
+  fallbackEnv.PATH = fallbackBin;
+  const fallback = JSON.parse(run(['install', '--json'], 0, fallbackEnv));
+  const fallbackTarget = path.join(fallbackHome, '.agents', 'skills', 'tmux-team');
+  assert.deepEqual(fallback.installed, [{ target: fallbackTarget, changed: true }]);
+  assert.ok(fs.lstatSync(fallbackTarget).isSymbolicLink());
+  assert.equal(fs.realpathSync(fallbackTarget), fs.realpathSync(path.dirname(source)));
+  for (const providerDirectory of ['.claude', '.codex', '.gemini', '.pi']) {
+    assert.equal(fs.existsSync(path.join(fallbackHome, providerDirectory)), false);
+  }
+
   // Only the disposable installed package is changed, proving links and the
   // viewer follow source updates without writing to the host's installed skill.
   const updated = `${content}\nPacked verification update.\n`;
   fs.writeFileSync(source, updated);
   assert.equal(fs.readFileSync(path.join(target, 'SKILL.md'), 'utf8'), updated);
-  assert.equal(fs.readFileSync(path.join(universal, 'SKILL.md'), 'utf8'), updated);
-  assert.equal(fs.readFileSync(path.join(claude, 'SKILL.md'), 'utf8'), updated);
+  for (const providerTarget of new Set(Object.values(providerTargets))) {
+    assert.equal(fs.readFileSync(path.join(providerTarget, 'SKILL.md'), 'utf8'), updated);
+  }
   assert.equal(run(['learn', '--skill']), updated);
 }
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -11,12 +11,29 @@ tmt install          # Detect installed providers
 tmt install claude   # Or select one explicitly
 tmt install codex
 tmt install gemini
+tmt install agy
+tmt install pi
+tmt install opencode
+tmt install all      # Install for every supported provider
 ```
 
-| Provider         | Native skill location                 |
-| ---------------- | ------------------------------------- |
-| Claude Code      | `~/.claude/skills/tmux-team/SKILL.md` |
-| Codex and Gemini | `~/.agents/skills/tmux-team/SKILL.md` |
+| Provider                   | Native skill location                        |
+| -------------------------- | -------------------------------------------- |
+| Claude Code                | `~/.claude/skills/tmux-team/SKILL.md`        |
+| Codex, Gemini and OpenCode | `~/.agents/skills/tmux-team/SKILL.md`        |
+| Antigravity CLI (`agy`)    | `~/.gemini/config/skills/tmux-team/SKILL.md` |
+| Pi                         | `~/.pi/agent/skills/tmux-team/SKILL.md`      |
+
+Installation is non-interactive and accepts `--json`. If no provider is detected,
+the shared `~/.agents/skills/tmux-team` target is installed without claiming a
+provider was found; its JSON result has `target` and `changed`, but no `agent`.
+This does not install the agent applications themselves. Explicit selectors work
+even before the selected provider is installed.
+
+Pi honors `PI_CODING_AGENT_DIR`: its target is `<agent-dir>/skills/tmux-team`.
+OpenCode's configuration directory is used for detection, including
+`OPENCODE_CONFIG_DIR` or `XDG_CONFIG_HOME`, but its installed skill remains in the shared home location.
+Use `--dir` for a different skill discovery root; TMT does not edit provider settings.
 
 The containing directory is a managed link to the installed package. Repeating
 installation is a no-op when the link is correct. Package updates at the same
@@ -29,6 +46,20 @@ can be invoked as `/tmux-team`; the CLI remains `tmt`. Installing files does not
 guarantee an already-running agent has reloaded them. Use its skill discovery
 or restart the session when necessary. The [Claude skill documentation](https://code.claude.com/docs/en/skills)
 describes its native personal skill location and invocation.
+
+Pi exposes `/skill:tmux-team`; OpenCode loads `tmux-team` through its `skill`
+tool. Antigravity discovers skill metadata when starting a conversation; ask it
+to load `tmux-team` or explicitly read `tmt learn --skill`. Provider permissions
+or disabled skill discovery can still prevent loading. Installing a link is not
+proof that a running session has loaded its content.
+
+Paths follow the [Antigravity skill documentation](https://www.agy.dev/docs/skills/),
+[Pi documentation](https://pi.dev/docs/latest/skills), and
+[OpenCode documentation](https://opencode.ai/docs/skills).
+Pi's native path also supports the locally verified 0.85.0 loader, which does not
+discover the shared `.agents` path by default. Older Antigravity documentation
+lists different directories; use a current CLI or explicitly select its actual
+discovery root rather than installing multiple competing copies.
 
 ## Inspect or choose a folder
 
@@ -45,6 +76,11 @@ unrelated siblings. Automatic drift reminders cover default locations, not
 arbitrary custom folders.
 
 ## Existing installations
+
+Update the CLI using your chosen release's installation command, run
+`tmt install`, then reload or restart the agent. For an existing conversation,
+ask the agent to run `tmt learn --skill`, read the complete output, and use it
+instead of remembered instructions from an older version.
 
 Existing unmanaged targets are preserved by default. Inspect a conflict before
 using `tmt install <provider> --force`; replacement creates a recoverable backup.

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -314,7 +314,7 @@ tmt unbind                            # remove the current pane identity
 tmt talk <target> "message"          # target a global name or pane
 tmt check <target> [lines]
 tmt list [target]                     # list identities or one pane
-tmt install [claude|codex|gemini|all]
+tmt install [claude|codex|gemini|agy|pi|opencode|all]
 tmt upgrade
 ```
 
@@ -357,8 +357,14 @@ Avoid sending secrets or credentials to another pane. For a requested send
 delay, use `--delay` rather than introducing a separate shell sleep.
 
 Install the same native skill with `tmt install` (auto-detects supported agents).
-Claude uses `~/.claude/skills/tmux-team`; Codex and Gemini share
-`~/.agents/skills/tmux-team`. No plugin or separate command wrapper is needed.
+Claude uses `~/.claude/skills/tmux-team`; Codex, Gemini and OpenCode share
+`~/.agents/skills/tmux-team`. Antigravity CLI (`agy`) uses
+`~/.gemini/config/skills/tmux-team`; Pi uses `~/.pi/agent/skills/tmux-team`
+(or `<PI_CODING_AGENT_DIR>/skills/tmux-team` when configured).
+All targets link the same bundled content. No plugin or separate command wrapper is needed.
+Installation is non-interactive; `--json` is supported. With no detected provider,
+the shared target is installed and its result omits `agent`. This does not install
+an agent application. An existing `.agents` directory alone is not provider evidence.
 Claude's native skill can be invoked as `/tmux-team`. Inspect conflicts before
 using `--force`, which creates recoverable skill backups outside the discovery root.
 An old Claude `commands/team.md`
@@ -366,6 +372,11 @@ is preserved with a warning by default; explicit forced Claude installation can
 back it up after the native skill is installed. Plugin settings are never modified.
 Managed links follow package updates. `tmt upgrade` tracks npm `latest`, not
 commit-pinned previews; follow the selected release's installation instructions.
+After upgrading the CLI, run `tmt install` and reload or restart the agent.
+For an existing conversation, run `tmt learn --skill` and read its complete output
+before using remembered commands. Pi can load `/skill:tmux-team`; OpenCode uses
+its `skill` tool. Installation does not bypass provider permissions or guarantee
+that a running conversation has refreshed its instructions.
 
 ## Configuration safety
 
@@ -422,7 +433,7 @@ options; `--verbose` and `--debug` are not supported there.
 
 `tmt learn --skill` prints the exact bundled universal skill; plain `tmt learn`
 shows the guide. Both are text-only. Install default integrations with
-`tmt install [claude|codex|gemini|all]`, or choose a skills root explicitly:
+`tmt install [claude|codex|gemini|agy|pi|opencode|all]`, or choose a skills root explicitly:
 
 ```bash
 tmt install --dir ./my-skills

--- a/src/cli-contract.test.ts
+++ b/src/cli-contract.test.ts
@@ -9,7 +9,7 @@ import {
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
-import { getSkillConfigs } from './skill-installation.js';
+import { getSkillConfigs, SKILL_AGENTS } from './skill-installation.js';
 import { CURRENT_MIGRATIONS } from './storage/migrations.js';
 import {
   expectError,
@@ -62,6 +62,18 @@ describe('real CLI process contract', () => {
   );
 
   it(
+    'shows every supported provider and the no-provider fallback in the real CLI guide',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        const result = await runCli(sandbox, ['learn']);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain(`${SKILL_AGENTS.join(', ')}.`);
+        expect(result.stdout).toContain('shared skill without claiming a provider');
+      })
+  );
+
+  it(
     'installs all skill integrations into isolated HOME with shipped source bytes',
     { timeout: 10_000 },
     () =>
@@ -71,16 +83,29 @@ describe('real CLI process contract', () => {
         const document = parseWholeStdout(result) as {
           installed: Array<{ agent: string; target: string }>;
         };
-        expect(document.installed.map((item) => item.agent)).toEqual(['claude', 'codex', 'gemini']);
+        expect(document.installed.map((item) => item.agent)).toEqual([
+          'claude',
+          'codex',
+          'gemini',
+          'agy',
+          'pi',
+          'opencode',
+        ]);
 
         const configs = getSkillConfigs();
         const claudeTarget = path.join(sandbox.home, '.claude', 'skills', 'tmux-team');
         const universalTarget = path.join(sandbox.home, '.agents', 'skills', 'tmux-team');
+        const agyTarget = path.join(sandbox.home, '.gemini', 'config', 'skills', 'tmux-team');
+        const piTarget = path.join(sandbox.home, '.pi', 'agent', 'skills', 'tmux-team');
         expect(lstatSync(claudeTarget).isSymbolicLink()).toBe(true);
         expect(lstatSync(universalTarget).isSymbolicLink()).toBe(true);
+        expect(lstatSync(agyTarget).isSymbolicLink()).toBe(true);
+        expect(lstatSync(piTarget).isSymbolicLink()).toBe(true);
         expect(realpathSync(claudeTarget)).toBe(realpathSync(configs.claude.source));
         expect(realpathSync(universalTarget)).toBe(realpathSync(configs.codex.source));
         expect(realpathSync(claudeTarget)).toBe(realpathSync(universalTarget));
+        expect(realpathSync(agyTarget)).toBe(realpathSync(universalTarget));
+        expect(realpathSync(piTarget)).toBe(realpathSync(universalTarget));
         expect(readFileSync(path.join(claudeTarget, 'SKILL.md'))).toEqual(
           readFileSync(path.join(configs.claude.source, 'SKILL.md'))
         );
@@ -88,6 +113,35 @@ describe('real CLI process contract', () => {
         expect(readFileSync(path.join(universalTarget, 'SKILL.md'))).toEqual(
           readFileSync(path.join(configs.codex.source, 'SKILL.md'))
         );
+      })
+  );
+
+  it(
+    'falls back to the shared skill target without inventing a provider',
+    { timeout: 10_000 },
+    () =>
+      withSandbox(async (sandbox) => {
+        mkdirSync(path.join(sandbox.root, 'empty-bin'));
+        sandbox.env.PATH = path.join(sandbox.root, 'empty-bin');
+        delete sandbox.env.PI_CODING_AGENT_DIR;
+        const target = path.join(sandbox.home, '.agents', 'skills', 'tmux-team');
+
+        const first = await runCli(sandbox, ['install', '--json']);
+        expect(first.status).toBe(0);
+        expect(parseWholeStdout(first)).toEqual({ installed: [{ target, changed: true }] });
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+
+        const second = await runCli(sandbox, ['install']);
+        expect(second.status).toBe(0);
+        expect(second.stdout).toContain(`skill linked at ${target}`);
+        expect(second.stdout).not.toContain('custom skill');
+
+        const third = await runCli(sandbox, ['install', '--json']);
+        expect(third.status).toBe(0);
+        expect(parseWholeStdout(third)).toEqual({ installed: [{ target, changed: false }] });
+        expect(existsSync(path.join(sandbox.home, '.claude'))).toBe(false);
+        expect(existsSync(path.join(sandbox.home, '.gemini'))).toBe(false);
+        expect(existsSync(path.join(sandbox.home, '.pi'))).toBe(false);
       })
   );
 

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -79,12 +79,18 @@ describe('cmdInstall', () => {
   const originalHome = process.env.HOME;
   const originalTmux = process.env.TMUX;
   const originalCodexHome = process.env.CODEX_HOME;
+  const originalPiDirectory = process.env.PI_CODING_AGENT_DIR;
+  const originalXdgDirectory = process.env.XDG_CONFIG_HOME;
+  const originalOpenCodeDirectory = process.env.OPENCODE_CONFIG_DIR;
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmux-team-install-'));
     homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmux-team-home-'));
     process.env.HOME = homeDir;
     process.env.CODEX_HOME = path.join(homeDir, '.codex');
+    delete process.env.PI_CODING_AGENT_DIR;
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.OPENCODE_CONFIG_DIR;
     delete process.env.TMUX;
   });
 
@@ -92,6 +98,12 @@ describe('cmdInstall', () => {
     process.env.HOME = originalHome;
     process.env.TMUX = originalTmux;
     process.env.CODEX_HOME = originalCodexHome;
+    if (originalPiDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalPiDirectory;
+    if (originalXdgDirectory === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = originalXdgDirectory;
+    if (originalOpenCodeDirectory === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = originalOpenCodeDirectory;
     fs.rmSync(testDir, { recursive: true, force: true });
     fs.rmSync(homeDir, { recursive: true, force: true });
     vi.doUnmock('../skill-installation.js');
@@ -251,6 +263,80 @@ describe('cmdInstall', () => {
     const ctx = createCtx(testDir, { flags: { force: true } });
     await cmdInstall(ctx);
     expect(fs.existsSync(path.join(homeDir, '.claude', 'skills', 'tmux-team'))).toBe(true);
+  });
+
+  it('detects provider directories and binaries without treating shared state as Codex', async () => {
+    vi.resetModules();
+    vi.doMock('node:os', () => ({
+      default: { homedir: () => homeDir },
+      homedir: () => homeDir,
+    }));
+    const previousPath = process.env.PATH;
+    const previousPiDirectory = process.env.PI_CODING_AGENT_DIR;
+    const previousXdgDirectory = process.env.XDG_CONFIG_HOME;
+    const previousOpenCodeDirectory = process.env.OPENCODE_CONFIG_DIR;
+    const emptyPath = path.join(testDir, 'empty-bin');
+    fs.mkdirSync(emptyPath);
+    process.env.PATH = emptyPath;
+    delete process.env.PI_CODING_AGENT_DIR;
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.OPENCODE_CONFIG_DIR;
+    try {
+      const { detectEnvironment } = await import('./install.js');
+      const directoryCases = [
+        ['agy', path.join(homeDir, '.gemini', 'config')],
+        ['pi', path.join(homeDir, '.pi', 'agent')],
+        ['opencode', path.join(homeDir, '.config', 'opencode')],
+      ] as const;
+      for (const [agent, directory] of directoryCases) {
+        fs.mkdirSync(directory, { recursive: true });
+        // The existing broad Gemini marker also covers Antigravity's nested
+        // ~/.gemini/config directory; this is intentional compatibility.
+        expect(detectEnvironment()).toEqual(agent === 'agy' ? ['gemini', 'agy'] : [agent]);
+        fs.rmSync(directory, { recursive: true, force: true });
+        if (agent === 'agy')
+          fs.rmSync(path.join(homeDir, '.gemini'), { recursive: true, force: true });
+      }
+
+      fs.mkdirSync(path.join(homeDir, '.agents'), { recursive: true });
+      process.env.CODEX_HOME = path.join(homeDir, '.agents');
+      expect(detectEnvironment()).toEqual([]);
+      fs.rmSync(path.join(homeDir, '.agents'), { recursive: true, force: true });
+      process.env.CODEX_HOME = path.join(homeDir, '.codex');
+
+      const overridePiDirectory = path.join(testDir, 'custom-pi-agent');
+      process.env.PI_CODING_AGENT_DIR = overridePiDirectory;
+      fs.mkdirSync(overridePiDirectory, { recursive: true });
+      expect(detectEnvironment()).toEqual(['pi']);
+      fs.rmSync(overridePiDirectory, { recursive: true, force: true });
+
+      const overrideXdgDirectory = path.join(testDir, 'custom-xdg');
+      process.env.XDG_CONFIG_HOME = overrideXdgDirectory;
+      fs.mkdirSync(path.join(overrideXdgDirectory, 'opencode'), { recursive: true });
+      expect(detectEnvironment()).toEqual(['opencode']);
+      fs.rmSync(overrideXdgDirectory, { recursive: true, force: true });
+
+      const overrideOpenCodeDirectory = path.join(testDir, 'custom-opencode');
+      process.env.OPENCODE_CONFIG_DIR = overrideOpenCodeDirectory;
+      fs.mkdirSync(overrideOpenCodeDirectory, { recursive: true });
+      expect(detectEnvironment()).toEqual(['opencode']);
+      fs.rmSync(overrideOpenCodeDirectory, { recursive: true, force: true });
+
+      for (const agent of ['agy', 'pi', 'opencode'] as const) {
+        fs.writeFileSync(path.join(emptyPath, agent), 'not executed');
+        expect(detectEnvironment()).toEqual([agent]);
+        fs.rmSync(path.join(emptyPath, agent));
+      }
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      if (previousPiDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = previousPiDirectory;
+      if (previousXdgDirectory === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = previousXdgDirectory;
+      if (previousOpenCodeDirectory === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+      else process.env.OPENCODE_CONFIG_DIR = previousOpenCodeDirectory;
+    }
   });
 
   it('installs all detected environments without prompting', async () => {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -16,7 +16,12 @@ import {
   getCustomSkillConfig,
   getLegacyClaudeCommand,
   getLegacyCodexDirectories,
+  getAgyConfigDirectory,
+  getOpenCodeConfigDirectory,
+  getPiCodingAgentDirectory,
+  getSharedAgentDirectory,
   getSkillConfigs,
+  getUniversalSkillConfig,
   hasBundledSkillSource,
   isSkillAgent,
   isCorrectLink,
@@ -52,15 +57,23 @@ function environmentDetected(agent: SkillAgent, home: string): boolean {
   switch (agent) {
     case 'claude':
       return fs.existsSync(path.join(home, '.claude')) || commandExists('claude');
-    case 'codex':
+    case 'codex': {
+      const codexHome = getCodexHome(home);
       return (
-        fs.existsSync(path.join(home, '.agents')) ||
         fs.existsSync(path.join(home, '.codex')) ||
-        fs.existsSync(getCodexHome()) ||
+        (path.resolve(codexHome) !== path.resolve(getSharedAgentDirectory(home)) &&
+          fs.existsSync(codexHome)) ||
         commandExists('codex')
       );
+    }
     case 'gemini':
       return fs.existsSync(path.join(home, '.gemini')) || commandExists('gemini');
+    case 'agy':
+      return fs.existsSync(getAgyConfigDirectory(home)) || commandExists('agy');
+    case 'pi':
+      return fs.existsSync(getPiCodingAgentDirectory(home)) || commandExists('pi');
+    case 'opencode':
+      return fs.existsSync(getOpenCodeConfigDirectory(home)) || commandExists('opencode');
   }
 }
 
@@ -139,6 +152,10 @@ function installCustom(ctx: Context, directory: string): InstallResult {
   return installSelectedSkill(ctx, selected);
 }
 
+function installUniversal(ctx: Context): InstallResult {
+  return installSelectedSkill(ctx, getUniversalSkillConfig());
+}
+
 function printNextSteps(ctx: Context, installed: InstallResult[]): void {
   if (ctx.flags.json) {
     ctx.ui.json({ installed });
@@ -147,10 +164,10 @@ function printNextSteps(ctx: Context, installed: InstallResult[]): void {
   const seenTargets = new Set<string>();
   for (const item of installed) {
     const shared = seenTargets.has(item.target);
-    const label = item.agent === undefined ? 'custom skill' : `${item.agent} skill`;
+    const label = item.agent === undefined ? 'skill' : `${item.agent} skill`;
     ctx.ui.success(
       shared
-        ? `${item.agent} integration uses the shared skill at ${item.target}`
+        ? `${item.agent ? `${item.agent} integration` : 'Skill'} uses the shared skill at ${item.target}`
         : `${label} linked at ${item.target}`
     );
     seenTargets.add(item.target);
@@ -197,11 +214,15 @@ export async function cmdInstall(ctx: Context, agent?: string, directory?: strin
       else if (requestedAgent) agents = [requestedAgent];
       else {
         agents = detectEnvironment();
-        // A clean machine gets the universal Open Agent Skill.
-        if (agents.length === 0) agents = ['codex'];
       }
-      for (const selected of agents) {
-        installed.push(installAgent(ctx, selected));
+      // A clean machine gets the universal Open Agent Skill without inventing
+      // a provider identity in the structured result.
+      if (agents.length === 0) {
+        installed.push(installUniversal(ctx));
+      } else {
+        for (const selected of agents) {
+          installed.push(installAgent(ctx, selected));
+        }
       }
     }
   } catch (error) {

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -4,7 +4,7 @@
 
 import { readFileSync } from 'node:fs';
 import { colors } from '../ui.js';
-import { getUniversalSkillFile } from '../skill-installation.js';
+import { getUniversalSkillFile, SKILL_AGENTS } from '../skill-installation.js';
 
 export function cmdLearn(skill = false): void {
   if (skill) {
@@ -20,6 +20,13 @@ ${colors.yellow('WHAT IS TMUX-TEAM?')}
   communicate with each other through active global identities.
 
 ${colors.yellow('CORE CONCEPT')}
+
+  Install agent guidance with tmt install (non-interactive), or choose a provider:
+  ${SKILL_AGENTS.join(', ')}. Use tmt install all for every supported provider.
+  With none detected, install places the shared skill without claiming a provider.
+  After updating the CLI, run tmt install and reload or restart the agent.
+  Existing conversations should read tmt learn --skill for current instructions.
+  Installing a skill does not install an agent application or grant permissions.
 
   A recipient runs in a tmux pane; the caller does not have to. When you talk:
   1. Your message is pasted via a tmux buffer

--- a/src/skill-installation.test.ts
+++ b/src/skill-installation.test.ts
@@ -1,18 +1,39 @@
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   ALL_SKILL_TARGET,
   getLegacyClaudeCommand,
   getLegacyCodexDirectories,
+  getOpenCodeConfigDirectory,
+  getPiCodingAgentDirectory,
   getUniversalSkillSource,
   getSkillConfigs,
   isSkillAgent,
   SKILL_AGENTS,
 } from './skill-installation.js';
 
+const ambientPiDirectory = process.env.PI_CODING_AGENT_DIR;
+const ambientXdgDirectory = process.env.XDG_CONFIG_HOME;
+const ambientOpenCodeDirectory = process.env.OPENCODE_CONFIG_DIR;
+
+beforeEach(() => {
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.XDG_CONFIG_HOME;
+  delete process.env.OPENCODE_CONFIG_DIR;
+});
+
+afterEach(() => {
+  if (ambientPiDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+  else process.env.PI_CODING_AGENT_DIR = ambientPiDirectory;
+  if (ambientXdgDirectory === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = ambientXdgDirectory;
+  if (ambientOpenCodeDirectory === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+  else process.env.OPENCODE_CONFIG_DIR = ambientOpenCodeDirectory;
+});
+
 describe('skill-installation provider inventory', () => {
   it('derives the typed provider set and skill config keys from one ordered list', () => {
-    expect(SKILL_AGENTS).toEqual(['claude', 'codex', 'gemini']);
+    expect(SKILL_AGENTS).toEqual(['claude', 'codex', 'gemini', 'agy', 'pi', 'opencode']);
     expect(SKILL_AGENTS.every((agent) => isSkillAgent(agent))).toBe(true);
     expect(isSkillAgent(ALL_SKILL_TARGET)).toBe(false);
     const configs = getSkillConfigs('/package', '/home');
@@ -26,7 +47,53 @@ describe('skill-installation provider inventory', () => {
       target: '/home/.agents/skills/tmux-team',
     });
     expect(configs.gemini).toEqual(configs.codex);
+    expect(configs.opencode).toEqual(configs.codex);
+    expect(configs.agy).toEqual({
+      source: getUniversalSkillSource('/package'),
+      target: '/home/.gemini/config/skills/tmux-team',
+    });
+    expect(configs.pi).toEqual({
+      source: getUniversalSkillSource('/package'),
+      target: '/home/.pi/agent/skills/tmux-team',
+    });
+    expect(getPiCodingAgentDirectory('/home')).toBe('/home/.pi/agent');
+    expect(getOpenCodeConfigDirectory('/home')).toBe('/home/.config/opencode');
     expect(getLegacyClaudeCommand('/home')).toBe('/home/.claude/commands/team.md');
+  });
+
+  it('uses provider directory overrides without changing the canonical source', () => {
+    const previousPiDirectory = process.env.PI_CODING_AGENT_DIR;
+    const previousXdgDirectory = process.env.XDG_CONFIG_HOME;
+    const previousOpenCodeDirectory = process.env.OPENCODE_CONFIG_DIR;
+    process.env.PI_CODING_AGENT_DIR = '/custom/pi-agent';
+    process.env.XDG_CONFIG_HOME = '/custom/config';
+    delete process.env.OPENCODE_CONFIG_DIR;
+    try {
+      const configs = getSkillConfigs('/package', '/home');
+      expect(configs.pi.target).toBe('/custom/pi-agent/skills/tmux-team');
+      expect(configs.opencode.target).toBe('/home/.agents/skills/tmux-team');
+      expect(getOpenCodeConfigDirectory('/home')).toBe('/custom/config/opencode');
+
+      for (const [value, expected] of [
+        ['~', '/home'],
+        ['~/custom/pi', '/home/custom/pi'],
+        ['/absolute/pi', '/absolute/pi'],
+        ['relative/pi', path.resolve('relative/pi')],
+      ]) {
+        process.env.PI_CODING_AGENT_DIR = value;
+        expect(getPiCodingAgentDirectory('/home')).toBe(expected);
+      }
+
+      process.env.OPENCODE_CONFIG_DIR = '/custom/opencode';
+      expect(getOpenCodeConfigDirectory('/home')).toBe('/custom/opencode');
+    } finally {
+      if (previousPiDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = previousPiDirectory;
+      if (previousXdgDirectory === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = previousXdgDirectory;
+      if (previousOpenCodeDirectory === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+      else process.env.OPENCODE_CONFIG_DIR = previousOpenCodeDirectory;
+    }
   });
 });
 

--- a/src/skill-installation.ts
+++ b/src/skill-installation.ts
@@ -4,7 +4,14 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /** Ordered provider inventory shared by skill installation and completion. */
-export const SKILL_AGENTS = Object.freeze(['claude', 'codex', 'gemini'] as const);
+export const SKILL_AGENTS = Object.freeze([
+  'claude',
+  'codex',
+  'gemini',
+  'agy',
+  'pi',
+  'opencode',
+] as const);
 export type SkillAgent = (typeof SKILL_AGENTS)[number];
 export const ALL_SKILL_TARGET = 'all' as const;
 
@@ -53,8 +60,40 @@ export function hasBundledSkillSource(source: string): boolean {
   }
 }
 
+export function getSharedAgentDirectory(home = os.homedir()): string {
+  return path.join(home, '.agents');
+}
+
 function getManagedSkillTarget(home: string): string {
-  return path.join(home, '.agents', 'skills', 'tmux-team');
+  return path.join(getSharedAgentDirectory(home), 'skills', 'tmux-team');
+}
+
+/** Resolve the shared Open Agent skill configuration used by several providers. */
+export function getUniversalSkillConfig(root = packageRoot(), home = os.homedir()): SkillConfig {
+  return {
+    source: getUniversalSkillSource(root),
+    target: getManagedSkillTarget(home),
+  };
+}
+
+/** Resolve Pi's native coding-agent directory, including its documented override. */
+export function getPiCodingAgentDirectory(home = os.homedir()): string {
+  const configured = process.env.PI_CODING_AGENT_DIR;
+  if (!configured) return path.join(home, '.pi', 'agent');
+  if (configured === '~') return home;
+  if (configured.startsWith('~/')) return path.join(home, configured.slice(2));
+  return path.resolve(configured);
+}
+
+/** Resolve OpenCode's provider-specific configuration directory for detection. */
+export function getOpenCodeConfigDirectory(home = os.homedir()): string {
+  if (process.env.OPENCODE_CONFIG_DIR) return process.env.OPENCODE_CONFIG_DIR;
+  return path.join(process.env.XDG_CONFIG_HOME || path.join(home, '.config'), 'opencode');
+}
+
+/** Resolve Antigravity's provider-specific configuration directory. */
+export function getAgyConfigDirectory(home = os.homedir()): string {
+  return path.join(home, '.gemini', 'config');
 }
 
 /** Resolve the pre-native Claude command path retained for migration. */
@@ -79,16 +118,24 @@ export function getSkillConfigs(
   root = packageRoot(),
   home = os.homedir()
 ): Record<SkillAgent, SkillConfig> {
-  const universal = getUniversalSkillSource(root);
-  const agentTarget = getManagedSkillTarget(home);
+  const universalConfig = getUniversalSkillConfig(root, home);
   return {
     claude: {
-      source: universal,
+      source: universalConfig.source,
       target: path.join(home, '.claude', 'skills', 'tmux-team'),
     },
     // Codex and Gemini intentionally share one official user-global location.
-    codex: { source: universal, target: agentTarget },
-    gemini: { source: universal, target: agentTarget },
+    codex: universalConfig,
+    gemini: universalConfig,
+    agy: {
+      source: universalConfig.source,
+      target: path.join(getAgyConfigDirectory(home), 'skills', 'tmux-team'),
+    },
+    pi: {
+      source: universalConfig.source,
+      target: path.join(getPiCodingAgentDirectory(home), 'skills', 'tmux-team'),
+    },
+    opencode: universalConfig,
   };
 }
 

--- a/src/test-support/cli-process.ts
+++ b/src/test-support/cli-process.ts
@@ -52,6 +52,16 @@ export function createSandbox(): Sandbox {
     mkdirSync(home);
 
     const globalDir = path.join(xdgConfigHome, 'tmux-team');
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: xdgConfigHome,
+      CODEX_HOME: path.join(home, '.codex'),
+    };
+    // Provider-specific overrides must not make contract tests write outside
+    // their isolated home directory.
+    delete env.PI_CODING_AGENT_DIR;
+    delete env.OPENCODE_CONFIG_DIR;
     return {
       root,
       cwd,
@@ -61,12 +71,7 @@ export function createSandbox(): Sandbox {
       globalConfig: path.join(globalDir, 'config.json'),
       database: path.join(globalDir, 'tmux-team.db'),
       localConfig: path.join(cwd, 'tmux-team.json'),
-      env: {
-        ...process.env,
-        HOME: home,
-        XDG_CONFIG_HOME: xdgConfigHome,
-        CODEX_HOME: path.join(home, '.codex'),
-      },
+      env,
     };
   } catch (error) {
     rmSync(root, { recursive: true, force: true });

--- a/src/update-check.test.ts
+++ b/src/update-check.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import https from 'node:https';
 import os from 'node:os';
@@ -11,6 +11,25 @@ import {
   runStartupChecks,
 } from './update-check.js';
 import type { Context } from './types.js';
+
+const ambientPiDirectory = process.env.PI_CODING_AGENT_DIR;
+const ambientXdgDirectory = process.env.XDG_CONFIG_HOME;
+const ambientOpenCodeDirectory = process.env.OPENCODE_CONFIG_DIR;
+
+beforeEach(() => {
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.XDG_CONFIG_HOME;
+  delete process.env.OPENCODE_CONFIG_DIR;
+});
+
+afterEach(() => {
+  if (ambientPiDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+  else process.env.PI_CODING_AGENT_DIR = ambientPiDirectory;
+  if (ambientXdgDirectory === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = ambientXdgDirectory;
+  if (ambientOpenCodeDirectory === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+  else process.env.OPENCODE_CONFIG_DIR = ambientOpenCodeDirectory;
+});
 
 describe('local installation drift', () => {
   let temp = '';
@@ -46,6 +65,24 @@ describe('local installation drift', () => {
         (issue) => issue.path === wrongTarget && issue.kind === 'wrong-link'
       )
     ).toBe(true);
+    const wrongAgyTarget = path.join(home, '.gemini', 'config', 'skills', 'tmux-team');
+    fs.mkdirSync(path.dirname(wrongAgyTarget), { recursive: true });
+    fs.symlinkSync(wrongSource, wrongAgyTarget);
+    const wrongPiTarget = path.join(home, '.pi', 'agent', 'skills', 'tmux-team');
+    fs.mkdirSync(path.dirname(wrongPiTarget), { recursive: true });
+    fs.symlinkSync(wrongSource, wrongPiTarget);
+    const extendedIssues = inspectLocalDrift({ home, root });
+    expect(extendedIssues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: wrongAgyTarget, kind: 'wrong-link' }),
+        expect.objectContaining({ path: wrongPiTarget, kind: 'wrong-link' }),
+      ])
+    );
+    expect(
+      extendedIssues.filter(
+        (issue) => issue.path === path.join(home, '.agents', 'skills', 'tmux-team')
+      )
+    ).toHaveLength(1);
     const customCodexHome = path.join(temp, 'custom-codex');
     fs.mkdirSync(path.join(customCodexHome, 'skills', 'tmux-team'), { recursive: true });
     fs.writeFileSync(path.join(customCodexHome, 'skills', 'tmux-team', 'SKILL.md'), 'old');

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -9,8 +9,10 @@ import {
   getLegacyClaudeCommand,
   getLegacyCodexDirectories,
   getSkillConfigs,
+  getUniversalSkillConfig,
   isCorrectLink,
   packageRoot,
+  SKILL_AGENTS,
   targetExists,
 } from './skill-installation.js';
 import type { Context } from './types.js';
@@ -54,9 +56,7 @@ export function inspectLocalDrift(options: DriftOptions = {}): DriftIssue[] {
   const root = options.root ?? packageRoot();
   const codexHome = options.codexHome ?? getCodexHome(home);
   const configs = getSkillConfigs(root, home);
-  const universal = configs.codex.source;
-  const agentsTarget = configs.codex.target;
-  const claudeTarget = configs.claude.target;
+  const sharedTarget = path.resolve(getUniversalSkillConfig(root, home).target);
   const issues: DriftIssue[] = [];
 
   for (const legacy of getLegacyCodexDirectories(home, codexHome)) {
@@ -68,10 +68,16 @@ export function inspectLocalDrift(options: DriftOptions = {}): DriftIssue[] {
       });
     }
   }
-  const universalIssue = linkIssue(agentsTarget, universal, 'Open Agent skill');
-  if (universalIssue) issues.push(universalIssue);
-  const claudeIssue = linkIssue(claudeTarget, universal, 'Claude skill');
-  if (claudeIssue) issues.push(claudeIssue);
+  const seenTargets = new Set<string>();
+  for (const agent of SKILL_AGENTS) {
+    const config = configs[agent];
+    const targetKey = path.resolve(config.target);
+    if (seenTargets.has(targetKey)) continue;
+    seenTargets.add(targetKey);
+    const label = targetKey === sharedTarget ? 'Open Agent skill' : `${agent} skill`;
+    const issue = linkIssue(config.target, config.source, label);
+    if (issue) issues.push(issue);
+  }
 
   const legacyClaudeCommand = getLegacyClaudeCommand(home);
   if (targetExists(legacyClaudeCommand)) {


### PR DESCRIPTION
## Summary

- Add native `tmt install agy`, `pi` and `opencode`, including auto-detection, install-all and existing inventory-derived completion.
- Keep one canonical skill: agy uses `~/.gemini/config/skills`, Pi uses its native agent directory, and OpenCode shares `.agents/skills` with Codex/Gemini.
- Honor Pi's directory override (including tilde/relative paths) and OpenCode's configuration-directory detection overrides.
- A clean machine installs the universal shared skill without inventing a detected Codex provider. `.agents` alone is not Codex evidence.
- Update README, plain learn, canonical installed guidance, installation guide and architecture. No provider-specific copies, plugins, dependency/schema/transport changes, or publication.

## Architecture and primary review

Reviewed head: `e45ce6b0514382127494f822f488c4b2b74f3f77`. README pins implementation `99d4a12bde0e0c63dbb8391a5bb8865c3669b2c1`.

Primary reviewed every changed file and surrounding installer, viewer, parser/completion, drift and test callers. Extend existing path/source/link owners; drift enumerates and deduplicates configured targets rather than adding a parallel provider registry. Existing conflict preservation, recoverable backups and legacy policies remain. No-provider JSON reuses target/changed without agent; there is no fictitious provider selector or interactive prompt.

Review refinements included coherent Pi override expansion, neutral shared ownership rather than Codex authority, an isolated Node-only PATH for packed fallback, and removal of ambient provider overrides from subprocess fixtures. Gemini provided supplementary read-only review through `req_e514fea1-3826-4a43-96e2-a20a116e5729`; no blockers. Primary reviewed later helper renaming/normalization rather than relying on stale details in that report.

## Verification

- [x] Node 24.20.0 `pnpm check`.
- [x] `pnpm test:run`: 67 files, 965 tests; coverage 95.71% statements/lines, 89.77% branches, 97.47% functions.
- [x] Actual packed native install: darwin/arm64/none; all six paths, exact source contents, explicit new-provider installs, neutral fallback, idempotence, overrides, safe backups and update visibility.
- [x] Deliberately broken retired-asset artifact rejected with exit 1 and the exact expected error; isolated temporary root empty afterward.
- [x] Canonical skill validator and diff whitespace checks.
- [x] Pi 0.85.0 real default loader discovered exactly one installed native skill with no diagnostics and the correct canonical realpath in a temporary agent directory.
- [x] OpenCode 1.18.29 real `debug skill` in isolated home/config/data/cache discovered exactly one TMT skill with exact canonical body equality. Temporary provider binary only; no global install, model call or credentials.
- [x] agy 1.1.27 bundled customization documentation and public binary confirm `.gemini/config/skills`. This is runtime/documentation evidence, not a claim of an isolated live model test.
- [x] Final local Docker E2E: 22 files, 83 tests passed in 273.65 seconds.
- [x] README exact public archive URL installed into an isolated prefix, reported 5.0.0-alpha.1, installed all six provider selectors and matched every installed skill target to the reviewed canonical contents.
- [x] All 10 exact-head CI checks passed in one run (34044374631), including Docker E2E (6m35s), Code quality, Unit tests and all six packed platforms plus their aggregate.

Initial quality run overlapped in-progress edits and reported formatting; final checks passed without weakened gates. The temporary OpenCode npm wrapper required postinstall setup, so discovery verification used its actual platform binary directly. An initial help invocation attempted a host data directory and was sandbox-blocked; subsequent verification isolated all provider data/config paths, without granting host write access.

## Research and lifecycle

- [TMT-58](https://linear.app/tigerpig-dev/issue/TMT-58), following delivered TMT-57 / PR #80.
- [Antigravity skills](https://www.agy.dev/docs/skills/), [Pi skills](https://pi.dev/docs/latest/skills), [OpenCode skills](https://opencode.ai/docs/skills).
- Pi's locally installed 0.85.0 loader does not implement the shared discovery described by newer web docs, so the native path deliberately supports that baseline. Older agy IDE/CLI paths are not auto-written; `--dir` remains the explicit escape hatch.
- Dedicated branch/worktree: `codex/tmt-58-providers` / `/Users/benhsieh/dev/tmt-58-providers`.
- Local-first, one candidate push; normal protected merge after reviewed-head checks. Sync main/Linear and remove the clean delivered worktree afterward.
- Version remains `5.0.0-alpha.1`. No npm publication, tags, releases, dist-tags, provider permission changes or plugin uninstall. Publication remains with the user.
