### PR TITLE
test: share CLI executable selection for the Rust rewrite

### DIFF
--- a/.agents/skills/tmt-e2e/SKILL.md
+++ b/.agents/skills/tmt-e2e/SKILL.md
@@ -36,6 +36,11 @@ Read the relevant files before changing behavior:
 
 - [`test/e2e/`](../../../test/e2e/): Vitest configuration, scenarios, harness, and mock-agent behavior.
 - [`scripts/run-e2e.mjs`](../../../scripts/run-e2e.mjs): Docker build/run wrapper and exit-code handling.
+- [`DEVELOPMENT.md#selecting-the-cli-under-test`](../../../DEVELOPMENT.md#selecting-the-cli-under-test):
+  shared executable/peer descriptors and container-path requirements. Reuse
+  `src/test-support/cli-executable.mjs`; never add a hard-coded Node launcher or
+  silent TS fallback. Prove selection reaches nested replies and real descendants
+  with causal results. TS-importing worker/pack tests are not native parity.
 - [`PERFORMANCE-BASELINE.md`](../../../PERFORMANCE-BASELINE.md) for optional runtime
   measurements. Use the same isolated fixture and causal assertions; keep timing
   samples out of ordinary CI thresholds and distinguish measured from unavailable

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -817,6 +817,19 @@ The test mock independently recognizes the documented request instruction frame
 and invokes the public reply CLI, rather than importing a production response
 store or completing requests through a test-only endpoint.
 
+`src/test-support/cli-executable.mjs` owns the test-only executable descriptor:
+an absolute executable plus an argv prefix. CLI-contract sandboxes and E2E
+fixtures validate/freeze the selection before allocating resources; the fixture
+propagates it to real tmux descendants and a separately selectable mock reply
+peer. The startup resource probe uses the same owner. This is plain ESM so mock
+agents and measurement scripts need no TypeScript loader to select a native CLI;
+the adjacent declaration exposes the narrow interface to TypeScript callers.
+Selection does not own spawning or disposal: each existing launcher retains its
+process-group, timeout, stream and cleanup rules. No production code reads these
+test settings, and the entire test-support directory remains excluded from npm.
+See DEVELOPMENT for selector usage and the distinction between selectable CLI
+contracts and TypeScript-only workers/pack probes.
+
 Identity, request and response concurrency suites share the bounded process
 harness in `src/test-support/request-workers.ts`. Each scenario owns its handles
 and stops workers in `finally` before deleting fixture files. Worker entrypoints

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -63,10 +63,53 @@ in `test/e2e/Dockerfile` from the current checkout, runs Vitest inside it with
 own tmux server on a private socket and
 launches the deterministic mock agent from `test/e2e/mock-agent.mjs`; no real
 agent, credentials, or host tmux session is used. The tests invoke
-`bin/tmux-team` as a subprocess and exercise CLI process propagation, tmux
+`bin/tmux-team` by default as a subprocess and exercise CLI process propagation, tmux
 transport, pane movement, and fixture cleanup. Failures include the
 container/Vitest output, and each fixture kills its private server and removes
 its temporary state.
+
+### Selecting the CLI under test
+
+`TMT_TEST_CLI` is a JSON descriptor with exactly `executable` (absolute path to an
+executable file) and `args` (string-array argv prefix). Omission selects the
+current test runner's absolute Node executable plus the checkout's public
+TypeScript wrapper as its prefix. This preserves tests that deliberately remove
+Node/provider discovery from PATH; it does not skip the wrapper's child process.
+`TMT_TEST_PEER_CLI` uses the same format for mock
+agent replies; omission uses the primary selection. An empty, malformed,
+missing or non-executable explicit selection fails; it never falls back to TS.
+Shell fragments are not parsed. Paths and prefix arguments may contain spaces
+and quotes. Selection is frozen per sandbox/fixture, before resource allocation.
+
+```bash
+# Host CLI contracts; use a real native build only once it supports the subset.
+TMT_TEST_CLI='{"executable":"/absolute/path/to/tmt","args":[]}' \
+  pnpm exec vitest run src/identity-cli-contract.test.ts
+
+# Docker paths refer to files INSIDE the image, not host executable paths.
+TMT_TEST_CLI='{"executable":"/workspace/bin/tmux-team","args":[]}' pnpm test:e2e
+
+# Explicit Node+wrapper is also a descriptor, not a special runtime mode.
+TMT_TEST_CLI='{"executable":"/usr/local/bin/node","args":["/workspace/bin/tmux-team"]}' \
+TMT_TEST_PEER_CLI='{"executable":"/workspace/bin/tmux-team","args":[]}' pnpm test:e2e
+```
+
+The Docker wrapper forwards both settings unchanged. A custom Linux binary must
+already be in the build context/image, or be mounted read-only in a manually
+managed task-owned image/container; no host-path mapping or cross-compilation is
+implicit. Keep `--rm --init --network none`, private fixture sockets and image
+cleanup. Do not feed a macOS binary to the Linux container. The resource probe
+uses the host descriptor and reports it; Docker latency reports record both
+descriptors. Record native build profile/toolchain separately when comparing.
+
+Selection reaches the shared CLI-contract helper, E2E commands, real tmux
+descendants and nested mock replies. Selector infrastructure tests deliberately
+exercise the TS reference and a non-Node recording wrapper, not native parity.
+Tests importing TypeScript services/concurrency workers, the bin-wrapper tests
+and packed storage probes remain TS-only evidence. They are not converted by an
+environment variable: retain their assertions until corresponding native
+units/concurrency and installed-artifact gates replace them. Native partial
+subsets must be named in the issue; never present one as full compatibility.
 
 The publication race scenario observes the CLI process tree's open database
 descriptors through Linux `/proc` before releasing the writer barrier. This

--- a/PERFORMANCE-BASELINE.md
+++ b/PERFORMANCE-BASELINE.md
@@ -151,9 +151,16 @@ No delay or polling default was changed to obtain these measurements.
 
 ## Native comparison and acceptance
 
-Executable selection is [#95](https://github.com/wkh237/tmux-team/issues/95), not
-implemented here. That slice must also let the resource probe select the native
-executable without changing measurement semantics. Measure **release** builds;
+Executable selection is provided by [#95](https://github.com/wkh237/tmux-team/issues/95).
+Use [the shared descriptors](DEVELOPMENT.md#selecting-the-cli-under-test) for both
+the resource probe and Docker scenarios. New reports record the selected executable
+(and the Docker peer); historical raw baseline reports remain unchanged. The Node
+version describes test tooling, not proof that the selected executable uses Node.
+Resource accounting and output assertions are unchanged. The shared default now
+pins the test runner's Node executable and invokes the same public wrapper,
+instead of finding Node through its shebang and PATH. Re-baseline both runtimes
+with this launcher for comparisons; do not claim these historical timings are
+measurements of the new launcher. Measure **release** builds;
 record toolchain, locked dependencies, target/linkage, binary size and source head.
 
 - Run old and new binaries on the same machine/container/resources with the same

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -145,12 +145,14 @@ No existing test proves Rust parity or mixed-runtime operation. Explicitly add:
 
 ## Test architecture transition
 
-Keep Vitest, Docker, private tmux sockets and deterministic mock agents. Add one
-test-only executable descriptor (absolute binary plus argument prefix), resolved
-once before fixture startup. Inject it through the existing harness, mock reply
-launcher and real-descendant launcher. Missing/non-executable selection must fail,
-never silently fall back to TS. Default remains TS until explicit cutover.
-Mixed-runtime cases need a second explicit peer descriptor, not per-test argv hacks.
+Keep Vitest, Docker, private tmux sockets and deterministic mock agents.
+[#95](https://github.com/wkh237/tmux-team/issues/95) adds the shared test-only
+executable descriptor (absolute binary plus argv prefix), validated before fixture
+allocation and used by CLI contracts, E2E, mock replies, real descendants and the
+resource probe. Missing/non-executable selection fails without TS fallback.
+Default remains TS until explicit cutover; an explicit peer descriptor supports
+future mixed-runtime cases. See [selector usage](DEVELOPMENT.md#selecting-the-cli-under-test).
+The seam itself proves neither native behavior nor mixed-runtime compatibility.
 
 Keep SQL oracles independent and read-only. Existing TS unit tests importing
 services/worker modules remain TS regression tests while corresponding Rust

--- a/scripts/benchmark-startup.mjs
+++ b/scripts/benchmark-startup.mjs
@@ -2,15 +2,15 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { performance } from 'node:perf_hooks';
 import { runPackedCommand } from './packed-command.mjs';
+import { resolveCliExecutables } from '../src/test-support/cli-executable.mjs';
 
 // Resource measurement is deliberately macOS-only. Docker scenarios own tmux
 // latency; do not compare these resource samples to Linux timing samples.
 assert.equal(process.platform, 'darwin', 'This resource probe requires macOS /usr/bin/time.');
 assert.equal(process.argv.length, 2, 'This probe does not accept arguments.');
-const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { cli } = resolveCliExecutables();
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-startup-baseline-'));
 const samples = [];
 try {
@@ -41,7 +41,8 @@ try {
         '-c',
         '/usr/bin/time -lp /bin/sh -c \'exec "$@" 2> "$TMT_BENCH_STDERR"\' bench "$@" 2> "$TMT_BENCH_METRICS"',
         'bench',
-        path.join(repo, 'bin/tmux-team'),
+        cli.executable,
+        ...cli.args,
         ...args,
       ],
       { cwd: root, env }
@@ -79,6 +80,7 @@ try {
   console.log(
     JSON.stringify({
       schemaVersion: 1,
+      executable: cli,
       platform: process.platform,
       arch: process.arch,
       kernel: os.release(),

--- a/scripts/run-e2e.mjs
+++ b/scripts/run-e2e.mjs
@@ -59,7 +59,20 @@ async function main() {
     ]);
     if (buildStatus !== 0) return interrupted ? 130 : buildStatus;
     if (interrupted) return 130;
-    const testStatus = await run('docker', ['run', '--rm', '--init', '--network', 'none', image]);
+    // Selectors name container-visible executables. Forward values as single
+    // argv entries; never translate host paths or evaluate shell fragments.
+    const selection = ['TMT_TEST_CLI', 'TMT_TEST_PEER_CLI'].flatMap((key) =>
+      process.env[key] === undefined ? [] : ['--env', `${key}=${process.env[key]}`]
+    );
+    const testStatus = await run('docker', [
+      'run',
+      '--rm',
+      '--init',
+      '--network',
+      'none',
+      ...selection,
+      image,
+    ]);
     return interrupted ? 130 : testStatus;
   } catch (error) {
     if (error?.code === 'ENOENT') {

--- a/src/cli-executable.test.ts
+++ b/src/cli-executable.test.ts
@@ -1,0 +1,264 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveCliExecutables } from './test-support/cli-executable.mjs';
+import { createCliProbe } from './test-support/cli-probe.js';
+import { createSandbox, parseWholeStdout, runCli } from './test-support/cli-process.js';
+
+const temporaryRoots: string[] = [];
+
+function temporaryRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-cli-executable-'));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function writeExecutable(root: string, name: string, source: string, mode = 0o755): string {
+  const executable = path.join(root, name);
+  fs.writeFileSync(executable, source, { mode });
+  return executable;
+}
+
+function descriptor(executable: string, args: readonly string[] = []): string {
+  return JSON.stringify({ executable, args });
+}
+
+function sandboxWithEnv(env: NodeJS.ProcessEnv) {
+  const sandbox = createSandbox(env);
+  temporaryRoots.push(sandbox.root);
+  return sandbox;
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (processIsAlive(pid)) {
+    if (Date.now() >= deadline) throw new Error(`Process ${pid} remained alive.`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+async function waitForFile(file: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!fs.existsSync(file)) {
+    if (Date.now() >= deadline) throw new Error(`File ${file} did not appear.`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('CLI executable descriptors', () => {
+  it('uses the TypeScript executable by default for both invocation roles', () => {
+    const executables = resolveCliExecutables({});
+
+    expect(path.isAbsolute(executables.cli.executable)).toBe(true);
+    expect(fs.statSync(executables.cli.executable).isFile()).toBe(true);
+    expect(executables.cli.executable).toBe(process.execPath);
+    expect(executables.cli.args).toHaveLength(1);
+    expect(fs.statSync(executables.cli.args[0]).isFile()).toBe(true);
+    expect(executables.peer).toBe(executables.cli);
+  });
+
+  it.each([
+    ['malformed JSON', '{'],
+    ['missing executable', JSON.stringify({ args: [] })],
+    ['relative executable', JSON.stringify({ executable: 'bin/tmt', args: [] })],
+    ['NUL in executable', JSON.stringify({ executable: '/tmp/tmt\0cli', args: [] })],
+    ['non-array prefix', JSON.stringify({ executable: process.execPath, args: '--flag' })],
+    ['non-string prefix item', JSON.stringify({ executable: process.execPath, args: [1] })],
+    ['NUL in prefix item', JSON.stringify({ executable: process.execPath, args: ['a\0b'] })],
+    [
+      'unknown descriptor key',
+      JSON.stringify({ executable: process.execPath, args: [], extra: true }),
+    ],
+  ])('rejects %s before any executable lookup', (_label, serialized) => {
+    expect(() => resolveCliExecutables({ TMT_TEST_CLI: serialized })).toThrow(/TMT_TEST_CLI/);
+  });
+
+  it('rejects a missing executable path', () => {
+    const root = temporaryRoot();
+    const executable = path.join(root, 'missing');
+
+    expect(() => resolveCliExecutables({ TMT_TEST_CLI: descriptor(executable) })).toThrow(
+      /TMT_TEST_CLI executable is unavailable or not executable/
+    );
+  });
+
+  it('rejects a directory descriptor', () => {
+    const root = temporaryRoot();
+    const executable = path.join(root, 'directory');
+    fs.mkdirSync(executable);
+
+    expect(() => resolveCliExecutables({ TMT_TEST_CLI: descriptor(executable) })).toThrow(
+      /TMT_TEST_CLI executable is unavailable or not executable/
+    );
+  });
+
+  it('rejects a non-executable file descriptor', () => {
+    const root = temporaryRoot();
+    const executable = writeExecutable(root, 'not-executable', '#!/bin/sh\n', 0o644);
+
+    expect(() => resolveCliExecutables({ TMT_TEST_CLI: descriptor(executable) })).toThrow(
+      /TMT_TEST_CLI executable is unavailable or not executable/
+    );
+  });
+
+  it('validates an explicitly selected peer and never falls back to the main executable', () => {
+    const root = temporaryRoot();
+    const main = writeExecutable(root, 'main', '#!/bin/sh\nexit 0\n');
+    const missingPeer = path.join(root, 'missing-peer');
+
+    expect(() =>
+      resolveCliExecutables({
+        TMT_TEST_CLI: descriptor(main),
+        TMT_TEST_PEER_CLI: descriptor(missingPeer),
+      })
+    ).toThrow(/TMT_TEST_PEER_CLI executable is unavailable/);
+  });
+
+  it('uses the selected main executable as the peer when no peer is supplied', () => {
+    const root = temporaryRoot();
+    const main = writeExecutable(root, 'main', '#!/bin/sh\nexit 0\n');
+    const defaults = resolveCliExecutables({});
+    const selected = resolveCliExecutables({ TMT_TEST_CLI: descriptor(main, ['--main-prefix']) });
+
+    expect(selected.cli).toEqual({ executable: main, args: ['--main-prefix'] });
+    expect(selected.peer).toBe(selected.cli);
+    expect(defaults.peer).not.toEqual(selected.cli);
+  });
+
+  it('returns frozen descriptor and prefix copies', () => {
+    const root = temporaryRoot();
+    const executable = writeExecutable(root, 'main', '#!/bin/sh\nexit 0\n');
+    const selected = resolveCliExecutables({
+      TMT_TEST_CLI: descriptor(executable, ['prefix', 'with spaces']),
+      TMT_TEST_PEER_CLI: descriptor(executable, ['peer']),
+    });
+
+    expect(Object.isFrozen(selected)).toBe(true);
+    expect(Object.isFrozen(selected.cli)).toBe(true);
+    expect(Object.isFrozen(selected.cli.args)).toBe(true);
+    expect(() => (selected.cli.args as string[]).push('mutated')).toThrow(TypeError);
+    expect(selected.cli.args).toEqual(['prefix', 'with spaces']);
+  });
+
+  it('resolves selection before sandbox allocation and snapshots it', () => {
+    const root = temporaryRoot();
+    const main = writeExecutable(root, 'main', '#!/bin/sh\nexit 0\n');
+    const executableEnv = { TMT_TEST_CLI: descriptor(main, ['stable']) };
+    const sandbox = sandboxWithEnv(executableEnv);
+    executableEnv.TMT_TEST_CLI = descriptor(path.join(root, 'missing'));
+
+    expect(sandbox.cli).toEqual({ executable: main, args: ['stable'] });
+    expect(fs.existsSync(sandbox.root)).toBe(true);
+  });
+
+  it('fails an invalid selector before creating a sandbox directory', () => {
+    const mkdtemp = vi.spyOn(fs, 'mkdtempSync');
+    try {
+      expect(() =>
+        createSandbox({ TMT_TEST_CLI: JSON.stringify({ executable: 'relative' }) })
+      ).toThrow(/TMT_TEST_CLI/);
+      expect(mkdtemp).not.toHaveBeenCalled();
+    } finally {
+      mkdtemp.mockRestore();
+    }
+  });
+
+  it.each(['default', 'explicit'])(
+    'runs the %s TypeScript executable through the real contract helper',
+    async (selection) => {
+      const sandbox = sandboxWithEnv(
+        selection === 'default'
+          ? {}
+          : { TMT_TEST_CLI: JSON.stringify(resolveCliExecutables({}).cli) }
+      );
+      const created = await runCli(sandbox, ['identity', 'create', 'Selected', '--json']);
+      const shown = await runCli(sandbox, ['identity', 'show', 'selected', '--json']);
+
+      expect(created.status).toBe(0);
+      expect(shown).toMatchObject({ status: 0, signal: null });
+      expect(parseWholeStdout(shown)).toMatchObject({
+        identity: parseWholeStdout(created).identity,
+      });
+      expect(parseWholeStdout(shown)).toMatchObject({
+        identity: { name: 'Selected', canonicalName: 'selected' },
+      });
+    },
+    10_000
+  );
+
+  it('runs an explicit non-Node probe and preserves its argv prefix and arguments', async () => {
+    const root = temporaryRoot();
+    const defaults = resolveCliExecutables({});
+    const probe = createCliProbe(root, defaults.cli);
+    const sandbox = sandboxWithEnv({ TMT_TEST_CLI: JSON.stringify(probe.descriptor) });
+    const identityName = "Reader's identity";
+    const created = await runCli(sandbox, ['identity', 'create', identityName, '--json']);
+    const shown = await runCli(sandbox, ['identity', 'show', identityName, '--json']);
+    const body = 'body with spaces; "$HOME" and \'quotes\'';
+    const args = ['role', 'set', body, '--identity', identityName, '--json'];
+    const role = await runCli(sandbox, args);
+    const persistedRole = await runCli(sandbox, [
+      'role',
+      'show',
+      '--identity',
+      identityName,
+      '--json',
+    ]);
+
+    expect(created.status).toBe(0);
+    expect(shown.status).toBe(0);
+    expect(parseWholeStdout(shown)).toMatchObject({ identity: { name: identityName } });
+    expect(role.status).toBe(0);
+    expect(persistedRole.status).toBe(0);
+    expect(parseWholeStdout(persistedRole)).toMatchObject({ role: { content: body } });
+    expect(probe.invocations()).toContainEqual([
+      defaults.cli.executable,
+      ...defaults.cli.args,
+      ...args,
+    ]);
+  }, 10_000);
+
+  it('propagates a selected executable nonzero exit without falling back', async () => {
+    const root = temporaryRoot();
+    const executable = writeExecutable(root, 'nonzero', '#!/bin/sh\nexit 23\n');
+    const sandbox = sandboxWithEnv({ TMT_TEST_CLI: descriptor(executable) });
+    const result = await runCli(sandbox, ['--version']);
+
+    expect(result).toEqual({ status: 23, signal: null, stdout: '', stderr: '' });
+  });
+
+  it('bounds selected executable runtime and cleans up its descendant process group', async () => {
+    const root = temporaryRoot();
+    const childPidPath = path.join(root, 'child.pid');
+    const executable = writeExecutable(
+      root,
+      'long-running',
+      '#!/bin/sh\n(sleep 30) &\necho "$!" > "$1"\nwhile :; do sleep 1; done\n'
+    );
+    const sandbox = sandboxWithEnv({ TMT_TEST_CLI: descriptor(executable, [childPidPath]) });
+
+    await expect(runCli(sandbox, [], { deadlineMs: 1_000 })).rejects.toThrow(
+      'CLI subprocess exceeded the 1000 millisecond test bound.'
+    );
+    await waitForFile(childPidPath, 1_000);
+    const childPid = Number(fs.readFileSync(childPidPath, 'utf8'));
+    expect(Number.isInteger(childPid)).toBe(true);
+    await waitForProcessExit(childPid, 2_000);
+    expect(processIsAlive(childPid)).toBe(false);
+  }, 10_000);
+});

--- a/src/e2e-runner.test.ts
+++ b/src/e2e-runner.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { createSandbox, runCli } from './test-support/cli-process.js';
+
+describe('Docker wrapper executable forwarding', () => {
+  it.each(['unset', 'selected', 'failed container'])(
+    'preserves argv, isolation and image cleanup with %s settings',
+    async (mode) => {
+      const sandbox = createSandbox({
+        TMT_TEST_CLI: JSON.stringify({
+          executable: process.execPath,
+          args: [fileURLToPath(new URL('../scripts/run-e2e.mjs', import.meta.url))],
+        }),
+      });
+      try {
+        const bin = path.join(sandbox.root, 'fake docker');
+        fs.mkdirSync(bin);
+        const log = path.join(sandbox.root, 'docker.jsonl');
+        fs.writeFileSync(
+          path.join(bin, 'docker'),
+          `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TMT_RUNNER_LOG, JSON.stringify(args) + '\\n');
+process.exitCode = args[0] === 'run' ? Number(process.env.TMT_RUNNER_STATUS) : 0;
+`,
+          { mode: 0o755 }
+        );
+        sandbox.env.PATH = `${bin}${path.delimiter}${process.env.PATH ?? ''}`;
+        sandbox.env.TMT_RUNNER_LOG = log;
+        const status = mode === 'failed container' ? 23 : 0;
+        sandbox.env.TMT_RUNNER_STATUS = String(status);
+        delete sandbox.env.TMT_TEST_CLI;
+        delete sandbox.env.TMT_TEST_PEER_CLI;
+        const primary = JSON.stringify({
+          executable: "/container/CLI's path",
+          args: ['prefix with spaces', '$HOME; quoted'],
+        });
+        const peer = JSON.stringify({ executable: '/container/peer', args: [] });
+        if (mode !== 'unset') {
+          sandbox.env.TMT_TEST_CLI = primary;
+          sandbox.env.TMT_TEST_PEER_CLI = peer;
+        }
+        expect(await runCli(sandbox, [])).toEqual({ status, signal: null, stdout: '', stderr: '' });
+        const calls = fs
+          .readFileSync(log, 'utf8')
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line) as string[]);
+        expect(calls).toHaveLength(3);
+        expect(calls[0].slice(0, 2)).toEqual(['build', '--tag']);
+        const image = calls[0][2];
+        expect(calls[1]).toEqual([
+          'run',
+          '--rm',
+          '--init',
+          '--network',
+          'none',
+          ...(mode === 'unset'
+            ? []
+            : ['--env', `TMT_TEST_CLI=${primary}`, '--env', `TMT_TEST_PEER_CLI=${peer}`]),
+          image,
+        ]);
+        expect(calls[2]).toEqual(['image', 'rm', '--force', image]);
+      } finally {
+        fs.rmSync(sandbox.root, { recursive: true, force: true });
+      }
+    },
+    10_000
+  );
+});

--- a/src/test-support/cli-executable.d.mts
+++ b/src/test-support/cli-executable.d.mts
@@ -1,0 +1,11 @@
+export interface CliExecutable {
+  readonly executable: string;
+  readonly args: readonly string[];
+}
+
+export interface CliExecutables {
+  readonly cli: CliExecutable;
+  readonly peer: CliExecutable;
+}
+
+export function resolveCliExecutables(env?: NodeJS.ProcessEnv): CliExecutables;

--- a/src/test-support/cli-executable.mjs
+++ b/src/test-support/cli-executable.mjs
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const defaultWrapper = fileURLToPath(new URL('../../bin/tmux-team', import.meta.url));
+
+// Test infrastructure only. Production commands never inspect these selectors.
+export function resolveCliExecutables(env = process.env) {
+  const cli = resolveDescriptor(env.TMT_TEST_CLI, 'TMT_TEST_CLI');
+  const peer =
+    env.TMT_TEST_PEER_CLI === undefined
+      ? cli
+      : resolveDescriptor(env.TMT_TEST_PEER_CLI, 'TMT_TEST_PEER_CLI');
+  return Object.freeze({ cli, peer });
+}
+
+function resolveDescriptor(serialized, label) {
+  let value;
+  try {
+    value =
+      serialized === undefined
+        ? { executable: process.execPath, args: [defaultWrapper] }
+        : JSON.parse(serialized);
+  } catch {
+    throw new Error(`${label} must be a JSON executable descriptor.`);
+  }
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    Object.keys(value).some((key) => key !== 'executable' && key !== 'args') ||
+    typeof value.executable !== 'string' ||
+    !path.isAbsolute(value.executable) ||
+    value.executable.includes('\0') ||
+    !Array.isArray(value.args) ||
+    !value.args.every((arg) => typeof arg === 'string' && !arg.includes('\0'))
+  ) {
+    throw new Error(
+      `${label} requires an absolute executable and a string-array args prefix; no other keys are accepted.`
+    );
+  }
+  try {
+    if (!fs.statSync(value.executable).isFile()) throw new Error('not a regular file');
+    fs.accessSync(value.executable, fs.constants.X_OK);
+  } catch (error) {
+    throw new Error(`${label} executable is unavailable or not executable: ${value.executable}`, {
+      cause: error,
+    });
+  }
+  return Object.freeze({ executable: value.executable, args: Object.freeze([...value.args]) });
+}

--- a/src/test-support/cli-probe.ts
+++ b/src/test-support/cli-probe.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { CliExecutable } from './cli-executable.mjs';
+
+/** A non-Node executable that records argv before execing the real selected CLI. */
+export function createCliProbe(
+  root: string,
+  delegate: CliExecutable
+): {
+  descriptor: CliExecutable;
+  invocations: () => string[][];
+} {
+  const executable = path.join(root, "CLI probe's executable");
+  const log = path.join(root, 'CLI invocations');
+  fs.writeFileSync(
+    executable,
+    `#!/bin/sh
+log="$1"
+shift
+[ "$1" = "prefix with spaces and 'quotes'" ] || exit 91
+shift
+printf '%s\\0' '__TMT_PROBE_INVOCATION__' "$@" >> "$log"
+exec "$@"
+`,
+    { mode: 0o755 }
+  );
+  return {
+    descriptor: {
+      executable,
+      args: [log, "prefix with spaces and 'quotes'", delegate.executable, ...delegate.args],
+    },
+    invocations: () =>
+      fs.existsSync(log)
+        ? fs
+            .readFileSync(log, 'utf8')
+            .split('__TMT_PROBE_INVOCATION__\0')
+            .slice(1)
+            .map((entry) => entry.split('\0').slice(0, -1))
+        : [],
+  };
+}

--- a/src/test-support/cli-process.ts
+++ b/src/test-support/cli-process.ts
@@ -2,15 +2,13 @@ import { spawn } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { expect } from 'vitest';
 import { CURRENT_MIGRATIONS } from '../storage/migrations.js';
 import { openStorageWithMigrations } from '../storage/sqlite-adapter.js';
-
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-export const binPath = path.join(repoRoot, 'bin', 'tmux-team');
+import { resolveCliExecutables, type CliExecutable } from './cli-executable.mjs';
 
 export interface Sandbox {
+  readonly cli: CliExecutable;
   readonly root: string;
   readonly cwd: string;
   readonly home: string;
@@ -42,7 +40,8 @@ export interface CliRunOptions {
 
 export type JsonDocument = Record<string, unknown>;
 
-export function createSandbox(): Sandbox {
+export function createSandbox(executableEnv: NodeJS.ProcessEnv = process.env): Sandbox {
+  const { cli } = resolveCliExecutables(executableEnv);
   const root = mkdtempSync(path.join(os.tmpdir(), 'tmux-team-cli-contract-'));
   try {
     const cwd = path.join(root, 'cwd');
@@ -63,6 +62,7 @@ export function createSandbox(): Sandbox {
     delete env.PI_CODING_AGENT_DIR;
     delete env.OPENCODE_CONFIG_DIR;
     return {
+      cli,
       root,
       cwd,
       home,
@@ -89,7 +89,7 @@ export function runCli(
   const deadlineMs = options.deadlineMs ?? 5_000;
   const hasStdin = options.stdin !== undefined;
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [binPath, ...args], {
+    const child = spawn(sandbox.cli.executable, [...sandbox.cli.args, ...args], {
       cwd: sandbox.cwd,
       env: sandbox.env,
       detached: true,
@@ -118,7 +118,7 @@ export function runCli(
     };
     const timer = setTimeout(() => {
       timedOut = true;
-      // The wrapper launches the TypeScript child; kill the process group so a
+      // A selected executable may launch children; kill the process group so a
       // timeout cannot leave that descendant running after the test exits.
       killProcessGroup();
     }, deadlineMs);

--- a/test/e2e/executable-selection.e2e.test.ts
+++ b/test/e2e/executable-selection.e2e.test.ts
@@ -1,0 +1,169 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveCliExecutables } from '../../src/test-support/cli-executable.mjs';
+import { createCliProbe } from '../../src/test-support/cli-probe.js';
+import { E2EFixture, withE2EFixture } from './harness.js';
+import { spawnRealTmuxCli, releaseRealTmuxCli, readRealTmuxCli } from './real-tmux-caller.js';
+
+describe('CLI executable selection', () => {
+  it.each(['default', 'explicit', 'shared probe', 'separate peer'])(
+    'preserves durable talk/result and real descendant behavior with %s selection',
+    async (selection) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-cli-selection-'));
+      try {
+        const { cli } = resolveCliExecutables({});
+        const primary = createCliProbe(root, cli);
+        const peerRoot = path.join(root, 'peer');
+        fs.mkdirSync(peerRoot);
+        const peer = createCliProbe(peerRoot, cli);
+        const executableEnv: NodeJS.ProcessEnv = {};
+        if (selection !== 'default') {
+          executableEnv.TMT_TEST_CLI = JSON.stringify(
+            selection === 'explicit' ? cli : primary.descriptor
+          );
+        }
+        if (selection === 'separate peer')
+          executableEnv.TMT_TEST_PEER_CLI = JSON.stringify(peer.descriptor);
+        let fixtureRoot = '';
+        let socketRoot = '';
+        await withE2EFixture(
+          async (fixture) => {
+            fixtureRoot = fixture.root;
+            socketRoot = fixture.socketRoot;
+            const descendant = await spawnRealTmuxCli(fixture, ['name', "Reader's identity"], {
+              name: 'selected',
+              stripTmux: true,
+              stripPane: true,
+            });
+            await releaseRealTmuxCli(fixture, descendant);
+            expect(readRealTmuxCli(descendant)).toMatchObject({
+              code: 0,
+              stderr: '',
+              stdout: { bound: true, name: "Reader's identity", pane: descendant.pane },
+            });
+            expect(JSON.parse(fixture.paneMetadata(descendant.pane))).toMatchObject({
+              globalIdentity: { panePid: descendant.panePid },
+            });
+            const talk = await fixture.runJsonCli<{ requestId: string; response: string }>([
+              'talk',
+              fixture.pane,
+              "request with 'quotes' and spaces",
+              '--no-preamble',
+              '--timeout',
+              '8',
+            ]);
+            expect(talk.code, talk.stderr || talk.stdout).toBe(0);
+            const requestId = talk.json!.requestId;
+            const body = "mock-agent response: request with 'quotes' and spaces";
+            expect(talk.json?.response).toBe(body);
+            await fixture.waitForEvent(
+              (event) =>
+                event.event === 'submitted' && event.requestId === requestId && event.body === body
+            );
+            const result = await fixture.runJsonCli(['result', requestId], { withoutTmux: true });
+            expect(result).toMatchObject({
+              code: 0,
+              stderr: '',
+              json: { requestId, status: 'completed', response: body },
+            });
+            if (selection.includes('probe') || selection === 'separate peer') {
+              const calls = primary.invocations();
+              expect(calls.some((args) => args.includes("Reader's identity"))).toBe(true);
+              expect(calls.some((args) => args.includes('talk'))).toBe(true);
+              expect(
+                calls.some((args) => args.includes('result') && args.includes(requestId))
+              ).toBe(true);
+              const replies = (selection === 'separate peer' ? peer : primary)
+                .invocations()
+                .filter((args) => args.includes('reply'));
+              expect(replies).toHaveLength(1);
+              expect(replies[0]).toContain(requestId);
+              if (selection === 'separate peer')
+                expect(calls.some((args) => args.includes('reply'))).toBe(false);
+            }
+          },
+          { executableEnv }
+        );
+        expect(fs.existsSync(fixtureRoot)).toBe(false);
+        expect(fs.existsSync(socketRoot)).toBe(false);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+    20_000
+  );
+
+  it('rejects invalid explicit peer selection before allocating a private server or files', () => {
+    const roots = () =>
+      fs
+        .readdirSync(os.tmpdir())
+        .filter((name) => name.startsWith('tmux-team-e2e-') || name.startsWith('te2e-'))
+        .sort();
+    const before = roots();
+    expect(() => new E2EFixture({ executableEnv: { TMT_TEST_PEER_CLI: '' } })).toThrow(
+      'TMT_TEST_PEER_CLI'
+    );
+    expect(roots()).toEqual(before);
+  });
+
+  it('cleans partial startup if the selected peer disappears after initial validation', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-disappearing-peer-'));
+    let fixture: E2EFixture | undefined;
+    try {
+      const peer = createCliProbe(root, resolveCliExecutables({}).cli);
+      fixture = new E2EFixture({
+        executableEnv: { TMT_TEST_PEER_CLI: JSON.stringify(peer.descriptor) },
+      });
+      fs.unlinkSync(peer.descriptor.executable);
+      await expect(fixture.start()).rejects.toThrow('failed to start its private tmux server');
+      expect(fixture.serverIsRunning()).toBe(false);
+      expect(fixture.mockProcessIsRunning()).toBe(false);
+      expect(fs.existsSync(fixture.root)).toBe(false);
+      expect(fs.existsSync(fixture.socketRoot)).toBe(false);
+    } finally {
+      await fixture?.stop();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('propagates a selected peer failure without a fallback reply or false completion', async () => {
+    let stopped: E2EFixture | undefined;
+    await withE2EFixture(
+      async (fixture) => {
+        stopped = fixture;
+        const talk = fixture.runCliProcess<{ requestId: string; status: string }>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'peer must fail',
+          '--no-preamble',
+          '--timeout',
+          '1',
+        ]);
+        const failure = await fixture.waitForEvent(
+          (event) => event.event === 'failure' && event.stage === 'reply'
+        );
+        expect(failure.exitCode).toBe(23);
+        const result = await talk.result;
+        expect(result).toMatchObject({ code: 4, json: { status: 'timeout' } });
+        expect(
+          fixture.events().some((event) => event.event === 'submitted' || event.event === 'summary')
+        ).toBe(false);
+        expect(
+          await fixture.runJsonCli(['result', result.json!.requestId], { withoutTmux: true })
+        ).toMatchObject({ code: 3, json: { error: { code: 'RESPONSE_NOT_AVAILABLE' } } });
+      },
+      {
+        executableEnv: {
+          TMT_TEST_PEER_CLI: JSON.stringify({ executable: '/bin/sh', args: ['-c', 'exit 23'] }),
+        },
+      }
+    );
+    expect(stopped?.serverIsRunning()).toBe(false);
+    expect(stopped?.mockProcessIsRunning()).toBe(false);
+    expect(fs.existsSync(stopped!.root)).toBe(false);
+    expect(fs.existsSync(stopped!.socketRoot)).toBe(false);
+  });
+});

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -3,9 +3,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  resolveCliExecutables,
+  type CliExecutables,
+} from '../../src/test-support/cli-executable.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const binPath = path.join(repoRoot, 'bin', 'tmux-team');
 const mockAgentPath = path.join(repoRoot, 'test', 'e2e', 'mock-agent.mjs');
 
 export interface CliResult<T = unknown> {
@@ -87,6 +90,8 @@ export interface MetadataBarrierOptions {
 }
 
 export interface E2EFixtureOptions {
+  /** Test-only selector environment, resolved before allocating fixture resources. */
+  executableEnv?: NodeJS.ProcessEnv;
   mode?: 'respond' | 'silent' | 'malformed' | 'virtualized' | 'fake-marker' | 'input-log';
   delayMs?: number;
   responseBodyBase64?: string;
@@ -110,19 +115,18 @@ function shellQuote(value: string): string {
 }
 
 export class E2EFixture {
-  readonly root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'tmux-team-e2e-')));
-  readonly socketRoot = fs.realpathSync(
-    fs.mkdtempSync(path.join(process.platform === 'darwin' ? '/private/tmp' : os.tmpdir(), 'te2e-'))
-  );
-  readonly workspace = path.join(this.root, 'workspace');
+  readonly executables: CliExecutables;
+  readonly root: string;
+  readonly socketRoot: string;
+  readonly workspace: string;
   readonly globalDir: string;
-  readonly logPath = path.join(this.root, 'mock-agent.jsonl');
-  readonly transportTracePath = path.join(this.root, 'transport-trace.log');
-  readonly forbiddenTmuxLogPath = path.join(this.root, 'forbidden-tmux.log');
-  readonly metadataBarrierDirectory = path.join(this.root, 'metadata-barrier');
-  readonly replyGateDirectory = path.join(this.root, 'reply-gate');
+  readonly logPath: string;
+  readonly transportTracePath: string;
+  readonly forbiddenTmuxLogPath: string;
+  readonly metadataBarrierDirectory: string;
+  readonly replyGateDirectory: string;
   readonly socket = `tmt-e2e-${process.pid}-${Math.random().toString(16).slice(2)}`;
-  readonly wrapperDir = path.join(this.root, 'bin');
+  readonly wrapperDir: string;
   readonly tmuxPath: string;
   pane = '';
   panePid = 0;
@@ -136,7 +140,26 @@ export class E2EFixture {
   private cliProcessPids = new Set<number>();
   private cliProcessResults = new Map<number, Promise<CliResult<unknown>>>();
 
-  constructor(options: { globalDir?: string } = {}) {
+  constructor(options: Pick<E2EFixtureOptions, 'globalDir' | 'executableEnv'> = {}) {
+    this.executables = resolveCliExecutables(options.executableEnv);
+    this.root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'tmux-team-e2e-')));
+    try {
+      this.socketRoot = fs.realpathSync(
+        fs.mkdtempSync(
+          path.join(process.platform === 'darwin' ? '/private/tmp' : os.tmpdir(), 'te2e-')
+        )
+      );
+    } catch (error) {
+      fs.rmSync(this.root, { recursive: true, force: true });
+      throw error;
+    }
+    this.workspace = path.join(this.root, 'workspace');
+    this.logPath = path.join(this.root, 'mock-agent.jsonl');
+    this.transportTracePath = path.join(this.root, 'transport-trace.log');
+    this.forbiddenTmuxLogPath = path.join(this.root, 'forbidden-tmux.log');
+    this.metadataBarrierDirectory = path.join(this.root, 'metadata-barrier');
+    this.replyGateDirectory = path.join(this.root, 'reply-gate');
+    this.wrapperDir = path.join(this.root, 'bin');
     this.globalDir = options.globalDir ?? path.join(this.root, 'global');
     try {
       this.tmuxPath = execFileSync('/bin/sh', ['-lc', 'command -v tmux'], {
@@ -277,7 +300,8 @@ exit ${'$'}status
         TMT_MOCK_MODE: options.mode ?? 'respond',
         TMT_MOCK_DELAY_MS: String(options.delayMs ?? 0),
         TMT_MOCK_LOG: this.logPath,
-        TMT_E2E_CLI_PATH: binPath,
+        TMT_TEST_CLI: JSON.stringify(this.executables.cli),
+        TMT_TEST_PEER_CLI: JSON.stringify(this.executables.peer),
       };
       if (options.responseBodyBase64 !== undefined)
         this.env.TMT_MOCK_RESPONSE_BODY_BASE64 = options.responseBodyBase64;
@@ -353,7 +377,7 @@ exit ${'$'}status
       env.TMT_E2E_TRANSPORT_FAULT_STAGE = options.transportFault.stage;
       env.TMT_E2E_TRANSPORT_TRACE_FILE = this.transportTracePath;
     }
-    const child = spawn(binPath, args, {
+    const child = spawn(this.executables.cli.executable, [...this.executables.cli.args, ...args], {
       cwd: options.cwd ?? this.workspace,
       env,
       detached: true,

--- a/test/e2e/mock-agent.mjs
+++ b/test/e2e/mock-agent.mjs
@@ -3,12 +3,13 @@
 import fs from 'node:fs';
 import { spawn } from 'node:child_process';
 import readline from 'node:readline';
+import { resolveCliExecutables } from '../../src/test-support/cli-executable.mjs';
 
 const mode = process.env.TMT_MOCK_MODE ?? 'respond';
 const delayMs = Number(process.env.TMT_MOCK_DELAY_MS ?? 0);
 const replyDelayMs = Number(process.env.TMT_MOCK_REPLY_DELAY_MS ?? delayMs);
 const logPath = process.env.TMT_MOCK_LOG;
-const cliPath = process.env.TMT_E2E_CLI_PATH;
+const { peer } = resolveCliExecutables();
 const virtualizedLineCount = 200;
 const maxReplyOutputBytes = 64 * 1024;
 const maxInlineReplyBytes = 4 * 1024;
@@ -95,7 +96,6 @@ function killReplyChild(child) {
 }
 
 function runReply(requestId, receipt, body) {
-  if (!cliPath) throw new Error('TMT_E2E_CLI_PATH is required for durable mock replies.');
   if (replyInput !== 'stdin' && replyInput !== 'message') {
     throw new Error(`Unsupported mock reply input mode '${replyInput}'.`);
   }
@@ -108,8 +108,8 @@ function runReply(requestId, receipt, body) {
   const inputArgs = replyInput === 'message' ? ['--message', body] : ['--stdin'];
   return new Promise((resolve) => {
     const child = spawn(
-      process.execPath,
-      [cliPath, 'reply', requestId, '--receipt', receipt, ...inputArgs, '--json'],
+      peer.executable,
+      [...peer.args, 'reply', requestId, '--receipt', receipt, ...inputArgs, '--json'],
       {
         cwd: process.cwd(),
         env: { ...process.env },

--- a/test/e2e/performance-baseline.e2e.test.ts
+++ b/test/e2e/performance-baseline.e2e.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
+import type { CliExecutables } from '../../src/test-support/cli-executable.mjs';
 import { performance } from 'node:perf_hooks';
 import { describe, expect, it } from 'vitest';
 import { durableState } from './identity-state-oracle.js';
@@ -88,6 +89,7 @@ interface BenchmarkSeries {
 }
 
 interface PerformanceBaselineReport {
+  executables: CliExecutables;
   schemaVersion: 1;
   benchmark: 'tmt-performance-baseline';
   generatedAt: string;
@@ -485,6 +487,7 @@ baselineSuite('TMT performance baseline', () => {
             }
 
             const report: PerformanceBaselineReport = {
+              executables: fixture.executables,
               schemaVersion: 1,
               benchmark: 'tmt-performance-baseline',
               generatedAt: new Date().toISOString(),

--- a/test/e2e/real-tmux-caller.ts
+++ b/test/e2e/real-tmux-caller.ts
@@ -1,10 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import type { E2EFixture } from './harness.js';
-
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const cliPath = path.join(repoRoot, 'bin', 'tmux-team');
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
@@ -40,9 +36,16 @@ export async function spawnRealTmuxCli(
   const exitPath = path.join(workspace, 'exit');
   const releasePath = path.join(workspace, 'release');
   const holdPath = path.join(workspace, 'hold-until-server-cleanup');
+  const cli = fixture.executables.cli;
+  const invocation = [
+    cli.executable,
+    ...cli.args,
+    ...(options.json === false ? [] : ['--json']),
+    ...args,
+  ];
   const command = [
     `while [ ! -f ${shellQuote(releasePath)} ]; do sleep 0.01; done`,
-    `env${options.stripTmux ? ' -u TMUX' : ''}${options.stripPane ? ' -u TMUX_PANE' : ''} ${shellQuote(cliPath)} ${options.json === false ? '' : '--json '}${args.map(shellQuote).join(' ')} >${shellQuote(outputPath)} 2>${shellQuote(errorPath)}`,
+    `env${options.stripTmux ? ' -u TMUX' : ''}${options.stripPane ? ' -u TMUX_PANE' : ''} ${invocation.map(shellQuote).join(' ')} >${shellQuote(outputPath)} 2>${shellQuote(errorPath)}`,
     `printf '%s' "$?" >${shellQuote(exitPath)}`,
     `while [ ! -f ${shellQuote(holdPath)} ]; do sleep 0.05; done`,
   ].join('; ');


### PR DESCRIPTION
## Scope

Closes #95. First implementation slice under #93; follows #94. Native grammar/workspace remains #96, storage #97, distribution #82.

- Add one test-only executable descriptor owner for contract sandboxes, Docker E2E commands, real tmux descendants, mock reply peers and startup/resource measurements.
- Accept an absolute executable plus an argv prefix. An explicit peer may differ; an omitted peer uses the primary. Invalid explicit selections fail without fallback.
- Keep the TypeScript default PATH-independent: current absolute Node plus the public wrapper. Explicit native executables launch directly, not through Node.
- Forward container-visible selections through the existing Docker wrapper; no implicit host-path mapping, new framework, dependency, matrix, production behavior, version bump or release.

## Architecture and review

Primary reviewer: Codex. Reviewed commit: `11f66e6bc1620ed2d1858318951abed0d0431790`.

Reviewed every changed file and relevant launcher callers, parser/output contracts, mock reply lifecycle, real ancestry fixture, resource runner, package exclusion and developer guidance. The shared plain-ESM descriptor only validates/freezes configuration; spawning, stream handling, deadlines and disposal remain with existing owners. Test support remains excluded from npm. TS-importing workers, wrapper contracts and packed probes are explicitly not native parity evidence.

Independent Luna review covered hidden launch sites, argument quoting, lifecycle ownership and false-positive risks. Findings/dispositions:

- Full local unit testing caught exit 127 in the existing install/PATH-isolation contract. Fixed the default centrally instead of weakening the test or restoring per-launcher defaults.
- Strengthened controlled-executable tests with real stripped-environment pane binding, exact persisted role/reply readback, selected peer failure and disappearing-peer partial startup cleanup.
- Explicit JSON/default parsing is tested separately; distinct executable and argv-prefix propagation is proved by a non-Node shell probe plus the explicit Node/wrapper and separate-peer Docker run. The E2E temporary-root inventory is confined to sequential tests in a private container; unit pre-allocation testing uses a filesystem-call spy to avoid cross-file races.
- Resource accounting remains unchanged, but the pinned-Node default differs from historical PATH/shebang lookup. Documentation requires paired re-baselining and makes no native performance claim.

## Verification

- [x] Primary reviewed changed files and relevant callers/tests.
- [x] `pnpm check`: types, lint and formatting passed.
- [x] `pnpm test:run`: 1,102 tests in 70 files passed; statements 95.66%, branches 89.47%, functions 97.55%; coverage gates passed.
- [x] Focused selector and Docker-wrapper units: 25 passed; focused Docker selector scenarios: 7 passed.
- [x] Full Docker run with initial default: 102 passed, optional benchmark skipped. Explicit primary Node/wrapper and separate direct-wrapper peer: 104 passed. Final default after the PATH fix: 104 passed. Private-server/descendant cleanup, timeout, interruption and failure contracts remain enabled.
- [x] macOS resource probe: controlled non-Node executable observed all 21 final-selector invocations; output/descriptor and temporary-root cleanup assertions passed. Diagnostic validation only, not performance evidence.
- [x] Updated E2E skill passed its validator. `git diff --check` passed.
- [x] Current-head CI checked before authorized merge: all 10 checks passed on `11f66e6bc1620ed2d1858318951abed0d0431790`, run `34096933837`, attempt 1. This includes code quality, unit tests, Docker E2E, six packed-install platforms and the native-package matrix gate.

## Lifecycle

Architecture, development guide, E2E skill, rewrite decision and performance guidance are updated in English. GitHub #95 records progress and the caught regression. One candidate CI push completed after local validation; no workflow changes or reruns were needed. Dedicated branch/worktree: `feat/95-cli-executable-selection` / `tmt-95-cli-executable-selection`. Cleanup follows successful merge and verification that no user work is present. No publication, global install or host tmux access.
