### PR TITLE
feat(ui): make pane badges opt-in and non-invasive

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -418,6 +418,24 @@ configuration. Config-consuming talk/check fail before tmux or request storage;
 help retains its safe default fallback. Exchange retention configuration uses
 this same owner, not another loader.
 
+### Opt-in pane presentation
+
+Global-only `ui.paneBadge` defaults to `off` and uses the existing configuration
+validation, raw-file preservation, projection, and CLI owner. Binding commands
+resolve it before identity mutation. Successful `name`/`this`/`add` then publish
+or clear the pane-local `@tmux-team.badge` through `Tmux.setPaneBadge`; `unbind`
+clears it without loading unrelated configuration. Failed identity mutations
+leave presentation untouched. Configuration writes themselves remain
+storage-only: no scan or retroactive refresh of existing panes.
+
+The adapter owns bounded label rendering and one bounded best-effort tmux
+option write. It neutralizes format-introducing hashes and controls and limits
+the name to 48 Unicode code points; durable names are unchanged. Cosmetic
+failure cannot undo a committed binding. This port must never change pane
+titles or window-scoped border format, position, or style. Users own theme
+integration and any restoration of an older overwritten layout. There is no
+automatic theme installer, secondary identity registry, or redraw subprocess.
+
 ## Caller context
 
 The tmux adapter owns current-pane evidence. Complete `TMUX_PANE` and `TMUX`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -208,6 +208,15 @@ the existing CLI contract suites, rather than inheriting the one-second unit
 default. Keep child-process termination bounds and behavioral assertions intact;
 test-runner budgets are not production timeout policy.
 
+Pane presentation tests must preserve application titles and user-owned border
+format, position, and style across default-off binding, explicit opt-in,
+configuration changes, conflicts, and unbinding. Use real grouped/linked windows
+to guard against accidentally introducing window-scoped writes. Verify the
+documented theme fragment with literal format-like names, and inject a cosmetic
+write failure while independently checking durable identity state. Configuration
+writes must remain storage-only, and invalid loaded settings must precede any
+identity mutation. A passing mocked adapter assertion alone is insufficient.
+
 ## Installed guidance source ownership
 
 Edit shared agent behavior only in `skills/tmux-team/SKILL.md`. All native

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ tmt help
 
 ## Boundaries worth knowing
 
+TMT leaves your tmux titles and border layout alone. Identity badges are off by
+default; opt in with `tmt config set ui.paneBadge on --global` and add the
+[badge fragment to your own theme](USER-GUIDE.md#optional-pane-badge).
+Use `tmt config show --json` to inspect settings and their file paths.
+
 TMT routes to live panes on the current tmux server. It does not provide an
 offline recipient queue, remote routing, shared memory, authentication, or MCP
 connectivity. Durable identity records and retained request/reply data are

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -170,6 +170,82 @@ tmt config set preambleEvery 3
 tmt config set exchange.retentionDays 90 --global
 ```
 
+| Setting | Default | Scope |
+| --- | --- | --- |
+| `preambleMode` | `always` | Local override or `--global`; `always` / `disabled` |
+| `preambleEvery` | `3` | Local override or `--global`; `0` disables injection |
+| `pasteEnterDelayMs` | `500` | Local override or `--global`; `0` removes the delay |
+| `exchange.retentionDays` | `90` | Global only; new requests, integer days `1..3650` |
+| `ui.paneBadge` | `off` | Global only; `on` / `off` |
+
+`config show --json` reports resolved values, sources, and actual file paths.
+Global settings normally live in `~/.config/tmux-team/config.json`; local
+overrides live in `./tmux-team.json`. Use the reported paths when a custom home
+or configuration root is in use. Global-only settings cannot be set or cleared
+locally. Unknown fields are preserved; invalid known fields should be repaired,
+not worked around by deleting the file.
+
+### Optional pane badge
+
+TMT never changes `pane_title`, `pane-border-format`, border position, or colors.
+The badge is **off by default**. To opt in:
+
+```bash
+tmt config set ui.paneBadge on --global
+tmt name alice
+```
+
+This publishes `alice (tmt)` in the pane-local `@tmux-team.badge` option.
+It does not display anything until you explicitly insert this fragment at the
+desired position in your own tmux `pane-border-format`:
+
+```text
+#{?@tmux-team.badge, [#{@tmux-team.badge}],}
+```
+
+For a theme showing the pane number on the left and `repo/branch` on the right,
+place the fragment after the pane number, before your right-aligned segment.
+Keep the existing expressions and styles; do not replace the whole theme with
+this fragment. The result is conceptually:
+
+```text
+---10.0 [alice (tmt)]----------------------------repo/branch---
+```
+
+Your theme controls color, alignment, and narrow-pane behavior. TMT does not
+reserve space or move the existing right-hand segment. For black text on a light
+blue background, hidden below 80 columns, an optional fragment is:
+
+```text
+#{?#{&&:#{@tmux-team.badge},#{e|>=:#{pane_width},80}},#[push-default]#[fg=black bg=colour153] #{@tmux-team.badge} #[default]#[pop-default],}
+```
+
+Adjust the width threshold for your theme; it is not an automatic fit calculation.
+The style save/restore assumes your surrounding theme does not already use
+`push-default`: tmux only supports one saved default, not nested style stacks.
+If it does, integrate the colors using that theme's own restoration mechanism.
+See the [tmux styles reference](https://man.openbsd.org/tmux#STYLES).
+
+Display labels replace
+`#` and control characters with non-executable text and truncate names after
+48 Unicode code points; the stored identity name remains unchanged.
+
+Configuration changes do not scan or rewrite panes. They apply on the next
+successful `name`, `this`, or `add` for that pane. To disable the current badge:
+
+```bash
+tmt config set ui.paneBadge off --global
+tmt this alice
+```
+
+`unbind` also clears the badge, even when it is disabled. Failed bindings leave
+it unchanged. Badge writes are bounded and best-effort: display failures do not
+undo a successful identity change. If an older TMT version already replaced
+your title or border format, restore it from your saved tmux configuration;
+TMT cannot reconstruct an overwritten theme.
+
+### Installation troubleshooting
+
 If npm reports a permissions error, use a user-owned Node installation or
 version manager and avoid adding `sudo` blindly. If `tmt` is not found after
 installation, check the npm global prefix and that its `bin` directory is on

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -330,8 +330,8 @@ tmt upgrade
 `name`, `this`, and `add` manage one global identity per pane. Names can be
 undeclared identities; they do not need to match a configured role. `add`
 accepts `%pane_id`, `window.pane`, or `session:window.pane` and stores the
-resolved stable `%pane_id`. There is no daemon. A pane title update is only a
-best-effort side effect and is not a separate command or API.
+resolved stable `%pane_id`. There is no daemon. Identity badges are off by
+default; TMT never changes pane titles or window border layout.
 
 Global identities are independent of the current working directory. `talk`,
 `check`, and `list` accept either a global name or a direct pane target. The
@@ -412,6 +412,33 @@ is no punctual physical deletion. A late accepted final has its own duration
 from submission, so metadata can outlive the original request horizon. Reads
 never acknowledge a result. Cleanup is not file shrinkage or secure erasure;
 wall-clock rollback can delay logical expiry while data remains stored.
+
+`tmt config set ui.paneBadge on --global` opts into a cosmetic pane-local
+`@tmux-team.badge` label, such as `alice (tmt)`; `off` is the default.
+It is global-only and uses `ui.paneBadge` in the same global file. Settings
+changes do not scan panes; the next successful `name`, `this`, or `add` applies
+the setting to that pane. `unbind` clears its badge regardless of the setting.
+With `off`, the next successful binding clears a previously published badge.
+Badge writes are bounded and best-effort; a display failure is not a reason to
+retry a successful identity mutation. Binding commands validate loaded settings
+before mutation.
+
+The label is invisible until the user inserts
+`#{?@tmux-team.badge, [#{@tmux-team.badge}],}` into their own
+`pane-border-format`, for example after the left pane number and before the
+right-aligned repository/branch. Preserve their complete existing format,
+title, border position, colors, and narrow-pane policy. Do not replace a theme
+or enable presentation without authorization. Display labels neutralize `#`
+and control characters and cap names at 48 Unicode code points; identity names
+are unchanged. Previously overwritten titles/layouts require restoration from
+the user's saved theme; do not guess or overwrite them as a migration.
+
+For an explicitly requested black-on-light-blue badge hidden below 80 columns:
+`#{?#{&&:#{@tmux-team.badge},#{e|>=:#{pane_width},80}},#[push-default]#[fg=black bg=colour153] #{@tmux-team.badge} #[default]#[pop-default],}`.
+The width threshold is theme-specific, not automatic fitting. The style
+save/restore is only suitable if the surrounding theme does not already use
+`push-default`; tmux does not support nested saved defaults. Otherwise use the
+theme's existing style restoration rather than inserting a conflicting stack.
 
 Invalid known fields in a loaded config return `CONFIG_ERROR` (exit 1) before
 talk/check effects, even when another layer would override them. Unknown and

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -67,7 +67,7 @@ function makeStubContext(): Context {
       listPanes: vi.fn(() => []),
       getCurrentPaneId: vi.fn(() => null),
       resolvePaneTarget: vi.fn((target: string) => target),
-      setPaneTitle: vi.fn(),
+      setPaneBadge: vi.fn(),
     },
     identityService: {
       createIdentity: vi.fn(() => {

--- a/src/commands/basic-commands.test.ts
+++ b/src/commands/basic-commands.test.ts
@@ -54,7 +54,7 @@ function createMockTmux(): Tmux {
     listPanes: vi.fn(() => []),
     getCurrentPaneId: vi.fn(() => null),
     resolvePaneTarget: vi.fn((target: string) => target),
-    setPaneTitle: vi.fn(),
+    setPaneBadge: vi.fn(),
   };
 }
 
@@ -667,7 +667,7 @@ describe('basic commands', () => {
       cmdConfig(ctx, configRequest('clear', { key: 'invalidkey', global: false }))
     ).toThrow(`exit(${ExitCodes.ERROR})`);
     expect(ctx.ui.error).toHaveBeenCalledWith(
-      'Invalid key: invalidkey. Valid keys: preambleMode, preambleEvery, pasteEnterDelayMs, exchange.retentionDays'
+      'Invalid key: invalidkey. Valid keys: preambleMode, ui.paneBadge, preambleEvery, pasteEnterDelayMs, exchange.retentionDays'
     );
   });
 

--- a/src/commands/config-command.test.ts
+++ b/src/commands/config-command.test.ts
@@ -48,6 +48,7 @@ function createCtx(
       pasteEnterDelayMs: 500,
     },
     exchange: { retentionDays: 90 },
+    ui: { paneBadge: 'off' },
     ...configOverrides,
   };
   const tmux: Tmux = {
@@ -56,7 +57,7 @@ function createCtx(
     listPanes: vi.fn(() => []),
     getCurrentPaneId: vi.fn(() => null),
     resolvePaneTarget: vi.fn((target: string) => target),
-    setPaneTitle: vi.fn(),
+    setPaneBadge: vi.fn(),
   };
   return {
     argv: [],
@@ -116,6 +117,8 @@ describe('cmdConfig', () => {
     expect(out.paths).toBeTruthy();
     expect(out.resolved.exchange.retentionDays).toBe(90);
     expect(out.sources.exchange.retentionDays).toBe('default');
+    expect(out.resolved.ui.paneBadge).toBe('off');
+    expect(out.sources.ui.paneBadge).toBe('default');
   });
 
   it('shows config as table in human mode', () => {
@@ -124,6 +127,7 @@ describe('cmdConfig', () => {
     expect(ctx.ui.table).toHaveBeenCalled();
     const tableCall = (ctx.ui.table as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(tableCall[1]).toContainEqual(['exchange.retentionDays', '90', '(default)']);
+    expect(tableCall[1]).toContainEqual(['ui.paneBadge', 'off', '(default)']);
   });
 
   it('rejects invalid keys and values', () => {
@@ -189,6 +193,22 @@ describe('cmdConfig', () => {
     });
   });
 
+  it('sets global pane badge and preserves unknown ui fields', () => {
+    const ctx = createCtx(testDir);
+    fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
+    fs.writeFileSync(
+      ctx.paths.globalConfig,
+      JSON.stringify({ keep: true, ui: { future: { enabled: true } } })
+    );
+
+    cmdConfig(ctx, configRequest('set', { key: 'ui.paneBadge', value: 'on', global: true }));
+
+    expect(JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf8'))).toEqual({
+      keep: true,
+      ui: { future: { enabled: true }, paneBadge: 'on' },
+    });
+  });
+
   it('rejects local exchange retention writes and clears before changing bytes', () => {
     const ctx = createCtx(testDir);
     const original = JSON.stringify({ keep: true, $config: { exchange: { retentionDays: 1 } } });
@@ -204,6 +224,22 @@ describe('cmdConfig', () => {
 
     expect(() =>
       cmdConfig(ctx, configRequest('clear', { key: 'exchange.retentionDays', global: false }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(fs.readFileSync(ctx.paths.localConfig, 'utf8')).toBe(original);
+  });
+
+  it('rejects local pane badge writes and clears before changing bytes', () => {
+    const ctx = createCtx(testDir);
+    const original = JSON.stringify({ keep: true, $config: { ui: { paneBadge: 'on' } } });
+    fs.writeFileSync(ctx.paths.localConfig, original);
+
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'ui.paneBadge', value: 'on', global: false }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(fs.readFileSync(ctx.paths.localConfig, 'utf8')).toBe(original);
+
+    expect(() =>
+      cmdConfig(ctx, configRequest('clear', { key: 'ui.paneBadge', global: false }))
     ).toThrow(`exit(${ExitCodes.ERROR})`);
     expect(fs.readFileSync(ctx.paths.localConfig, 'utf8')).toBe(original);
   });
@@ -257,6 +293,18 @@ describe('cmdConfig', () => {
     expect(out.sources.preambleEvery).toBe('global');
     expect(out.resolved.exchange.retentionDays).toBe(30);
     expect(out.sources.exchange.retentionDays).toBe('global');
+  });
+
+  it('shows global pane badge source', () => {
+    const ctx = createCtx(testDir, { json: true }, { ui: { paneBadge: 'on' } });
+    fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
+    fs.writeFileSync(ctx.paths.globalConfig, JSON.stringify({ ui: { paneBadge: 'on' } }));
+
+    cmdConfig(ctx, configRequest('show'));
+
+    const out = (ctx.ui as any).jsonCalls[0] as any;
+    expect(out.resolved.ui.paneBadge).toBe('on');
+    expect(out.sources.ui.paneBadge).toBe('global');
   });
 
   it('shows default source when no config has settings', () => {
@@ -325,6 +373,14 @@ describe('cmdConfig', () => {
     expect(fs.existsSync(ctx.paths.globalConfig)).toBe(false);
   });
 
+  it.each(['enabled', '', 'ON', '1'])('rejects invalid pane badge %j', (value) => {
+    const ctx = createCtx(testDir);
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'ui.paneBadge', value, global: true }))
+    ).toThrow(`exit(${ExitCodes.ERROR})`);
+    expect(fs.existsSync(ctx.paths.globalConfig)).toBe(false);
+  });
+
   it('uses strict integer syntax and preserves partial global defaults', () => {
     const ctx = createCtx(testDir);
     fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
@@ -365,5 +421,42 @@ describe('cmdConfig', () => {
       cmdConfig(ctx, configRequest('set', { key: 'preambleEvery', value: '5', global: true }))
     ).toThrow(/Invalid configuration/);
     expect(fs.readFileSync(ctx.paths.globalConfig, 'utf8')).toBe(original);
+  });
+
+  it('repairs an invalid pane badge while preserving ui siblings', () => {
+    const ctx = createCtx(testDir);
+    fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
+    fs.writeFileSync(
+      ctx.paths.globalConfig,
+      JSON.stringify({ ui: { paneBadge: 'invalid', future: { enabled: true } } })
+    );
+
+    cmdConfig(ctx, configRequest('set', { key: 'ui.paneBadge', value: 'off', global: true }));
+
+    expect(JSON.parse(fs.readFileSync(ctx.paths.globalConfig, 'utf8'))).toEqual({
+      ui: { paneBadge: 'off', future: { enabled: true } },
+    });
+  });
+
+  it('preserves bytes when a pane badge repair encounters an invalid container or sibling', () => {
+    const ctx = createCtx(testDir);
+    fs.mkdirSync(ctx.paths.globalDir, { recursive: true });
+
+    const invalidContainer = JSON.stringify({ ui: [] });
+    fs.writeFileSync(ctx.paths.globalConfig, invalidContainer);
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'ui.paneBadge', value: 'on', global: true }))
+    ).toThrow(/Invalid configuration/);
+    expect(fs.readFileSync(ctx.paths.globalConfig, 'utf8')).toBe(invalidContainer);
+
+    const invalidSibling = JSON.stringify({
+      ui: { paneBadge: 'off' },
+      defaults: { captureLines: 'bad' },
+    });
+    fs.writeFileSync(ctx.paths.globalConfig, invalidSibling);
+    expect(() =>
+      cmdConfig(ctx, configRequest('set', { key: 'ui.paneBadge', value: 'on', global: true }))
+    ).toThrow(/Invalid configuration/);
+    expect(fs.readFileSync(ctx.paths.globalConfig, 'utf8')).toBe(invalidSibling);
   });
 });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -15,11 +15,11 @@ import {
 } from '../config.js';
 import { createDefaultGlobalDefaults, isValidConfigSettingValue } from '../config-settings.js';
 
-type EnumConfigKey = 'preambleMode';
+type EnumConfigKey = 'preambleMode' | 'ui.paneBadge';
 type NumericConfigKey = 'preambleEvery' | 'pasteEnterDelayMs' | 'exchange.retentionDays';
 type ConfigKey = EnumConfigKey | NumericConfigKey;
 
-const ENUM_KEYS: EnumConfigKey[] = ['preambleMode'];
+const ENUM_KEYS: EnumConfigKey[] = ['preambleMode', 'ui.paneBadge'];
 const NUMERIC_KEYS: NumericConfigKey[] = [
   'preambleEvery',
   'pasteEnterDelayMs',
@@ -31,12 +31,13 @@ function isValidKey(key: string): key is ConfigKey {
   return VALID_KEYS.includes(key as ConfigKey);
 }
 
-function isGlobalOnlyKey(key: ConfigKey): key is 'exchange.retentionDays' {
-  return key === 'exchange.retentionDays';
+function isGlobalOnlyKey(key: ConfigKey): key is 'exchange.retentionDays' | 'ui.paneBadge' {
+  return key === 'exchange.retentionDays' || key === 'ui.paneBadge';
 }
 
 type ParsedSetting =
-  | { readonly key: EnumConfigKey; readonly value: 'always' | 'disabled' }
+  | { readonly key: 'preambleMode'; readonly value: 'always' | 'disabled' }
+  | { readonly key: 'ui.paneBadge'; readonly value: 'on' | 'off' }
   | { readonly key: NumericConfigKey; readonly value: number };
 
 function parseSetting(key: ConfigKey, value: string): ParsedSetting {
@@ -45,6 +46,12 @@ function parseSetting(key: ConfigKey, value: string): ParsedSetting {
       throw new Error(`Invalid value for ${key}: ${value}. Valid values: always, disabled`);
     }
     return { key, value: value as 'always' | 'disabled' };
+  }
+  if (key === 'ui.paneBadge') {
+    if (!isValidConfigSettingValue(key, value)) {
+      throw new Error(`Invalid value for ${key}: ${value}. Valid values: on, off`);
+    }
+    return { key, value: value as 'on' | 'off' };
   }
   if (value.length === 0 || /\D/u.test(value)) {
     throw new Error(`Invalid value for ${key}: ${value}. Must be a non-negative integer.`);
@@ -76,6 +83,9 @@ function showConfig(ctx: Context): void {
         exchange: {
           retentionDays: ctx.config.exchange.retentionDays,
         },
+        ui: {
+          paneBadge: ctx.config.ui.paneBadge,
+        },
       },
       sources: {
         preambleMode: localSettings?.preambleMode
@@ -97,6 +107,9 @@ function showConfig(ctx: Context): void {
               : 'default',
         exchange: {
           retentionDays: globalConfig.exchange?.retentionDays !== undefined ? 'global' : 'default',
+        },
+        ui: {
+          paneBadge: globalConfig.ui?.paneBadge !== undefined ? 'global' : 'default',
         },
       },
       paths: {
@@ -142,6 +155,11 @@ function showConfig(ctx: Context): void {
         'exchange.retentionDays',
         String(ctx.config.exchange.retentionDays),
         exchangeRetentionSource,
+      ],
+      [
+        'ui.paneBadge',
+        ctx.config.ui.paneBadge,
+        globalConfig.ui?.paneBadge !== undefined ? '(global)' : '(default)',
       ],
     ]
   );
@@ -192,6 +210,8 @@ function setConfig(ctx: Context, key: string, value: string, global: boolean): v
       globalConfig.defaults.pasteEnterDelayMs = parsed.value;
     } else if (parsed.key === 'exchange.retentionDays') {
       globalConfig.exchange = { ...globalConfig.exchange, retentionDays: parsed.value };
+    } else if (parsed.key === 'ui.paneBadge') {
+      globalConfig.ui = { ...globalConfig.ui, paneBadge: parsed.value };
     }
     saveGlobalConfig(ctx.paths, globalConfig);
     ctx.ui.success(`Set ${key}=${value} in global config`);

--- a/src/commands/global-identity.ts
+++ b/src/commands/global-identity.ts
@@ -38,14 +38,17 @@ export function bindIdentity(
   name: string,
   options: { readonly current?: boolean } = {}
 ): void {
+  // Validate configuration before committing identity effects. Only the actual
+  // cosmetic update below is best-effort.
+  const badgeEnabled = ctx.config.ui.paneBadge === 'on';
   try {
     const identity = options.current
       ? ctx.identityService.bindCurrent(name)
       : ctx.identityService.bindPane(paneId, name);
     try {
-      ctx.tmux.setPaneTitle(paneId, identity.name);
+      ctx.tmux.setPaneBadge(paneId, badgeEnabled ? identity.name : null);
     } catch {
-      // Identity metadata is authoritative; title synchronization is presentation only.
+      // Identity metadata is authoritative; badges are presentation only.
     }
     if (ctx.flags.json) ctx.ui.json({ bound: true, name: identity.name, pane: paneId });
     else ctx.ui.success(`Bound '${identity.name}' to pane ${paneId}`);
@@ -62,6 +65,11 @@ export function unbindIdentity(ctx: Context, paneId: string): void {
     const identity = ctx.identityService.unbindCurrent();
     if (!identity) {
       failIdentity(ctx, 'UNBOUND_PANE', 'Pane has no active global name.');
+    }
+    try {
+      ctx.tmux.setPaneBadge(paneId, null);
+    } catch {
+      // Clearing a cosmetic label cannot undo a successful unbind.
     }
     if (ctx.flags.json) {
       ctx.ui.json({ unbound: true, name: identity.name, pane: paneId });

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -207,6 +207,9 @@ ${colors.yellow('SETTINGS')}
   tmux-team config set exchange.retentionDays 90 --global
   Retention accepts integer days 1..3650, global-only, for new requests only.
   Reads/retries do not renew expiry; cleanup is bounded and opportunistic.
+  tmux-team config set ui.paneBadge on --global
+  Badges default to off; apply on the next name/this/add. Unbind clears them.
+  Display requires your own theme fragment; TMT never changes titles or borders.
   --wait is retired; --lines is only for check, not talk.
   Stored mode/maxCaptureLines settings are inert and preserved, not migrated.
   config clear mode removes only the obsolete local mode key.

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -34,7 +34,7 @@ function createCtx(testDir: string, overrides?: Partial<{ flags: Partial<Flags> 
     listPanes: vi.fn(() => []),
     getCurrentPaneId: vi.fn(() => null),
     resolvePaneTarget: vi.fn((target: string) => target),
-    setPaneTitle: vi.fn(),
+    setPaneBadge: vi.fn(),
   };
   return {
     argv: [],

--- a/src/commands/name.test.ts
+++ b/src/commands/name.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { cmdName } from './name.js';
 import { cmdThis } from './this.js';
 import { cmdAdd } from './add.js';
+import { cmdUnbind } from './unbind.js';
 import { IdentityServiceError } from '../identity-service.js';
 import type { Context, IdentityService } from '../types.js';
 import { createDefaultConfig } from '../config-settings.js';
@@ -23,7 +24,7 @@ function context(json = false): Context {
     listPanes: vi.fn(() => []),
     getCurrentPaneId: vi.fn(() => '%1'),
     resolvePaneTarget: vi.fn((target: string) => target),
-    setPaneTitle: vi.fn(),
+    setPaneBadge: vi.fn(),
   };
   const identityService: IdentityService = {
     createIdentity: vi.fn(() => {
@@ -86,14 +87,14 @@ describe('global identity commands', () => {
     expect(() => cmdName(ctx, 'Backend')).toThrow();
     expect(legacyRead).not.toHaveBeenCalled();
     expect(legacyWrite).not.toHaveBeenCalled();
-    expect(ctx.tmux.setPaneTitle).not.toHaveBeenCalled();
+    expect(ctx.tmux.setPaneBadge).not.toHaveBeenCalled();
     expect(ctx.ui.success).not.toHaveBeenCalled();
   });
-  it('binds the current pane through the durable service and keeps title output', () => {
+  it('binds the current pane with the badge disabled by default', () => {
     const ctx = context();
     cmdName(ctx, 'Backend');
     expect(ctx.identityService.bindCurrent).toHaveBeenCalledWith('Backend');
-    expect(ctx.tmux.setPaneTitle).toHaveBeenCalledWith('%1', 'Backend');
+    expect(ctx.tmux.setPaneBadge).toHaveBeenCalledWith('%1', null);
     expect(ctx.ui.success).toHaveBeenCalledWith("Bound 'Backend' to pane %1");
   });
 
@@ -157,7 +158,7 @@ describe('global identity commands', () => {
     expect(ctx.ui.json).toHaveBeenCalledWith({
       error: { code: 'NAME_ALREADY_ACTIVE', message: 'Name is already active on another pane.' },
     });
-    expect(ctx.tmux.setPaneTitle).not.toHaveBeenCalled();
+    expect(ctx.tmux.setPaneBadge).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -206,17 +207,77 @@ describe('global identity commands', () => {
       });
       expect(() => handler(ctx, 'alice')).toThrow('exit(5)');
       expect(ctx.ui.json).toHaveBeenCalledOnce();
-      expect(ctx.tmux.setPaneTitle).not.toHaveBeenCalled();
+      expect(ctx.tmux.setPaneBadge).not.toHaveBeenCalled();
     }
     expect(vi.mocked(contexts[0].ui.json).mock.calls).toEqual(
       vi.mocked(contexts[1].ui.json).mock.calls
     );
   });
 
-  it('keeps a successful bind when title synchronization fails', () => {
+  it.each([cmdName, cmdThis])(
+    'publishes an opted-in badge through the shared binding path',
+    (handler) => {
+      const ctx = context(true);
+      ctx.config.ui.paneBadge = 'on';
+      handler(ctx, 'Backend');
+      expect(ctx.tmux.setPaneBadge).toHaveBeenCalledWith('%1', 'Backend');
+      expect(ctx.ui.json).toHaveBeenCalledWith({ bound: true, name: 'Backend', pane: '%1' });
+    }
+  );
+
+  it('publishes an opted-in explicit-pane badge', () => {
+    const ctx = context(true);
+    ctx.config.ui.paneBadge = 'on';
+    cmdAdd(ctx, '%2', 'Backend');
+    expect(ctx.tmux.setPaneBadge).toHaveBeenCalledWith('%2', 'Backend');
+  });
+
+  it('does not commit a binding when configuration cannot be loaded', () => {
     const ctx = context();
-    (ctx.tmux.setPaneTitle as ReturnType<typeof vi.fn>).mockImplementation(() => {
-      throw new Error('title unavailable');
+    Object.defineProperty(ctx, 'config', {
+      get: () => {
+        throw new Error('invalid configuration');
+      },
+    });
+    expect(() => cmdName(ctx, 'Backend')).toThrow('invalid configuration');
+    expect(ctx.identityService.bindCurrent).not.toHaveBeenCalled();
+    expect(ctx.tmux.setPaneBadge).not.toHaveBeenCalled();
+  });
+
+  it('clears only the badge after a successful unbind without loading settings', () => {
+    const ctx = context(true);
+    vi.mocked(ctx.identityService.unbindCurrent).mockReturnValue(identity());
+    Object.defineProperty(ctx, 'config', {
+      get: () => {
+        throw new Error('unexpected config read');
+      },
+    });
+    cmdUnbind(ctx);
+    expect(ctx.tmux.setPaneBadge).toHaveBeenCalledWith('%1', null);
+    expect(ctx.ui.json).toHaveBeenCalledWith({ unbound: true, name: 'Backend', pane: '%1' });
+  });
+
+  it('does not change a badge when unbind fails', () => {
+    const ctx = context(true);
+    vi.mocked(ctx.identityService.unbindCurrent).mockReturnValue(undefined);
+    expect(() => cmdUnbind(ctx)).toThrow('exit(1)');
+    expect(ctx.tmux.setPaneBadge).not.toHaveBeenCalled();
+  });
+
+  it('keeps a successful unbind when clearing the badge fails', () => {
+    const ctx = context(true);
+    vi.mocked(ctx.identityService.unbindCurrent).mockReturnValue(identity());
+    vi.mocked(ctx.tmux.setPaneBadge).mockImplementation(() => {
+      throw new Error('badge unavailable');
+    });
+    cmdUnbind(ctx);
+    expect(ctx.ui.json).toHaveBeenCalledWith({ unbound: true, name: 'Backend', pane: '%1' });
+  });
+
+  it('keeps a successful bind when badge synchronization fails', () => {
+    const ctx = context();
+    (ctx.tmux.setPaneBadge as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('badge unavailable');
     });
     cmdName(ctx, 'backend');
     expect(ctx.identityService.bindCurrent).toHaveBeenCalledWith('backend');

--- a/src/commands/preamble.test.ts
+++ b/src/commands/preamble.test.ts
@@ -53,7 +53,7 @@ function createContext(service: PreambleService, flags: Partial<Context['flags']
       listPanes: vi.fn(() => []),
       getCurrentPaneId: vi.fn(() => null),
       resolvePaneTarget: vi.fn(() => null),
-      setPaneTitle: vi.fn(),
+      setPaneBadge: vi.fn(),
     },
     preambleService: service,
     identityService: {

--- a/src/commands/talk.test.ts
+++ b/src/commands/talk.test.ts
@@ -178,7 +178,7 @@ function createMockTmux(options: { readonly onSend?: (message: string) => void }
     listPanes: () => [],
     getCurrentPaneId: () => null,
     resolvePaneTarget: (target: string) => target,
-    setPaneTitle: () => undefined,
+    setPaneBadge: () => undefined,
     getEndpointSnapshot: () => ({
       server: {
         serverId: ENDPOINT.serverId,

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -76,7 +76,7 @@ function context(json = false): Context {
       listPanes: vi.fn(() => []),
       getCurrentPaneId: vi.fn(() => '%1'),
       resolvePaneTarget: vi.fn(),
-      setPaneTitle: vi.fn(),
+      setPaneBadge: vi.fn(),
     },
     identityService,
     get requestService(): Context['requestService'] {

--- a/src/config-settings.test.ts
+++ b/src/config-settings.test.ts
@@ -28,6 +28,7 @@ describe('config settings policy', () => {
         pasteEnterDelayMs: 500,
       },
       exchange: { retentionDays: 90 },
+      ui: { paneBadge: 'off' },
     });
     expect(createDefaultGlobalDefaults()).toEqual(second.defaults);
   });
@@ -45,6 +46,8 @@ describe('config settings policy', () => {
     ['pasteEnterDelayMs', 2_147_483_647],
     ['exchange.retentionDays', 1],
     ['exchange.retentionDays', 3650],
+    ['ui.paneBadge', 'on'],
+    ['ui.paneBadge', 'off'],
   ] as const)('accepts %s=%s', (key, value) => {
     expect(isValidConfigSettingValue(key, value)).toBe(true);
   });
@@ -65,6 +68,8 @@ describe('config settings policy', () => {
     ['exchange.retentionDays', 0],
     ['exchange.retentionDays', 3651],
     ['exchange.retentionDays', 1.5],
+    ['ui.paneBadge', 'enabled'],
+    ['ui.paneBadge', 'ON'],
   ] as const)('rejects %s=%s', (key, value) => {
     expect(isValidConfigSettingValue(key, value)).toBe(false);
   });
@@ -84,6 +89,10 @@ describe('config settings policy', () => {
     );
   });
 
+  it.each([null, [], 'on'])('rejects the invalid ui container %j', (ui) => {
+    expect(() => validateAndProjectGlobalConfig({ ui }, file)).toThrowError(ConfigValidationError);
+  });
+
   it('validates known values in global and local layers, including overridden values', () => {
     expect(() =>
       validateAndProjectGlobalConfig(
@@ -97,6 +106,9 @@ describe('config settings policy', () => {
     expect(() =>
       validateAndProjectLocalSettings({ $config: { preambleEvery: null } }, file)
     ).toThrowError(ConfigValidationError);
+    expect(() =>
+      validateAndProjectGlobalConfig({ ui: { paneBadge: 'enabled' } }, file)
+    ).toThrowError(ConfigValidationError);
   });
 
   it('projects known fields without importing unknown or retired fields', () => {
@@ -107,6 +119,7 @@ describe('config settings policy', () => {
           mode: 'wait',
           defaults: { timeout: 120, maxCaptureLines: 999, future: true },
           exchange: { retentionDays: 90, future: true },
+          ui: { paneBadge: 'on', future: true },
         },
         file
       )
@@ -114,6 +127,7 @@ describe('config settings policy', () => {
       preambleMode: 'disabled',
       defaults: { timeout: 120 },
       exchange: { retentionDays: 90 },
+      ui: { paneBadge: 'on' },
     });
     expect(
       validateAndProjectLocalSettings(
@@ -149,6 +163,7 @@ describe('config settings policy', () => {
     expect(() => validateGlobalConfigShape({ exchange: [] }, file)).toThrowError(
       ConfigValidationError
     );
+    expect(() => validateGlobalConfigShape({ ui: [] }, file)).toThrowError(ConfigValidationError);
     expect(() => validateLocalConfigShape({ $config: [] }, file)).toThrowError(
       ConfigValidationError
     );

--- a/src/config-settings.ts
+++ b/src/config-settings.ts
@@ -2,6 +2,7 @@ import type {
   ConfigDefaults,
   GlobalConfig,
   GlobalExchangeSettings,
+  GlobalUiSettings,
   LocalSettings,
   ResolvedConfig,
 } from './types.js';
@@ -30,6 +31,9 @@ const DEFAULT_CONFIG = {
   exchange: {
     retentionDays: DEFAULT_EXCHANGE_RETENTION_DAYS,
   },
+  ui: {
+    paneBadge: 'off',
+  },
 } as const;
 
 type JsonObject = Record<string, unknown>;
@@ -40,7 +44,8 @@ export type ConfigSettingKey =
   | 'captureLines'
   | 'preambleEvery'
   | 'pasteEnterDelayMs'
-  | 'exchange.retentionDays';
+  | 'exchange.retentionDays'
+  | 'ui.paneBadge';
 
 export class ConfigValidationError extends Error {
   constructor(
@@ -88,6 +93,10 @@ function isValidPreambleMode(value: unknown): value is 'always' | 'disabled' {
   return value === 'always' || value === 'disabled';
 }
 
+function isValidPaneBadge(value: unknown): value is 'on' | 'off' {
+  return value === 'on' || value === 'off';
+}
+
 interface SettingRule {
   readonly valid: (value: unknown) => boolean;
   readonly expected: string;
@@ -113,6 +122,7 @@ const SETTING_RULES: Record<ConfigSettingKey, SettingRule> = {
     valid: isValidExchangeRetentionDays,
     expected: `an integer from ${MIN_EXCHANGE_RETENTION_DAYS} through ${MAX_EXCHANGE_RETENTION_DAYS}`,
   },
+  'ui.paneBadge': { valid: isValidPaneBadge, expected: "'on' or 'off'" },
 };
 
 export function isValidConfigSettingValue(key: ConfigSettingKey, value: unknown): boolean {
@@ -140,6 +150,7 @@ export function validateGlobalConfigShape(
   const root = validateObject(value, filePath, '<root>');
   if (hasOwn(root, 'defaults')) validateObject(root.defaults, filePath, 'defaults');
   if (hasOwn(root, 'exchange')) validateObject(root.exchange, filePath, 'exchange');
+  if (hasOwn(root, 'ui')) validateObject(root.ui, filePath, 'ui');
 }
 
 /** Validate only the JSON container shape so a targeted config repair is possible. */
@@ -171,6 +182,13 @@ export function validateGlobalConfig(
       );
     }
   }
+  if (hasOwn(root, 'ui')) {
+    const ui = root.ui as JsonObject;
+    if (hasOwn(ui, 'paneBadge')) {
+      const rule = SETTING_RULES['ui.paneBadge'];
+      validateKnownField(ui.paneBadge, filePath, 'ui.paneBadge', rule.valid, rule.expected);
+    }
+  }
   if (!hasOwn(root, 'defaults')) return;
   const defaults = root.defaults as JsonObject;
   validateKnownSettings(defaults, filePath, 'defaults.', [
@@ -198,6 +216,7 @@ export interface ValidatedGlobalConfig {
   readonly preambleMode?: GlobalConfig['preambleMode'];
   readonly defaults?: Partial<ConfigDefaults>;
   readonly exchange?: Pick<GlobalExchangeSettings, 'retentionDays'>;
+  readonly ui?: Pick<GlobalUiSettings, 'paneBadge'>;
 }
 
 export interface ValidatedLocalSettings {
@@ -207,6 +226,7 @@ export interface ValidatedLocalSettings {
 function projectGlobalConfig(value: JsonObject): ValidatedGlobalConfig {
   const rawDefaults = isJsonObject(value.defaults) ? value.defaults : undefined;
   const rawExchange = isJsonObject(value.exchange) ? value.exchange : undefined;
+  const rawUi = isJsonObject(value.ui) ? value.ui : undefined;
   return {
     ...(value.preambleMode !== undefined && {
       preambleMode: value.preambleMode as GlobalConfig['preambleMode'],
@@ -230,6 +250,9 @@ function projectGlobalConfig(value: JsonObject): ValidatedGlobalConfig {
     }),
     ...(rawExchange?.retentionDays !== undefined && {
       exchange: { retentionDays: rawExchange.retentionDays as number },
+    }),
+    ...(rawUi?.paneBadge !== undefined && {
+      ui: { paneBadge: rawUi.paneBadge as 'on' | 'off' },
     }),
   };
 }
@@ -274,6 +297,7 @@ export function createDefaultConfig(): ResolvedConfig {
     preambleMode: DEFAULT_CONFIG.preambleMode,
     defaults: { ...DEFAULT_CONFIG.defaults },
     exchange: { ...DEFAULT_CONFIG.exchange },
+    ui: { ...DEFAULT_CONFIG.ui },
   };
 }
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -208,6 +208,23 @@ describe('loadConfig', () => {
     expect(config.defaults.captureLines).toBe(100);
     expect(config.defaults.pasteEnterDelayMs).toBe(500);
     expect(config.exchange.retentionDays).toBe(90);
+    expect(config.ui.paneBadge).toBe('off');
+  });
+
+  it('loads global pane badge while ignoring the local opaque value', () => {
+    const globalConfig = { ui: { paneBadge: 'on', future: { enabled: true } } };
+    const localConfig = { $config: { ui: { paneBadge: 'off' } } };
+
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p === mockPaths.globalConfig) return JSON.stringify(globalConfig);
+      if (p === mockPaths.localConfig) return JSON.stringify(localConfig);
+      return '';
+    });
+
+    const config = loadConfig(mockPaths);
+
+    expect(config.ui.paneBadge).toBe('on');
   });
 
   it('loads global exchange retention but ignores local exchange data', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -163,6 +163,9 @@ export function loadConfig(paths: Paths): ResolvedConfig {
     if (knownGlobal.exchange?.retentionDays !== undefined) {
       config.exchange.retentionDays = knownGlobal.exchange.retentionDays;
     }
+    if (knownGlobal.ui?.paneBadge !== undefined) {
+      config.ui.paneBadge = knownGlobal.ui.paneBadge;
+    }
   }
 
   // Load local settings. Other local JSON fields remain opaque and are never

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -35,7 +35,7 @@ describe('createContext', () => {
       listPanes: vi.fn(() => []),
       getCurrentPaneId: vi.fn(() => null),
       resolvePaneTarget: vi.fn((target: string) => target),
-      setPaneTitle: vi.fn(),
+      setPaneBadge: vi.fn(),
     };
 
     const loadConfig = vi.fn(() => config);
@@ -75,7 +75,7 @@ describe('createContext', () => {
       listPanes: vi.fn(() => []),
       getCurrentPaneId: vi.fn(() => null),
       resolvePaneTarget: vi.fn((target: string) => target),
-      setPaneTitle: vi.fn(),
+      setPaneBadge: vi.fn(),
     };
 
     const loadConfig = vi.fn(() => config);

--- a/src/tmux.test.ts
+++ b/src/tmux.test.ts
@@ -1459,31 +1459,44 @@ describe('createTmux', () => {
     });
   });
 
-  describe('pane titles', () => {
-    it('sets the title and displays it right-aligned in the themed pane border', () => {
+  describe('opt-in pane badges', () => {
+    it('sets only the owned pane option with bounded subprocess execution', () => {
       const tmux = createTmux();
 
-      tmux.setPaneTitle('%9', 'backend');
+      tmux.setPaneBadge('%9', 'backend');
 
-      expect(mockedExecFileSync).toHaveBeenNthCalledWith(
-        1,
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
         'tmux',
-        ['select-pane', '-t', '%9', '-T', 'backend'],
+        ['set-option', '-p', '-t', '%9', '@tmux-team.badge', 'backend (tmt)'],
+        expect.objectContaining({ timeout: 1000, killSignal: 'SIGKILL', maxBuffer: 1024 * 1024 })
+      );
+    });
+
+    it('clears only the owned pane option', () => {
+      createTmux().setPaneBadge('%9', null);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        'tmux',
+        ['set-option', '-p', '-u', '-t', '%9', '@tmux-team.badge'],
         expect.any(Object)
       );
-      expect(mockedExecFileSync).toHaveBeenNthCalledWith(
-        2,
-        'tmux',
-        ['set-window-option', '-t', '%9', 'pane-border-status', 'top'],
-        expect.any(Object)
-      );
-      expect(mockedExecFileSync).toHaveBeenNthCalledWith(
-        3,
-        'tmux',
-        ['set-window-option', '-t', '%9', 'pane-border-format', '#[align=right]#{pane_title}'],
-        expect.any(Object)
-      );
-      expect(mockedExecFileSync.mock.calls[2]?.[1]).not.toContain('#[fg=');
+    });
+
+    it.each([
+      ['#[fg=red]#{pane_title}#(touch nope)', '＃[fg=red]＃{pane_title}＃(touch nope) (tmt)'],
+      ['line\n\u009bname', 'line  name (tmt)'],
+      ['😀'.repeat(49), '😀'.repeat(48) + '… (tmt)'],
+    ])('keeps %s display-only and bounded', (name, expected) => {
+      createTmux().setPaneBadge('%9', name);
+      expect(mockedExecFileSync.mock.calls[0]?.[1]).toEqual([
+        'set-option',
+        '-p',
+        '-t',
+        '%9',
+        '@tmux-team.badge',
+        expected,
+      ]);
     });
   });
 });

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -595,18 +595,19 @@ export function createTmux(): Tmux {
       }
     },
 
-    setPaneTitle(paneId: string, title: string): void {
-      execFileSync('tmux', ['select-pane', '-t', paneId, '-T', title], { stdio: 'pipe' });
-      // Keep the title visible in the pane border and let tmux inherit the
-      // active/inactive border colors from the user's theme.
-      execFileSync('tmux', ['set-window-option', '-t', paneId, 'pane-border-status', 'top'], {
-        stdio: 'pipe',
-      });
-      execFileSync(
-        'tmux',
-        ['set-window-option', '-t', paneId, 'pane-border-format', '#[align=right]#{pane_title}'],
-        { stdio: 'pipe' }
-      );
+    setPaneBadge(paneId: string, name: string | null): void {
+      const args = ['set-option', '-p'];
+      if (name === null) args.push('-u');
+      args.push('-t', paneId, '@tmux-team.badge');
+      if (name !== null) {
+        // This is a bounded display label, never identity or executable format.
+        // Replace format introducers and terminal controls rather than allowing
+        // an identity name to inject tmux styling or nested command expansion.
+        const characters = Array.from(name.replaceAll('#', '＃').replace(/\p{Cc}/gu, ' '));
+        const label = characters.slice(0, 48).join('') + (characters.length > 48 ? '…' : '');
+        args.push(`${label} (tmt)`);
+      }
+      execFileSync('tmux', args, { stdio: 'pipe', ...commandOptions() });
     },
 
     getCurrentPaneId(): string | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,10 +42,20 @@ export interface GlobalExchangeSettings {
   [key: string]: unknown;
 }
 
+export interface PaneUiConfig {
+  paneBadge: 'on' | 'off';
+}
+
+export interface GlobalUiSettings {
+  paneBadge?: PaneUiConfig['paneBadge'];
+  [key: string]: unknown;
+}
+
 export interface GlobalConfig {
   preambleMode: 'always' | 'disabled';
   defaults: ConfigDefaults;
   exchange?: GlobalExchangeSettings;
+  ui?: GlobalUiSettings;
 }
 
 export interface LocalSettings {
@@ -63,6 +73,7 @@ export interface ResolvedConfig {
   preambleMode: 'always' | 'disabled';
   defaults: ConfigDefaults;
   exchange: ExchangeConfig;
+  ui: PaneUiConfig;
 }
 
 export interface Flags {
@@ -112,7 +123,8 @@ export interface Tmux {
   /** Return only the caller's verified pane; never an ambient/default pane. */
   getCurrentPaneId: () => string | null;
   resolvePaneTarget: (target: string) => string | null;
-  setPaneTitle: (paneId: string, title: string) => void;
+  /** Publish a cosmetic label only; never change user titles or window styles. */
+  setPaneBadge: (paneId: string, name: string | null) => void;
   getEndpointSnapshot?: (options?: TmuxOperationOptions) => TmuxEndpointSnapshot;
   setDurableIdentity?: (
     paneId: string,

--- a/test/e2e/exchange-attention.e2e.test.ts
+++ b/test/e2e/exchange-attention.e2e.test.ts
@@ -130,22 +130,32 @@ describe.sequential('Exchange attention through the real Docker/tmux fixture', (
 
         // Bind the same durable identity and prove omitted --identity uses verified caller
         // evidence. The explicit offline path above never touched tmux or parsed config.
-        expect(success(await fixture.runJsonCli(['name', 'Alice']))).toEqual({
-          bound: true,
-          name: 'Alice',
-          pane: fixture.pane,
-        });
+        const bindWithValidSettings = async (name: string, pane: string): Promise<void> => {
+          // Binding now validates badge configuration. Repair only for that operation,
+          // then restore malformed settings before each implicit exchange read below.
+          expect(fs.readFileSync(path.join(fixture.globalDir, 'config.json'), 'utf8')).toBe(
+            configs.global
+          );
+          expect(fs.readFileSync(path.join(fixture.workspace, 'tmux-team.json'), 'utf8')).toBe(
+            configs.local
+          );
+          fs.writeFileSync(path.join(fixture.globalDir, 'config.json'), '{}');
+          fs.writeFileSync(path.join(fixture.workspace, 'tmux-team.json'), '{}');
+          expect(success(await fixture.runJsonCli(['name', name]))).toEqual({
+            bound: true,
+            name: 'Alice',
+            pane,
+          });
+          expect(malformedConfig(fixture)).toEqual(configs);
+        };
+        await bindWithValidSettings('Alice', fixture.pane);
         const implicit = success<{ items: Array<Record<string, unknown>> }>(
           await fixture.runJsonCli(['x', 'list'])
         );
         expect(implicit.items.some((item) => item.requestId === requestId)).toBe(true);
 
         const restarted = await fixture.restartServer();
-        expect(success(await fixture.runJsonCli(['name', 'alice']))).toEqual({
-          bound: true,
-          name: 'Alice',
-          pane: restarted.pane,
-        });
+        await bindWithValidSettings('alice', restarted.pane);
         const afterRebind = success<{ identity: PublicIdentity }>(
           await fixture.runJsonCli(['x', 'show', requestId])
         );

--- a/test/e2e/pane-badge.e2e.test.ts
+++ b/test/e2e/pane-badge.e2e.test.ts
@@ -1,0 +1,214 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type CliResult, type E2EFixture } from './harness.js';
+import { durableState } from './identity-state-oracle.js';
+
+const BADGE_OPTION = '@tmux-team.badge';
+const USER_FORMAT = '#[align=left]#{window_index}.#{pane_index}#[align=right]repo/branch';
+const BADGE_FRAGMENT = '#{?@tmux-team.badge, [#{@tmux-team.badge}],}';
+const COLORED_BADGE_FRAGMENT =
+  '#{?#{&&:#{@tmux-team.badge},#{e|>=:#{pane_width},80}},#[push-default]#[fg=black bg=colour153] #{@tmux-team.badge} #[default]#[pop-default],}';
+
+function successful<T>(result: CliResult<T>): T {
+  expect(result.code, result.stderr || result.stdout).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.json).toBeDefined();
+  return result.json as T;
+}
+
+function badge(fixture: E2EFixture): string {
+  // The minimal Docker image has no UTF-8 locale. Request UTF-8 output so tmux
+  // does not render wide characters as underscores in this read-side oracle.
+  return fixture.tmux(['-u', 'show-options', '-p', '-qv', '-t', fixture.pane, BADGE_OPTION]).trim();
+}
+
+function appearance(fixture: E2EFixture) {
+  return {
+    title: fixture.tmux(['display-message', '-p', '-t', fixture.pane, '#{pane_title}']),
+    position: fixture.tmux(['show-options', '-w', '-v', '-t', fixture.pane, 'pane-border-status']),
+    format: fixture.tmux(['show-options', '-w', '-v', '-t', fixture.pane, 'pane-border-format']),
+    style: fixture.tmux(['show-options', '-w', '-v', '-t', fixture.pane, 'pane-border-style']),
+  };
+}
+
+function configureUserAppearance(fixture: E2EFixture): void {
+  fixture.tmux(['select-pane', '-t', fixture.pane, '-T', 'original application title']);
+  fixture.tmux(['set-option', '-w', '-t', fixture.pane, 'pane-border-status', 'bottom']);
+  fixture.tmux(['set-option', '-w', '-t', fixture.pane, 'pane-border-format', USER_FORMAT]);
+  fixture.tmux(['set-option', '-w', '-t', fixture.pane, 'pane-border-style', 'fg=green']);
+}
+
+describe.sequential('non-invasive pane badge presentation', () => {
+  it('preserves titles and shared window layout with the default-off badge', async () => {
+    await withE2EFixture(async (fixture) => {
+      configureUserAppearance(fixture);
+      fixture.tmux(['new-session', '-d', '-t', 'e2e', '-s', 'grouped']);
+      const before = appearance(fixture);
+      successful(await fixture.runJsonCli(['name', 'alice']));
+      expect(badge(fixture)).toBe('');
+      expect(appearance(fixture)).toEqual(before);
+      successful(await fixture.runJsonCli(['this', 'alice']));
+      successful(await fixture.runJsonCli(['unbind']));
+      expect(appearance(fixture)).toEqual(before);
+      expect(badge(fixture)).toBe('');
+      expect(durableState(fixture).bindings).toHaveLength(0);
+      expect(durableState(fixture).identities).toHaveLength(1);
+    });
+  });
+
+  it('publishes only an opted-in label and applies config changes on the next binding', async () => {
+    await withE2EFixture(async (fixture) => {
+      configureUserAppearance(fixture);
+      // The user, not TMT, chooses where to insert the fragment in their theme.
+      const integrated = USER_FORMAT.replace('#[align=right]', `${BADGE_FRAGMENT}#[align=right]`);
+      fixture.tmux(['set-option', '-w', '-t', fixture.pane, 'pane-border-format', integrated]);
+      fixture.tmux(['new-session', '-d', '-s', 'independent', 'sleep 300']);
+      fixture.tmux(['link-window', '-s', 'e2e:0', '-t', 'independent:']);
+      const before = appearance(fixture);
+      successful(
+        await fixture.runJsonCli(['config', 'set', 'ui.paneBadge', 'on', '--global'], {
+          withoutTmux: true,
+        })
+      );
+      expect(badge(fixture)).toBe('');
+      successful(await fixture.runJsonCli(['add', fixture.pane, 'alice']));
+      expect(badge(fixture)).toBe('alice (tmt)');
+      const rendered = fixture.tmux(['display-message', '-p', '-t', fixture.pane, integrated]);
+      expect(rendered).toContain(' [alice (tmt)]');
+      expect(rendered).toContain('repo/branch');
+      expect(appearance(fixture)).toEqual(before);
+
+      const metadata = fixture.paneMetadata();
+      const bindings = durableState(fixture).bindings;
+      const conflict = await fixture.runJsonCli(['add', fixture.pane, 'other']);
+      expect(conflict.code).toBe(5);
+      expect(conflict.json).toMatchObject({ error: { code: 'PANE_ALREADY_BOUND' } });
+      expect(badge(fixture)).toBe('alice (tmt)');
+      expect(fixture.paneMetadata()).toBe(metadata);
+      expect(durableState(fixture).bindings).toEqual(bindings);
+
+      successful(
+        await fixture.runJsonCli(['config', 'set', 'ui.paneBadge', 'off', '--global'], {
+          withoutTmux: true,
+        })
+      );
+      expect(badge(fixture)).toBe('alice (tmt)');
+      successful(await fixture.runJsonCli(['this', 'alice']));
+      expect(badge(fixture)).toBe('');
+      expect(
+        fixture.tmux(['-u', 'display-message', '-p', '-t', fixture.pane, BADGE_FRAGMENT]).trim()
+      ).toBe('');
+      successful(
+        await fixture.runJsonCli(['config', 'set', 'ui.paneBadge', 'on', '--global'], {
+          withoutTmux: true,
+        })
+      );
+      successful(await fixture.runJsonCli(['name', 'alice']));
+      expect(badge(fixture)).toBe('alice (tmt)');
+      successful(await fixture.runJsonCli(['unbind']));
+      expect(badge(fixture)).toBe('');
+      expect(appearance(fixture)).toEqual(before);
+    });
+  });
+
+  it('keeps format-like identity names literal in the cosmetic label', async () => {
+    await withE2EFixture(async (fixture) => {
+      successful(await fixture.runJsonCli(['config', 'set', 'ui.paneBadge', 'on', '--global']));
+      const name = '#[fg=red]#{pane_title}#(false)';
+      successful(await fixture.runJsonCli(['name', name]));
+      const label = '＃[fg=red]＃{pane_title}＃(false) (tmt)';
+      expect(badge(fixture)).toBe(label);
+      expect(
+        fixture.tmux(['-u', 'display-message', '-p', '-t', fixture.pane, BADGE_FRAGMENT]).trim()
+      ).toBe(`[${label}]`);
+      expect(successful(await fixture.runJsonCli(['whoami']))).toEqual({
+        bound: true,
+        name,
+        pane: fixture.pane,
+      });
+    });
+  });
+
+  it('expands the documented colored fragment only for a bound, wide pane', async () => {
+    await withE2EFixture(async (fixture) => {
+      configureUserAppearance(fixture);
+      const before = appearance(fixture);
+      successful(await fixture.runJsonCli(['config', 'set', 'ui.paneBadge', 'on', '--global']));
+      successful(await fixture.runJsonCli(['name', 'alice']));
+      const rendered = () =>
+        fixture.tmux(['display-message', '-p', '-t', fixture.pane, COLORED_BADGE_FRAGMENT]).trim();
+      fixture.tmux(['resize-window', '-t', fixture.pane, '-x', '120']);
+      expect(rendered()).toBe(
+        '#[push-default]#[fg=black bg=colour153] alice (tmt) #[default]#[pop-default]'
+      );
+      fixture.tmux(['resize-window', '-t', fixture.pane, '-x', '60']);
+      expect(rendered()).toBe('');
+      fixture.tmux(['resize-window', '-t', fixture.pane, '-x', '120']);
+      successful(await fixture.runJsonCli(['unbind']));
+      expect(rendered()).toBe('');
+      expect(appearance(fixture)).toEqual(before);
+    });
+  });
+
+  it('preserves successful binding and unbinding when badge writes are denied', async () => {
+    await withE2EFixture(async (fixture) => {
+      configureUserAppearance(fixture);
+      const before = appearance(fixture);
+      successful(await fixture.runJsonCli(['config', 'set', 'ui.paneBadge', 'on', '--global']));
+      const wrapper = path.join(fixture.wrapperDir, 'tmux');
+      const denied = path.join(fixture.root, 'badge-denied.log');
+      fs.writeFileSync(
+        wrapper,
+        fs
+          .readFileSync(wrapper, 'utf8')
+          .replace(
+            '#!/bin/sh\n',
+            `#!/bin/sh\nfor argument in "$@"; do\n  if [ "$argument" = "@tmux-team.badge" ]; then printf 'denied\\n' >> '${denied}'; exit 1; fi\ndone\n`
+          )
+      );
+      successful(await fixture.runJsonCli(['name', 'alice']));
+      expect(successful(await fixture.runJsonCli(['whoami']))).toEqual({
+        bound: true,
+        name: 'alice',
+        pane: fixture.pane,
+      });
+      expect(durableState(fixture).bindings).toHaveLength(1);
+      successful(await fixture.runJsonCli(['unbind']));
+      expect(durableState(fixture).bindings).toHaveLength(0);
+      expect(fs.readFileSync(denied, 'utf8').trim().split('\n')).toEqual(['denied', 'denied']);
+      expect(appearance(fixture)).toEqual(before);
+    });
+  });
+
+  it('rejects invalid badge settings before binding but still permits unbinding', async () => {
+    await withE2EFixture(async (fixture) => {
+      configureUserAppearance(fixture);
+      const before = appearance(fixture);
+      successful(await fixture.runJsonCli(['config', 'set', 'ui.paneBadge', 'on', '--global']));
+      successful(await fixture.runJsonCli(['name', 'alice']));
+      const committed = durableState(fixture);
+      const metadata = fixture.paneMetadata();
+      const configPath = path.join(fixture.globalDir, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({ ui: { paneBadge: 'invalid' } }));
+
+      for (const command of [
+        ['name', 'alice'],
+        ['this', 'alice'],
+        ['add', fixture.pane, 'alice'],
+      ]) {
+        const rejected = await fixture.runJsonCli(command);
+        expect(rejected.code).toBe(1);
+        expect(rejected.json).toMatchObject({ error: { code: 'CONFIG_ERROR' } });
+        expect(durableState(fixture)).toEqual(committed);
+        expect(fixture.paneMetadata()).toBe(metadata);
+        expect(badge(fixture)).toBe('alice (tmt)');
+      }
+
+      successful(await fixture.runJsonCli(['unbind']));
+      expect(durableState(fixture).bindings).toHaveLength(0);
+      expect(badge(fixture)).toBe('');
+      expect(appearance(fixture)).toEqual(before);
+    });
+  });
+});


### PR DESCRIPTION
## Scope

Closes #90. Builds on #89's attached-target fix, already merged through #91.

Replace invasive identity title updates with an explicitly configured, default-off pane badge. TMT never changes user pane titles or window border format, position, or colors.

## Input/output and usage

```bash
tmt config set ui.paneBadge on --global
tmt name alice
```

This publishes `alice (tmt)` only in `@tmux-team.badge`. Display requires explicit integration into the user's own theme; documented plain and black-on-light-blue/narrow-pane fragments are verified against real tmux.

- Default `off`; global-only `on|off` validated through the existing config owner and CLI parser.
- `config set` remains storage-only. The next successful `name`/`this`/`add` applies the setting to that pane; disabling it clears the label on that refresh.
- `unbind` clears the label without reading unrelated configuration. Failed identity mutations leave presentation untouched.
- Binding validates loaded configuration before mutation. Cosmetic write failure is bounded and cannot turn a committed identity change into a reported failure.
- Labels neutralize format hashes and control characters and bound the display name to 48 Unicode code points without changing durable names.
- Previously overwritten themes cannot be reconstructed automatically. No scan, automatic theme installer, redraw subprocess, daemon, or identity registry was added.

## Architecture and review

Reused `config-settings` validation/projection, existing raw-file preservation, `commands/config`, shared binding/unbinding commands, and the tmux adapter. Replaced the presentation port with `setPaneBadge` rather than retaining a competing title API.

Primary review covered all changed files and config/caller/list consumers. Independent review found no blocking semantic issues. The existing exchange-attention fixture was updated to use valid settings only while binding, then reinstate malformed settings before every exchange read; its storage-independence checks remain intact.

Reviewed head: `98e6008e5309b33d0bf2ba53e8a39596dff13a1e`. Synchronizing the main merge changed only ancestry: its entire tree is identical to Docker-tested combined commit `8f5a74ffca5372e593286f6de8e153602f1dfbe4`. Quality and all unit tests were rerun on the final head.

README, USER-GUIDE, the single canonical installed skill, CLI help, architecture, and developer verification guidance are updated. Theme style-stack and width-threshold limitations are explicit.

## Verification

- [x] `pnpm check`: passed, zero lint warnings/errors.
- [x] `pnpm test:run` on the combined candidate: 68 files / 1,077 tests passed; coverage gates passed (95.66% statements, 89.47% branches).
- [x] Six focused real-Docker badge scenarios: default-off, opt-in/config timing/conflicts/unbind, literal names, colored/narrow-pane fragment, denied writes, and invalid settings with unbind recovery.
- [x] `pnpm test:e2e`: 25 files / 96 tests passed twice (277.93s and 277.59s); the second run includes the reviewed #89 implementation. No host tmux or network-enabled peers were used.
- [x] Canonical skill validator passed; packed native verifier checks installed skill bytes, links, reinstall/update behavior, and actual application storage on macOS arm64.
- [x] All 10 CI checks passed on reviewed head `98e6008e5309b33d0bf2ba53e8a39596dff13a1e` in run `34084941466`; merged normally with head matching and no protection bypass.

## Lifecycle

GitHub #90 records scope, decisions, test refinements, and review evidence. The worktree remains isolated and will be removed only after safe merge/push and clean-state verification. No host tmux/theme change, global installation, version bump, or publication is included.
