### PR TITLE
fix(tmux): prefer attached session display targets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -552,8 +552,11 @@ and linked windows legitimately repeat stable pane IDs with different targets.
 The adapter validates every row before deduplication, including rows that would
 otherwise be discarded. Repeated IDs must agree on pane PID and raw metadata;
 conflicting evidence fails closed. Display target, cwd and foreground command
-are not endpoint identity; the existing projection retains the first row's
-presentation. Current snapshots and foreign probes share this validation.
+are not endpoint identity; the presentation projection prefers a row whose
+`session_attached` value is positive, while retaining first-seen order for ties
+and when all rows are detached. This preference is presentation-only and does
+not alter pane identity, routing, binding validation or caller evidence. Current
+snapshots and foreign probes share this validation.
 
 Binding publication, active reconciliation and unbind share the repository's
 SQLite immediate-transaction boundary. Authoritative endpoint snapshots are

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,6 +106,10 @@ multiple session targets for one stable pane ID, then verify scoped operations
 and full discovery both retain one binding. Validate malformed and conflicting
 duplicate rows in both orders before deduplication; repeated rows alone are not
 incomplete evidence. Preserve subprocess-count gates and causal durable replies.
+Attach a real fixture-owned client when testing target presentation, including
+a detached-first linked row. Assert the attached target through both public
+`list` and focused `list <target>` without changing stable pane routing. Client
+readiness must identify that client, and fixture cleanup must reap it.
 
 | Changed area                            | Required checks                                                                     |
 | --------------------------------------- | ----------------------------------------------------------------------------------- |

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -29,6 +29,7 @@ function endpointRow(
     paneId?: string;
     target?: string;
     panePid?: string;
+    sessionAttached?: string;
     metadata?: string;
   } = {}
 ): string {
@@ -42,6 +43,7 @@ function endpointRow(
     '/foreign',
     'node',
     overrides.panePid ?? '654',
+    overrides.sessionAttached ?? '0',
     overrides.metadata ?? '',
   ].join(ENDPOINT_SEPARATOR);
 }
@@ -378,6 +380,32 @@ describe('createTmux', () => {
       expect(createTmux().listPanes()).toMatchObject([
         { id: '%1', panePid: 4242, metadata: { version: 1 } },
       ]);
+    });
+
+    it.each([
+      ['detached first, attached later', ['0', '1'], 'attached:1.0'],
+      ['attached first, detached later', ['1', '0'], 'first:1.0'],
+      ['detached first, attached twice later', ['0', '2'], 'attached:1.0'],
+      ['both attached', ['1', '1'], 'first:1.0'],
+      ['neither attached', ['0', '0'], 'first:1.0'],
+    ] as const)('selects the presentation row for %s', (_label, attached, expectedTarget) => {
+      mockedExecSync.mockReturnValue(
+        attached
+          .map((sessionAttached, index) =>
+            [
+              '%1',
+              index === 0 ? 'first:1.0' : 'attached:1.0',
+              '/repo',
+              'codex',
+              '4242',
+              sessionAttached,
+              '',
+            ].join(ENDPOINT_SEPARATOR)
+          )
+          .join('\n') + '\n'
+      );
+
+      expect(createTmux().listPanes()).toMatchObject([{ id: '%1', target: expectedTarget }]);
     });
 
     it('does not query pane options when list-panes omits user metadata', () => {
@@ -1065,6 +1093,7 @@ describe('createTmux', () => {
             '/repo',
             'codex',
             '654',
+            '0',
             '{"version":1}',
           ].join('__TMT_FIELD_4f1c__') + '\n'
         );
@@ -1340,6 +1369,17 @@ describe('createTmux', () => {
         expect(mockedExecFileSync).toHaveBeenCalledTimes(source === 'current' ? 2 : 1);
       });
 
+      it('prefers an attached session presentation row', () => {
+        const detached = endpointRow({ target: 'detached:1.0', sessionAttached: '0' });
+        const attached = endpointRow({ target: 'attached:1.0', sessionAttached: '2' });
+        const result = readRows([detached, attached]);
+
+        expect(result).toMatchObject({
+          status: 'live',
+          snapshot: { panes: [{ id: '%9', target: 'attached:1.0' }] },
+        });
+      });
+
       it('preserves matching opaque metadata containing the field separator', () => {
         const metadata = JSON.stringify({ version: 1, opaque: ENDPOINT_SEPARATOR });
         const result = readRows([
@@ -1365,7 +1405,8 @@ describe('createTmux', () => {
             endpointRow().split(ENDPOINT_SEPARATOR).slice(0, 9).join(ENDPOINT_SEPARATOR),
           ],
         ])('does not hide %s through deduplication', (_label, invalid) => {
-          const rows = invalidFirst ? [invalid, endpointRow()] : [endpointRow(), invalid];
+          const valid = endpointRow({ sessionAttached: '2', target: 'attached:1.0' });
+          const rows = invalidFirst ? [invalid, valid] : [valid, invalid];
           if (source === 'current') {
             expect(() => readRows(rows)).toThrow(/tmux endpoint snapshot contains/);
           } else {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -71,51 +71,78 @@ function emptyMetadata(): PaneAgentMetadata {
   return { version: 1 };
 }
 
+interface ParsedPaneRow {
+  readonly pane: PaneInfo;
+  readonly attached: boolean;
+}
+
+function parsePaneRow(line: string): ParsedPaneRow {
+  const fields = line.includes(PANE_FIELD_SEPARATOR)
+    ? line.split(PANE_FIELD_SEPARATOR)
+    : line.split('\t');
+  const withAttachment = fields.length >= 7;
+  const modern = fields.length >= 6;
+  const [id, target, cwd, command, panePidText, sessionAttachedText, metadataText] = withAttachment
+    ? [
+        fields[0],
+        fields[1],
+        fields[2],
+        fields[3],
+        fields[4],
+        fields[5],
+        line.includes(PANE_FIELD_SEPARATOR)
+          ? fields.slice(6).join(PANE_FIELD_SEPARATOR)
+          : fields[6],
+      ]
+    : modern
+      ? [
+          fields[0],
+          fields[1],
+          fields[2],
+          fields[3],
+          fields[4],
+          undefined,
+          line.includes(PANE_FIELD_SEPARATOR)
+            ? fields.slice(5).join(PANE_FIELD_SEPARATOR)
+            : fields[5],
+        ]
+      : fields.length >= 5
+        ? [fields[0], fields[1], fields[2], fields[3], undefined, undefined, fields[4]]
+        : [fields[0], undefined, undefined, fields[1] ?? '', undefined, undefined, fields[2] ?? ''];
+  // User options are expanded in the same list-panes batch as the pane
+  // evidence. A missing or malformed value is simply absent metadata;
+  // querying each pane here would turn an unbound server into O(panes)
+  // subprocesses.
+  const metadata = safeParseMetadata(metadataText);
+  return {
+    pane: {
+      id: id || '',
+      ...(target && { target }),
+      ...(cwd && { cwd }),
+      command: command || '',
+      ...(panePidText && Number.isInteger(Number(panePidText)) && { panePid: Number(panePidText) }),
+      suggestedName: detectAgentName(command || ''),
+      ...(metadata && { metadata }),
+    },
+    attached: Number.isInteger(Number(sessionAttachedText)) && Number(sessionAttachedText) > 0,
+  };
+}
+
 function parsePaneOutput(output: string): PaneInfo[] {
-  const seen = new Set<string>();
-  return output
+  const seen = new Map<string, ParsedPaneRow>();
+  output
     .split('\n')
     .filter((line) => line.trim())
-    .map((line) => {
-      const fields = line.includes(PANE_FIELD_SEPARATOR)
-        ? line.split(PANE_FIELD_SEPARATOR)
-        : line.split('\t');
-      const [id, target, cwd, command, panePidText, metadataText] =
-        fields.length >= 6
-          ? [
-              fields[0],
-              fields[1],
-              fields[2],
-              fields[3],
-              fields[4],
-              line.includes(PANE_FIELD_SEPARATOR)
-                ? fields.slice(5).join(PANE_FIELD_SEPARATOR)
-                : fields[5],
-            ]
-          : fields.length >= 5
-            ? [fields[0], fields[1], fields[2], fields[3], undefined, fields[4]]
-            : [fields[0], undefined, undefined, fields[1] ?? '', undefined, fields[2] ?? ''];
-      // User options are expanded in the same list-panes batch as the pane
-      // evidence. A missing or malformed value is simply absent metadata;
-      // querying each pane here would turn an unbound server into O(panes)
-      // subprocesses.
-      const metadata = safeParseMetadata(metadataText);
-      return {
-        id: id || '',
-        ...(target && { target }),
-        ...(cwd && { cwd }),
-        command: command || '',
-        ...(panePidText &&
-          Number.isInteger(Number(panePidText)) && { panePid: Number(panePidText) }),
-        suggestedName: detectAgentName(command || ''),
-        ...(metadata && { metadata }),
-      };
-    })
-    .filter((pane) => {
-      if (!pane.id || seen.has(pane.id)) return false;
-      seen.add(pane.id);
-      return true;
+    .map(parsePaneRow)
+    .forEach((row) => {
+      if (!row.pane.id) return;
+      const previous = seen.get(row.pane.id);
+      // Grouped sessions and linked windows repeat pane IDs with different
+      // presentation targets. Prefer an attached session's presentation, but
+      // retain first-seen order for ties and when all rows are detached.
+      if (!previous || (row.attached && !previous.attached)) seen.set(row.pane.id, row);
     });
+  return [...seen.values()].map(({ pane }) => pane);
 }
 
 function endpointFormat(): string {
@@ -129,6 +156,7 @@ function endpointFormat(): string {
     '#{pane_current_path}',
     '#{pane_current_command}',
     '#{pane_pid}',
+    '#{session_attached}',
     `#{${AGENT_METADATA_OPTION}}`,
   ].join(PANE_FIELD_SEPARATOR);
 }
@@ -223,7 +251,7 @@ function parseEndpointSnapshot(
 
   const server = parseServerEvidence(output, options.expectedServerId);
   const evidence = rows.map((line) => line.split(PANE_FIELD_SEPARATOR));
-  const completeEvidence = evidence.every((fields) => fields.length >= 10);
+  const completeEvidence = evidence.every((fields) => fields.length >= 11);
   if (options.requireCompleteEvidence && !completeEvidence) {
     throw new Error('tmux endpoint snapshot contains inconsistent server evidence');
   }
@@ -236,7 +264,7 @@ function parseEndpointSnapshot(
       if (!PANE_ID_PATTERN.test(paneId) || !Number.isSafeInteger(panePid) || panePid <= 0) {
         throw new Error('tmux endpoint snapshot contains incomplete pane evidence');
       }
-      const metadata = fields.slice(9).join(PANE_FIELD_SEPARATOR);
+      const metadata = fields.slice(10).join(PANE_FIELD_SEPARATOR);
       const previous = seen.get(paneId);
       // Grouped sessions and linked windows repeat panes with different display
       // targets. Validate every row before deduplication so a later malformed
@@ -570,7 +598,7 @@ export function createTmux(): Tmux {
       try {
         // Get all panes with stable IDs, human tmux targets, cwd, commands, and tmux-team metadata.
         const output = execSync(
-          `tmux list-panes -a -F "#{pane_id}${PANE_FIELD_SEPARATOR}#{session_name}:#{window_index}.#{pane_index}${PANE_FIELD_SEPARATOR}#{pane_current_path}${PANE_FIELD_SEPARATOR}#{pane_current_command}${PANE_FIELD_SEPARATOR}#{pane_pid}${PANE_FIELD_SEPARATOR}#{${AGENT_METADATA_OPTION}}"`,
+          `tmux list-panes -a -F "#{pane_id}${PANE_FIELD_SEPARATOR}#{session_name}:#{window_index}.#{pane_index}${PANE_FIELD_SEPARATOR}#{pane_current_path}${PANE_FIELD_SEPARATOR}#{pane_current_command}${PANE_FIELD_SEPARATOR}#{pane_pid}${PANE_FIELD_SEPARATOR}#{session_attached}${PANE_FIELD_SEPARATOR}#{${AGENT_METADATA_OPTION}}"`,
           {
             encoding: 'utf-8',
             stdio: ['pipe', 'pipe', 'pipe'],

--- a/test/e2e/grouped-session.e2e.test.ts
+++ b/test/e2e/grouped-session.e2e.test.ts
@@ -49,6 +49,7 @@ interface CommandError {
 interface PaneTargetRow {
   id: string;
   target: string;
+  sessionAttached: number;
 }
 
 function json<T>(result: CliResult<T>): T {
@@ -61,13 +62,18 @@ function json<T>(result: CliResult<T>): T {
 
 function listPaneTargets(fixture: E2EFixture): PaneTargetRow[] {
   return fixture
-    .tmux(['list-panes', '-a', '-F', '#{pane_id}|#{session_name}:#{window_index}.#{pane_index}'])
+    .tmux([
+      'list-panes',
+      '-a',
+      '-F',
+      '#{pane_id}|#{session_name}:#{window_index}.#{pane_index}|#{session_attached}',
+    ])
     .trim()
     .split('\n')
     .filter(Boolean)
     .map((line) => {
-      const [id = '', target = ''] = line.split('|');
-      return { id, target };
+      const [id = '', target = '', attachedText = '0'] = line.split('|');
+      return { id, target, sessionAttached: Number(attachedText) };
     });
 }
 
@@ -264,6 +270,7 @@ describe.sequential('grouped and linked tmux pane identity evidence', () => {
     await withObservableCleanup(async (fixture) => {
       const trace = installTmuxTrace(fixture);
       fixture.tmux(['new-session', '-d', '-t', 'e2e', '-s', 'grouped']);
+      await fixture.attachSessionClient('e2e');
       expectRepeatedPaneTargets(fixture, fixture.pane);
 
       const descendant = await runRealName(fixture, 'GroupedDescendant', {
@@ -280,6 +287,18 @@ describe.sequential('grouped and linked tmux pane identity evidence', () => {
         trace,
         'grouped'
       );
+      const attachedTargets = expectRepeatedPaneTargets(fixture, explicit.pane).filter(
+        (row) => row.sessionAttached > 0
+      );
+      expect(attachedTargets).toHaveLength(1);
+      const focused = json(
+        await fixture.runJsonCli<FocusedListResult>(['list', fixture.paneTarget(explicit.pane)])
+      );
+      expect(focused.pane.target).toBe(attachedTargets[0]?.target);
+      const listed = json(await fixture.runJsonCli<ListResult>(['list']));
+      expect(
+        listed.identities.find((identity) => identity.name === 'GroupedExplicit')?.target
+      ).toBe(attachedTargets[0]?.target);
       expect(descendant.pane).not.toBe(explicit.pane);
     });
   }, 45_000);
@@ -300,7 +319,9 @@ describe.sequential('grouped and linked tmux pane identity evidence', () => {
         '300',
       ]);
       fixture.tmux(['link-window', '-s', 'e2e:0', '-t', 'independent:']);
-      expectRepeatedPaneTargets(fixture, fixture.pane);
+      await fixture.attachSessionClient('independent');
+      const initialRows = expectRepeatedPaneTargets(fixture, fixture.pane);
+      expect(initialRows[0]?.sessionAttached).toBe(0);
 
       const descendant = await runRealName(fixture, 'LinkedDescendant', {
         linkToSession: 'independent',
@@ -315,6 +336,18 @@ describe.sequential('grouped and linked tmux pane identity evidence', () => {
         'linked'
       );
 
+      const attachedTargets = expectRepeatedPaneTargets(fixture, explicit.pane).filter(
+        (row) => row.sessionAttached > 0
+      );
+      expect(attachedTargets).toHaveLength(1);
+      const focused = json(
+        await fixture.runJsonCli<FocusedListResult>(['list', fixture.paneTarget(explicit.pane)])
+      );
+      expect(focused.pane.target).toBe(attachedTargets[0]?.target);
+      const listed = json(await fixture.runJsonCli<ListResult>(['list']));
+      expect(listed.identities.find((identity) => identity.name === 'LinkedExplicit')?.target).toBe(
+        attachedTargets[0]?.target
+      );
       expect(descendant.pane).not.toBe(explicit.pane);
       const duplicateRows = expectRepeatedPaneTargets(fixture, explicit.pane);
       expect(new Set(duplicateRows.map((row) => row.target)).size).toBeGreaterThan(1);

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -132,6 +132,7 @@ export class E2EFixture {
   private serverStarted = false;
   private env: NodeJS.ProcessEnv = {};
   private panePids: number[] = [];
+  private attachedClients: ReturnType<typeof spawn>[] = [];
   private cliProcessPids = new Set<number>();
   private cliProcessResults = new Map<number, Promise<CliResult<unknown>>>();
 
@@ -463,6 +464,41 @@ exit ${'$'}status
     return { pane, pid, workspace };
   }
 
+  /** Attach a real control-mode tmux client to the disposable fixture server. */
+  async attachSessionClient(session: string): Promise<void> {
+    if (!this.started) throw new Error('E2E fixture must be started before attaching a client.');
+    const client = spawn(
+      this.tmuxPath,
+      ['-f', '/dev/null', '-L', this.socket, '-C', 'attach-session', '-t', session],
+      { env: this.env, stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    let spawnError: Error | undefined;
+    client.once('error', (error) => {
+      spawnError = error;
+    });
+    client.stdout?.resume();
+    client.stderr?.resume();
+    this.attachedClients.push(client);
+    await this.waitFor(
+      () => {
+        if (spawnError) {
+          throw new Error(`Could not start tmux client for '${session}'.`, { cause: spawnError });
+        }
+        return (
+          client.exitCode === null &&
+          client.signalCode === null &&
+          client.pid !== undefined &&
+          this.tmux(['list-clients', '-t', session, '-F', '#{client_pid}'])
+            .trim()
+            .split('\n')
+            .includes(String(client.pid))
+        );
+      },
+      2_000,
+      `tmux client attached to '${session}'`
+    );
+  }
+
   /**
    * Restart the fixture's private tmux server while retaining the fixture
    * environment and global directory. Pane user-options belong to a server,
@@ -689,6 +725,37 @@ exit ${'$'}status
       );
     }
     this.cliProcessResults.clear();
+    const attachedClients = this.attachedClients.splice(0);
+    await Promise.all(
+      attachedClients.map(async (client) => {
+        if (client.exitCode === null && client.signalCode === null) {
+          try {
+            client.kill('SIGKILL');
+          } catch (error) {
+            cleanupError ??= new Error('Could not stop an attached E2E tmux client.', {
+              cause: error,
+            });
+          }
+        }
+        if (client.exitCode !== null || client.signalCode !== null) return;
+        const closed = await new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => {
+            client.removeListener('close', onClose);
+            resolve(false);
+          }, 1_000);
+          const onClose = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+          };
+          client.once('close', onClose);
+        });
+        if (!closed) {
+          cleanupError ??= new Error(
+            `Attached E2E tmux client ${client.pid ?? 'unknown'} survived cleanup.`
+          );
+        }
+      })
+    );
     if (this.serverStarted) {
       try {
         this.tmux(['kill-server']);


### PR DESCRIPTION
## Scope

Closes #89.

Prefer an attached session's human-readable target when grouped sessions or linked windows produce multiple rows for one stable pane. This changes display selection only, not pane identity, routing, caller resolution, or binding validity.

## Architecture and review

- Reused the existing batched tmux snapshot parser and presentation projection. The same query includes `session_attached`; no extra tmux call or per-pane fan-out was added.
- Any positive attached-client count outranks a detached row. Equal preference retains first-seen order, including all-detached sessions.
- Every row still passes server/PID/raw-metadata consistency checks before deduplication, including current snapshots and foreign probes.
- Primary review covered the complete diff, snapshot/probe consumers, identity-aware target resolution, both list output paths, and fixture lifecycle. Findings were addressed: real-client readiness identifies the owned PID, streams are drained, startup errors are handled, and cleanup is bounded and reaped.
- Reviewed commit: `f626e8ed6b8c7c0dcbbc026fbf93cf5d2ec719df`.
- Updated `ARCHITECTURE.md` and `DEVELOPMENT.md` for the presentation preference and real-client verification contract.

## Verification

- [x] Primary review of every changed file and relevant callers/tests.
- [x] `pnpm check`: passed, zero lint warnings/errors.
- [x] `pnpm test:run`: 68 files, 1,049 tests passed; coverage gates passed (95.64% statements, 89.41% branches).
- [x] `pnpm test:e2e`: complete local Docker suite passed twice; 24 files / 90 tests per run.
- [x] Real grouped/linked tests assert both unqualified `list --json` and focused listing, including detached-first ordering, stable bindings, conflicts, causal durable replies, and cleanup.
- [x] Large-session regression gate retains 5 subprocesses for both small and large `whoami` observations.
- [x] All 10 CI checks passed on the reviewed head in run `34084364744`; merged normally with head matching and no protection bypass.

## Lifecycle

GitHub Issues are the tracker for this repository, as requested by the maintainer. Scope, decisions, and local evidence are recorded in #89. The isolated worktree will be removed only after safe merge/push and clean-state verification. No host tmux mutation, global install, version bump, or publication is included.
