### PR TITLE
fix: support grouped and linked tmux pane evidence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -427,6 +427,8 @@ lookup may identify a unique pane process on the selected tmux server. An
 ambient active pane or session name is never caller evidence. Supplied malformed,
 stale or conflicting evidence must not be rescued by fallback. Missing process
 visibility, inaccessible sockets or ambiguous matches yield no caller. This
+lookup deduplicates matching session/pane rows before counting candidates;
+conflicting process/socket/server evidence for a repeated pane is still rejected. This
 supports environment-stripped descendants, not arbitrary sandbox isolation;
 nondefault servers still need a usable server-selection mechanism.
 The fallback uses the system `ps` utility with a shared one-second deadline
@@ -544,6 +546,14 @@ malformed scopes or incomplete endpoint evidence fail closed. This bounds
 subprocess fan-out and returned pane evidence, not tmux's internal traversal
 time. Metadata publication still explicitly reads the selected pane's options
 to preserve unrelated fields before writing; those failures remain fatal.
+
+`list-panes -a` enumerates session/pane rows, not unique panes: grouped sessions
+and linked windows legitimately repeat stable pane IDs with different targets.
+The adapter validates every row before deduplication, including rows that would
+otherwise be discarded. Repeated IDs must agree on pane PID and raw metadata;
+conflicting evidence fails closed. Display target, cwd and foreground command
+are not endpoint identity; the existing projection retains the first row's
+presentation. Current snapshots and foreign probes share this validation.
 
 Binding publication, active reconciliation and unbind share the repository's
 SQLite immediate-transaction boundary. Authoritative endpoint snapshots are

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,6 +100,13 @@ and cleanup; never seed every pane with placeholder metadata to make a test fast
 Scoped reads must preserve unrelated stale rows while full discovery may reconcile
 them. Both paths must share the existing binding-evidence predicate.
 
+Snapshot coverage must include grouped sessions and independently linked windows,
+not only many panes in one session. Assert that the fixture actually produces
+multiple session targets for one stable pane ID, then verify scoped operations
+and full discovery both retain one binding. Validate malformed and conflicting
+duplicate rows in both orders before deduplication; repeated rows alone are not
+incomplete evidence. Preserve subprocess-count gates and causal durable replies.
+
 | Changed area                            | Required checks                                                                     |
 | --------------------------------------- | ----------------------------------------------------------------------------------- |
 | Production TypeScript                   | `pnpm type:check`, `pnpm lint`, `pnpm format:check`                                 |

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -27,6 +27,7 @@ function endpointRow(
     socketPath?: string;
     serverPid?: string;
     paneId?: string;
+    target?: string;
     panePid?: string;
     metadata?: string;
   } = {}
@@ -37,7 +38,7 @@ function endpointRow(
     overrides.serverPid ?? '321',
     '1700000000',
     overrides.paneId ?? '%9',
-    'main:1.0',
+    overrides.target ?? 'main:1.0',
     '/foreign',
     'node',
     overrides.panePid ?? '654',
@@ -845,6 +846,41 @@ describe('createTmux', () => {
       );
     });
 
+    it('discovers one caller pane repeated by grouped sessions without extra probes', () => {
+      vi.stubEnv('TMUX', '');
+      vi.stubEnv('TMUX_PANE', '');
+      const row = ['%7', String(process.pid), '/tmp/default.sock', '321'].join(
+        CALLER_PANE_SEPARATOR
+      );
+      mockedExecFileSync
+        .mockReturnValueOnce(`${process.pid} 0\n`)
+        .mockReturnValueOnce(`${row}\n${row}\n`);
+
+      expect(createTmux().getCurrentPaneId()).toBe('%7');
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    describe.each([false, true])('conflicting caller row first: %s', (conflictFirst) => {
+      it.each([
+        ['pane PID', 1, '1'],
+        ['socket', 2, '/tmp/other.sock'],
+        ['server PID', 3, '999'],
+      ] as const)('rejects repeated pane IDs with a different %s', (_label, index, value) => {
+        vi.stubEnv('TMUX', '');
+        vi.stubEnv('TMUX_PANE', '');
+        const fields = ['%7', String(process.pid), '/tmp/default.sock', '321'];
+        const row = fields.join(CALLER_PANE_SEPARATOR);
+        fields[index] = value;
+        const conflicting = fields.join(CALLER_PANE_SEPARATOR);
+        const rows = conflictFirst ? [conflicting, row] : [row, conflicting];
+        mockedExecFileSync
+          .mockReturnValueOnce(`${process.pid} 0\n`)
+          .mockReturnValueOnce(rows.join('\n'));
+
+        expect(createTmux().getCurrentPaneId()).toBeNull();
+      });
+    });
+
     it('rejects an ambiguous process-to-pane match', () => {
       vi.stubEnv('TMUX', '');
       vi.stubEnv('TMUX_PANE', '');
@@ -1059,14 +1095,20 @@ describe('createTmux', () => {
       );
     });
 
-    it('keeps a full 200-pane endpoint snapshot to one list subprocess for unbound panes', () => {
-      mockedExecFileSync
-        .mockReturnValueOnce(`${VALID_SERVER_ID}\n`)
-        .mockReturnValueOnce(
-          Array.from({ length: 200 }, (_, index) =>
-            endpointRow({ paneId: `%${index}`, panePid: String(654 + index) })
-          ).join('\n') + '\n'
-        );
+    it('keeps a full 200-pane grouped snapshot to one list subprocess and one entry per pane', () => {
+      mockedExecFileSync.mockReturnValueOnce(`${VALID_SERVER_ID}\n`).mockReturnValueOnce(
+        Array.from({ length: 200 }, (_, index) =>
+          ['main', 'grouped'].map((session) =>
+            endpointRow({
+              paneId: `%${index}`,
+              panePid: String(654 + index),
+              target: `${session}:${index}.0`,
+            })
+          )
+        )
+          .flat()
+          .join('\n') + '\n'
+      );
 
       const snapshot = createTmux().getEndpointSnapshot?.();
 
@@ -1278,11 +1320,58 @@ describe('createTmux', () => {
       });
     });
 
-    it('returns unknown for duplicate pane evidence instead of treating a partial parse as live', () => {
-      mockedExecFileSync.mockReturnValueOnce(`${endpointRow()}\n${endpointRow()}\n`);
+    describe.each(['current', 'foreign'] as const)('%s repeated pane evidence', (source) => {
+      function readRows(rows: string[]) {
+        if (source === 'current') mockedExecFileSync.mockReturnValueOnce(`${VALID_SERVER_ID}\n`);
+        mockedExecFileSync.mockReturnValueOnce(rows.join('\n') + '\n');
+        const tmux = createTmux();
+        return source === 'current'
+          ? { status: 'live', snapshot: tmux.getEndpointSnapshot?.({ paneIds: ['%9'] }) }
+          : tmux.probeEndpoint?.('/tmp/foreign.sock', 321, { paneIds: ['%9'] });
+      }
 
-      expect(createTmux().probeEndpoint?.('/tmp/foreign.sock', 321)).toEqual({
-        status: 'unknown',
+      it.each(['main:1.0', 'grouped:7.0'])('accepts repeated rows targeting %s', (target) => {
+        const result = readRows([endpointRow(), endpointRow({ target })]);
+        expect(result).toMatchObject({
+          status: 'live',
+          snapshot: { panes: [{ id: '%9', panePid: 654, target: 'main:1.0' }] },
+        });
+        expect(result?.status === 'live' && result.snapshot?.panes).toHaveLength(1);
+        expect(mockedExecFileSync).toHaveBeenCalledTimes(source === 'current' ? 2 : 1);
+      });
+
+      it('preserves matching opaque metadata containing the field separator', () => {
+        const metadata = JSON.stringify({ version: 1, opaque: ENDPOINT_SEPARATOR });
+        const result = readRows([
+          endpointRow({ metadata }),
+          endpointRow({ metadata, target: 'linked:9.0' }),
+        ]);
+        expect(result).toMatchObject({
+          status: 'live',
+          snapshot: { panes: [{ metadata: { version: 1, opaque: ENDPOINT_SEPARATOR } }] },
+        });
+      });
+
+      describe.each([false, true])('invalid row first: %s', (invalidFirst) => {
+        it.each([
+          ['missing pane ID', endpointRow({ paneId: '' })],
+          ['invalid pane PID', endpointRow({ panePid: '0' })],
+          ['different pane PID', endpointRow({ panePid: '999' })],
+          ['different metadata', endpointRow({ metadata: '{"version":1}' })],
+          ['malformed metadata mismatch', endpointRow({ metadata: 'not-json' })],
+          ['different server PID', endpointRow({ serverPid: '999' })],
+          [
+            'truncated row',
+            endpointRow().split(ENDPOINT_SEPARATOR).slice(0, 9).join(ENDPOINT_SEPARATOR),
+          ],
+        ])('does not hide %s through deduplication', (_label, invalid) => {
+          const rows = invalidFirst ? [invalid, endpointRow()] : [endpointRow(), invalid];
+          if (source === 'current') {
+            expect(() => readRows(rows)).toThrow(/tmux endpoint snapshot contains/);
+          } else {
+            expect(readRows(rows)).toEqual({ status: 'unknown' });
+          }
+        });
       });
     });
 

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -222,28 +222,35 @@ function parseEndpointSnapshot(
   if (rows.length === 0) throw new Error('tmux endpoint snapshot is empty');
 
   const server = parseServerEvidence(output, options.expectedServerId);
-  const completeEvidence = rows.every((line) => line.split(PANE_FIELD_SEPARATOR).length >= 10);
+  const evidence = rows.map((line) => line.split(PANE_FIELD_SEPARATOR));
+  const completeEvidence = evidence.every((fields) => fields.length >= 10);
   if (options.requireCompleteEvidence && !completeEvidence) {
     throw new Error('tmux endpoint snapshot contains inconsistent server evidence');
   }
 
-  const paneOutput = rows
-    .map((line) => line.split(PANE_FIELD_SEPARATOR).slice(4).join(PANE_FIELD_SEPARATOR))
+  if (options.requireCompleteEvidence) {
+    const seen = new Map<string, { panePid: number; metadata: string }>();
+    for (const fields of evidence) {
+      const paneId = fields[4] ?? '';
+      const panePid = Number(fields[8]);
+      if (!PANE_ID_PATTERN.test(paneId) || !Number.isSafeInteger(panePid) || panePid <= 0) {
+        throw new Error('tmux endpoint snapshot contains incomplete pane evidence');
+      }
+      const metadata = fields.slice(9).join(PANE_FIELD_SEPARATOR);
+      const previous = seen.get(paneId);
+      // Grouped sessions and linked windows repeat panes with different display
+      // targets. Validate every row before deduplication so a later malformed
+      // or contradictory process/metadata observation cannot disappear.
+      if (previous && (previous.panePid !== panePid || previous.metadata !== metadata)) {
+        throw new Error('tmux endpoint snapshot contains conflicting pane evidence');
+      }
+      seen.set(paneId, { panePid, metadata });
+    }
+  }
+  const paneOutput = evidence
+    .map((fields) => fields.slice(4).join(PANE_FIELD_SEPARATOR))
     .join('\n');
   const panes = parsePaneOutput(paneOutput);
-  if (
-    options.requireCompleteEvidence &&
-    (panes.length !== rows.length ||
-      panes.some(
-        (pane) =>
-          !/^%\d+$/.test(pane.id) ||
-          typeof pane.panePid !== 'number' ||
-          !Number.isSafeInteger(pane.panePid) ||
-          pane.panePid <= 0
-      ))
-  ) {
-    throw new Error('tmux endpoint snapshot contains incomplete pane evidence');
-  }
   return {
     server,
     panes,
@@ -431,7 +438,14 @@ function discoverCallerPane(
     })
   )
     return null;
-  const candidates = parsedRows
+  const uniqueRows = new Map<string, string[]>();
+  for (const fields of parsedRows) {
+    const id = fields[0]!; // The shape and ID were validated above.
+    const previous = uniqueRows.get(id);
+    if (previous && fields.some((field, index) => field !== previous[index])) return null;
+    uniqueRows.set(id, fields);
+  }
+  const candidates = [...uniqueRows.values()]
     .filter(([id, panePid, socketPath, serverPid]) => {
       const numericPanePid = Number(panePid);
       if (!ancestry.has(numericPanePid)) return false;

--- a/test/e2e/grouped-session.e2e.test.ts
+++ b/test/e2e/grouped-session.e2e.test.ts
@@ -1,0 +1,323 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { durableState } from './identity-state-oracle.js';
+import { withE2EFixture, type CliResult, type E2EFixture } from './harness.js';
+import { readRealTmuxCli, releaseRealTmuxCli, spawnRealTmuxCli } from './real-tmux-caller.js';
+import { installTmuxTrace } from './tmux-trace.js';
+
+interface BindingResult {
+  bound: true;
+  name: string;
+  pane: string;
+}
+
+interface WhoamiResult {
+  bound: boolean;
+  name?: string;
+  pane: string;
+}
+
+interface IdentityListItem {
+  name: string;
+  canonicalName: string;
+  pane: string;
+  target?: string;
+  cwd?: string;
+  command: string;
+}
+
+interface ListResult {
+  identities: IdentityListItem[];
+}
+
+interface FocusedListResult {
+  target: string;
+  identity: { name: string; canonicalName: string } | null;
+  pane: { id: string; target?: string; cwd?: string; command: string };
+}
+
+interface TalkResult {
+  status: string;
+  requestId: string;
+  response: string;
+}
+
+interface CommandError {
+  error: { code: string; message: string };
+}
+
+interface PaneTargetRow {
+  id: string;
+  target: string;
+}
+
+function json<T>(result: CliResult<T>): T {
+  expect(result.code, result.stderr || result.stdout).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.stdout.trim()).not.toBe('');
+  expect(result.json).toBeDefined();
+  return result.json as T;
+}
+
+function listPaneTargets(fixture: E2EFixture): PaneTargetRow[] {
+  return fixture
+    .tmux(['list-panes', '-a', '-F', '#{pane_id}|#{session_name}:#{window_index}.#{pane_index}'])
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const [id = '', target = ''] = line.split('|');
+      return { id, target };
+    });
+}
+
+function expectRepeatedPaneTargets(fixture: E2EFixture, paneId: string): PaneTargetRow[] {
+  const repeated = listPaneTargets(fixture).filter((row) => row.id === paneId);
+  expect(repeated.length).toBeGreaterThanOrEqual(2);
+  expect(new Set(repeated.map((row) => row.target)).size).toBeGreaterThan(1);
+  return repeated;
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function withObservableCleanup(
+  callback: (fixture: E2EFixture) => Promise<void>
+): Promise<void> {
+  const cleanup = { root: '', socketRoot: '', serverPid: 0 };
+  await withE2EFixture(async (fixture) => {
+    cleanup.root = fixture.root;
+    cleanup.socketRoot = fixture.socketRoot;
+    cleanup.serverPid = fixture.serverPid;
+    await callback(fixture);
+  });
+  expect(cleanup.root).not.toBe('');
+  expect(cleanup.socketRoot).not.toBe('');
+  expect(fs.existsSync(cleanup.root)).toBe(false);
+  expect(fs.existsSync(cleanup.socketRoot)).toBe(false);
+  expect(processIsRunning(cleanup.serverPid)).toBe(false);
+}
+
+async function runRealName(
+  fixture: E2EFixture,
+  name: string,
+  options: {
+    stripTmux?: boolean;
+    stripPane?: boolean;
+    linkToSession?: string;
+  }
+): Promise<{ pane: string; pid: number }> {
+  const { linkToSession, ...callerOptions } = options;
+  const real = await spawnRealTmuxCli(fixture, ['name', name], {
+    name: `real-${name.toLowerCase()}`,
+    ...callerOptions,
+  });
+  if (linkToSession) {
+    const windowTarget = fixture.paneTarget(real.pane).replace(/\.\d+$/, '');
+    fixture.tmux(['link-window', '-s', windowTarget, '-t', `${linkToSession}:`]);
+  }
+  expectRepeatedPaneTargets(fixture, real.pane);
+  await releaseRealTmuxCli(fixture, real);
+  expect(readRealTmuxCli<BindingResult>(real)).toEqual({
+    code: 0,
+    stdout: { bound: true, name, pane: real.pane },
+    stderr: '',
+  });
+  return { pane: real.pane, pid: real.panePid };
+}
+
+async function exerciseBoundMockPane(
+  fixture: E2EFixture,
+  identityName: string,
+  pane: { pane: string; pid: number },
+  peer: { name: string; pane: string },
+  trace: ReturnType<typeof installTmuxTrace>,
+  messagePrefix: string
+): Promise<void> {
+  const opaqueMetadata = {
+    version: 1,
+    unrelated: 'preserve grouped-session evidence',
+    nested: { source: 'e2e', enabled: true },
+  };
+  fixture.tmux([
+    'set-option',
+    '-p',
+    '-t',
+    pane.pane,
+    '@tmux-team.agent',
+    JSON.stringify(opaqueMetadata),
+  ]);
+  const peerMetadataBeforeConflict = fixture.paneMetadata(peer.pane);
+
+  const added = await fixture.runJsonCli<BindingResult>(['add', pane.pane, identityName]);
+  expect(json(added)).toEqual({ bound: true, name: identityName, pane: pane.pane });
+  const metadataAfterAdd = fixture.paneMetadata(pane.pane);
+  expect(JSON.parse(metadataAfterAdd)).toMatchObject(opaqueMetadata);
+
+  trace.clear();
+  const whoami = await fixture.runJsonCli<WhoamiResult>(['whoami'], { pane: pane.pane });
+  expect(json(whoami)).toEqual({ bound: true, name: identityName, pane: pane.pane });
+  const scopedInvocations = trace.invocations();
+  const paneQueries = scopedInvocations.filter((invocation) =>
+    invocation.startsWith('list-panes\t')
+  );
+  expect(paneQueries).toHaveLength(1);
+  expect(paneQueries[0]).toContain(' -f ');
+  expect(
+    scopedInvocations.filter(
+      (invocation) => invocation.startsWith('show-options\t') && invocation.includes(' -p ')
+    )
+  ).toEqual([]);
+
+  const listed = json(await fixture.runJsonCli<ListResult>(['list']));
+  expect(listed.identities).toHaveLength(2);
+  expect(new Set(listed.identities.map((identity) => identity.name)).size).toBe(
+    listed.identities.length
+  );
+  expect(listed.identities).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: identityName,
+        canonicalName: identityName.toLowerCase(),
+        pane: pane.pane,
+      }),
+      expect.objectContaining({ name: peer.name, pane: peer.pane }),
+    ])
+  );
+
+  const target = fixture.paneTarget(pane.pane);
+  const focused = json(await fixture.runJsonCli<FocusedListResult>(['list', target]));
+  const observedTargets = new Set(
+    listPaneTargets(fixture)
+      .filter((row) => row.id === pane.pane)
+      .map((row) => row.target)
+  );
+  expect(focused).toMatchObject({
+    target,
+    identity: { name: identityName, canonicalName: identityName.toLowerCase() },
+    pane: { id: pane.pane },
+  });
+  expect(focused.pane.target).toBeDefined();
+  expect(observedTargets).toContain(focused.pane.target);
+
+  const stateBeforeConflict = durableState(fixture);
+  const metadataBeforeConflict = fixture.paneMetadata(pane.pane);
+  const conflict = await fixture.runJsonCli<CommandError>(['add', pane.pane, 'ConflictingName']);
+  expect(conflict.code).toBe(5);
+  expect(conflict.json).toEqual({
+    error: { code: 'PANE_ALREADY_BOUND', message: 'Pane is already bound to another name.' },
+  });
+  expect(fixture.paneMetadata(pane.pane)).toBe(metadataBeforeConflict);
+  expect(fixture.paneMetadata(peer.pane)).toBe(peerMetadataBeforeConflict);
+  const stateAfterConflict = durableState(fixture);
+  expect(stateAfterConflict.bindings).toEqual(stateBeforeConflict.bindings);
+  expect(stateAfterConflict.profiles).toEqual(stateBeforeConflict.profiles);
+  expect(metadataAfterAdd).toBe(metadataBeforeConflict);
+
+  const message = `${messagePrefix} exact durable reply`;
+  const talk = json(
+    await fixture.runJsonCli<TalkResult>([
+      'talk',
+      identityName,
+      message,
+      '--no-preamble',
+      '--timeout',
+      '10',
+    ])
+  );
+  expect(talk).toMatchObject({
+    status: 'completed',
+    requestId: expect.stringMatching(/^req_[0-9a-f-]+$/),
+    response: `mock-agent response: ${message}`,
+  });
+  const submitted = await fixture.waitForEvent(
+    (event) =>
+      event.event === 'submitted' &&
+      event.requestId === talk.requestId &&
+      event.pid === pane.pid &&
+      event.message === message
+  );
+  expect(submitted).toMatchObject({
+    requestId: talk.requestId,
+    pid: pane.pid,
+    message,
+    body: `mock-agent response: ${message}`,
+  });
+  const durable = json(
+    await fixture.runJsonCli<TalkResult>(['result', talk.requestId], { withoutTmux: true })
+  );
+  expect(durable).toMatchObject({
+    status: 'completed',
+    requestId: talk.requestId,
+    response: `mock-agent response: ${message}`,
+  });
+}
+
+describe.sequential('grouped and linked tmux pane identity evidence', () => {
+  it('deduplicates grouped-session caller evidence for a cold stripped descendant', async () => {
+    await withObservableCleanup(async (fixture) => {
+      const trace = installTmuxTrace(fixture);
+      fixture.tmux(['new-session', '-d', '-t', 'e2e', '-s', 'grouped']);
+      expectRepeatedPaneTargets(fixture, fixture.pane);
+
+      const descendant = await runRealName(fixture, 'GroupedDescendant', {
+        stripTmux: true,
+        stripPane: true,
+      });
+      const explicit = await fixture.createMockPane('grouped-explicit');
+      expectRepeatedPaneTargets(fixture, explicit.pane);
+      await exerciseBoundMockPane(
+        fixture,
+        'GroupedExplicit',
+        explicit,
+        { name: 'GroupedDescendant', pane: descendant.pane },
+        trace,
+        'grouped'
+      );
+      expect(descendant.pane).not.toBe(explicit.pane);
+    });
+  }, 45_000);
+
+  it('keeps linked-window duplicate rows stable with complete caller context', async () => {
+    await withObservableCleanup(async (fixture) => {
+      const trace = installTmuxTrace(fixture);
+      fixture.tmux([
+        'new-session',
+        '-d',
+        '-s',
+        'independent',
+        '-n',
+        'placeholder',
+        '-c',
+        fixture.workspace,
+        'sleep',
+        '300',
+      ]);
+      fixture.tmux(['link-window', '-s', 'e2e:0', '-t', 'independent:']);
+      expectRepeatedPaneTargets(fixture, fixture.pane);
+
+      const descendant = await runRealName(fixture, 'LinkedDescendant', {
+        linkToSession: 'independent',
+      });
+      const explicit = { pane: fixture.pane, pid: fixture.panePid };
+      await exerciseBoundMockPane(
+        fixture,
+        'LinkedExplicit',
+        explicit,
+        { name: 'LinkedDescendant', pane: descendant.pane },
+        trace,
+        'linked'
+      );
+
+      expect(descendant.pane).not.toBe(explicit.pane);
+      const duplicateRows = expectRepeatedPaneTargets(fixture, explicit.pane);
+      expect(new Set(duplicateRows.map((row) => row.target)).size).toBeGreaterThan(1);
+    });
+  }, 45_000);
+});

--- a/test/e2e/multi-server.e2e.test.ts
+++ b/test/e2e/multi-server.e2e.test.ts
@@ -64,8 +64,11 @@ describe.sequential('global identities across isolated tmux servers', () => {
     ).rejects.toThrow('intentional multi-server scenario failure');
   });
 
-  it('preserves foreign bindings and refuses a live name collision despite identical pane IDs', async () => {
+  it('preserves grouped foreign bindings and refuses a live name collision despite identical pane IDs', async () => {
     await withTwoServers(async (a, b) => {
+      b.tmux(['new-session', '-d', '-t', 'e2e', '-s', 'grouped']);
+      const remoteRows = b.tmux(['list-panes', '-a', '-F', '#{pane_id}']).trim().split('\n');
+      expect(remoteRows.filter((pane) => pane === b.pane)).toHaveLength(2);
       successful(await b.runJsonCli(['name', 'Remote']));
       successful(await b.runJsonCli(['role', 'set', 'Keep the remote profile.']));
       const before = durableState(b);


### PR DESCRIPTION
## Scope

Closes #87. Follow-up to #85 and PR #86; keep #85 open for company-machine confirmation.

Restore grouped-session and linked-window identity commands without restoring per-pane subprocess fan-out. `list-panes -a` contains session/pane rows, not unique pane IDs. The previous snapshot row-count assertion rejected healthy repeated rows. Primary surrounding-code review also found duplicate caller candidates breaking environment-stripped descendants.

## Architecture and review

- Runtime ownership remains in the existing tmux adapter; no alternate resolver, cache, schema, dependency, timeout increase, or sandbox bypass.
- Validate all snapshot rows before the existing pane projection deduplicates them. Repeated IDs must agree on pane PID and raw metadata; malformed or contradictory evidence fails closed. Display targets may differ, and the first presentation remains authoritative for display only.
- Caller discovery validates consistent process/socket/server evidence before counting unique pane candidates. Distinct candidates remain ambiguous.
- Current snapshots and foreign probes retain one validation path. Existing IdentityService publication/reconciliation, indexed lookup and target resolver contracts are unchanged.
- Reviewed snapshot/caller implementations, current and foreign consumers, identity evidence predicates, all six changed files, fixture setup/cleanup, and deterministic subprocess and durable-response assertions. Independent read-only review found no additional correctness issues.
- Primary review corrected the old duplicate-rejection test, ensured real descendant panes are duplicated before execution, distinguished server-ID reads from per-pane metadata reads, removed a display-target assumption, and corrected the E2E oracle separator after its initial failure. No assertion was weakened to hide a production failure.
- Reviewed commit: `300787eaccb5886a3fc9ec942910c1a7f1d5524a`.

## Verification

- `pnpm check`: passed.
- `pnpm test:run`: 1,042 tests in 68 files passed; coverage 95.63% statements/lines, 89.45% branches, 97.54% functions.
- New snapshot unit cases fail on the original implementation; the caller refinement independently reproduces duplicate-candidate failure and conflicting PID acceptance before its correction.
- Original main `06b4124` fails both final grouped/linked Docker scenarios: `PANE_NOT_FOUND` for the stripped grouped descendant, `RECONCILIATION_FAILED` for the complete-context linked descendant. The grouped foreign-server scenario also fails on original main.
- Focused fixed Docker grouped/linked scenarios passed; large-session and multi-server scenarios passed 8/8. The 200-extra-pane whoami gate retains 5 -> 5 subprocesses.
- Actual packed native/CLI/skill/storage verification passed on local macOS arm64: `Packed install verified: darwin/arm64/none`. No global install or lifecycle-script permission change.
- Two complete `pnpm test:e2e` runs passed 90/90 in 24 files (269.24 and 269.96 seconds) on the same reviewed commit. Both full runs retained 5 -> 5 subprocesses in the large-session gate.
- All ten CI checks passed on reviewed head `300787eaccb5886a3fc9ec942910c1a7f1d5524a`, run `34080704522`: Code quality, Unit tests, Docker E2E, six packed-platform checks and Native package matrix. One pushed candidate; no CI reruns or bypass.

## Lifecycle and limitations

- GitHub #87 is the tracker per the user's project-specific workflow; repository template references to Linear are not used.
- `ARCHITECTURE.md` and `DEVELOPMENT.md` now document row multiplicity, validation-before-deduplication and representative test coverage.
- No command grammar or installed-skill instructions changed, so the canonical end-user skill needs no semantic update.
- Generic diagnostic error reporting and sandbox access remain separate work. No npm release, version bump or global installation performed.
- Dedicated branch/worktree: `codex/87-grouped-pane-evidence`, `/Users/benhsieh/dev/tmt-87-grouped-pane-evidence`. Cleanup follows reviewed CI and normal authorized merge.
