### PR TITLE
fix: restore verified tmux caller discovery and stageful metadata errors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -420,12 +420,20 @@ this same owner, not another loader.
 
 ## Caller context
 
-The tmux adapter owns current-pane evidence: a strict `TMUX_PANE` ID and the
-socket/server PID in `TMUX` must agree with a bounded, read-only query of that
-explicit pane. Missing, malformed, stale or mismatched evidence yields no caller;
-there is no ambient/default-pane fallback. Environment evidence selects local
-context, not an authenticated principal, and is not a defense against deliberate
-environment spoofing.
+The tmux adapter owns current-pane evidence. Complete `TMUX_PANE` and `TMUX`
+environment evidence must agree with a bounded query of that explicit pane.
+When environment evidence is missing, a bounded read-only process-ancestry
+lookup may identify a unique pane process on the selected tmux server. An
+ambient active pane or session name is never caller evidence. Supplied malformed,
+stale or conflicting evidence must not be rescued by fallback. Missing process
+visibility, inaccessible sockets or ambiguous matches yield no caller. This
+supports environment-stripped descendants, not arbitrary sandbox isolation;
+nondefault servers still need a usable server-selection mechanism.
+The fallback uses the system `ps` utility with a shared one-second deadline
+and a bounded ancestry depth/output size. A system without `ps` cannot use this
+fallback; the normal complete-environment path does not acquire that dependency.
+Environment/process evidence selects local context, not an authenticated
+principal, and is not a defense against deliberate environment spoofing.
 
 `name`, `this`, `whoami` and `unbind` reject missing caller context with
 `PANE_NOT_FOUND` (exit 3) before opening identity storage. Implicit role access
@@ -515,6 +523,15 @@ SQLite immediate-transaction boundary. Authoritative endpoint snapshots are
 taken after acquiring the write lock, so a reconciler cannot prune a new
 binding using evidence captured before publication. Bind verifies the written
 metadata against fresh server/pane evidence before committing its success.
+
+Metadata adapter failures distinguish reads from writes through the narrow
+`pane-metadata-error.ts` contract. Public errors expose only the stage and
+bounded exit/permission classification, never raw stderr, command arguments or
+metadata payloads. Post-publication verification failures identify mismatched
+pane/server or database binding evidence instead of claiming that the write
+failed. These diagnostics do not change transaction rollback or durable-identity
+retention. The CLI does not infer an outside-tmux warning solely from `$TMUX`;
+operation-specific resolution supplies the actual result.
 
 The lock acquisition uses the existing five-second SQLite busy timeout. Tmux
 work inside the boundary shares a three-second monotonic deadline after lock

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,6 +82,14 @@ Changed public CLI behavior needs representative real subprocess input/output
 coverage; tmux integration uses the existing Docker harness. A feature issue
 authorizes its matching tests, not unrelated expansion of the E2E foundation.
 
+Caller discovery regressions require a CLI process genuinely descended from a
+tmux pane process, with environment stripped and another pane active. Spawning
+the CLI outside tmux with injected environment tests a different contract.
+Preserve rejection tests for outside callers, malformed/conflicting evidence
+and unavailable process information. An environment-stripped fixture is not
+proof that a specific provider sandbox permits process/socket access; report
+that verification gap separately.
+
 | Changed area                            | Required checks                                                                     |
 | --------------------------------------- | ----------------------------------------------------------------------------------- |
 | Production TypeScript                   | `pnpm type:check`, `pnpm lint`, `pnpm format:check`                                 |

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -125,21 +125,6 @@ async function runContextCommand(
       },
     });
 
-    const tmuxRequired = new Set([
-      'talk',
-      'send',
-      'check',
-      'read',
-      'this',
-      'name',
-      'add',
-      'whoami',
-      'unbind',
-    ]);
-    if (!process.env.TMUX && tmuxRequired.has(command)) {
-      ctx.ui.warn('Not running inside tmux. Some features may not work.');
-    }
-
     await runStartupChecks(ctx, command);
     await dispatchCommand(ctx, parsed);
   } catch (error) {

--- a/src/exchange-cli-contract.test.ts
+++ b/src/exchange-cli-contract.test.ts
@@ -429,10 +429,19 @@ describe('real CLI Exchange attention contract', () => {
       withSandbox(async (sandbox) => {
         const seeded = seedExchange(sandbox, 'Alice', 'req_exchange_implicit');
         const tmuxLog = await calibratedTmuxGuard(sandbox);
+        // Fix process visibility independently of the host sandbox: the CLI's
+        // PID has no parent, and the guarded server cannot supply a pane.
+        const psPath = path.join(sandbox.root, 'forbidden-bin', 'ps');
+        writeFileSync(psPath, '#!/bin/sh\nprintf "%s 0\\n" "$4"\n');
+        chmodSync(psPath, 0o755);
         const implicit = await runCli(sandbox, ['x', 'list', '--json']);
         expect(implicit.status).toBe(1);
         expectError(implicit, 'IDENTITY_REQUIRED');
-        expect(existsSync(tmuxLog)).toBe(false);
+        // Implicit selection may discover, but must never mutate tmux or
+        // proceed without evidence. Reset the calibrated guard for explicit
+        // storage-only operations, which must make zero tmux invocations.
+        expect(fs.readFileSync(tmuxLog, 'utf8')).toMatch(/^list-panes -a -F [^\n]+\n$/);
+        fs.rmSync(tmuxLog);
         const missing = await runCli(sandbox, ['x', 'list', '--identity', 'missing', '--json']);
         expect(missing.status).toBe(3);
         expectError(missing, 'NAME_NOT_FOUND');

--- a/src/identity-service.test.ts
+++ b/src/identity-service.test.ts
@@ -10,6 +10,7 @@ import {
   IdentityServiceError,
 } from './identity-service.js';
 import { openIdentityRepository } from './storage/identity-repository.js';
+import { PaneMetadataError } from './pane-metadata-error.js';
 import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
 import type { PaneInfo, Paths, Tmux, TmuxEndpointSnapshot } from './types.js';
 
@@ -1013,6 +1014,25 @@ describe('durable identity service', () => {
     repository.close();
   });
 
+  it.each(['read', 'write'] as const)(
+    'preserves the %s stage and safe failure classification without committing a binding',
+    (stage) => {
+      const test = fixture();
+      const cause = Object.assign(new Error('private subprocess arguments'), { code: 'EPERM' });
+      test.tmux.setDurableIdentity = () => {
+        throw new PaneMetadataError(stage, { cause });
+      };
+      const service = createTestService(test);
+      expect(() => service.bindCurrent('Stage failure')).toThrow(
+        `Could not ${stage} pane metadata (EPERM).`
+      );
+      const repository = openIdentityRepository(test.paths.databaseFile);
+      expect(repository.findBindings()).toEqual([]);
+      expect(repository.findByCanonicalName('stage failure')).toBeDefined();
+      repository.close();
+    }
+  );
+
   it('rolls back when metadata publication verifies a missing marker while retaining identity data', () => {
     const test = fixture();
     const seed = openIdentityRepository(test.paths.databaseFile);
@@ -1022,7 +1042,9 @@ describe('durable identity service', () => {
     test.tmux.setDurableIdentity = () => {};
     const service = createTestService(test);
 
-    expect(() => service.bindCurrent(identity.name)).toThrow('Could not write pane metadata.');
+    expect(() => service.bindCurrent(identity.name)).toThrow(
+      'Pane metadata verification failed: pane/server identity does not match.'
+    );
     const repository = openIdentityRepository(test.paths.databaseFile);
     expect(repository.findBindings()).toEqual([]);
     expect(repository.findByCanonicalName(identity.canonicalName)).toEqual(identity);

--- a/src/identity-service.ts
+++ b/src/identity-service.ts
@@ -9,6 +9,7 @@ import {
   type DurableIdentityResolution,
 } from './identity-context.js';
 import { resolveTarget } from './target-resolver.js';
+import { PaneMetadataError } from './pane-metadata-error.js';
 import type { TargetIdentity, TargetResolverPort } from './target-resolver.js';
 import type {
   IdentityService,
@@ -115,7 +116,7 @@ function endpointSnapshot(tmux: Tmux, options: TmuxOperationOptions = {}): TmuxE
     } catch (error) {
       throw new IdentityServiceError(
         'RECONCILIATION_FAILED',
-        'Could not inspect the tmux endpoint.',
+        error instanceof PaneMetadataError ? error.message : 'Could not inspect the tmux endpoint.',
         {
           cause: error,
         }
@@ -244,11 +245,17 @@ function verifyPublished(
     !paneMatches(binding, pane) ||
     !metadataMatches(pane, identity, binding)
   ) {
-    throw new Error('Durable pane metadata could not be verified.');
+    throw new IdentityServiceError(
+      'RECONCILIATION_FAILED',
+      'Pane metadata verification failed: pane/server identity does not match.'
+    );
   }
   const persisted = repository.findBindingByPane(paneId, binding.serverId);
   if (!persisted || persisted.id !== binding.id || persisted.identityId !== identity.id) {
-    throw new Error('Durable binding could not be verified.');
+    throw new IdentityServiceError(
+      'RECONCILIATION_FAILED',
+      'Pane metadata verification failed: database binding does not match.'
+    );
   }
 }
 
@@ -283,6 +290,9 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
       return operation();
     } catch (error) {
       if (error instanceof IdentityServiceError) throw error;
+      if (error instanceof PaneMetadataError) {
+        throw new IdentityServiceError('RECONCILIATION_FAILED', error.message, { cause: error });
+      }
       throw new IdentityServiceError('RECONCILIATION_FAILED', message, { cause: error });
     }
   };
@@ -446,12 +456,14 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
       try {
         if (!tmux.setDurableIdentity) throw new Error('Durable tmux metadata is unavailable.');
         tmux.setDurableIdentity(paneId, identity, binding, options);
-        verifyPublished(repository, tmux, identity, binding, paneId, options);
       } catch (error) {
-        throw new IdentityServiceError('RECONCILIATION_FAILED', 'Could not write pane metadata.', {
-          cause: error,
-        });
+        throw new IdentityServiceError(
+          'RECONCILIATION_FAILED',
+          error instanceof PaneMetadataError ? error.message : 'Could not write pane metadata.',
+          { cause: error }
+        );
       }
+      verifyPublished(repository, tmux, identity, binding, paneId, options);
       return identity;
     }, 'Could not publish identity state.');
   };

--- a/src/pane-metadata-error.test.ts
+++ b/src/pane-metadata-error.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { PaneMetadataError } from './pane-metadata-error.js';
+
+describe('pane metadata failure diagnostics', () => {
+  it.each([
+    [{ code: 'EPERM' }, ' (EPERM)'],
+    [{ code: 'EACCES' }, ' (EACCES)'],
+    [{ status: 1 }, ' (tmux exit 1)'],
+    [{ signal: 'SIGKILL' }, ' (SIGKILL)'],
+    [{ code: 'private payload', status: -1 }, ''],
+  ])('exposes only safe failure classification for %j', (fields, suffix) => {
+    const cause = Object.assign(new Error('private argv and metadata'), fields, {
+      stderr: 'private subprocess output',
+    });
+    const error = new PaneMetadataError('write', { cause });
+    expect(error.message).toBe(`Could not write pane metadata${suffix}.`);
+    expect(error.stage).toBe('write');
+    expect(error.cause).toBe(cause);
+  });
+
+  it('reports read stage without relying on an arbitrary cause', () => {
+    expect(new PaneMetadataError('read', { cause: 'private text' }).message).toBe(
+      'Could not read pane metadata.'
+    );
+  });
+});

--- a/src/pane-metadata-error.ts
+++ b/src/pane-metadata-error.ts
@@ -1,0 +1,28 @@
+export type PaneMetadataStage = 'read' | 'write';
+
+function failureSummary(cause: unknown): string {
+  if (!(cause instanceof Error)) return '';
+  // Never expose subprocess stderr, argv or metadata JSON in public errors.
+  const code = Object.getOwnPropertyDescriptor(cause, 'code')?.value;
+  if (['EACCES', 'EPERM', 'ENOENT', 'ETIMEDOUT', 'ENOBUFS'].includes(code)) {
+    return ` (${code})`;
+  }
+  const status = Object.getOwnPropertyDescriptor(cause, 'status')?.value;
+  if (Number.isInteger(status) && status > 0 && status <= 255) {
+    return ` (tmux exit ${status})`;
+  }
+  const signal = Object.getOwnPropertyDescriptor(cause, 'signal')?.value;
+  if (signal === 'SIGKILL' || signal === 'SIGTERM') return ` (${signal})`;
+  return '';
+}
+
+/** Safe adapter failure detail shared with the identity application boundary. */
+export class PaneMetadataError extends Error {
+  constructor(
+    readonly stage: PaneMetadataStage,
+    options?: { readonly cause?: unknown }
+  ) {
+    super(`Could not ${stage} pane metadata${failureSummary(options?.cause)}.`, options);
+    this.name = 'PaneMetadataError';
+  }
+}

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -611,9 +611,53 @@ describe('createTmux', () => {
       };
 
       expect(() => createTmux().setDurableIdentity!('%9', identity, binding)).toThrow(
-        'tmux read failed'
+        expect.objectContaining({
+          name: 'PaneMetadataError',
+          stage: 'read',
+          message: 'Could not read pane metadata.',
+          cause: expect.objectContaining({ message: 'tmux read failed' }),
+        })
       );
       expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('wraps metadata write failures without retrying or leaking subprocess details', () => {
+      const identity: DurableIdentity = {
+        id: 'identity-1',
+        name: 'Alice',
+        canonicalName: 'alice',
+        createdAt: 'created',
+        updatedAt: 'updated',
+      };
+      const binding: TmuxBinding = {
+        id: 'binding-1',
+        identityId: identity.id,
+        transport: 'tmux',
+        paneId: '%9',
+        serverId: 'server-1',
+        socketPath: '/tmp/tmux.sock',
+        serverPid: 321,
+        serverStartTime: 'started',
+        panePid: 654,
+        boundAt: 'bound',
+        lastVerifiedAt: 'verified',
+      };
+      const cause = Object.assign(new Error('private tmux stderr'), { code: 'EPERM' });
+      mockedExecFileSync
+        .mockReturnValueOnce(JSON.stringify({ version: 1 }))
+        .mockImplementationOnce(() => {
+          throw cause;
+        });
+
+      expect(() => createTmux().setDurableIdentity!('%9', identity, binding)).toThrow(
+        expect.objectContaining({
+          name: 'PaneMetadataError',
+          stage: 'write',
+          message: 'Could not write pane metadata (EPERM).',
+          cause,
+        })
+      );
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
     });
 
     it('treats a quiet absent metadata option as an empty metadata object', () => {
@@ -670,13 +714,17 @@ describe('createTmux', () => {
       );
     });
 
-    it('does not fall back to the ambient tmux server without caller evidence', () => {
+    it('uses bounded process evidence when both caller environment values are absent', () => {
       vi.stubEnv('TMUX', '');
       vi.stubEnv('TMUX_PANE', '');
-      mockedExecSync.mockReturnValue('%7\n');
       const tmux = createTmux();
       expect(tmux.getCurrentPaneId()).toBeNull();
-      expect(mockedExecFileSync).not.toHaveBeenCalled();
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        'ps',
+        ['-o', 'pid=,ppid=', '-p', String(process.pid)],
+        expect.any(Object)
+      );
       expect(mockedExecSync).not.toHaveBeenCalled();
     });
 
@@ -686,7 +734,7 @@ describe('createTmux', () => {
         tmux: undefined,
         pane: '%9',
         output: undefined,
-        calls: 0,
+        calls: 1,
       },
       {
         label: 'malformed pane target',
@@ -762,6 +810,145 @@ describe('createTmux', () => {
       const tmux = createTmux();
       expect(tmux.getCurrentPaneId()).toBeNull();
     });
+
+    it('discovers the unique pane containing the caller process outside tmux env', () => {
+      vi.stubEnv('TMUX', '');
+      vi.stubEnv('TMUX_PANE', '');
+      const parentPid = process.pid + 1;
+      mockedExecFileSync
+        .mockReturnValueOnce(`${process.pid} ${parentPid}\n`)
+        .mockReturnValueOnce(`${parentPid} 0\n`)
+        .mockReturnValueOnce(
+          `%7${CALLER_PANE_SEPARATOR}${parentPid}${CALLER_PANE_SEPARATOR}/tmp/default.sock${CALLER_PANE_SEPARATOR}321\n`
+        );
+
+      expect(createTmux().getCurrentPaneId()).toBe('%7');
+      expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+        'tmux',
+        ['list-panes', '-a', '-F', expect.stringContaining('#{pane_pid}')],
+        expect.objectContaining({
+          timeout: expect.any(Number),
+          maxBuffer: 64 * 1024,
+          killSignal: 'SIGKILL',
+        })
+      );
+    });
+
+    it('rejects an ambiguous process-to-pane match', () => {
+      vi.stubEnv('TMUX', '');
+      vi.stubEnv('TMUX_PANE', '');
+      const parentPid = process.pid + 1;
+      mockedExecFileSync
+        .mockReturnValueOnce(`${process.pid} ${parentPid}\n`)
+        .mockReturnValueOnce(`${parentPid} 0\n`)
+        .mockReturnValueOnce(
+          `%7${CALLER_PANE_SEPARATOR}${parentPid}${CALLER_PANE_SEPARATOR}/tmp/default.sock${CALLER_PANE_SEPARATOR}321\n` +
+            `%8${CALLER_PANE_SEPARATOR}${parentPid}${CALLER_PANE_SEPARATOR}/tmp/default.sock${CALLER_PANE_SEPARATOR}321\n`
+        );
+
+      expect(createTmux().getCurrentPaneId()).toBeNull();
+    });
+
+    it('rejects discovery when process ancestry cannot be read', () => {
+      vi.stubEnv('TMUX', '');
+      vi.stubEnv('TMUX_PANE', '');
+      mockedExecFileSync.mockImplementationOnce(() => {
+        throw new Error('ps unavailable');
+      });
+
+      expect(createTmux().getCurrentPaneId()).toBeNull();
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('validates partial pane evidence against the discovered process', () => {
+      vi.stubEnv('TMUX', '');
+      vi.stubEnv('TMUX_PANE', '%7');
+      const parentPid = process.pid + 1;
+      mockedExecFileSync
+        .mockReturnValueOnce(`${process.pid} ${parentPid}\n`)
+        .mockReturnValueOnce(`${parentPid} 0\n`)
+        .mockReturnValueOnce(
+          `%8${CALLER_PANE_SEPARATOR}${parentPid}${CALLER_PANE_SEPARATOR}/tmp/default.sock${CALLER_PANE_SEPARATOR}321\n`
+        );
+
+      expect(createTmux().getCurrentPaneId()).toBeNull();
+    });
+
+    it.each([
+      ['/tmp/custom.sock', '321', '%7'],
+      ['/tmp/other.sock', '321', null],
+      ['/tmp/custom.sock', '999', null],
+    ])('checks partial server evidence against %s/%s', (socket, server, expected) => {
+      vi.stubEnv('TMUX', '/tmp/custom.sock,321,0');
+      vi.stubEnv('TMUX_PANE', '');
+      mockedExecFileSync
+        .mockReturnValueOnce(`${process.pid} 0\n`)
+        .mockReturnValueOnce(
+          ['%7', String(process.pid), socket, server].join(CALLER_PANE_SEPARATOR)
+        );
+      expect(createTmux().getCurrentPaneId()).toBe(expected);
+      expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+        'tmux',
+        ['-S', '/tmp/custom.sock', 'list-panes', '-a', '-F', expect.any(String)],
+        expect.any(Object)
+      );
+    });
+
+    it.each([
+      ['', '123', '/tmp/default.sock', '321'],
+      ['%8', '0', '/tmp/default.sock', '321'],
+      ['%8', '123', '', '321'],
+      ['%8', '123', '/tmp/default.sock', '0'],
+      ['%8', '123', '/tmp/default.sock'],
+    ])('rejects malformed rows alongside a valid candidate: %j', (...fields) => {
+      vi.stubEnv('TMUX', '');
+      vi.stubEnv('TMUX_PANE', '');
+      mockedExecFileSync
+        .mockReturnValueOnce(`${process.pid} 0\n`)
+        .mockReturnValueOnce(
+          ['%7', String(process.pid), '/tmp/default.sock', '321'].join(CALLER_PANE_SEPARATOR) +
+            '\n' +
+            fields.join(CALLER_PANE_SEPARATOR)
+        );
+      expect(createTmux().getCurrentPaneId()).toBeNull();
+    });
+
+    it.each(['ancestry', 'pane listing'])(
+      'rejects a shared deadline exhausted during %s',
+      (stage) => {
+        vi.stubEnv('TMUX', '');
+        vi.stubEnv('TMUX_PANE', '');
+        let now = 0;
+        const clock = vi.spyOn(performance, 'now').mockImplementation(() => now);
+        mockedExecFileSync.mockImplementation((command) => {
+          if (command === 'ps') {
+            if (stage === 'ancestry') now = 1000;
+            return `${process.pid} 0\n`;
+          }
+          now = 1000;
+          return ['%7', String(process.pid), '/tmp/default.sock', '321'].join(
+            CALLER_PANE_SEPARATOR
+          );
+        });
+        try {
+          expect(createTmux().getCurrentPaneId()).toBeNull();
+          expect(mockedExecFileSync).toHaveBeenCalledTimes(stage === 'ancestry' ? 1 : 2);
+        } finally {
+          clock.mockRestore();
+        }
+      }
+    );
+
+    it('does not mistake an unrelated pane process for the caller', () => {
+      vi.stubEnv('TMUX', '');
+      vi.stubEnv('TMUX_PANE', '');
+      mockedExecFileSync
+        .mockReturnValueOnce(`${process.pid} 0\n`)
+        .mockReturnValueOnce(
+          ['%7', String(process.pid + 1), '/tmp/default.sock', '321'].join(CALLER_PANE_SEPARATOR)
+        );
+      expect(createTmux().getCurrentPaneId()).toBeNull();
+    });
   });
 
   describe('durable endpoint snapshots', () => {
@@ -780,7 +967,13 @@ describe('createTmux', () => {
           throw new Error('metadata fallback failed');
         });
 
-      expect(() => createTmux().getEndpointSnapshot?.()).toThrow('metadata fallback failed');
+      expect(() => createTmux().getEndpointSnapshot?.()).toThrow(
+        expect.objectContaining({
+          name: 'PaneMetadataError',
+          stage: 'read',
+          cause: expect.objectContaining({ message: 'metadata fallback failed' }),
+        })
+      );
     });
 
     it('uses integer per-command timeouts bounded by a decreasing shared deadline', () => {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -14,6 +14,7 @@ import type {
   TmuxOperationOptions,
 } from './types.js';
 import { sendTmuxMessage } from './tmux-message.js';
+import { PaneMetadataError } from './pane-metadata-error.js';
 
 const AGENT_METADATA_OPTION = '@tmux-team.agent';
 const SERVER_ID_OPTION = '@tmux-team.server-id';
@@ -26,6 +27,8 @@ const TMUX_CAPTURE_MAX_BUFFER = 4 * 1024 * 1024;
 const CALLER_PANE_TIMEOUT_MS = 1_000;
 const CALLER_PANE_MAX_BUFFER = 4096;
 const CALLER_PANE_SEPARATOR = '__TMT_CALLER_PANE_4f1c__';
+const CALLER_ANCESTRY_MAX_DEPTH = 64;
+const CALLER_DISCOVERY_MAX_BUFFER = 64 * 1024;
 const SERVER_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PANE_ID_PATTERN = /^%\d+$/;
 
@@ -196,11 +199,13 @@ function isMissingProcess(error: unknown): boolean {
   );
 }
 
-function callerTmuxContext(
-  value: string | undefined
-):
-  | { readonly socketPath: string; readonly serverPid: number; readonly sessionId: string }
-  | undefined {
+interface CallerTmuxContext {
+  readonly socketPath: string;
+  readonly serverPid: number;
+  readonly sessionId: string;
+}
+
+function callerTmuxContext(value: string | undefined): CallerTmuxContext | undefined {
   if (!value) return undefined;
   const lastComma = value.lastIndexOf(',');
   const previousComma = value.lastIndexOf(',', lastComma - 1);
@@ -220,10 +225,31 @@ function callerTmuxContext(
 
 function callerPaneId(): string | null {
   const paneId = process.env.TMUX_PANE;
-  if (!paneId || !PANE_ID_PATTERN.test(paneId)) return null;
-  const context = callerTmuxContext(process.env.TMUX);
-  if (!context) return null;
+  const tmuxValue = process.env.TMUX;
+  if (paneId && !PANE_ID_PATTERN.test(paneId)) return null;
+  const context = callerTmuxContext(tmuxValue);
+  if (tmuxValue && !context) return null;
 
+  // Keep the fully populated environment as the cheap, strict path. In
+  // particular, do not let discovery hide stale or mismatched explicit
+  // evidence.
+  if (paneId && context) return verifyCallerPane(paneId, context);
+  return discoverCallerPane(paneId || undefined, context);
+}
+
+function callerCommandOptions(timeout: number): {
+  timeout: number;
+  maxBuffer: number;
+  killSignal: 'SIGKILL';
+} {
+  return {
+    timeout,
+    maxBuffer: CALLER_DISCOVERY_MAX_BUFFER,
+    killSignal: 'SIGKILL',
+  };
+}
+
+function verifyCallerPane(paneId: string, context: CallerTmuxContext): string | null {
   try {
     const output = execFileSync(
       'tmux',
@@ -258,6 +284,106 @@ function callerPaneId(): string | null {
   } catch {
     return null;
   }
+}
+
+function callerAncestry(deadline: number): Set<number> | null {
+  const ancestry = new Set<number>();
+  let pid = process.pid;
+  for (let depth = 0; depth < CALLER_ANCESTRY_MAX_DEPTH; depth += 1) {
+    if (!Number.isSafeInteger(pid) || pid <= 0 || ancestry.has(pid)) return null;
+    ancestry.add(pid);
+    let output: string;
+    try {
+      const timeout = Math.floor(deadline - performance.now());
+      if (timeout <= 0) return null;
+      output = execFileSync('ps', ['-o', 'pid=,ppid=', '-p', String(pid)], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        ...callerCommandOptions(timeout),
+      });
+    } catch {
+      return null;
+    }
+    if (typeof output !== 'string') return null;
+    const rows = output
+      .trim()
+      .split(/\r?\n/)
+      .map((row) => row.trim().split(/\s+/))
+      .filter((row) => row.length > 0);
+    if (
+      rows.length !== 1 ||
+      rows[0]?.length !== 2 ||
+      !/^\d+$/.test(rows[0][0] ?? '') ||
+      !/^\d+$/.test(rows[0][1] ?? '')
+    ) {
+      return null;
+    }
+    const returnedPid = Number(rows[0][0]);
+    const parentPid = Number(rows[0][1]);
+    if (returnedPid !== pid || !Number.isSafeInteger(parentPid) || parentPid < 0) return null;
+    if (parentPid === 0) return ancestry;
+    pid = parentPid;
+  }
+  return null;
+}
+
+function discoverCallerPane(
+  paneId: string | undefined,
+  context: CallerTmuxContext | undefined
+): string | null {
+  const deadline = performance.now() + CALLER_PANE_TIMEOUT_MS;
+  const ancestry = callerAncestry(deadline);
+  if (!ancestry) return null;
+  const format = `#{pane_id}${CALLER_PANE_SEPARATOR}#{pane_pid}${CALLER_PANE_SEPARATOR}#{socket_path}${CALLER_PANE_SEPARATOR}#{pid}`;
+  let output: string;
+  try {
+    const timeout = Math.floor(deadline - performance.now());
+    if (timeout <= 0) return null;
+    const args = context
+      ? ['-S', context.socketPath, 'list-panes', '-a', '-F', format]
+      : ['list-panes', '-a', '-F', format];
+    output = execFileSync('tmux', args, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...callerCommandOptions(timeout),
+    });
+  } catch {
+    return null;
+  }
+  if (performance.now() >= deadline) return null;
+  if (typeof output !== 'string') return null;
+  const rows = output.trim().split(/\r?\n/).filter(Boolean);
+  if (rows.length === 0) return null;
+  const parsedRows = rows.map((row) => row.split(CALLER_PANE_SEPARATOR));
+  if (
+    parsedRows.some((fields) => fields.length !== 4) ||
+    parsedRows.some(([id, panePid, socketPath, serverPid]) => {
+      const numericPanePid = Number(panePid);
+      const numericServerPid = Number(serverPid);
+      return (
+        !id ||
+        !PANE_ID_PATTERN.test(id) ||
+        !/^\d+$/.test(panePid ?? '') ||
+        !Number.isSafeInteger(numericPanePid) ||
+        numericPanePid <= 0 ||
+        !socketPath ||
+        !/^\d+$/.test(serverPid ?? '') ||
+        !Number.isSafeInteger(numericServerPid) ||
+        numericServerPid <= 0
+      );
+    })
+  )
+    return null;
+  const candidates = parsedRows
+    .filter(([id, panePid, socketPath, serverPid]) => {
+      const numericPanePid = Number(panePid);
+      if (!ancestry.has(numericPanePid)) return false;
+      if (context && (socketPath !== context.socketPath || serverPid !== String(context.serverPid)))
+        return false;
+      return paneId === undefined || id === paneId;
+    })
+    .map(([id]) => id);
+  return candidates.length === 1 ? (candidates[0] ?? null) : null;
 }
 
 function remainingTimeout(options: TmuxOperationOptions = {}): number {
@@ -396,8 +522,8 @@ export function createTmux(): Tmux {
     },
 
     getCurrentPaneId(): string | null {
-      // Implicit commands may select only a pane proven by the caller's tmux
-      // environment. Never fall back to the ambient/default server.
+      // Select only verified environment or process-ancestry evidence, never
+      // the ambient server's active pane.
       return callerPaneId();
     },
 
@@ -498,15 +624,20 @@ function readPaneMetadataStrict(
   paneId: string,
   options: TmuxOperationOptions = {}
 ): PaneAgentMetadata {
-  const output = execFileSync(
-    'tmux',
-    ['show-options', '-q', '-p', '-t', paneId, '-v', AGENT_METADATA_OPTION],
-    {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      ...commandOptions(options),
-    }
-  );
+  let output: string;
+  try {
+    output = execFileSync(
+      'tmux',
+      ['show-options', '-q', '-p', '-t', paneId, '-v', AGENT_METADATA_OPTION],
+      {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        ...commandOptions(options),
+      }
+    );
+  } catch (cause) {
+    throw new PaneMetadataError('read', { cause });
+  }
   return safeParseMetadata(output) ?? emptyMetadata();
 }
 
@@ -519,20 +650,24 @@ function writePaneMetadata(
   metadata: PaneAgentMetadata,
   options: TmuxOperationOptions = {}
 ): void {
-  if (!hasMetadata(metadata)) {
-    execFileSync('tmux', ['set-option', '-p', '-u', '-t', paneId, AGENT_METADATA_OPTION], {
-      stdio: 'pipe',
-      ...commandOptions(options),
-    });
-    return;
-  }
-
-  execFileSync(
-    'tmux',
-    ['set-option', '-p', '-t', paneId, AGENT_METADATA_OPTION, JSON.stringify(metadata)],
-    {
-      stdio: 'pipe',
-      ...commandOptions(options),
+  try {
+    if (!hasMetadata(metadata)) {
+      execFileSync('tmux', ['set-option', '-p', '-u', '-t', paneId, AGENT_METADATA_OPTION], {
+        stdio: 'pipe',
+        ...commandOptions(options),
+      });
+      return;
     }
-  );
+
+    execFileSync(
+      'tmux',
+      ['set-option', '-p', '-t', paneId, AGENT_METADATA_OPTION, JSON.stringify(metadata)],
+      {
+        stdio: 'pipe',
+        ...commandOptions(options),
+      }
+    );
+  } catch (cause) {
+    throw new PaneMetadataError('write', { cause });
+  }
 }

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
 
 ARG TMUX_VERSION=3.3a-3
+ARG PROCPS_VERSION=2:4.0.2-3
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y "tmux=${TMUX_VERSION}" \
+  && apt-get install --no-install-recommends -y "tmux=${TMUX_VERSION}" "procps=${PROCPS_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install --global pnpm@10.33.0

--- a/test/e2e/caller-context.e2e.test.ts
+++ b/test/e2e/caller-context.e2e.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { withE2EFixture, type CliResult, type E2EFixture } from './harness.js';
+import { readRealTmuxCli, releaseRealTmuxCli, spawnRealTmuxCli } from './real-tmux-caller.js';
 
 interface CommandError {
   error: { code: string; message: string };
@@ -59,6 +60,94 @@ async function seedIdentity(fixture: E2EFixture, name: string, profile: string):
 }
 
 describe.sequential('strict caller context', () => {
+  it.each([
+    ['missing TMUX_PANE', { stripPane: true }],
+    ['missing TMUX and TMUX_PANE', { stripTmux: true, stripPane: true }],
+  ])(
+    'discovers the originating pane from a real tmux child process with %s',
+    async (
+      _label,
+      contextOptions: { readonly stripTmux?: boolean; readonly stripPane?: boolean }
+    ) => {
+      await withE2EFixture(async (fixture) => {
+        const real = await spawnRealTmuxCli(fixture, ['name', 'RealCaller'], {
+          name: contextOptions.stripTmux ? 'caller-both-missing' : 'caller-pane-missing',
+          ...contextOptions,
+        });
+
+        const peer = await fixture.createMockPane('active-peer');
+        fixture.tmux(['select-pane', '-t', peer.pane]);
+        await releaseRealTmuxCli(fixture, real);
+
+        const result = readRealTmuxCli<{ bound: boolean; name: string; pane: string }>(real);
+        expect(result).toEqual({
+          code: 0,
+          stdout: { bound: true, name: 'RealCaller', pane: real.pane },
+          stderr: '',
+        });
+        const binding = durableState(fixture).bindings.find(
+          (row) => (row as { pane_id?: string }).pane_id === real.pane
+        ) as { pane_id: string; pane_pid: number } | undefined;
+        expect(binding).toMatchObject({ pane_id: real.pane, pane_pid: real.panePid });
+        expect(JSON.parse(fixture.paneMetadata(real.pane))).toMatchObject({
+          globalIdentity: { panePid: real.panePid },
+        });
+        expect(fixture.paneMetadata(peer.pane)).toBe('');
+        expect(fixture.mockProcessIsRunning(real.panePid)).toBe(true);
+      });
+    },
+    20_000
+  );
+
+  it('resolves the this alias from the real pane ancestry with both variables missing', async () => {
+    let panePid = 0;
+    let fixtureRef: E2EFixture | undefined;
+    await withE2EFixture(async (fixture) => {
+      fixtureRef = fixture;
+      const real = await spawnRealTmuxCli(fixture, ['this', 'AliasCaller'], {
+        name: 'caller-this-both-missing',
+        stripTmux: true,
+        stripPane: true,
+      });
+      panePid = real.panePid;
+      const peer = await fixture.createMockPane('alias-active-peer');
+      fixture.tmux(['select-pane', '-t', peer.pane]);
+      await releaseRealTmuxCli(fixture, real);
+
+      const result = readRealTmuxCli<{ bound: boolean; name: string; pane: string }>(real);
+      expect(result).toEqual({
+        code: 0,
+        stdout: { bound: true, name: 'AliasCaller', pane: real.pane },
+        stderr: '',
+      });
+      expect(fixture.paneMetadata(peer.pane)).toBe('');
+    });
+    expect(panePid).toBeGreaterThan(0);
+    expect(fixtureRef?.mockProcessIsRunning(panePid)).toBe(false);
+  }, 20_000);
+
+  it('does not report a stripped descendant as outside tmux in human output', async () => {
+    await withE2EFixture(async (fixture) => {
+      const real = await spawnRealTmuxCli(fixture, ['whoami'], {
+        name: 'human-caller-both-missing',
+        stripTmux: true,
+        stripPane: true,
+        json: false,
+      });
+      const bound = await fixture.runJsonCli(['add', real.pane, 'HumanCaller'], {
+        outsideTmux: true,
+      });
+      expect(bound.code, bound.stderr || bound.stdout).toBe(0);
+      await releaseRealTmuxCli(fixture, real);
+
+      const result = readRealTmuxCli<string>(real);
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain("Bound identity 'HumanCaller'");
+      expect(result.stdout).not.toContain('Not running inside tmux. Some features may not work.');
+    });
+  }, 20_000);
+
   it('uses real socket and selected-pane evidence for every implicit identity and role operation', async () => {
     await withE2EFixture(async (fixture) => {
       await seedIdentity(fixture, 'Current', 'initial caller profile');

--- a/test/e2e/real-tmux-caller.ts
+++ b/test/e2e/real-tmux-caller.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { E2EFixture } from './harness.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const cliPath = path.join(repoRoot, 'bin', 'tmux-team');
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+export interface RealTmuxCli {
+  readonly pane: string;
+  readonly panePid: number;
+  readonly outputPath: string;
+  readonly errorPath: string;
+  readonly exitPath: string;
+  readonly releasePath: string;
+}
+
+/**
+ * Launch one real CLI process as a child of a tmux pane process. The command
+ * deliberately removes the normal tmux environment so caller discovery must
+ * use the process ancestry and the private server's real pane list.
+ */
+export async function spawnRealTmuxCli(
+  fixture: E2EFixture,
+  args: string[],
+  options: {
+    readonly name: string;
+    readonly stripTmux?: boolean;
+    readonly stripPane?: boolean;
+    readonly json?: boolean;
+  }
+): Promise<RealTmuxCli> {
+  const workspace = fixture.createWorkspace(`real-${options.name}`);
+  const outputPath = path.join(workspace, 'stdout');
+  const errorPath = path.join(workspace, 'stderr');
+  const exitPath = path.join(workspace, 'exit');
+  const releasePath = path.join(workspace, 'release');
+  const holdPath = path.join(workspace, 'hold-until-server-cleanup');
+  const command = [
+    `while [ ! -f ${shellQuote(releasePath)} ]; do sleep 0.01; done`,
+    `env${options.stripTmux ? ' -u TMUX' : ''}${options.stripPane ? ' -u TMUX_PANE' : ''} ${shellQuote(cliPath)} ${options.json === false ? '' : '--json '}${args.map(shellQuote).join(' ')} >${shellQuote(outputPath)} 2>${shellQuote(errorPath)}`,
+    `printf '%s' "$?" >${shellQuote(exitPath)}`,
+    `while [ ! -f ${shellQuote(holdPath)} ]; do sleep 0.05; done`,
+  ].join('; ');
+  const pane = fixture
+    .tmux([
+      'new-window',
+      '-d',
+      '-P',
+      '-F',
+      '#{pane_id}',
+      '-t',
+      'e2e',
+      '-n',
+      options.name,
+      '-c',
+      workspace,
+      `${shellQuote('/bin/sh')} -c ${shellQuote(command)}`,
+    ])
+    .trim();
+  const panePid = Number(fixture.tmux(['display-message', '-p', '-t', pane, '#{pane_pid}']).trim());
+  if (!pane || !Number.isInteger(panePid) || panePid <= 0) {
+    throw new Error(`Could not create real CLI pane '${options.name}'.`);
+  }
+  await fixture.waitFor(() => fixture.mockProcessIsRunning(panePid), 2_000, 'real CLI pane');
+  return { pane, panePid, outputPath, errorPath, exitPath, releasePath };
+}
+
+export async function releaseRealTmuxCli(fixture: E2EFixture, process: RealTmuxCli): Promise<void> {
+  fs.writeFileSync(process.releasePath, 'run');
+  await fixture.waitFor(
+    () =>
+      fs.existsSync(process.exitPath) && /^\d+$/.test(fs.readFileSync(process.exitPath, 'utf8')),
+    5_000,
+    'real CLI completion'
+  );
+}
+
+export function readRealTmuxCli<T>(process: RealTmuxCli): {
+  code: number;
+  stdout: T;
+  stderr: string;
+} {
+  const text = fs.readFileSync(process.outputPath, 'utf8');
+  return {
+    code: Number(fs.readFileSync(process.exitPath, 'utf8')),
+    stdout: (text.trimStart().startsWith('{') ? JSON.parse(text) : text) as T,
+    stderr: fs.readFileSync(process.errorPath, 'utf8'),
+  };
+}

--- a/test/e2e/role-lifecycle.e2e.test.ts
+++ b/test/e2e/role-lifecycle.e2e.test.ts
@@ -170,7 +170,7 @@ describe.sequential('durable role profiles', () => {
     });
   }, 30_000);
 
-  it('distinguishes missing identity, absent role, and missing implicit context without invoking tmux offline', async () => {
+  it('keeps explicit roles offline while rejecting unrelated implicit callers after discovery', async () => {
     await withE2EFixture(async (fixture) => {
       const invalid = await fixture.runJsonCli(['role', 'set', 'inline', '--file', 'file.md']);
       expect(invalid.code).toBe(1);
@@ -180,18 +180,24 @@ describe.sequential('durable role profiles', () => {
       });
       expect(missing.code).toBe(3);
       expect(missing.json).toMatchObject({ error: { code: 'NAME_NOT_FOUND' } });
-      const outside = await fixture.runJsonCli(['role', 'show'], { withoutTmux: true });
+      // Implicit selection may perform bounded read-only discovery. Explicit
+      // identity access above/below must still never invoke tmux.
+      const outside = await fixture.runJsonCli(['role', 'show'], { outsideTmux: true });
       expect(outside.code).toBe(1);
       expect(outside.json).toMatchObject({ error: { code: 'IDENTITY_REQUIRED' } });
       const unbound = await fixture.runJsonCli(['role', 'show']);
       expect(unbound.code).toBe(1);
       expect(unbound.json).toMatchObject({ error: { code: 'IDENTITY_REQUIRED' } });
       expect((await fixture.runJsonCli(['name', 'Empty'])).code).toBe(0);
+      const metadataBefore = fixture.paneMetadata();
+      const profilesBefore = storedProfiles(fixture);
       const outsideWithBoundDefault = await fixture.runJsonCli(['role', 'show'], {
-        withoutTmux: true,
+        outsideTmux: true,
       });
       expect(outsideWithBoundDefault.code).toBe(1);
       expect(outsideWithBoundDefault.json).toMatchObject({ error: { code: 'IDENTITY_REQUIRED' } });
+      expect(fixture.paneMetadata()).toBe(metadataBefore);
+      expect(storedProfiles(fixture)).toEqual(profilesBefore);
       expect((await showOffline(fixture, 'Empty')).role).toBeNull();
       expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
       // Calibrate the guard: a command that actually needs tmux must trip it.


### PR DESCRIPTION
## Summary

- Restore current-pane discovery for environment-stripped descendants of a real tmux pane while preserving strict complete-environment validation.
- Use a bounded process-parent chain and a unique matching pane PID on the selected server, not the active pane or a session name. Reject malformed/conflicting evidence, ambiguous matches, unavailable process information and deadline exhaustion.
- Distinguish metadata reads/writes from post-publication verification failures. Public diagnostics carry only safe failure classifications; preserve original causes internally and transactional rollback behavior.
- Remove the unconditional missing-TMUX warning; operation-specific resolution determines whether the command can run.
- Maintain architecture and verification guidance. Add pinned procps to the isolated E2E image; ordinary complete-environment operations do not require ps.

## Architecture and primary review

Reviewed head: `8346ae03af0740e961756326a3db08b31557ec6e`. Production implementation: `fda53118e3efc1a25b5107a921877e63ba8e614c`; the follow-up changes only the Exchange subprocess test.

The existing tmux adapter owns caller discovery and metadata I/O. The narrow pane-metadata-error contract follows the existing transport-error precedent; application services do not depend on the concrete tmux adapter. No new identity resolver, database, provider-specific branch, daemon, environment mutation or socket scan is introduced.

Primary personally reviewed runtime changes, service/command callers, the error projection, test assertions and fixture lifecycle. Review refinements included a shared monotonic discovery deadline, malformed-row rejection, real descendant name/this tests instead of prebound-only whoami tests, independent durable-state assertions, the exact human warning assertion and completion-file readiness. Unknown caller and explicit offline identity semantics remain distinct.

## Verification

- [x] Local Node 24.20.0 quality checks.
- [x] Final isolated run after the Exchange test refinement: 68 unit/contract files, 989 tests passed; coverage 95.72% statements/lines, 89.62% branches, 97.5% functions.
- [x] Original-adapter regression proof: both new real-tmux name cases fail with PANE_NOT_FOUND/exit 3 when the original adapter is mounted read-only into the candidate test image.
- [x] macOS process-parent query syntax checked without inspecting command lines.
- [x] Exact public GitHub archive at reviewed head installed into a temporary prefix; CLI version and isolated SQLite-backed identity listing succeeded.
- [x] Actual packed native-install verification passed on darwin/arm64/none, including storage and skill installation contracts.
- [x] Two consecutive full Docker E2E passes: 22 files / 87 tests each (263.12s and 268.24s), including real descendant cleanup.
- [x] All ten CI checks passed on reviewed head 8346ae03af0740e961756326a3db08b31557ec6e in run 34074936094; normal protected merge, no bypass.

The first full Docker run passed 86/87 tests, including all new caller tests. Its one failure was the former implicit-role assumption that missing environment forbids even read-only tmux discovery. The revision allows discovery for implicit outside callers while preserving explicit no-tmux guards and adding metadata/profile preservation assertions; this is the intended contract change, not relaxed identity validation.

A later full unit run concurrent with Docker hit the unchanged response-content test's real 100ms EOF deadline (988/989 passed). The first full run passed. Final isolated verification after Docker passed all 989 tests; no deadline or assertion was relaxed and no response implementation changed.

First-candidate Linux CI exposed the same obsolete no-discovery assumption in an Exchange subprocess test. The local sandbox's restricted ps visibility had masked it. The follow-up makes process visibility deterministic, asserts exactly one read-only discovery call for implicit selection, and retains calibrated zero-tmux assertions for explicit storage-only access. Focused Exchange tests pass on both local macOS and a network-isolated Linux container; full local quality and all 989 tests pass again. No production change or blind workflow rerun was used. A second candidate push is required for this test-only correction.

## Limitations and delivery

Refs #83. Keep the issue open for the reporter's actual provider/environment verification: stripping environment variables is not proof of support for a sandbox that blocks process visibility or socket access. The reported raw tmux empty pane format has not been reproduced or attributed to a root cause. Better metadata diagnostics do not claim to fix every underlying metadata failure.

No broad socket discovery: missing TMUX on a nondefault server still requires a usable server-selection mechanism. The fallback requires ps and has a one-second shared budget; absent/unreadable evidence fails closed. Ordinary complete-environment calls keep their fast path.

No npm publication, release/tag, provider permission changes or user-data deletion. Version remains unchanged. Dedicated branch/worktree: codex/83-pane-discovery / /Users/benhsieh/dev/tmt-83-pane-discovery. TMT work is tracked in GitHub Issues, not Linear.
