### PR TITLE
perf: scope identity verification and batch tmux metadata reads

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,7 +96,7 @@ identity-scoped explicit acknowledgement. It does not authorize a duplicate
 service or database, a new X-specific ID format, guessed identity backfill, or
 changes to the shipped `talk`/`reply`/`result` verbs. Reads do not acknowledge;
 service-owned reads may perform logical expiry and bounded opportunistic cleanup;
-`check` remains diagnostic and retains its existing reconciliation behavior.
+`check` remains diagnostic and reconciles only its selected identity binding.
 Timeout remains observer-only; offline queues, leases, memory, and MCP state are
 separate future work. SQLite supplies no autonomous TTL scheduler, so this does
 not promise punctual physical deletion or database-file shrinkage. Keep this
@@ -267,7 +267,7 @@ Recipient resolution precedes originator lookup and remains independent.
 
 The internal target projection carries durable identity and binding evidence,
 without extending public ActiveRegistration. Before preparation, the existing
-binding evaluator checks this evidence against a fresh full endpoint snapshot.
+binding evaluator checks this evidence against a fresh recipient-scoped endpoint snapshot.
 Changed server/socket/process or identity/binding markers fail closed. This is
 a verified observation of the intended recipient, not a guarantee against a
 later rebind before processing. Recipient UUID persists independently of cadence,
@@ -513,10 +513,37 @@ Active discovery still requires a verified binding; explicit data access does no
 
 Discovery and reconciliation use one local binding-evidence evaluator in
 `identity-service.ts`, composing identity/pane presence, server and process
-evidence, and durable metadata agreement. Reconciliation alone applies the
-foreign-socket preservation guard before evaluation; discovery still excludes
-bindings that do not match the current server. The shared predicate does not
+evidence, and durable metadata agreement. Scoped and full reconciliation share
+the foreign-socket preservation guard and binding mutation helper; discovery
+still excludes bindings that do not match the current server. The shared predicate does not
 change publication, transaction, or routing policy.
+
+Single-target operations select only relevant evidence. Caller lookup and unbind
+read the caller pane and its indexed database binding; named lookup reads the
+canonical identity and its unique binding. Binding checks the target and any
+existing location for the selected name, including bounded foreign-server
+probing when needed. Post-publication verification and talk's fresh recipient
+check request only that pane. No scoped observation prunes or touches unrelated
+bindings. Bare `list` and explicit internal reconciliation remain full discovery
+operations and can remove stale current-server bindings. Durable identities are
+never removed by either kind of reconciliation.
+
+The existing target resolver passes pane/canonical-name selection into the
+identity-aware view, preserving pane-first interpretation without materializing
+all identities. Verified target projections retain pane details from the same
+observation, so `list` does not perform a second discovery to render them.
+Identity and binding lookups use existing SQLite unique keys; no schema change,
+alternate resolver, cached presence or new connection is introduced.
+
+The tmux adapter reads pane metadata in the same `list-panes -F` batch as
+endpoint evidence. This format and pane filters are verified on the pinned
+tmux 3.3a; absent metadata does not justify another subprocess per pane.
+Scoped snapshots use tmux's `-f` filter, with a server-only observation when
+the selected pane is absent. Empty scopes never expand to all panes, and
+malformed scopes or incomplete endpoint evidence fail closed. This bounds
+subprocess fan-out and returned pane evidence, not tmux's internal traversal
+time. Metadata publication still explicitly reads the selected pane's options
+to preserve unrelated fields before writing; those failures remain fatal.
 
 Binding publication, active reconciliation and unbind share the repository's
 SQLite immediate-transaction boundary. Authoritative endpoint snapshots are

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -90,6 +90,16 @@ and unavailable process information. An environment-stripped fixture is not
 proof that a specific provider sandbox permits process/socket access; report
 that verification gap separately.
 
+Identity performance regressions require mostly-unbound large sessions as well
+as small fixtures. Assert subprocess counts and scoped evidence requests, not
+only elapsed-time thresholds: unrelated panes must not add per-pane subprocesses
+to a single-target operation. Record wall time as diagnostic evidence, with
+startup and transport delays distinguished from identity work. Real Docker
+scenarios must verify bindings, conflicts, untouched metadata, causal replies
+and cleanup; never seed every pane with placeholder metadata to make a test fast.
+Scoped reads must preserve unrelated stale rows while full discovery may reconcile
+them. Both paths must share the existing binding-evidence predicate.
+
 | Changed area                            | Required checks                                                                     |
 | --------------------------------------- | ----------------------------------------------------------------------------------- |
 | Production TypeScript                   | `pnpm type:check`, `pnpm lint`, `pnpm format:check`                                 |

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -296,13 +296,22 @@ Do not treat a failed bind as permission to delete data or try unrelated names.
 
 ## Commands
 
-`name`, `this`, `whoami` and `unbind` require matching live `TMUX` and
-`TMUX_PANE` caller context. Missing, malformed or stale context returns
-`PANE_NOT_FOUND` (exit 3), not the default pane's identity. Implicit `role`
+`name`, `this`, `whoami` and `unbind` require a verified live caller pane.
+Matching `TMUX` and `TMUX_PANE` provide the normal evidence; missing variables
+may be resolved through a bounded process-ancestry lookup on the selected server.
+Malformed, conflicting or unresolvable context returns `PANE_NOT_FOUND` (exit 3),
+not the default pane's identity. Implicit `role`
 access returns `IDENTITY_REQUIRED` (exit 1). Do not fabricate caller variables:
 outside tmux, use explicit `add <pane-target> <global-name>`, `talk <target>`,
 `check <target>`, or `role show|set|clear --identity <name>`. Explicit selection
 does not bind or authenticate the caller.
+
+Sandbox permissions still apply: tmux operations need socket access, and durable
+operations need access to TMT's SQLite storage. If access is denied, use the
+provider's normal approval flow for the authorized operation; do not fabricate
+caller variables, overwrite pane metadata, or delete storage as a workaround.
+Single-target commands validate the selected binding, not every unrelated pane.
+Use `list` for full active discovery; it is not a prerequisite for `talk` or `check`.
 
 ```bash
 tmt list

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -136,7 +136,12 @@ function createCtx(
     currentIdentity: vi.fn(),
     resolveIdentity: vi.fn(),
     activeIdentities: vi.fn(() => registrations.map(activeIdentity)),
-    resolveActive: vi.fn(),
+    resolveActive: vi.fn((target: string) => {
+      const registration = registrations.find(
+        (entry) => entry.paneId === target || entry.canonicalName === target.toLowerCase()
+      );
+      return registration ? activeIdentity(registration) : undefined;
+    }),
     reconcile: vi.fn(),
   };
   return {
@@ -299,8 +304,17 @@ describe('basic commands', () => {
       flags: { json: true },
       identities: [{ name: 'claude', canonicalName: 'claude', paneId: '%1' }],
     });
-    ctx.tmux.listPanes = vi.fn(() => [
-      { id: '%1', target: 'main:1.0', cwd: '/repo', command: 'claude', suggestedName: 'claude' },
+    vi.mocked(ctx.identityService.activeIdentities).mockReturnValue([
+      {
+        ...activeIdentity({ name: 'claude', canonicalName: 'claude', paneId: '%1' }),
+        pane: {
+          id: '%1',
+          target: 'main:1.0',
+          cwd: '/repo',
+          command: 'claude',
+          suggestedName: 'claude',
+        },
+      },
     ]);
     cmdList(ctx);
     expect((ctx.ui as any).jsonCalls).toEqual([
@@ -319,23 +333,27 @@ describe('basic commands', () => {
     ]);
   });
 
-  it('cmdList joins one pane snapshot into the v5 identity schema', () => {
+  it('cmdList reuses verified pane details without a second discovery', () => {
     const ctx = createCtx(testDir, { flags: { json: true } });
     const identities = [
       { name: 'Zed', canonicalName: 'zed', paneId: '%2' },
       { name: 'Alice', canonicalName: 'alice', paneId: '%1' },
     ];
-    (ctx.identityService.activeIdentities as ReturnType<typeof vi.fn>).mockReturnValue(
-      identities.map(activeIdentity)
-    );
-    ctx.tmux.listPanes = vi.fn(() => [
+    const panes = [
       { id: '%1', target: 'main:1.0', cwd: '/repo', command: 'claude', suggestedName: 'claude' },
       { id: '%2', target: 'main:1.1', cwd: '/tmp', command: 'zsh', suggestedName: null },
-    ]);
+    ];
+    vi.mocked(ctx.identityService.activeIdentities).mockReturnValue(
+      identities.map((entry) => ({
+        ...activeIdentity(entry),
+        pane: panes.find((pane) => pane.id === entry.paneId)!,
+      }))
+    );
 
     cmdList(ctx);
 
-    expect(ctx.tmux.listPanes).toHaveBeenCalledTimes(1);
+    expect(ctx.tmux.listPanes).not.toHaveBeenCalled();
+    expect(ctx.identityService.activeIdentities).toHaveBeenCalledTimes(1);
     expect((ctx.ui as any).jsonCalls).toEqual([
       {
         identities: [
@@ -364,11 +382,20 @@ describe('basic commands', () => {
     const ctx = createCtx(testDir, { flags: { json: true } });
     ctx.tmux.resolvePaneTarget = vi.fn(() => '%9');
     (ctx.identityService.activeIdentities as ReturnType<typeof vi.fn>).mockReturnValue([]);
-    ctx.tmux.listPanes = vi.fn(() => [
-      { id: '%9', target: 'main:9.0', cwd: '/tmp', command: 'zsh', suggestedName: null },
-    ]);
+    ctx.tmux.getEndpointSnapshot = vi.fn(() => ({
+      server: {
+        serverId: 'server',
+        socketPath: '/tmp/tmux.sock',
+        serverPid: 1,
+        serverStartTime: 'now',
+      },
+      panes: [{ id: '%9', target: 'main:9.0', cwd: '/tmp', command: 'zsh', suggestedName: null }],
+    }));
 
     cmdList(ctx, '9.0');
+
+    expect(ctx.tmux.getEndpointSnapshot).toHaveBeenCalledWith({ paneIds: ['%9'] });
+    expect(ctx.tmux.listPanes).not.toHaveBeenCalled();
 
     expect((ctx.ui as any).jsonCalls).toEqual([
       {
@@ -385,6 +412,14 @@ describe('basic commands', () => {
     expect(ctx.ui.info).toHaveBeenCalled();
   });
 
+  it('cmdList rejects missing scoped evidence instead of inventing pane details', () => {
+    const ctx = createCtx(testDir);
+    ctx.tmux.resolvePaneTarget = vi.fn(() => '%9');
+    expect(() => cmdList(ctx, '%9')).toThrow('Resolved pane evidence is unavailable.');
+    expect(ctx.ui.table).not.toHaveBeenCalled();
+    expect(ctx.tmux.listPanes).not.toHaveBeenCalled();
+  });
+
   it('cmdList prints table when agents exist', () => {
     const ctx = createCtx(testDir, {
       identities: [{ name: 'claude', canonicalName: 'claude', paneId: '%1' }],
@@ -393,15 +428,22 @@ describe('basic commands', () => {
     expect(ctx.ui.table).toHaveBeenCalled();
   });
 
-  it('cmdList shows dashes for missing pane metadata', () => {
+  it('cmdList shows dashes for absent details in the verified pane projection', () => {
     const ctx = createCtx(testDir, {
       identities: [{ name: 'claude', canonicalName: 'claude', paneId: '%1' }],
     });
-    ctx.tmux.listPanes = vi.fn(() => [{ id: '%1', command: '', suggestedName: null }]);
+    vi.mocked(ctx.identityService.activeIdentities).mockReturnValue([
+      {
+        ...activeIdentity({ name: 'claude', canonicalName: 'claude', paneId: '%1' }),
+        pane: { id: '%1', command: '', suggestedName: null },
+      },
+    ]);
     cmdList(ctx);
     expect(ctx.ui.table).toHaveBeenCalled();
     const tableCall = (ctx.ui.table as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(tableCall[1][0][2]).toBe('-');
+    expect(ctx.identityService.activeIdentities).toHaveBeenCalledTimes(1);
+    expect(ctx.tmux.listPanes).not.toHaveBeenCalled();
   });
 
   it('cmdList errors when positional target is neither identity nor pane', () => {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -17,9 +17,7 @@ function publicIdentity(identity: PublicIdentity): PublicIdentity {
   };
 }
 
-function paneDetails(ctx: Context, paneId: string, panes?: Map<string, PaneInfo>) {
-  const paneMap = panes ?? new Map(ctx.tmux.listPanes().map((pane) => [pane.id, pane]));
-  const pane = paneMap.get(paneId);
+function paneDetails(paneId: string, pane?: PaneInfo) {
   return {
     id: paneId,
     ...(pane?.target && { target: pane.target }),
@@ -45,7 +43,12 @@ export function cmdList(ctx: Context, target?: string): void {
     }
 
     const identity = resolution.value.identity;
-    const pane = paneDetails(ctx, resolution.value.paneId);
+    const paneId = resolution.value.paneId;
+    const observedPane =
+      identity?.pane ??
+      tmux.getEndpointSnapshot?.({ paneIds: [paneId] }).panes.find((pane) => pane.id === paneId);
+    if (!observedPane) throw new Error('Resolved pane evidence is unavailable.');
+    const pane = paneDetails(paneId, observedPane);
     if (flags.json) {
       ui.json({
         target,
@@ -63,12 +66,11 @@ export function cmdList(ctx: Context, target?: string): void {
   }
 
   const identities = sortedGlobalIdentities(runtimeTmux);
-  const panes = new Map(tmux.listPanes().map((pane) => [pane.id, pane]));
 
   if (flags.json) {
     ui.json({
       identities: identities.map((identity) => {
-        const pane = paneDetails(ctx, identity.paneId, panes);
+        const pane = paneDetails(identity.paneId, identity.pane);
         return {
           ...publicIdentity(identity),
           pane: identity.paneId,
@@ -89,7 +91,7 @@ export function cmdList(ctx: Context, target?: string): void {
   ui.table(
     ['NAME', 'PANE', 'TARGET', 'CWD', 'COMMAND'],
     identities.map((identity) => {
-      const pane = paneDetails(ctx, identity.paneId, panes);
+      const pane = paneDetails(identity.paneId, identity.pane);
       return [identity.name, pane.id, pane.target ?? '-', pane.cwd ?? '-', pane.command || '-'];
     })
   );

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -291,7 +291,13 @@ function createContext(
           activeIdentity(name, `%${index + 1}`)
         )
       ),
-      resolveActive: vi.fn(),
+      resolveActive: vi.fn((target: string) =>
+        (overrides.identities ?? ['claude', 'codex', 'gemini'])
+          .map((name, index) => activeIdentity(name, `%${index + 1}`))
+          .find(
+            (entry) => entry.binding.paneId === target || entry.identity.canonicalName === target
+          )
+      ),
       reconcile: vi.fn(),
     },
     preambleService,

--- a/src/commands/talk.ts
+++ b/src/commands/talk.ts
@@ -361,7 +361,7 @@ export async function cmdTalk(
   let endpoint;
   try {
     if (!tmux.getEndpointSnapshot) throw new Error('Tmux endpoint evidence is unavailable.');
-    const snapshot = tmux.getEndpointSnapshot();
+    const snapshot = tmux.getEndpointSnapshot({ paneIds: [pane] });
     if (resolution.value.identity) {
       assertTargetIdentityEvidence(resolution.value.identity, snapshot);
     }

--- a/src/identity-service.test.ts
+++ b/src/identity-service.test.ts
@@ -12,7 +12,7 @@ import {
 import { openIdentityRepository } from './storage/identity-repository.js';
 import { PaneMetadataError } from './pane-metadata-error.js';
 import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
-import type { PaneInfo, Paths, Tmux, TmuxEndpointSnapshot } from './types.js';
+import type { PaneInfo, Paths, Tmux, TmuxEndpointSnapshot, TmuxOperationOptions } from './types.js';
 
 const directories: string[] = [];
 const repositories: Array<ReturnType<typeof openIdentityRepository>> = [];
@@ -38,7 +38,13 @@ function fixture() {
   const tmux = {
     getCurrentPaneId: () => '%1',
     resolvePaneTarget: (target: string) => (target === '%1' ? '%1' : null),
-    getEndpointSnapshot: () => snapshot,
+    getEndpointSnapshot: (options?: TmuxOperationOptions) => ({
+      ...snapshot,
+      panes:
+        options?.paneIds === undefined
+          ? snapshot.panes
+          : snapshot.panes.filter((pane) => options.paneIds!.includes(pane.id)),
+    }),
     setDurableIdentity: (paneId: string, identity: DurableIdentity, binding: TmuxBinding) => {
       const target = snapshot.panes.find((item) => item.id === paneId);
       if (!target) throw new Error(`Unknown pane '${paneId}'.`);
@@ -313,28 +319,26 @@ describe('durable identity service', () => {
     expect(service.resolveIdentity()).toEqual({ status: 'required' });
   });
 
-  it('fails closed for ambiguous implicit identity evidence', () => {
+  it('enforces caller binding uniqueness in storage instead of enumerating all bindings', () => {
     const test = fixture();
     const base = openIdentityRepository(test.paths.databaseFile);
     repositories.push(base);
     const service = createIdentityService({ tmux: test.tmux, repository: base });
     service.bindCurrent('ambiguous');
-    const ambiguousRepository = {
-      ...base,
-      findBindings: () => {
-        const bindings = base.findBindings();
-        return [...bindings, ...bindings];
-      },
-    };
-    const ambiguousService = createIdentityService({
-      tmux: test.tmux,
-      repository: ambiguousRepository,
+    const binding = base.findBindings()[0]!;
+    const other = base.createIdentity('Other', 'other');
+    expect(() =>
+      base.createBinding({ ...binding, id: 'duplicate', identityId: other.id })
+    ).toThrow();
+    const enumeration = vi.spyOn(base, 'findBindings').mockImplementation(() => {
+      throw new Error('Caller lookup must not enumerate bindings.');
     });
-
-    expect(ambiguousService.resolveIdentity()).toEqual({ status: 'ambiguous' });
-    expect(() => ambiguousService.currentIdentity()).toThrow(
-      expect.objectContaining({ code: 'IDENTITY_AMBIGUOUS' })
-    );
+    expect(service.resolveIdentity()).toMatchObject({
+      status: 'bound',
+      identity: { name: 'ambiguous' },
+    });
+    expect(service.currentIdentity()?.binding.id).toBe(binding.id);
+    expect(enumeration).not.toHaveBeenCalled();
   });
 
   it('creates one durable identity and a verified transient binding', () => {
@@ -1241,5 +1245,81 @@ describe('durable identity service', () => {
     expect(() => service.bindPane('%99', 'missing-pane')).toThrow(
       "Pane target '%99' was not found."
     );
+  });
+
+  it('keeps single-target operations scoped and preserves unrelated stale bindings', () => {
+    const test = fixture();
+    addSecondPane(test);
+    const base = openIdentityRepository(test.paths.databaseFile);
+    repositories.push(base);
+    const service = createIdentityService({ tmux: test.tmux, repository: base });
+    service.bindPane('%2', 'unrelated');
+    const stale = base.findBindingByIdentity(base.findByCanonicalName('unrelated')!.id)!;
+    const allPanes = test.tmux.getEndpointSnapshot!().panes;
+    allPanes.find((pane) => pane.id === '%2')!.metadata = undefined;
+    test.setSnapshot({
+      ...test.tmux.getEndpointSnapshot!(),
+      panes: [
+        ...allPanes,
+        ...Array.from({ length: 198 }, (_, index) => ({
+          id: `%${index + 3}`,
+          panePid: index + 3000,
+          command: 'sh',
+          suggestedName: null,
+        })),
+      ],
+    });
+    const snapshots = vi.spyOn(test.tmux, 'getEndpointSnapshot');
+    const bindings = vi.spyOn(base, 'findBindings').mockImplementation(() => {
+      throw new Error('Single-target operations must not enumerate bindings.');
+    });
+    const identities = vi.spyOn(base, 'listIdentities').mockImplementation(() => {
+      throw new Error('Single-target operations must not enumerate identities.');
+    });
+
+    const identity = service.bindCurrent('scoped');
+    expect(service.currentIdentity()?.identity.id).toBe(identity.id);
+    expect(service.resolveActive('SCOPED')?.identity.id).toBe(identity.id);
+    expect(service.resolveActive('%1')?.identity.id).toBe(identity.id);
+    expect(service.unbindCurrent()?.id).toBe(identity.id);
+    expect(base.findBindingByIdentity(stale.identityId)).toEqual(stale);
+    expect(base.findById(identity.id)).toEqual(identity);
+    expect(snapshots.mock.calls.length).toBeGreaterThan(0);
+    for (const [options] of snapshots.mock.calls) expect(options?.paneIds).toEqual(['%1']);
+    expect(bindings).not.toHaveBeenCalled();
+    expect(identities).not.toHaveBeenCalled();
+
+    bindings.mockRestore();
+    identities.mockRestore();
+    expect(service.activeIdentities()).toEqual([]);
+    expect(base.findBindingByIdentity(stale.identityId)).toBeUndefined();
+    expect(base.findById(stale.identityId)?.name).toBe('unrelated');
+  });
+
+  it('includes the conflicting local pane when binding a name and preserves both locations', () => {
+    const test = fixture();
+    addSecondPane(test);
+    const service = createTestService(test);
+    service.bindPane('%2', 'occupied');
+    const snapshots = vi.spyOn(test.tmux, 'getEndpointSnapshot');
+    expect(() => service.bindPane('%1', 'occupied')).toThrowError(
+      expect.objectContaining({ code: 'NAME_ALREADY_ACTIVE' })
+    );
+    expect(snapshots.mock.calls.map(([options]) => options?.paneIds)).toEqual([
+      ['%1'],
+      ['%1', '%2'],
+    ]);
+    expect(test.pane.metadata).toBeUndefined();
+    expect(service.resolveActive('occupied')?.binding.paneId).toBe('%2');
+  });
+
+  it('does not probe tmux for a missing or offline explicit name', () => {
+    const test = fixture();
+    const service = createTestService(test);
+    service.createIdentity('offline');
+    const snapshot = vi.spyOn(test.tmux, 'getEndpointSnapshot');
+    expect(service.resolveActive('missing')).toBeUndefined();
+    expect(service.resolveActive('offline')).toBeUndefined();
+    expect(snapshot).not.toHaveBeenCalled();
   });
 });

--- a/src/identity-service.ts
+++ b/src/identity-service.ts
@@ -1,14 +1,12 @@
 import { performance } from 'node:perf_hooks';
-import { validateName } from './domain/names.js';
+import { isPaneTarget, normalizeName, validateName } from './domain/names.js';
 import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
 import {
   requireDurableIdentity,
   resolveDurableIdentity,
-  IdentitySelectionError,
   type IdentitySelector,
   type DurableIdentityResolution,
 } from './identity-context.js';
-import { resolveTarget } from './target-resolver.js';
 import { PaneMetadataError } from './pane-metadata-error.js';
 import type { TargetIdentity, TargetResolverPort } from './target-resolver.js';
 import type {
@@ -33,10 +31,12 @@ export interface IdentityServiceOptions {
 export interface IdentityRepository {
   withImmediateTransaction<T>(operation: () => T): T;
   findByCanonicalName(canonicalName: string): DurableIdentity | undefined;
+  findById(id: string): DurableIdentity | undefined;
   createIdentity(name: string, canonicalName: string): DurableIdentity;
   listIdentities(): DurableIdentity[];
   findBindings(): TmuxBinding[];
   findBindingByPane(paneId: string, serverId: string): TmuxBinding | undefined;
+  findBindingByIdentity(identityId: string): TmuxBinding | undefined;
   createBinding(binding: Omit<TmuxBinding, 'id'> & { id?: string }): TmuxBinding;
   touchBinding(id: string, lastVerifiedAt: string): void;
   removeBinding(id: string): void;
@@ -159,11 +159,13 @@ function verifiedBindingEvidence(
 function targetIdentity(item: {
   readonly identity: DurableIdentity;
   readonly binding: TmuxBinding;
+  readonly pane: PaneInfo;
 }): TargetIdentity {
   return {
     name: item.identity.name,
     canonicalName: item.identity.canonicalName,
     paneId: item.binding.paneId,
+    pane: item.pane,
     evidence: {
       identity: item.identity,
       binding: item.binding,
@@ -237,7 +239,7 @@ function verifyPublished(
   paneId: string,
   options: TmuxOperationOptions
 ): void {
-  const snapshot = endpointSnapshot(tmux, options);
+  const snapshot = endpointSnapshot(tmux, { ...options, paneIds: [paneId] });
   const pane = findPane(snapshot, paneId);
   if (
     !pane ||
@@ -266,7 +268,10 @@ function probeForeignEndpoint(
 ): TmuxEndpointProbe {
   if (!tmux.probeEndpoint) return { status: 'unknown' };
   try {
-    return tmux.probeEndpoint(binding.socketPath, binding.serverPid, options);
+    return tmux.probeEndpoint(binding.socketPath, binding.serverPid, {
+      ...options,
+      paneIds: [binding.paneId],
+    });
   } catch {
     return { status: 'unknown' };
   }
@@ -277,7 +282,13 @@ export function identityAwareTmux(tmux: Tmux, service: IdentityService): Tmux & 
   if (!service) throw new Error('Identity service is required for target resolution.');
   return {
     ...tmux,
-    listGlobalIdentities: () => service.activeIdentities().map(targetIdentity),
+    listGlobalIdentities: (selection) => {
+      if (!selection) return service.activeIdentities().map(targetIdentity);
+      const item = service.resolveActive(
+        'paneId' in selection ? selection.paneId : selection.canonicalName
+      );
+      return item ? [targetIdentity(item)] : [];
+    },
   };
 }
 
@@ -309,26 +320,38 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
       message
     );
 
+  // Both scoped and full discovery reconcile only bindings covered by their
+  // snapshot. Foreign sockets are never pruned based on local absence.
+  const activeBinding = (
+    binding: TmuxBinding | undefined,
+    identity: DurableIdentity | undefined,
+    snapshot: TmuxEndpointSnapshot
+  ) => {
+    if (!binding || binding.socketPath !== snapshot.server.socketPath) return undefined;
+    const evidence = verifiedBindingEvidence(binding, identity, snapshot);
+    if (!evidence) {
+      repository.removeBinding(binding.id);
+      return undefined;
+    }
+    repository.touchBinding(binding.id, new Date().toISOString());
+    return { ...evidence, binding };
+  };
+
+  const activePane = (paneId: string, options: TmuxOperationOptions) => {
+    const snapshot = endpointSnapshot(tmux, { ...options, paneIds: [paneId] });
+    const binding = repository.findBindingByPane(paneId, snapshot.server.serverId);
+    return activeBinding(
+      binding,
+      binding ? repository.findById(binding.identityId) : undefined,
+      snapshot
+    );
+  };
+
   const reconcileWithinTransaction = (options: TmuxOperationOptions): TmuxEndpointSnapshot => {
     const snapshot = endpointSnapshot(tmux, options);
-    const allBindings = repository.findBindings();
     const identities = new Map(repository.listIdentities().map((item) => [item.id, item]));
-
-    for (const binding of allBindings) {
-      // A command can observe only its current tmux server. Never prune a
-      // binding owned by another socket merely because its panes are absent
-      // from this endpoint snapshot.
-      if (binding.socketPath !== snapshot.server.socketPath) continue;
-      const evidence = verifiedBindingEvidence(
-        binding,
-        identities.get(binding.identityId),
-        snapshot
-      );
-      if (!evidence) {
-        repository.removeBinding(binding.id);
-      } else {
-        repository.touchBinding(binding.id, new Date().toISOString());
-      }
+    for (const binding of repository.findBindings()) {
+      activeBinding(binding, identities.get(binding.identityId), snapshot);
     }
     return snapshot;
   };
@@ -342,9 +365,10 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
   const currentIdentityContext = () => {
     const currentPane = tmux.getCurrentPaneId();
     if (!currentPane) return undefined;
-    const matches = active().filter((entry) => entry.binding.paneId === currentPane);
-    if (matches.length > 1) return { status: 'ambiguous' as const };
-    return matches[0];
+    return coordinated(
+      (options) => activePane(currentPane, options),
+      'Could not inspect current identity.'
+    );
   };
 
   const active = () => {
@@ -359,7 +383,7 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
     // The authoritative snapshot is repeated only after the writer lock is
     // acquired below; this preflight prevents a missing pane from leaving a
     // newly-created identity behind.
-    paneEvidence(endpointSnapshot(tmux), paneId);
+    paneEvidence(endpointSnapshot(tmux, { paneIds: [paneId] }), paneId);
     let identity: DurableIdentity;
     try {
       identity = createOrResolve(repository, name).identity;
@@ -374,11 +398,18 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
       );
     }
     return coordinated((options) => {
-      const snapshot = endpointSnapshot(tmux, options);
+      const existingIdentityBinding = repository.findBindingByIdentity(identity.id);
+      const snapshot = endpointSnapshot(tmux, {
+        ...options,
+        paneIds: [
+          ...new Set([
+            paneId,
+            ...(existingIdentityBinding ? [existingIdentityBinding.paneId] : []),
+          ]),
+        ],
+      });
       const pane = paneEvidence(snapshot, paneId);
-      const endpointBinding = repository
-        .findBindings()
-        .filter((item) => item.paneId === paneId && item.serverId === snapshot.server.serverId)[0];
+      const endpointBinding = repository.findBindingByPane(paneId, snapshot.server.serverId);
       let current: TmuxBinding | undefined = endpointBinding;
       if (current && (!serverMatches(current, snapshot.server) || !paneMatches(current, pane))) {
         repository.removeBinding(current.id);
@@ -390,9 +421,6 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
           'Pane is already bound to another name.'
         );
       }
-      const existingIdentityBinding = repository
-        .findBindings()
-        .find((item) => item.identityId === identity.id);
       if (existingIdentityBinding && existingIdentityBinding.id !== current?.id) {
         const existingPane = findPane(snapshot, existingIdentityBinding.paneId);
         if (
@@ -506,10 +534,7 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
       if (!current) return undefined;
       const paneId = current;
       return coordinated((options) => {
-        const snapshot = reconcileWithinTransaction(options);
-        const item = mapActive(repository, snapshot, repository.findBindings()).find(
-          (entry) => entry.binding.paneId === paneId
-        );
+        const item = activePane(paneId, options);
         if (!item) return undefined;
         try {
           if (tmux.clearDurableIdentity) {
@@ -535,14 +560,7 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
       }, 'Could not unbind identity state.');
     },
     currentIdentity() {
-      const current = currentIdentityContext();
-      if (current && 'status' in current) {
-        throw new IdentitySelectionError(
-          'IDENTITY_AMBIGUOUS',
-          'Current pane has ambiguous identity binding.'
-        );
-      }
-      return current;
+      return currentIdentityContext();
     },
     resolveIdentity(selector?: IdentitySelector): DurableIdentityResolution {
       return resolveDurableIdentity(
@@ -555,17 +573,17 @@ export function createIdentityService(options: IdentityServiceOptions): Identity
     },
     activeIdentities: active,
     resolveActive(target) {
-      const items = active();
-      const identities = items.map(targetIdentity);
-      const result = resolveTarget(
-        {
-          ...tmux,
-          listGlobalIdentities: () => identities,
-        },
-        target
-      );
-      if (!result.ok) return undefined;
-      return items.find((item) => item.binding.paneId === result.value.paneId);
+      const paneId = isPaneTarget(target) ? tmux.resolvePaneTarget(target) : undefined;
+      if (paneId === null) return undefined;
+      return coordinated((options) => {
+        if (paneId) return activePane(paneId, options);
+        const identity = repository.findByCanonicalName(normalizeName(target));
+        if (!identity) return undefined;
+        const binding = repository.findBindingByIdentity(identity.id);
+        if (!binding) return undefined;
+        const snapshot = endpointSnapshot(tmux, { ...options, paneIds: [binding.paneId] });
+        return activeBinding(binding, identity, snapshot);
+      }, 'Could not inspect target identity.');
     },
     reconcile,
   };

--- a/src/storage/identity-repository.ts
+++ b/src/storage/identity-repository.ts
@@ -106,6 +106,14 @@ export function openIdentityRepository(location: StorageLocation): IdentityRepos
         .get(canonicalName) as IdentityRow | undefined;
       return row ? identity(row) : undefined;
     },
+    findById(id) {
+      const row = requireOpen()
+        .prepare(
+          'SELECT id, name, canonical_name, created_at, updated_at FROM identities WHERE id = ?'
+        )
+        .get(id) as IdentityRow | undefined;
+      return row ? identity(row) : undefined;
+    },
     createIdentity(name, canonicalName) {
       const now = new Date().toISOString();
       const value = {
@@ -141,9 +149,17 @@ export function openIdentityRepository(location: StorageLocation): IdentityRepos
     findBindingByPane(paneId, serverId) {
       const row = requireOpen()
         .prepare(
-          'SELECT id, identity_id, transport, pane_id, server_id, socket_path, server_pid, server_start_time, pane_pid, bound_at, last_verified_at FROM bindings WHERE pane_id = ? AND server_id = ?'
+          "SELECT id, identity_id, transport, pane_id, server_id, socket_path, server_pid, server_start_time, pane_pid, bound_at, last_verified_at FROM bindings WHERE transport = 'tmux' AND pane_id = ? AND server_id = ?"
         )
         .get(paneId, serverId) as BindingRow | undefined;
+      return row ? binding(row) : undefined;
+    },
+    findBindingByIdentity(identityId) {
+      const row = requireOpen()
+        .prepare(
+          'SELECT id, identity_id, transport, pane_id, server_id, socket_path, server_pid, server_start_time, pane_pid, bound_at, last_verified_at FROM bindings WHERE identity_id = ?'
+        )
+        .get(identityId) as BindingRow | undefined;
       return row ? binding(row) : undefined;
     },
     createBinding(value) {

--- a/src/target-resolver.test.ts
+++ b/src/target-resolver.test.ts
@@ -33,6 +33,17 @@ describe('shared target resolver', () => {
     expect(result).toMatchObject({ ok: true, value: { paneId: '%3', kind: 'identity' } });
   });
 
+  it('passes a precise pane or canonical-name selector instead of requesting discovery', () => {
+    const listGlobalIdentities = vi.fn(() => []);
+    const port = resolver({ listGlobalIdentities });
+    resolveTarget(port, '%14');
+    resolveTarget(port, ' Ａlice ');
+    expect(listGlobalIdentities.mock.calls).toEqual([
+      [{ paneId: '%14' }],
+      [{ canonicalName: 'alice' }],
+    ]);
+  });
+
   it('preserves internal identity evidence through target resolution', () => {
     const identity = {
       id: 'identity-1',

--- a/src/target-resolver.ts
+++ b/src/target-resolver.ts
@@ -3,9 +3,12 @@
 import { isPaneTarget, normalizeName } from './domain/names.js';
 import type { DurableIdentity, TmuxBinding } from './domain/identity.js';
 import type { ActiveRegistration } from './domain/types.js';
+import type { PaneInfo } from './types.js';
 
 /** Internal active target projection carrying the evidence used by delivery. */
 export interface TargetIdentity extends ActiveRegistration {
+  /** Pane details from the same verified observation; not a second discovery. */
+  readonly pane?: PaneInfo;
   readonly evidence?: {
     readonly identity: DurableIdentity;
     readonly binding: TmuxBinding;
@@ -22,7 +25,9 @@ export interface ResolvedTarget {
 /** The minimum capability needed to resolve a user-facing pane or identity target. */
 export interface TargetResolverPort {
   readonly resolvePaneTarget: (target: string) => string | null;
-  readonly listGlobalIdentities: () => TargetIdentity[];
+  readonly listGlobalIdentities: (
+    selection?: { readonly paneId: string } | { readonly canonicalName: string }
+  ) => TargetIdentity[];
 }
 
 export type TargetResolutionErrorCode = 'PANE_NOT_FOUND' | 'NAME_NOT_FOUND';
@@ -54,7 +59,7 @@ export function resolveTarget(resolver: TargetResolverPort, input: string): Targ
       };
     }
     const identity = resolver
-      .listGlobalIdentities()
+      .listGlobalIdentities({ paneId })
       .filter((entry) => entry.paneId === paneId)
       .sort(
         (a, b) =>
@@ -70,7 +75,7 @@ export function resolveTarget(resolver: TargetResolverPort, input: string): Targ
 
   const canonical = normalizeName(input);
   const identity = resolver
-    .listGlobalIdentities()
+    .listGlobalIdentities({ canonicalName: canonical })
     .filter(
       (entry) =>
         (entry.canonicalName && entry.canonicalName === canonical) ||

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -28,6 +28,7 @@ function endpointRow(
     serverPid?: string;
     paneId?: string;
     panePid?: string;
+    metadata?: string;
   } = {}
 ): string {
   return [
@@ -40,7 +41,7 @@ function endpointRow(
     '/foreign',
     'node',
     overrides.panePid ?? '654',
-    '',
+    overrides.metadata ?? '',
   ].join(ENDPOINT_SEPARATOR);
 }
 
@@ -378,7 +379,7 @@ describe('createTmux', () => {
       ]);
     });
 
-    it('falls back to pane options when list-panes omits user metadata', () => {
+    it('does not query pane options when list-panes omits user metadata', () => {
       mockedExecSync.mockReturnValue('%1\tmain:2.0\t/repo\tnode\t\n');
       mockedExecFileSync.mockReturnValue(
         '{"version":1,"globalIdentity":{"name":"Alice","canonicalName":"alice"}}\n'
@@ -390,14 +391,24 @@ describe('createTmux', () => {
           target: 'main:2.0',
           cwd: '/repo',
           command: 'node',
-          metadata: { version: 1, globalIdentity: { name: 'Alice', canonicalName: 'alice' } },
         },
       ]);
-      expect(mockedExecFileSync).toHaveBeenCalledWith(
-        'tmux',
-        ['show-options', '-p', '-t', '%1', '-v', '@tmux-team.agent'],
-        expect.any(Object)
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+    });
+
+    it('keeps a full 200-pane listing to one tmux subprocess for unbound panes', () => {
+      mockedExecSync.mockReturnValue(
+        Array.from(
+          { length: 200 },
+          (_, index) => `%${index}\tmain:1.${index}\t/repo\tzsh\t\n`
+        ).join('')
       );
+
+      const panes = createTmux().listPanes();
+
+      expect(panes).toHaveLength(200);
+      expect(mockedExecSync).toHaveBeenCalledTimes(1);
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
     });
 
     it.each([
@@ -959,21 +970,15 @@ describe('createTmux', () => {
       expect(mockedExecFileSync).not.toHaveBeenCalled();
     });
 
-    it('propagates strict fallback metadata read failures', () => {
+    it('does not query pane metadata when list output omits it', () => {
       mockedExecFileSync
         .mockReturnValueOnce(`${VALID_SERVER_ID}\n`)
-        .mockReturnValueOnce(`${endpointRow()}\n`)
-        .mockImplementationOnce(() => {
-          throw new Error('metadata fallback failed');
-        });
+        .mockReturnValueOnce(`${endpointRow()}\n`);
 
-      expect(() => createTmux().getEndpointSnapshot?.()).toThrow(
-        expect.objectContaining({
-          name: 'PaneMetadataError',
-          stage: 'read',
-          cause: expect.objectContaining({ message: 'metadata fallback failed' }),
-        })
-      );
+      const snapshot = createTmux().getEndpointSnapshot?.();
+      expect(snapshot?.panes[0]?.id).toBe('%9');
+      expect(snapshot?.panes[0]).not.toHaveProperty('metadata');
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
     });
 
     it('uses integer per-command timeouts bounded by a decreasing shared deadline', () => {
@@ -1003,7 +1008,7 @@ describe('createTmux', () => {
           expect(timeout).toBeLessThanOrEqual(1_000);
           return timeout;
         });
-        expect(timeouts).toEqual([900, 750, 600]);
+        expect(timeouts).toEqual([900, 750]);
       } finally {
         clock.mockRestore();
       }
@@ -1052,6 +1057,130 @@ describe('createTmux', () => {
         ['list-panes', '-a', '-F', expect.stringContaining('#{socket_path}')],
         expect.any(Object)
       );
+    });
+
+    it('keeps a full 200-pane endpoint snapshot to one list subprocess for unbound panes', () => {
+      mockedExecFileSync
+        .mockReturnValueOnce(`${VALID_SERVER_ID}\n`)
+        .mockReturnValueOnce(
+          Array.from({ length: 200 }, (_, index) =>
+            endpointRow({ paneId: `%${index}`, panePid: String(654 + index) })
+          ).join('\n') + '\n'
+        );
+
+      const snapshot = createTmux().getEndpointSnapshot?.();
+
+      expect(snapshot?.panes).toHaveLength(200);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
+      expect(
+        mockedExecFileSync.mock.calls.some(
+          ([, args]) => Array.isArray(args) && args.includes('show-options') && args.includes('-p')
+        )
+      ).toBe(false);
+    });
+
+    it('scopes pane evidence and metadata to requested IDs while retaining tmux order', () => {
+      mockedExecFileSync
+        .mockReturnValueOnce(`${VALID_SERVER_ID}\n`)
+        .mockReturnValueOnce(
+          `${endpointRow({ paneId: '%10' })}\n${endpointRow({ paneId: '%11' })}\n`
+        );
+
+      const snapshot = createTmux().getEndpointSnapshot?.({ paneIds: ['%11', '%10'] });
+
+      expect(snapshot?.panes.map((pane) => pane.id)).toEqual(['%10', '%11']);
+      expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+        'tmux',
+        [
+          'list-panes',
+          '-a',
+          '-f',
+          expect.stringContaining('#{==:#{pane_id},%11}'),
+          '-F',
+          expect.any(String),
+        ],
+        expect.any(Object)
+      );
+    });
+
+    it('returns coherent server evidence when every scoped pane is absent', () => {
+      mockedExecFileSync
+        .mockReturnValueOnce(`${VALID_SERVER_ID}\n`)
+        .mockReturnValueOnce('')
+        .mockReturnValueOnce(
+          [VALID_SERVER_ID, '/tmp/foreign.sock', '321', '1700000000'].join(ENDPOINT_SEPARATOR) +
+            '\n'
+        );
+
+      const snapshot = createTmux().getEndpointSnapshot?.({ paneIds: ['%404'] });
+
+      expect(snapshot).toEqual({
+        server: {
+          serverId: VALID_SERVER_ID,
+          socketPath: '/tmp/foreign.sock',
+          serverPid: 321,
+          serverStartTime: '1700000000',
+        },
+        panes: [],
+      });
+      expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+        'tmux',
+        ['display-message', '-p', expect.stringContaining('#{socket_path}')],
+        expect.any(Object)
+      );
+    });
+
+    it('uses server-only evidence for an explicitly empty scope', () => {
+      mockedExecFileSync
+        .mockReturnValueOnce(`${VALID_SERVER_ID}\n`)
+        .mockReturnValueOnce(
+          [VALID_SERVER_ID, '/tmp/foreign.sock', '321', '1700000000'].join(ENDPOINT_SEPARATOR) +
+            '\n'
+        );
+
+      const snapshot = createTmux().getEndpointSnapshot?.({ paneIds: [] });
+
+      expect(snapshot?.panes).toEqual([]);
+      expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+        'tmux',
+        ['display-message', '-p', expect.stringContaining('#{socket_path}')],
+        expect.any(Object)
+      );
+      expect(mockedExecFileSync).not.toHaveBeenCalledWith(
+        'tmux',
+        expect.arrayContaining(['list-panes']),
+        expect.any(Object)
+      );
+    });
+
+    it('rejects invalid scoped pane IDs before invoking tmux', () => {
+      expect(() => createTmux().getEndpointSnapshot?.({ paneIds: ['not-a-pane'] })).toThrow(
+        'tmux pane scope contains an invalid pane ID'
+      );
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+    });
+
+    it('rejects truncated full pane evidence instead of returning a pruning snapshot', () => {
+      mockedExecFileSync
+        .mockReturnValueOnce(`${VALID_SERVER_ID}\n`)
+        .mockReturnValueOnce(
+          `${endpointRow().split(ENDPOINT_SEPARATOR).slice(0, 9).join(ENDPOINT_SEPARATOR)}\n`
+        );
+
+      expect(() => createTmux().getEndpointSnapshot?.()).toThrow(
+        'tmux endpoint snapshot contains inconsistent server evidence'
+      );
+    });
+
+    it('ignores malformed metadata without issuing a pane-specific query', () => {
+      mockedExecFileSync
+        .mockReturnValueOnce(`${VALID_SERVER_ID}\n`)
+        .mockReturnValueOnce(`${endpointRow({ metadata: 'not-json' })}\n`);
+
+      const snapshot = createTmux().getEndpointSnapshot?.();
+
+      expect(snapshot?.panes[0]).not.toHaveProperty('metadata');
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
     });
 
     it('rejects mixed server evidence instead of constructing a torn snapshot', () => {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -11,6 +11,7 @@ import type {
   PaneInfo,
   TmuxEndpointProbe,
   TmuxEndpointSnapshot,
+  TmuxServerEvidence,
   TmuxOperationOptions,
 } from './types.js';
 import { sendTmuxMessage } from './tmux-message.js';
@@ -70,11 +71,7 @@ function emptyMetadata(): PaneAgentMetadata {
   return { version: 1 };
 }
 
-function parsePaneOutput(
-  output: string,
-  allowMetadataFallback = true,
-  metadataOptions: TmuxOperationOptions & { readonly strictFallback?: boolean } = {}
-): PaneInfo[] {
+function parsePaneOutput(output: string): PaneInfo[] {
   const seen = new Set<string>();
   return output
     .split('\n')
@@ -98,11 +95,11 @@ function parsePaneOutput(
           : fields.length >= 5
             ? [fields[0], fields[1], fields[2], fields[3], undefined, fields[4]]
             : [fields[0], undefined, undefined, fields[1] ?? '', undefined, fields[2] ?? ''];
-      // tmux 3.3 may omit pane user options in list formats. The fallback is
-      // conservative because all independent evidence must still agree.
-      const metadata =
-        safeParseMetadata(metadataText) ??
-        (allowMetadataFallback ? tryReadPaneMetadata(id || '', metadataOptions) : undefined);
+      // User options are expanded in the same list-panes batch as the pane
+      // evidence. A missing or malformed value is simply absent metadata;
+      // querying each pane here would turn an unbound server into O(panes)
+      // subprocesses.
+      const metadata = safeParseMetadata(metadataText);
       return {
         id: id || '',
         ...(target && { target }),
@@ -136,25 +133,39 @@ function endpointFormat(): string {
   ].join(PANE_FIELD_SEPARATOR);
 }
 
-function parseEndpointSnapshot(
-  output: string,
-  options: {
-    readonly expectedServerId?: string;
-    readonly allowMetadataFallback: boolean;
-    readonly metadataOptions?: TmuxOperationOptions & { readonly strictFallback?: boolean };
-    readonly requireCompleteEvidence?: boolean;
-  }
-): TmuxEndpointSnapshot {
-  const rows = output.split('\n').filter((line) => line.trim());
-  if (rows.length === 0) throw new Error('tmux endpoint snapshot is empty');
+function serverFormat(): string {
+  return [`#{${SERVER_ID_OPTION}}`, '#{socket_path}', '#{pid}', '#{start_time}'].join(
+    PANE_FIELD_SEPARATOR
+  );
+}
 
-  const evidence = rows.map((line) => line.split(PANE_FIELD_SEPARATOR).slice(0, 4));
+function scopedPaneIds(options: TmuxOperationOptions): string[] | undefined {
+  if (options.paneIds === undefined) return undefined;
+  const paneIds = [...new Set(options.paneIds)];
+  if (paneIds.some((paneId) => !PANE_ID_PATTERN.test(paneId))) {
+    throw new Error('tmux pane scope contains an invalid pane ID');
+  }
+  return paneIds;
+}
+
+function paneFilter(paneIds: readonly string[]): string {
+  const expressions = paneIds.map((paneId) => `#{==:#{pane_id},${paneId}}`);
+  const first = expressions[0];
+  if (!first) throw new Error('A pane filter requires at least one valid pane ID.');
+  return expressions
+    .slice(1)
+    .reduce((combined, expression) => `#{||:${combined},${expression}}`, first);
+}
+
+function parseServerEvidence(output: string, expectedServerId?: string): TmuxServerEvidence {
+  const rows = output.split('\n').filter((line) => line.trim());
+  if (rows.length === 0) throw new Error('tmux server evidence is empty');
+  const evidence = rows.map((line) => line.split(PANE_FIELD_SEPARATOR));
   const [serverId = '', socketPath, serverPidText, serverStartTime] = evidence[0] ?? [];
   const serverPid = Number(serverPidText);
-  const completeEvidence = rows.every((line) => line.split(PANE_FIELD_SEPARATOR).length >= 10);
   if (
-    (options.expectedServerId !== undefined && serverId !== options.expectedServerId) ||
-    (options.requireCompleteEvidence && (!SERVER_ID_PATTERN.test(serverId) || !completeEvidence)) ||
+    (expectedServerId !== undefined && serverId !== expectedServerId) ||
+    !SERVER_ID_PATTERN.test(serverId) ||
     !socketPath ||
     !serverStartTime ||
     !Number.isSafeInteger(serverPid) ||
@@ -169,11 +180,57 @@ function parseEndpointSnapshot(
   ) {
     throw new Error('tmux endpoint snapshot contains inconsistent server evidence');
   }
+  return { serverId, socketPath, serverPid, serverStartTime };
+}
+
+function endpointListArgs(options: TmuxOperationOptions, socketPath?: string): string[] {
+  const args = socketPath ? ['-S', socketPath] : [];
+  args.push('list-panes', '-a');
+  const paneIds = scopedPaneIds(options);
+  if (paneIds !== undefined && paneIds.length > 0) args.push('-f', paneFilter(paneIds));
+  args.push('-F', endpointFormat());
+  return args;
+}
+
+function serverEvidenceArgs(socketPath?: string): string[] {
+  const args = socketPath ? ['-S', socketPath] : [];
+  args.push('display-message', '-p', serverFormat());
+  return args;
+}
+
+function readServerEvidence(
+  options: TmuxOperationOptions,
+  socketPath: string | undefined,
+  expectedServerId?: string
+): TmuxServerEvidence {
+  const output = execFileSync('tmux', serverEvidenceArgs(socketPath), {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...commandOptions(options),
+  });
+  return parseServerEvidence(output, expectedServerId);
+}
+
+function parseEndpointSnapshot(
+  output: string,
+  options: {
+    readonly expectedServerId?: string;
+    readonly requireCompleteEvidence?: boolean;
+  }
+): TmuxEndpointSnapshot {
+  const rows = output.split('\n').filter((line) => line.trim());
+  if (rows.length === 0) throw new Error('tmux endpoint snapshot is empty');
+
+  const server = parseServerEvidence(output, options.expectedServerId);
+  const completeEvidence = rows.every((line) => line.split(PANE_FIELD_SEPARATOR).length >= 10);
+  if (options.requireCompleteEvidence && !completeEvidence) {
+    throw new Error('tmux endpoint snapshot contains inconsistent server evidence');
+  }
 
   const paneOutput = rows
     .map((line) => line.split(PANE_FIELD_SEPARATOR).slice(4).join(PANE_FIELD_SEPARATOR))
     .join('\n');
-  const panes = parsePaneOutput(paneOutput, options.allowMetadataFallback, options.metadataOptions);
+  const panes = parsePaneOutput(paneOutput);
   if (
     options.requireCompleteEvidence &&
     (panes.length !== rows.length ||
@@ -188,7 +245,7 @@ function parseEndpointSnapshot(
     throw new Error('tmux endpoint snapshot contains incomplete pane evidence');
   }
   return {
-    server: { serverId, socketPath, serverPid, serverStartTime },
+    server,
     panes,
   };
 }
@@ -418,9 +475,22 @@ function probeEndpoint(
     return { status: 'unknown' };
   }
 
+  let paneIds: string[] | undefined;
+  try {
+    paneIds = scopedPaneIds(options);
+  } catch {
+    return { status: 'unknown' };
+  }
+
   let output: string;
   try {
-    output = execFileSync('tmux', ['-S', socketPath, 'list-panes', '-a', '-F', endpointFormat()], {
+    if (paneIds !== undefined && paneIds.length === 0) {
+      const snapshot = { server: readServerEvidence(options, socketPath), panes: [] };
+      return snapshot.server.socketPath === socketPath
+        ? { status: 'live', snapshot }
+        : { status: 'unknown' };
+    }
+    output = execFileSync('tmux', endpointListArgs(options, socketPath), {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: Math.min(ENDPOINT_PROBE_TIMEOUT_MS, remainingTimeout(options)),
@@ -437,10 +507,14 @@ function probeEndpoint(
   }
 
   try {
-    const snapshot = parseEndpointSnapshot(output, {
-      allowMetadataFallback: false,
-      requireCompleteEvidence: true,
-    });
+    let snapshot: TmuxEndpointSnapshot;
+    if (output.trim()) {
+      snapshot = parseEndpointSnapshot(output, { requireCompleteEvidence: true });
+    } else if (paneIds !== undefined) {
+      snapshot = { server: readServerEvidence(options, socketPath), panes: [] };
+    } else {
+      return { status: 'unknown' };
+    }
     return snapshot.server.socketPath === socketPath
       ? { status: 'live', snapshot }
       : { status: 'unknown' };
@@ -584,40 +658,23 @@ function ensureServerId(options: TmuxOperationOptions = {}): string {
 }
 
 function readEndpointSnapshot(options: TmuxOperationOptions = {}) {
+  const paneIds = scopedPaneIds(options);
   const expectedServerId = ensureServerId(options);
-  const output = execFileSync('tmux', ['list-panes', '-a', '-F', endpointFormat()], {
+  if (paneIds !== undefined && paneIds.length === 0) {
+    return { server: readServerEvidence(options, undefined, expectedServerId), panes: [] };
+  }
+  const output = execFileSync('tmux', endpointListArgs(options), {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     ...commandOptions(options),
   });
-  return parseEndpointSnapshot(output, {
-    expectedServerId,
-    allowMetadataFallback: true,
-    metadataOptions: { ...options, strictFallback: true },
-  });
-}
-
-function tryReadPaneMetadata(
-  paneId: string,
-  options: TmuxOperationOptions & { readonly strictFallback?: boolean } = {}
-): PaneAgentMetadata | undefined {
-  if (!paneId) return undefined;
-  if (options.strictFallback) {
-    return readPaneMetadataStrict(paneId, options);
+  if (output.trim()) {
+    return parseEndpointSnapshot(output, { expectedServerId, requireCompleteEvidence: true });
   }
-  try {
-    const output = execFileSync(
-      'tmux',
-      ['show-options', '-p', '-t', paneId, '-v', AGENT_METADATA_OPTION],
-      {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }
-    );
-    return safeParseMetadata(output);
-  } catch {
-    return undefined;
+  if (paneIds === undefined) {
+    throw new Error('tmux endpoint snapshot is empty');
   }
+  return { server: readServerEvidence(options, undefined, expectedServerId), panes: [] };
 }
 
 function readPaneMetadataStrict(

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,8 @@ export interface Tmux {
 export interface TmuxOperationOptions {
   /** Monotonic deadline shared by every subprocess in one operation. */
   readonly deadlineMs?: number;
+  /** Undefined selects all panes; an explicit set limits endpoint evidence. */
+  readonly paneIds?: readonly string[];
 }
 
 export interface TmuxServerEvidence {

--- a/test/e2e/large-session.e2e.test.ts
+++ b/test/e2e/large-session.e2e.test.ts
@@ -1,0 +1,305 @@
+import fs from 'node:fs';
+import { performance } from 'node:perf_hooks';
+import { describe, expect, it } from 'vitest';
+import { durableState } from './identity-state-oracle.js';
+import { withE2EFixture, type CliResult, type E2EFixture, type MockEvent } from './harness.js';
+import { readRealTmuxCli, releaseRealTmuxCli, spawnRealTmuxCli } from './real-tmux-caller.js';
+import { installTmuxTrace } from './tmux-trace.js';
+
+const UNBOUND_PANE_COUNT = 200;
+
+interface CommandError {
+  error: { code: string; message: string };
+}
+
+interface WhoamiResult {
+  bound: boolean;
+  name?: string;
+  pane: string;
+}
+
+interface CheckResult {
+  target: string;
+  pane: string;
+  identity?: { name: string; canonicalName: string };
+  lines: number;
+  output: string;
+}
+
+interface TalkResult {
+  status: string;
+  target: string;
+  pane: string;
+  response: string;
+  requestId: string;
+}
+
+interface BindingResult {
+  bound: true;
+  name: string;
+  pane: string;
+}
+
+function json<T>(result: CliResult<T>): T {
+  expect(result.stderr).toBe('');
+  expect(result.stdout.trim()).not.toBe('');
+  expect(result.json).toBeDefined();
+  return result.json as T;
+}
+
+function commandCount(commands: string[], command: string): number {
+  return commands.filter((entry) => entry === command).length;
+}
+
+function invocationArgs(invocation: string): string {
+  const separator = invocation.indexOf('\t');
+  return separator < 0 ? invocation : invocation.slice(separator + 1);
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createUnboundSleepingPanes(fixture: E2EFixture): Promise<string[]> {
+  const panes: string[] = [];
+  for (let index = 0; index < UNBOUND_PANE_COUNT; index += 1) {
+    const pane = fixture
+      .tmux([
+        'new-window',
+        '-d',
+        '-P',
+        '-F',
+        '#{pane_id}',
+        '-t',
+        'e2e',
+        '-n',
+        `idle-${String(index).padStart(3, '0')}`,
+        '-c',
+        fixture.workspace,
+        'sleep 300',
+      ])
+      .trim();
+    if (!pane) throw new Error(`Could not create sleeping pane ${index}.`);
+    panes.push(pane);
+  }
+  return panes;
+}
+
+async function waitForDurableReply(
+  fixture: E2EFixture,
+  result: TalkResult,
+  pid: number,
+  message: string
+): Promise<MockEvent> {
+  expect(result.status).toBe('completed');
+  expect(result.response).toBe(`mock-agent response: ${message}`);
+  return fixture.waitForEvent(
+    (event) =>
+      event.event === 'submitted' &&
+      event.requestId === result.requestId &&
+      event.pid === pid &&
+      event.body === `mock-agent response: ${message}`
+  );
+}
+
+describe.sequential('scoped identity operations in a large tmux session', () => {
+  it(
+    'keeps fresh binding, routing, conflicts, and inspection cost scoped to selected panes',
+    { timeout: 60_000 },
+    async () => {
+      const cleanup = { root: '', socketRoot: '', serverPid: 0 };
+      await withE2EFixture(async (fixture) => {
+        cleanup.root = fixture.root;
+        cleanup.socketRoot = fixture.socketRoot;
+        cleanup.serverPid = fixture.serverPid;
+
+        const trace = installTmuxTrace(fixture);
+        // Initialize server/storage through the public CLI before comparing
+        // steady-state costs. No identity is bound and no pane metadata seeded.
+        const initialized = await fixture.runJsonCli<WhoamiResult>(['whoami']);
+        expect(initialized.code).toBe(0);
+        expect(json(initialized)).toEqual({ bound: false, pane: fixture.pane });
+        trace.clear();
+        const smallStartedAt = performance.now();
+        const smallWhoami = await fixture.runJsonCli<WhoamiResult>(['whoami']);
+        const smallDurationMs = performance.now() - smallStartedAt;
+        expect(smallWhoami.code).toBe(0);
+        expect(json(smallWhoami)).toEqual({ bound: false, pane: fixture.pane });
+        const smallCommands = trace.commands();
+        const smallInvocations = trace.invocations();
+        expect(smallCommands).toContain('list-panes');
+        const smallMetadataReads = commandCount(smallCommands, 'show-options');
+        expect(smallMetadataReads).toBeGreaterThan(0);
+
+        const idlePanes = await createUnboundSleepingPanes(fixture);
+        expect(idlePanes).toHaveLength(UNBOUND_PANE_COUNT);
+        const idleMetadata = idlePanes.map((pane) => fixture.paneMetadata(pane));
+        expect(idleMetadata.every((metadata) => metadata === '')).toBe(true);
+
+        trace.clear();
+        const largeStartedAt = performance.now();
+        const largeWhoami = await fixture.runJsonCli<WhoamiResult>(['whoami']);
+        const largeDurationMs = performance.now() - largeStartedAt;
+        expect(largeWhoami.code).toBe(0);
+        expect(json(largeWhoami)).toEqual({ bound: false, pane: fixture.pane });
+        const largeCommands = trace.commands();
+        const largeInvocations = trace.invocations();
+        expect(largeCommands).toContain('list-panes');
+        // Durations are diagnostic evidence only; subprocess counts are the
+        // deterministic regression gate for the former O(panes) fallback.
+        console.info('Large-session whoami diagnostics', {
+          smallDurationMs: Math.round(smallDurationMs),
+          largeDurationMs: Math.round(largeDurationMs),
+          smallSubprocesses: smallInvocations.length,
+          largeSubprocesses: largeInvocations.length,
+        });
+        expect(largeInvocations.length).toBe(smallInvocations.length);
+        expect(commandCount(largeCommands, 'show-options')).toBe(smallMetadataReads);
+
+        const opaqueMetadata = {
+          version: 1,
+          unrelated: 'preserve-me',
+          nested: { owner: 'fixture', enabled: true },
+        };
+        fixture.tmux([
+          'set-option',
+          '-p',
+          '-t',
+          fixture.pane,
+          '@tmux-team.agent',
+          JSON.stringify(opaqueMetadata),
+        ]);
+
+        // This is intentionally the first binding operation after the large
+        // session exists. It exercises the cold explicit-target publication
+        // path without creating metadata in every idle pane.
+        trace.clear();
+        const named = await fixture.runJsonCli<BindingResult>([
+          'add',
+          fixture.pane,
+          'LargeSession',
+        ]);
+        expect(named.code).toBe(0);
+        expect(json(named)).toEqual({ bound: true, name: 'LargeSession', pane: fixture.pane });
+        const addListInvocations = trace
+          .invocations()
+          .map(invocationArgs)
+          .filter((args) => args.includes('list-panes'));
+        expect(addListInvocations.length).toBeGreaterThan(0);
+        expect(addListInvocations.every((args) => args.includes(' -f '))).toBe(true);
+
+        const metadataAfterName = fixture.paneMetadata();
+        expect(JSON.parse(metadataAfterName)).toMatchObject(opaqueMetadata);
+        expect(JSON.parse(metadataAfterName)).toMatchObject({
+          globalIdentity: { name: 'LargeSession', canonicalName: 'largesession' },
+        });
+        const repeated = await fixture.runJsonCli<BindingResult>(['this', 'LargeSession']);
+        expect(repeated.code).toBe(0);
+        expect(json(repeated)).toEqual(json(named));
+
+        // Caller discovery is exercised from a real descendant of a tmux pane,
+        // while preserving the default tmux environment for this positive path.
+        const realName = await spawnRealTmuxCli(fixture, ['name', 'DescendantAlias'], {
+          name: 'real-name',
+        });
+        await releaseRealTmuxCli(fixture, realName);
+        const realNameResult = readRealTmuxCli<BindingResult>(realName);
+        expect(realNameResult).toMatchObject({
+          code: 0,
+          stdout: { bound: true, name: 'DescendantAlias', pane: realName.pane },
+          stderr: '',
+        });
+
+        const whoami = await fixture.runJsonCli<WhoamiResult>(['whoami']);
+        expect(whoami.code).toBe(0);
+        expect(json(whoami)).toEqual({ bound: true, name: 'LargeSession', pane: fixture.pane });
+
+        const namedCheck = await fixture.runJsonCli<CheckResult>([
+          'check',
+          'LargeSession',
+          '--lines=20',
+        ]);
+        expect(namedCheck.code).toBe(0);
+        expect(json(namedCheck)).toMatchObject({
+          target: 'LargeSession',
+          pane: fixture.pane,
+          identity: { name: 'LargeSession', canonicalName: 'largesession' },
+          lines: 20,
+        });
+
+        const directCheck = await fixture.runJsonCli<CheckResult>([
+          'check',
+          fixture.pane,
+          '--lines=20',
+        ]);
+        expect(directCheck.code).toBe(0);
+        expect(json(directCheck)).toMatchObject({
+          target: fixture.pane,
+          pane: fixture.pane,
+          identity: { name: 'LargeSession', canonicalName: 'largesession' },
+          lines: 20,
+        });
+
+        const namedTalk = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          'LargeSession',
+          'named large-session request',
+          '--no-preamble',
+          '--timeout',
+          '10',
+        ]);
+        expect(namedTalk.code).toBe(0);
+        await waitForDurableReply(
+          fixture,
+          json(namedTalk),
+          fixture.panePid,
+          'named large-session request'
+        );
+
+        const directTalk = await fixture.runJsonCli<TalkResult>([
+          'talk',
+          fixture.pane,
+          'direct large-session request',
+          '--no-preamble',
+          '--timeout',
+          '10',
+        ]);
+        expect(directTalk.code).toBe(0);
+        await waitForDurableReply(
+          fixture,
+          json(directTalk),
+          fixture.panePid,
+          'direct large-session request'
+        );
+
+        const stateBeforeConflict = durableState(fixture);
+        const metadataBeforeConflict = fixture.paneMetadata();
+        const conflict = await fixture.runJsonCli<CommandError>([
+          'add',
+          fixture.pane,
+          'ConflictingName',
+        ]);
+        expect(conflict.code).toBe(5);
+        expect(json(conflict)).toEqual({
+          error: { code: 'PANE_ALREADY_BOUND', message: 'Pane is already bound to another name.' },
+        });
+        expect(fixture.paneMetadata()).toBe(metadataBeforeConflict);
+        const stateAfterConflict = durableState(fixture);
+        expect(stateAfterConflict.bindings).toEqual(stateBeforeConflict.bindings);
+        expect(stateAfterConflict.profiles).toEqual(stateBeforeConflict.profiles);
+        expect(idlePanes.map((pane) => fixture.paneMetadata(pane))).toEqual(idleMetadata);
+      });
+
+      expect(cleanup.root).not.toBe('');
+      expect(cleanup.socketRoot).not.toBe('');
+      expect(fs.existsSync(cleanup.root)).toBe(false);
+      expect(fs.existsSync(cleanup.socketRoot)).toBe(false);
+      expect(processIsRunning(cleanup.serverPid)).toBe(false);
+    }
+  );
+});

--- a/test/e2e/tmux-trace.ts
+++ b/test/e2e/tmux-trace.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { E2EFixture } from './harness.js';
+
+export interface TmuxTrace {
+  readonly path: string;
+  readonly clear: () => void;
+  readonly invocations: () => string[];
+  readonly commands: () => string[];
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/**
+ * Add a narrow invocation trace around the fixture's existing tmux wrapper.
+ * The wrapper remains responsible for the private socket and all existing
+ * failure injection; this layer only records subprocess fan-out from a CLI.
+ */
+export function installTmuxTrace(fixture: E2EFixture): TmuxTrace {
+  const wrapperPath = path.join(fixture.wrapperDir, 'tmux');
+  const delegatedWrapperPath = path.join(fixture.wrapperDir, 'tmux-inner');
+  const tracePath = path.join(fixture.root, 'tmux-command-trace.log');
+
+  fs.renameSync(wrapperPath, delegatedWrapperPath);
+  fs.writeFileSync(
+    wrapperPath,
+    `#!/bin/sh
+printf '%s\\t%s\\n' "${'$'}1" "${'$'}*" >> ${shellQuote(tracePath)}
+exec ${shellQuote(delegatedWrapperPath)} "${'$'}@"
+`,
+    { mode: 0o755 }
+  );
+
+  fs.writeFileSync(tracePath, '');
+
+  return {
+    path: tracePath,
+    clear: () => fs.writeFileSync(tracePath, ''),
+    invocations: () => fs.readFileSync(tracePath, 'utf8').split('\n').filter(Boolean),
+    commands: () =>
+      fs
+        .readFileSync(tracePath, 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map((invocation) => invocation.slice(0, invocation.indexOf('\t'))),
+  };
+}


### PR DESCRIPTION
## Scope

Refs #85. Optimize v5 identity operations on large, mostly-unbound tmux servers without raising deadlines or changing command syntax.

- Remove the per-pane metadata fallback: pane metadata is available in the same batch format on the verified tmux 3.3a baseline.
- Scope caller/target reads, binding publication, unbind and recipient revalidation to the relevant pane(s). Use existing indexed SQLite identity/binding keys rather than enumerating all identities.
- Keep bare `list` as full discovery, reusing its verified pane details instead of performing a second discovery.
- Preserve metadata read-before-write, post-publication verification, same/foreign-server conflicts, durable identity retention and the shared transaction deadline.
- Update architecture, verification guidance and the canonical installed skill. No schema, dependency, release version, daemon or sandbox-permission change.

## Architecture and review

The existing IdentityService, target resolver, SQLite repository and tmux adapter retain their ownership. Scoped and full reconciliation share the same evidence predicate and binding mutation helper; there is no cached presence or second identity implementation. Scoped reads preserve unrelated stale bindings, while full discovery may reconcile stale bindings on the current server. Foreign sockets remain protected.

Scoped snapshots use tmux's pane filter. A missing selected pane returns validated server evidence and no pane; empty scope never becomes global discovery. Invalid scope and incomplete endpoint evidence fail closed. This bounds subprocess fan-out and returned evidence, not tmux's internal traversal time.

Primary review covered all changed files, existing selector callers, metadata publication/rollback, unique storage keys, request endpoint fencing, and scenario/fixture ownership. Supplementary read-only review checked service/target changes. Review findings corrected before acceptance:

- Reject invalid/empty scope widening and share server-evidence parsing.
- Require the large session before first binding, not after setup has already succeeded.
- Use exact subprocess-count equality instead of arbitrary timing/count slack.
- Reuse the existing real-descendant fixture, mock agent and independent SQL oracle.
- Correct a stale list test fixture after removing the second discovery.
- Replace an impossible duplicated-binding mock with a real SQLite uniqueness rejection and a no-enumeration caller test; the existing storage constraints own binding uniqueness.

Reviewed commit: `f135aaad2d79c09d5f2531cb2fefb7a2bdaaba0f`.

## Verification

- [x] Primary reviewer reviewed changed files and relevant callers/tests.
- [x] Final local commands/results recorded below.
- [x] All ten required CI checks passed on reviewed head `f135aaad2d79c09d5f2531cb2fefb7a2bdaaba0f` in run `34077998392`; normal protected merge, no bypass.

Local evidence:

- `pnpm check`: passed.
- `pnpm test:run`: 1,002 tests passed across 68 files; coverage gates passed (95.63% statements/lines, 89.41% branches, 97.54% functions).
- `pnpm test:e2e`: two consecutive full passes, 88/88 tests in 23 files each (266.43s and 266.38s); second large-session measurement remained 5 -> 5 subprocesses (154 -> 153 ms).
- Focused real Docker identity/caller scenarios: 17 passed.
- Focused large-session scenario: passed. Small vs 200 additional unbound panes: `whoami` subprocess count **5 -> 5**, observed wall time **167 -> 173 ms** in one Docker run (diagnostic, not a portable latency guarantee).
- Same large-session regression against original committed tmux/identity/target code: failed as expected, **6 -> 206** subprocesses; observed **155 -> 562 ms**. The regression gate detects fan-out even on a machine where the deadline has not yet expired.
- Packed CLI/native SQLite/skill verification: passed on darwin/arm64 with the actual packed artifact, including exact skill bytes and installation behavior.
- Skill frontmatter validator: passed using a disposable validator environment; no repository dependency added.
- Additional exact GitHub URI trial with local pnpm 11.25.0 downloaded the reviewed commit, and its installed `tmt --version` and isolated `identity list --json` both passed. However, the installer exited 1 with `ERR_PNPM_IGNORED_BUILDS` for skipped better-sqlite3/esbuild scripts, including with `--ignore-scripts`. Do not call that installer invocation a complete pass. No scripts were approved and no policy was relaxed. This local pnpm installation-policy difference is separate from #85; the repository's pinned pnpm 10.33.0 and packed cross-platform installation gates passed.

The large-session scenario covers cold explicit `add`, real pane-descendant `name`, `this`, `whoami`, named/direct `check` and durable `talk/reply`, conflicts, opaque metadata preservation and private-server cleanup. Existing cross-server, publication race and failure tests remain enabled. Tests use isolated Docker/private tmux and deterministic peers, not user panes or live agents.

A preliminary focused invocation mounted Vitest's config directory read-only and failed before tests because Vite writes a temporary compiled config. The corrected invocation mounted only source files read-only; no test or production assertion was relaxed.

## Project lifecycle

- GitHub #85 is the tracker, per the current project instruction; no Linear updates.
- Branch: `codex/85-scoped-identity`.
- Merged as `06b41240fced8c083edd266f8211ffd9fa80326f`. Local main fast-forwarded cleanly; the verified clean, pushed worktree `/Users/benhsieh/dev/tmt-85-scoped-identity` was removed and metadata pruned. No issue-85 containers/images remain; unrelated older images were preserved.
- Keep #85 open for the reporter's company-machine verification. Sandbox permission failures observed separately in #83 are not fixed or bypassed here.
- No npm publication or global installation change.
