### PR TITLE
feat(native): preserve SQLite lifecycle and schema compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm check
 
   native-rust:
-    name: Native Rust grammar
+    name: Native Rust contracts
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -53,6 +53,7 @@ jobs:
           cargo test --locked
           cargo +1.88.0 build --locked
           cargo build --locked
+          cargo build --locked --example storage-probe
       - name: Set up Node.js test tooling
         uses: actions/setup-node@v4
         with:
@@ -68,8 +69,9 @@ jobs:
       - name: Verify native process and shared parser contracts
         env:
           TMT_TEST_CLI: '{"executable":"${{ github.workspace }}/rust/target/debug/tmt","args":[]}'
+          TMT_TEST_STORAGE_PROBE: '{"executable":"${{ github.workspace }}/rust/target/debug/examples/storage-probe","args":[]}'
         run: |
-          pnpm test:native:cli
+          pnpm test:native
           pnpm exec vitest run src/cli-contract.test.ts -t 'reports JSON parse errors|rejects ignored options|validates invalid options|keeps JSON leaf|does not treat|keeps a literal|does not reinterpret|rejects JSON mode for text-only'
 
   unit-tests:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -893,8 +893,8 @@ failure semantics; merely introducing an interface is not an architectural fix.
 `rust/` contains a development-only native CLI under #96; installed entry points
 remain TypeScript. `tmt-core` owns pure numeric limits, while `tmt-cli` owns one
 Clap grammar, typed requests, presentation and explicit no-effects rejection for
-unimplemented commands. No concrete adapter package is created before #97's first
-storage implementation. Neither core nor typed requests depend on concrete IO.
+unimplemented commands. `tmt-adapters` owns the schema 8 SQLite lifecycle under
+#97; neither core nor typed requests depend on concrete IO.
 
 Help and completion use a filtered projection of the same grammar, excluding
 hidden rejection syntax and unrelated inherited options. Parser errors choose
@@ -904,7 +904,7 @@ invocations without exposing Clap to application use cases. The binary returns
 an exit status through `main` and does not terminate from a domain operation.
 
 Native syntax includes the approved #100 amendment (`rm`/`remove`, temporary
-binding defaults and `-s`/`--save`). Storage, retirement, workspace selection and
+binding defaults and `-s`/`--save`). Identity repositories, retirement, workspace selection and
 promotion are not yet implemented. The durable-global invariants elsewhere in
 this map still describe the shipped TypeScript runtime, not the amended future
 native lifecycle. See [RUST-REWRITE.md](RUST-REWRITE.md) for transition boundaries.
@@ -914,6 +914,22 @@ native-preview process assertions. It requires a selected build, rather than
 silently testing TS. The named shared parser-contract subset remains separate
 from full native parity. Native unit tests cover typed grammar and core policy;
 real tmux behavior remains gated by the existing Docker harness as it is ported.
+
+The native storage adapter owns one synchronous, private rusqlite connection.
+Opening enforces private files, WAL, foreign keys, the five-second busy timeout,
+NORMAL synchronization and real FTS5 availability. Migrations 1–8 retain their
+historical definitions, immediate transaction boundaries and lock-held history
+rechecks. Migration 6 keeps frozen seven-day retention, bounded batches and
+JavaScript-safe saturating timestamps; this is not today's configuration policy.
+Close always releases the connection even if checkpoint fails, preserving the
+primary error. Cold WAL transitions can return retryable contention, as in the
+TypeScript adapter; no new retry loop is hidden in this lifecycle layer.
+
+`storage-probe` is a development-only example using that real adapter, not a
+public CLI command or alternate storage implementation. Shared bounded subprocess
+tests compare closed TypeScript schema-prefix fixtures and independent SQL
+observations, reverse-reopen with TypeScript and exercise failure recovery.
+These tests establish storage compatibility, not native request/identity parity.
 
 The [Rust rewrite decision](RUST-REWRITE.md) records the proposed native package
 boundaries, compatibility/test matrix, data coexistence gates and dependency

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,6 +33,8 @@ pnpm dev -- --help
 
 The `rust/` workspace is not the installed runtime yet. It implements only
 help/version/completion and typed grammar; effectful commands explicitly fail.
+The separate storage adapter implements schema 8 lifecycle compatibility, tested
+through a development-only probe rather than an installed command.
 Use the exact toolchain from `rust/rust-toolchain.toml` and run from `rust/`:
 
 ```bash
@@ -40,6 +42,7 @@ cargo fmt --all --check
 cargo clippy --locked --all-targets -- -D warnings
 cargo test --locked
 cargo build --locked
+cargo build --locked --example storage-probe
 cargo +1.88.0 build --locked
 ```
 
@@ -47,11 +50,19 @@ From the repository root, select the built executable explicitly:
 
 ```bash
 TMT_TEST_CLI='{"executable":"/absolute/checkout/rust/target/debug/tmt","args":[]}' \
-  pnpm test:native:cli
+  TMT_TEST_STORAGE_PROBE='{"executable":"/absolute/checkout/rust/target/debug/examples/storage-probe","args":[]}' \
+  pnpm test:native
 ```
 
 This preview-specific suite reuses the shared sandbox and bounded process
-launcher; it does not replace TypeScript or Docker verification. Also run the
+launcher; it does not replace TypeScript or Docker verification. Storage tests
+create and close TypeScript schema-prefix fixtures, migrate through the actual
+Rust adapter, and compare independent SQL schema/data with the TypeScript result.
+They also exercise reverse opens, rollback, history rejection and bounded writer
+contention. Neither executable selector may silently fall back to TypeScript.
+The probe accepts only a database path and runs open/health/checkpoint/close;
+it has no arbitrary SQL or failure-injection command and is not packaged.
+Also run the
 existing parser-only public contract subset through the same selection:
 
 ```bash
@@ -63,8 +74,8 @@ TMT_TEST_CLI='{"executable":"/absolute/checkout/rust/target/debug/tmt","args":[]
 Keep Cargo workspace version synchronized with the package version while both
 runtimes coexist. Check the resolved dependency graph's licenses, MSRVs and
 current RustSec advisories when changing Cargo.lock. `tmt-core` must remain free
-of CLI/concrete-IO dependencies. Add `tmt-adapters` when concrete storage arrives,
-not as an empty speculative abstraction. See RUST-REWRITE for the dependency
+of CLI/concrete-IO dependencies. `tmt-adapters` owns the concrete SQLite lifecycle;
+keep its raw connection private. See RUST-REWRITE for the dependency
 decision and explicit exceptions under #100.
 
 For runtime-rewrite work, read [RUST-REWRITE.md](RUST-REWRITE.md) for the proposed

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -48,10 +48,9 @@ is by responsibility, not a mechanical copy of every TypeScript file.
 
 ### Implemented native preview
 
-The `rust/` workspace currently contains `tmt-core` (pure numeric policy) and
-`tmt-cli` (grammar, typed invocation translation and output). `tmt-adapters`
-will be introduced with its first concrete storage consumer in #97, not as an
-empty facade. The npm entry points still execute TypeScript. No command silently
+The `rust/` workspace contains `tmt-core` (pure numeric policy),
+`tmt-cli` (grammar, typed invocation translation and output), and `tmt-adapters`
+(schema 8 SQLite lifecycle under #97). The npm entry points still execute TypeScript. No command silently
 delegates from native to Node.
 
 The preview implements help, version and Bash/Zsh completion. All recognized
@@ -78,13 +77,31 @@ locked builds on both versions are required. The selected released dependencies
 are Clap 4.6.6, clap_complete 4.6.9 and serde_json 1.0.151. Clap disables defaults,
 enabling only std/help/usage/error-context/suggestions/string; the string feature
 supports projecting grammar metadata without a duplicate command inventory.
-No derive, color, async runtime, SQLite or process dependency is introduced yet.
-Published manifests for the locked graph declare MSRVs at or below 1.85; licenses
+No derive, color, async runtime or process dependency is introduced yet.
+Published manifests for the original grammar graph declare MSRVs at or below 1.85; licenses
 are MIT/Apache-2.0 compatible alternatives, with unicode-ident also carrying
 Unicode-3.0. RustSec database revision
 `5a0ebedfe8bdd2e295b171f4162f8c977bcad9a5` contained no advisory entries for the
 locked dependency package names when inspected. This dated inspection is not a
 permanent security guarantee; repeat on dependency updates.
+
+#97 pins rusqlite 0.40.2 with default features disabled and only `bundled` enabled,
+using libsqlite3-sys 0.38.2. This gives a synchronous adapter with a controlled
+SQLite build, including FTS5, without an ORM, pool or extension-loading API.
+The added dependency licenses are MIT or MIT/Apache-2.0. At the same RustSec
+revision, the nine entries for rusqlite, libsqlite3-sys, shlex and smallvec all
+list patched ranges containing the locked versions. Some manifests omit MSRV,
+so actual Rust 1.88 locked compilation remains the acceptance evidence.
+
+Schema 8 remains unchanged. Native migrations retain the historical names,
+column/index/foreign-key definitions and seven-day migration backfill rather
+than applying today's retention configuration retroactively. The private
+connection exposes only lifecycle operations until repositories are ported.
+A non-installed `storage-probe` example allows bounded cross-runtime tests of
+the real adapter, without adding arbitrary SQL or fault flags to public syntax.
+Cold concurrent WAL transitions can report retryable busy errors even with a
+busy timeout; this preserves the existing storage boundary, not an all-openers
+success guarantee. See [SQLite busy-handler behavior](https://sqlite.org/c3ref/busy_handler.html).
 
 ### Execution and resource ownership
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "pnpm test:run",
     "test:watch": "vitest",
     "test:e2e": "node scripts/run-e2e.mjs",
-    "test:native:cli": "vitest run --config test/native/vitest.config.ts",
+    "test:native": "vitest run --config test/native/vitest.config.ts",
     "test:run": "vitest run --coverage && node scripts/check-coverage.mjs --threshold 90 --branches 85",
     "lint": "oxlint src/",
     "e2e:typecheck": "tsc --project tsconfig.e2e.json --noEmit",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,6 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "cc"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,16 +60,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "proc-macro2"
@@ -71,6 +122,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -116,6 +180,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "smallvec"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +206,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tmt-adapters"
+version = "5.0.0-alpha.1"
+dependencies = [
+ "rusqlite",
+ "serde_json",
+ "tmt-core",
 ]
 
 [[package]]
@@ -151,6 +236,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "zmij"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/tmt-core", "crates/tmt-cli"]
+members = ["crates/tmt-core", "crates/tmt-adapters", "crates/tmt-cli"]
 resolver = "3"
 
 [workspace.package]
@@ -14,6 +14,7 @@ tmt-core = { path = "crates/tmt-core" }
 clap = { version = "=4.6.6", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions", "string"] }
 clap_complete = { version = "=4.6.9", default-features = false }
 serde_json = "=1.0.151"
+rusqlite = { version = "=0.40.2", default-features = false, features = ["bundled"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tmt-adapters"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+tmt-core.workspace = true
+rusqlite.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/rust/crates/tmt-adapters/examples/storage-probe.rs
+++ b/rust/crates/tmt-adapters/examples/storage-probe.rs
@@ -1,0 +1,48 @@
+//! Development-only lifecycle probe for independent cross-runtime fixtures.
+//! This is not a supported tmt command and is never an installed artifact.
+
+use std::{
+    io::{self, Write},
+    process::ExitCode,
+};
+use tmt_adapters::storage::{CheckpointMode, Storage, StorageError};
+
+fn run(path: &std::path::Path) -> Result<serde_json::Value, StorageError> {
+    let mut storage = Storage::open(path)?;
+    let observed = (|| {
+        let health = storage.health()?;
+        storage.checkpoint(CheckpointMode::Passive)?;
+        Ok(serde_json::json!({
+            "path": health.path, "open": true, "schemaVersion": health.schema_version,
+            "journalMode": health.journal_mode, "foreignKeys": health.foreign_keys,
+            "busyTimeoutMs": health.busy_timeout_ms, "synchronous": health.synchronous,
+            "fts5": health.fts5,
+        }))
+    })();
+    let cleanup = storage.close();
+    let health = observed?;
+    cleanup?;
+    Ok(health)
+}
+
+fn main() -> ExitCode {
+    let args = std::env::args_os().skip(1).collect::<Vec<_>>();
+    if args.len() != 1 {
+        eprintln!("Usage: storage-probe <isolated-database-path>");
+        return ExitCode::FAILURE;
+    }
+    let (document, status) = match run(std::path::Path::new(&args[0])) {
+        Ok(health) => (health, ExitCode::SUCCESS),
+        Err(error) => (
+            serde_json::json!({"error": {
+                "code": error.code.as_str(), "message": error.message,
+                "migrationVersion": error.migration_version, "retryable": error.retryable,
+            }}),
+            ExitCode::FAILURE,
+        ),
+    };
+    if writeln!(io::stdout().lock(), "{document}").is_err() {
+        return ExitCode::FAILURE;
+    }
+    status
+}

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -1,0 +1,3 @@
+//! Concrete native adapters. Application policy must not depend on this crate.
+
+pub mod storage;

--- a/rust/crates/tmt-adapters/src/storage/errors.rs
+++ b/rust/crates/tmt-adapters/src/storage/errors.rs
@@ -1,0 +1,95 @@
+use std::{error::Error, fmt};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageErrorCode {
+    Busy,
+    Corrupt,
+    Permission,
+    IncompatibleSchema,
+    Migration,
+    Unknown,
+    Closed,
+}
+
+impl StorageErrorCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Busy => "busy",
+            Self::Corrupt => "corrupt",
+            Self::Permission => "permission",
+            Self::IncompatibleSchema => "incompatible-schema",
+            Self::Migration => "migration",
+            Self::Unknown => "unknown",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct StorageError {
+    pub code: StorageErrorCode,
+    pub message: String,
+    pub migration_version: Option<u32>,
+    pub retryable: bool,
+    cause: Option<Box<dyn Error + Send + Sync>>,
+}
+
+impl StorageError {
+    pub(crate) fn new(code: StorageErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            migration_version: None,
+            retryable: code == StorageErrorCode::Busy,
+            cause: None,
+        }
+    }
+
+    pub(crate) fn caused_by(mut self, cause: impl Error + Send + Sync + 'static) -> Self {
+        self.cause = Some(Box::new(cause));
+        self
+    }
+
+    pub(crate) fn migration(version: u32, cause: Self) -> Self {
+        let retryable = cause.retryable;
+        let mut error = Self::new(
+            StorageErrorCode::Migration,
+            format!("Migration {version} failed"),
+        )
+        .caused_by(cause);
+        error.migration_version = Some(version);
+        error.retryable = retryable;
+        error
+    }
+}
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for StorageError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_deref()
+            .map(|cause| cause as &(dyn Error + 'static))
+    }
+}
+
+pub(crate) fn classify(error: rusqlite::Error, operation: &str) -> StorageError {
+    use rusqlite::ErrorCode;
+    let code = match error.sqlite_error_code() {
+        Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked) => StorageErrorCode::Busy,
+        Some(ErrorCode::DatabaseCorrupt | ErrorCode::NotADatabase) => StorageErrorCode::Corrupt,
+        Some(ErrorCode::CannotOpen | ErrorCode::ReadOnly | ErrorCode::PermissionDenied) => {
+            StorageErrorCode::Permission
+        }
+        _ => StorageErrorCode::Unknown,
+    };
+    StorageError::new(code, format!("{operation} failed")).caused_by(error)
+}
+
+pub(crate) fn incompatible(message: impl Into<String>) -> StorageError {
+    StorageError::new(StorageErrorCode::IncompatibleSchema, message)
+}

--- a/rust/crates/tmt-adapters/src/storage/migrations.rs
+++ b/rust/crates/tmt-adapters/src/storage/migrations.rs
@@ -1,0 +1,278 @@
+use rusqlite::{Connection, TransactionBehavior, params};
+use tmt_core::limits::MAX_JS_SAFE_INTEGER;
+
+use super::errors::{StorageError, StorageErrorCode, classify, incompatible};
+
+struct Migration {
+    name: &'static str,
+    sql: &'static str,
+}
+
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        name: "create durable identities and transient tmux bindings",
+        sql: include_str!("schema/001.sql"),
+    },
+    Migration {
+        name: "create optional identity role profiles",
+        sql: include_str!("schema/002.sql"),
+    },
+    Migration {
+        name: "create durable identity preambles",
+        sql: include_str!("schema/003.sql"),
+    },
+    Migration {
+        name: "create request attempts and preamble cadence counters",
+        sql: include_str!("schema/004.sql"),
+    },
+    Migration {
+        name: "create immutable request responses",
+        sql: include_str!("schema/005.sql"),
+    },
+    Migration {
+        name: "freeze exchange retention and response expiry horizons",
+        sql: include_str!("schema/006_columns.sql"),
+    },
+    Migration {
+        name: "retain request provenance and bounded original prompts",
+        sql: include_str!("schema/007.sql"),
+    },
+    Migration {
+        name: "add identity-scoped exchange attention revisions",
+        sql: include_str!("schema/008.sql"),
+    },
+];
+
+pub(super) fn apply(connection: &mut Connection) -> Result<(), StorageError> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| classify(error, "Initialize migration history"))?;
+    transaction.execute_batch("CREATE TABLE IF NOT EXISTS _migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL)")
+        .map_err(|error| classify(error, "Initialize migration history"))?;
+    validate_table(&transaction)?;
+    transaction
+        .commit()
+        .map_err(|error| classify(error, "Commit migration history"))?;
+    let current = validate_history(connection)?;
+    for (index, migration) in MIGRATIONS.iter().enumerate().skip(current) {
+        let version = index as u32 + 1;
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| classify(error, "Acquire migration lock"))?;
+        let apply_one = (|| {
+            // A concurrent opener may already have applied this version. The
+            // authoritative history check is inside the immediate writer lock.
+            if validate_history(&transaction)? >= version as usize {
+                return Ok(());
+            }
+            transaction
+                .execute_batch(migration.sql)
+                .map_err(|error| classify(error, "Apply migration SQL"))?;
+            if version == 6 {
+                backfill_retention(&transaction)?;
+            }
+            transaction.execute(
+                "INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+                params![version, migration.name],
+            ).map_err(|error| classify(error, "Record migration"))?;
+            Ok(())
+        })();
+        apply_one.map_err(|error| StorageError::migration(version, error))?;
+        transaction
+            .commit()
+            .map_err(|error| classify(error, "Commit migration"))?;
+    }
+    Ok(())
+}
+
+fn validate_table(connection: &Connection) -> Result<(), StorageError> {
+    let mut query = connection
+        .prepare("PRAGMA table_info(_migrations)")
+        .map_err(|error| classify(error, "Inspect migration schema"))?;
+    let columns = query
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(5)?,
+            ))
+        })
+        .map_err(|error| classify(error, "Inspect migration schema"))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| classify(error, "Read migration schema"))?;
+    let expected = [
+        ("version", "INTEGER", 0, 1),
+        ("name", "TEXT", 1, 0),
+        ("applied_at", "TEXT", 1, 0),
+    ];
+    if columns.len() != expected.len()
+        || columns.iter().zip(expected).any(|(actual, expected)| {
+            actual.0 != expected.0
+                || actual.1.to_ascii_uppercase() != expected.1
+                || actual.2 != expected.2
+                || actual.3 != expected.3
+        })
+    {
+        return Err(incompatible(
+            "The _migrations table does not match the supported schema",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_history(connection: &Connection) -> Result<usize, StorageError> {
+    let mut statement = connection
+        .prepare("SELECT version, name FROM _migrations ORDER BY version")
+        .map_err(|error| classify(error, "Read migration history"))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|error| classify(error, "Read migration history"))?;
+    let mut count = 0;
+    for row in rows {
+        let (version, name) = row.map_err(|error| {
+            incompatible("Migration history contains invalid values").caused_by(error)
+        })?;
+        if version != count as i64 + 1 {
+            return Err(incompatible(format!(
+                "Migration history is not contiguous at version {version}"
+            )));
+        }
+        let Some(definition) = MIGRATIONS.get(count) else {
+            return Err(incompatible(format!(
+                "Database requires unsupported migration version {version}"
+            )));
+        };
+        if definition.name != name {
+            return Err(incompatible(format!(
+                "Migration {version} has changed from {name} to {}",
+                definition.name
+            )));
+        }
+        count += 1;
+    }
+    Ok(count)
+}
+
+// Historical migration policy is frozen independently of today's settings.
+const LEGACY_RETENTION_MS: i64 = 7 * 86_400_000;
+const SETTLEMENT_FLOOR_MS: i64 = 86_400_000;
+
+fn saturating_deadline(value: i64, delta: i64) -> Result<i64, StorageError> {
+    let maximum = MAX_JS_SAFE_INTEGER as i64;
+    if !(1..=maximum).contains(&value) || !(0..=maximum).contains(&delta) {
+        return Err(StorageError::new(
+            StorageErrorCode::Unknown,
+            "Historical timestamp is outside the supported range",
+        ));
+    }
+    Ok(value.saturating_add(delta).min(maximum))
+}
+
+fn backfill_retention(connection: &Connection) -> Result<(), StorageError> {
+    let mut first = connection.prepare("SELECT attempt_id, prepared_at_ms, expires_at_ms, settled_at_ms FROM request_attempts ORDER BY attempt_id LIMIT 100")
+        .map_err(|error| classify(error, "Prepare retention migration"))?;
+    let mut next = connection.prepare("SELECT attempt_id, prepared_at_ms, expires_at_ms, settled_at_ms FROM request_attempts WHERE attempt_id > ? ORDER BY attempt_id LIMIT 100")
+        .map_err(|error| classify(error, "Prepare retention migration"))?;
+    let mut update = connection
+        .prepare("UPDATE request_attempts SET retention_expires_at_ms = ? WHERE attempt_id = ?")
+        .map_err(|error| classify(error, "Prepare retention migration"))?;
+    let mut previous: Option<String> = None;
+    loop {
+        let read = |row: &rusqlite::Row<'_>| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+            ))
+        };
+        let rows = match &previous {
+            Some(previous) => next.query_map([previous], read),
+            None => first.query_map([], read),
+        }
+        .map_err(|error| classify(error, "Read historical attempts"))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| classify(error, "Decode historical attempts"))?;
+        if rows.is_empty() {
+            break;
+        }
+        for (id, prepared, expires, settled) in rows {
+            // The historical reply-acceptance window is also seven days.
+            let horizon = saturating_deadline(prepared, LEGACY_RETENTION_MS)?
+                .max(saturating_deadline(expires, SETTLEMENT_FLOOR_MS)?)
+                .max(
+                    settled
+                        .map(|time| saturating_deadline(time, SETTLEMENT_FLOOR_MS))
+                        .transpose()?
+                        .unwrap_or(0),
+                );
+            update
+                .execute(params![horizon, id])
+                .map_err(|error| classify(error, "Backfill attempt horizon"))?;
+            previous = Some(id);
+        }
+    }
+
+    let mut first = connection.prepare("SELECT request_id, submitted_at_ms FROM request_responses ORDER BY request_id LIMIT 100")
+        .map_err(|error| classify(error, "Prepare response migration"))?;
+    let mut next = connection.prepare("SELECT request_id, submitted_at_ms FROM request_responses WHERE request_id > ? ORDER BY request_id LIMIT 100")
+        .map_err(|error| classify(error, "Prepare response migration"))?;
+    let mut update = connection
+        .prepare("UPDATE request_responses SET response_expires_at_ms = ? WHERE request_id = ?")
+        .map_err(|error| classify(error, "Prepare response migration"))?;
+    let mut previous: Option<String> = None;
+    loop {
+        let read = |row: &rusqlite::Row<'_>| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?));
+        let rows = match &previous {
+            Some(previous) => next.query_map([previous], read),
+            None => first.query_map([], read),
+        }
+        .map_err(|error| classify(error, "Read historical responses"))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| classify(error, "Decode historical responses"))?;
+        if rows.is_empty() {
+            break;
+        }
+        for (id, submitted) in rows {
+            update
+                .execute(params![
+                    saturating_deadline(submitted, LEGACY_RETENTION_MS)?,
+                    id
+                ])
+                .map_err(|error| classify(error, "Backfill response horizon"))?;
+            previous = Some(id);
+        }
+    }
+    connection.execute_batch("UPDATE request_attempts SET retention_expires_at_ms = MAX(retention_expires_at_ms, COALESCE((SELECT response_expires_at_ms FROM request_responses WHERE request_responses.request_id = request_attempts.request_id AND request_responses.attempt_id = request_attempts.attempt_id), retention_expires_at_ms))")
+        .map_err(|error| classify(error, "Extend matching response horizons"))?;
+    connection
+        .execute_batch(include_str!("schema/006_indexes.sql"))
+        .map_err(|error| classify(error, "Index retention horizons"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn historical_deadlines_saturate_but_do_not_accept_invalid_anchors() {
+        assert_eq!(
+            saturating_deadline(1, LEGACY_RETENTION_MS).unwrap(),
+            604_800_001
+        );
+        assert_eq!(
+            saturating_deadline(MAX_JS_SAFE_INTEGER as i64 - 1, LEGACY_RETENTION_MS).unwrap(),
+            MAX_JS_SAFE_INTEGER as i64
+        );
+        for value in [i64::MIN, -1, 0, MAX_JS_SAFE_INTEGER as i64 + 1, i64::MAX] {
+            assert_eq!(
+                saturating_deadline(value, 1).unwrap_err().code,
+                StorageErrorCode::Unknown
+            );
+        }
+    }
+}

--- a/rust/crates/tmt-adapters/src/storage/mod.rs
+++ b/rust/crates/tmt-adapters/src/storage/mod.rs
@@ -1,0 +1,203 @@
+mod errors;
+mod migrations;
+
+#[cfg(test)]
+mod tests;
+
+use rusqlite::Connection;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+pub use errors::{StorageError, StorageErrorCode};
+use errors::{classify, incompatible};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckpointMode {
+    Passive,
+    Truncate,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct StorageHealth {
+    pub path: PathBuf,
+    pub schema_version: u32,
+    pub journal_mode: &'static str,
+    pub foreign_keys: bool,
+    pub busy_timeout_ms: u32,
+    pub synchronous: &'static str,
+    pub fts5: bool,
+}
+
+/// One invocation-owned connection. The raw handle never crosses this adapter's
+/// boundary. Explicit close reports failures; Connection's RAII remains a safety
+/// net for early returns and unwinding, not a replacement for fallible cleanup.
+pub struct Storage {
+    path: PathBuf,
+    connection: Option<Connection>,
+}
+
+impl Storage {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, StorageError> {
+        let path = path.as_ref().to_path_buf();
+        let directory = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        secure_directory(directory)?;
+        let mut connection =
+            Connection::open(&path).map_err(|error| classify(error, "Open storage"))?;
+        let prepare = (|| {
+            connection
+                .pragma_update(None, "foreign_keys", "ON")
+                .map_err(|error| classify(error, "Configure foreign keys"))?;
+            connection
+                .busy_timeout(Duration::from_millis(5000))
+                .map_err(|error| classify(error, "Configure busy timeout"))?;
+            connection
+                .pragma_update(None, "journal_mode", "WAL")
+                .map_err(|error| classify(error, "Configure WAL"))?;
+            connection
+                .pragma_update(None, "synchronous", "NORMAL")
+                .map_err(|error| classify(error, "Configure synchronous policy"))?;
+            connection.execute_batch("CREATE VIRTUAL TABLE temp._tmt_fts5_check USING fts5(content); DROP TABLE temp._tmt_fts5_check;")
+                .map_err(|error| incompatible("The SQLite runtime does not provide FTS5").caused_by(error))?;
+            migrations::apply(&mut connection)?;
+            secure_files(&path)
+        })();
+        if let Err(primary) = prepare {
+            // Closing must not replace the error that prevented a usable handle.
+            let _ = connection.close();
+            return Err(primary);
+        }
+        Ok(Self {
+            path,
+            connection: Some(connection),
+        })
+    }
+
+    pub fn health(&self) -> Result<StorageHealth, StorageError> {
+        let connection = self.connection()?;
+        let policy = connection.query_row(
+            "SELECT (SELECT foreign_keys FROM pragma_foreign_keys), (SELECT journal_mode FROM pragma_journal_mode), (SELECT timeout FROM pragma_busy_timeout), (SELECT synchronous FROM pragma_synchronous)",
+            [], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?, row.get::<_, i64>(3)?)),
+        ).map_err(|error| classify(error, "Read storage health"))?;
+        if policy != (1, "wal".into(), 5000, 1) {
+            return Err(incompatible(
+                "The SQLite connection does not match storage policy",
+            ));
+        }
+        let version = connection
+            .query_row(
+                "SELECT COALESCE(MAX(version), 0) FROM _migrations",
+                [],
+                |row| row.get::<_, u32>(0),
+            )
+            .map_err(|error| classify(error, "Read schema version"))?;
+        Ok(StorageHealth {
+            path: self.path.clone(),
+            schema_version: version,
+            journal_mode: "wal",
+            foreign_keys: true,
+            busy_timeout_ms: 5000,
+            synchronous: "normal",
+            fts5: true,
+        })
+    }
+
+    pub fn checkpoint(&self, mode: CheckpointMode) -> Result<(), StorageError> {
+        checkpoint(self.connection()?, &self.path, mode)
+    }
+
+    pub fn close(&mut self) -> Result<(), StorageError> {
+        let Some(connection) = self.connection.take() else {
+            return Ok(());
+        };
+        let checkpoint_result = checkpoint(&connection, &self.path, CheckpointMode::Passive);
+        let close_result = connection
+            .close()
+            .map_err(|(_connection, error)| classify(error, "Close storage"));
+        // Both effects have already run. Preserve the first failure.
+        checkpoint_result.and(close_result)
+    }
+
+    fn connection(&self) -> Result<&Connection, StorageError> {
+        self.connection
+            .as_ref()
+            .ok_or_else(|| StorageError::new(StorageErrorCode::Closed, "Storage is already closed"))
+    }
+}
+
+fn checkpoint(
+    connection: &Connection,
+    path: &Path,
+    mode: CheckpointMode,
+) -> Result<(), StorageError> {
+    let statement = match mode {
+        CheckpointMode::Passive => "PRAGMA wal_checkpoint(PASSIVE)",
+        CheckpointMode::Truncate => "PRAGMA wal_checkpoint(TRUNCATE)",
+    };
+    // A busy result row is not an exception in the reference adapter. Do not
+    // reinterpret passive checkpoint contention as a failed committed command.
+    connection
+        .query_row(statement, [], |row| row.get::<_, i64>(0))
+        .map_err(|error| classify(error, "Checkpoint storage"))?;
+    secure_files(path)
+}
+
+fn secure_directory(path: &Path) -> Result<(), StorageError> {
+    let result = (|| {
+        let mut builder = fs::DirBuilder::new();
+        builder.recursive(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+            builder.mode(0o700);
+            builder.create(path)?;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+        }
+        #[cfg(not(unix))]
+        builder.create(path)?;
+        Ok::<(), std::io::Error>(())
+    })();
+    result.map_err(|error| {
+        StorageError::new(
+            StorageErrorCode::Permission,
+            "Cannot secure storage directory",
+        )
+        .caused_by(error)
+    })
+}
+
+fn secure_files(path: &Path) -> Result<(), StorageError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for suffix in ["", "-wal", "-shm"] {
+            let mut file = path.as_os_str().to_os_string();
+            file.push(suffix);
+            match fs::metadata(&file) {
+                Ok(_) => fs::set_permissions(&file, fs::Permissions::from_mode(0o600)).map_err(
+                    |error| {
+                        StorageError::new(
+                            StorageErrorCode::Permission,
+                            "Cannot secure storage file",
+                        )
+                        .caused_by(error)
+                    },
+                )?,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(StorageError::new(
+                        StorageErrorCode::Permission,
+                        "Cannot inspect storage file",
+                    )
+                    .caused_by(error));
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/rust/crates/tmt-adapters/src/storage/schema/001.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/001.sql
@@ -1,0 +1,23 @@
+CREATE TABLE identities (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  canonical_name TEXT NOT NULL UNIQUE,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE TABLE bindings (
+  id TEXT PRIMARY KEY,
+  identity_id TEXT NOT NULL REFERENCES identities(id) ON DELETE CASCADE,
+  transport TEXT NOT NULL CHECK (transport = 'tmux'),
+  pane_id TEXT NOT NULL,
+  server_id TEXT NOT NULL,
+  socket_path TEXT NOT NULL,
+  server_pid INTEGER NOT NULL,
+  server_start_time TEXT NOT NULL,
+  pane_pid INTEGER NOT NULL,
+  bound_at TEXT NOT NULL,
+  last_verified_at TEXT NOT NULL,
+  UNIQUE(identity_id),
+  UNIQUE(transport, server_id, pane_id)
+);
+CREATE INDEX bindings_endpoint ON bindings(transport, server_id, pane_id);

--- a/rust/crates/tmt-adapters/src/storage/schema/002.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/002.sql
@@ -1,0 +1,5 @@
+CREATE TABLE role_profiles (
+  identity_id TEXT NOT NULL PRIMARY KEY REFERENCES identities(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);

--- a/rust/crates/tmt-adapters/src/storage/schema/003.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/003.sql
@@ -1,0 +1,5 @@
+CREATE TABLE identity_preambles (
+  identity_id TEXT NOT NULL PRIMARY KEY REFERENCES identities(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);

--- a/rust/crates/tmt-adapters/src/storage/schema/004.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/004.sql
@@ -1,0 +1,38 @@
+CREATE TABLE preamble_counters (
+  identity_id TEXT PRIMARY KEY REFERENCES identities(id) ON DELETE CASCADE,
+  reserved_count INTEGER NOT NULL CHECK (reserved_count >= 0),
+  updated_at_ms INTEGER NOT NULL
+);
+CREATE TABLE request_attempts (
+  attempt_id TEXT PRIMARY KEY,
+  request_id TEXT NOT NULL UNIQUE,
+  nonce TEXT,
+  identity_id TEXT REFERENCES identities(id) ON DELETE SET NULL,
+  server_id TEXT NOT NULL,
+  socket_path TEXT NOT NULL,
+  server_pid INTEGER NOT NULL CHECK (server_pid > 0),
+  server_start_time TEXT NOT NULL,
+  pane_id TEXT NOT NULL,
+  pane_pid INTEGER NOT NULL CHECK (pane_pid > 0),
+  wait_active INTEGER NOT NULL CHECK (wait_active IN (0, 1)),
+  status TEXT NOT NULL CHECK (
+    status IN ('prepared', 'sending', 'sent', 'uncertain', 'definitely_failed')
+  ),
+  preamble_every INTEGER CHECK (preamble_every IS NULL OR preamble_every > 0),
+  inject_preamble INTEGER NOT NULL CHECK (inject_preamble IN (0, 1)),
+  cadence_reserved INTEGER NOT NULL CHECK (cadence_reserved IN (0, 1)),
+  prepared_at_ms INTEGER NOT NULL,
+  sending_at_ms INTEGER,
+  settled_at_ms INTEGER,
+  wait_released_at_ms INTEGER,
+  expires_at_ms INTEGER NOT NULL
+);
+CREATE INDEX request_attempts_endpoint_active
+  ON request_attempts (
+    server_id, socket_path, server_pid, server_start_time, pane_id, pane_pid,
+    wait_active, status, prepared_at_ms
+  );
+CREATE INDEX request_attempts_retention
+  ON request_attempts (wait_active, status, settled_at_ms);
+CREATE INDEX request_attempts_expiry
+  ON request_attempts (expires_at_ms, status);

--- a/rust/crates/tmt-adapters/src/storage/schema/005.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/005.sql
@@ -1,0 +1,17 @@
+ALTER TABLE request_attempts
+  ADD COLUMN response_submitted_at_ms INTEGER;
+CREATE TABLE request_responses (
+  request_id TEXT PRIMARY KEY,
+  attempt_id TEXT NOT NULL,
+  server_id TEXT NOT NULL,
+  socket_path TEXT NOT NULL,
+  server_pid INTEGER NOT NULL CHECK (server_pid > 0),
+  server_start_time TEXT NOT NULL,
+  pane_id TEXT NOT NULL,
+  pane_pid INTEGER NOT NULL CHECK (pane_pid > 0),
+  body TEXT NOT NULL,
+  body_bytes INTEGER NOT NULL CHECK (body_bytes >= 0),
+  submitted_at_ms INTEGER NOT NULL CHECK (submitted_at_ms > 0)
+);
+CREATE INDEX request_responses_retention
+  ON request_responses (submitted_at_ms);

--- a/rust/crates/tmt-adapters/src/storage/schema/006_columns.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/006_columns.sql
@@ -1,0 +1,6 @@
+ALTER TABLE request_attempts
+  ADD COLUMN retention_days INTEGER NOT NULL DEFAULT 7;
+ALTER TABLE request_attempts
+  ADD COLUMN retention_expires_at_ms INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE request_responses
+  ADD COLUMN response_expires_at_ms INTEGER NOT NULL DEFAULT 0;

--- a/rust/crates/tmt-adapters/src/storage/schema/006_indexes.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/006_indexes.sql
@@ -1,0 +1,9 @@
+CREATE INDEX request_attempts_retention_horizon
+  ON request_attempts (retention_expires_at_ms, attempt_id);
+CREATE INDEX request_attempts_cleanup_expiry
+  ON request_attempts (expires_at_ms, attempt_id)
+  WHERE wait_active = 1 OR status IN ('prepared', 'sending');
+CREATE INDEX request_responses_expiry
+  ON request_responses (response_expires_at_ms, request_id);
+CREATE INDEX request_responses_attempt
+  ON request_responses (attempt_id, response_expires_at_ms);

--- a/rust/crates/tmt-adapters/src/storage/schema/007.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/007.sql
@@ -1,0 +1,21 @@
+ALTER TABLE request_attempts
+  ADD COLUMN originator_kind TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (originator_kind IN ('unknown', 'explicit', 'verified'));
+ALTER TABLE request_attempts
+  ADD COLUMN originator_identity_id TEXT
+    CHECK (
+      (originator_kind = 'unknown' AND originator_identity_id IS NULL) OR
+      (originator_kind IN ('explicit', 'verified') AND originator_identity_id IS NOT NULL)
+    );
+ALTER TABLE request_attempts
+  ADD COLUMN recipient_identity_id TEXT;
+ALTER TABLE request_attempts
+  ADD COLUMN message_text TEXT;
+ALTER TABLE request_attempts
+  ADD COLUMN message_bytes INTEGER
+    CHECK (message_bytes IS NULL OR message_bytes >= 0);
+ALTER TABLE request_attempts
+  ADD COLUMN message_expires_at_ms INTEGER;
+CREATE INDEX request_attempts_prompt_expiry
+  ON request_attempts (message_expires_at_ms, attempt_id)
+  WHERE message_text IS NOT NULL;

--- a/rust/crates/tmt-adapters/src/storage/schema/008.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/008.sql
@@ -1,0 +1,45 @@
+ALTER TABLE request_attempts
+  ADD COLUMN attention_revision INTEGER NOT NULL DEFAULT 0
+    CHECK (
+      typeof(attention_revision) = 'integer' AND
+      attention_revision >= 0 AND attention_revision <= 9007199254740991
+    );
+ALTER TABLE request_attempts
+  ADD COLUMN attention_acknowledged_revision INTEGER NOT NULL DEFAULT 0
+    CHECK (
+      typeof(attention_acknowledged_revision) = 'integer' AND
+      attention_acknowledged_revision >= 0 AND attention_acknowledged_revision <= 9007199254740991
+    );
+CREATE TABLE request_attention_identities (
+  identity_id TEXT PRIMARY KEY,
+  latest_revision INTEGER NOT NULL CHECK (
+    typeof(latest_revision) = 'integer' AND
+    latest_revision >= 0 AND latest_revision <= 9007199254740991
+  ),
+  acknowledged_through INTEGER NOT NULL CHECK (
+    typeof(acknowledged_through) = 'integer' AND
+    acknowledged_through <= latest_revision AND
+    acknowledged_through >= 0 AND acknowledged_through <= 9007199254740991
+  )
+);
+WITH ranked AS (
+  SELECT attempt_id,
+         ROW_NUMBER() OVER (
+           PARTITION BY originator_identity_id
+           ORDER BY prepared_at_ms, request_id
+         ) AS revision
+  FROM request_attempts
+  WHERE originator_identity_id IS NOT NULL
+)
+UPDATE request_attempts
+SET attention_revision = (
+  SELECT revision FROM ranked WHERE ranked.attempt_id = request_attempts.attempt_id
+)
+WHERE attempt_id IN (SELECT attempt_id FROM ranked);
+INSERT INTO request_attention_identities (identity_id, latest_revision, acknowledged_through)
+  SELECT originator_identity_id, MAX(attention_revision), 0
+  FROM request_attempts
+  WHERE originator_identity_id IS NOT NULL
+  GROUP BY originator_identity_id;
+CREATE INDEX request_attempts_attention
+  ON request_attempts (originator_identity_id, attention_revision, request_id);

--- a/rust/crates/tmt-adapters/src/storage/tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/tests.rs
@@ -1,0 +1,234 @@
+use std::{
+    fs,
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use super::*;
+
+struct Fixture {
+    directory: PathBuf,
+    database: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let directory = std::env::temp_dir().join(format!(
+            "tmt-native-storage-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&directory).expect("create unique test directory");
+        Self {
+            database: directory.join("state").join("tmux-team.db"),
+            directory,
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.directory).expect("remove isolated storage fixture");
+    }
+}
+
+#[test]
+fn open_enforces_connection_features_and_private_files() {
+    let fixture = Fixture::new();
+    let mut storage = Storage::open(&fixture.database).unwrap();
+    assert_eq!(
+        storage.health().unwrap(),
+        StorageHealth {
+            path: fixture.database.clone(),
+            schema_version: 8,
+            journal_mode: "wal",
+            foreign_keys: true,
+            busy_timeout_ms: 5000,
+            synchronous: "normal",
+            fts5: true,
+        }
+    );
+    let connection = storage.connection().unwrap();
+    connection.execute_batch("CREATE VIRTUAL TABLE temp.search_probe USING fts5(content); INSERT INTO temp.search_probe VALUES ('native durable reply');").unwrap();
+    let result: String = connection
+        .query_row(
+            "SELECT content FROM temp.search_probe WHERE search_probe MATCH 'durable'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(result, "native durable reply");
+    assert!(
+        connection
+            .execute(
+                "INSERT INTO role_profiles VALUES ('missing', 'role', 'now')",
+                []
+            )
+            .is_err()
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            fs::metadata(fixture.database.parent().unwrap())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        for suffix in ["", "-wal", "-shm"] {
+            let file = PathBuf::from(format!("{}{suffix}", fixture.database.display()));
+            assert_eq!(
+                fs::metadata(file).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+    storage.close().unwrap();
+    storage.close().unwrap();
+    assert_eq!(storage.health().unwrap_err().code, StorageErrorCode::Closed);
+    assert_eq!(
+        storage
+            .checkpoint(CheckpointMode::Passive)
+            .unwrap_err()
+            .code,
+        StorageErrorCode::Closed
+    );
+}
+
+#[test]
+fn failed_checkpoint_still_closes_and_rolls_back_the_active_transaction() {
+    let fixture = Fixture::new();
+    let mut storage = Storage::open(&fixture.database).unwrap();
+    storage.connection().unwrap().execute_batch("BEGIN IMMEDIATE; INSERT INTO identities VALUES ('uncommitted', 'Test', 'test', 'now', 'now');").unwrap();
+    assert_eq!(storage.close().unwrap_err().code, StorageErrorCode::Busy);
+    assert_eq!(storage.health().unwrap_err().code, StorageErrorCode::Closed);
+    storage.close().unwrap();
+    let verification = Connection::open(&fixture.database).unwrap();
+    let count: i64 = verification
+        .query_row("SELECT COUNT(*) FROM identities", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        count, 0,
+        "close must release the failed checkpoint's writer and roll back"
+    );
+    verification
+        .execute_batch("BEGIN IMMEDIATE; COMMIT;")
+        .unwrap();
+}
+
+#[test]
+fn health_rejects_changed_connection_policy() {
+    let fixture = Fixture::new();
+    let mut storage = Storage::open(&fixture.database).unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .pragma_update(None, "foreign_keys", "OFF")
+        .unwrap();
+    assert_eq!(
+        storage.health().unwrap_err().code,
+        StorageErrorCode::IncompatibleSchema
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn open_errors_preserve_existing_files() {
+    let fixture = Fixture::new();
+    fs::write(fixture.database.parent().unwrap(), b"unrelated file").unwrap();
+    let error = Storage::open(&fixture.database)
+        .err()
+        .expect("directory collision must fail");
+    assert_eq!(error.code, StorageErrorCode::Permission);
+    assert_eq!(
+        fs::read(fixture.database.parent().unwrap()).unwrap(),
+        b"unrelated file"
+    );
+
+    let corrupt = fixture.directory.join("corrupt.db");
+    fs::write(&corrupt, b"not a SQLite database").unwrap();
+    let error = Storage::open(&corrupt)
+        .err()
+        .expect("corrupt data must fail");
+    assert_eq!(error.code, StorageErrorCode::Corrupt);
+    assert_eq!(fs::read(corrupt).unwrap(), b"not a SQLite database");
+}
+
+#[test]
+fn concurrent_openers_commit_each_migration_only_once() {
+    let fixture = Fixture::new();
+    // Establish WAL independently without applying any migration. This tests
+    // migration convergence, not SQLite's separate journal-mode transition.
+    fs::create_dir(fixture.database.parent().unwrap()).unwrap();
+    let initial = Connection::open(&fixture.database).unwrap();
+    initial.pragma_update(None, "journal_mode", "WAL").unwrap();
+    initial.close().unwrap();
+    for result in concurrent_opens(&fixture) {
+        assert_eq!(result.unwrap(), 8);
+    }
+    assert_complete_history(&fixture);
+}
+
+#[test]
+fn cold_open_race_only_returns_success_or_retryable_contention() {
+    let fixture = Fixture::new();
+    let mut successful = 0;
+    for result in concurrent_opens(&fixture) {
+        match result {
+            Ok(version) => {
+                assert_eq!(version, 8);
+                successful += 1;
+            }
+            Err(error) => {
+                // Like the TypeScript lifecycle adapter, no retry policy is
+                // hidden here. SQLite may skip its busy handler during a
+                // competing journal-mode transition to avoid deadlock.
+                assert_eq!(error.code, StorageErrorCode::Busy);
+                assert!(error.retryable);
+            }
+        }
+    }
+    assert!(successful > 0);
+    let mut recovered = Storage::open(&fixture.database).unwrap();
+    assert_eq!(recovered.health().unwrap().schema_version, 8);
+    recovered.close().unwrap();
+    assert_complete_history(&fixture);
+}
+
+fn concurrent_opens(fixture: &Fixture) -> Vec<Result<u32, StorageError>> {
+    let barrier = std::sync::Barrier::new(4);
+    std::thread::scope(|scope| {
+        let handles = (0..4)
+            .map(|_| {
+                scope.spawn(|| {
+                    barrier.wait();
+                    let mut storage = Storage::open(&fixture.database)?;
+                    let health = storage.health()?;
+                    storage.close()?;
+                    Ok::<_, StorageError>(health.schema_version)
+                })
+            })
+            .collect::<Vec<_>>();
+        // Scoped threads are joined before fixture cleanup even after a panic.
+        let results = handles
+            .into_iter()
+            .map(|handle| handle.join())
+            .collect::<Vec<_>>();
+        results.into_iter().map(Result::unwrap).collect()
+    })
+}
+
+fn assert_complete_history(fixture: &Fixture) {
+    let verification = Connection::open(&fixture.database).unwrap();
+    let count: i64 = verification
+        .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 8);
+    let check: String = verification
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(check, "ok");
+}

--- a/test/native/storage-fixture.ts
+++ b/test/native/storage-fixture.ts
@@ -1,0 +1,451 @@
+import Database from 'better-sqlite3';
+import path from 'node:path';
+import { openStorageWithMigrations } from '../../src/storage/sqlite-adapter.js';
+import { CURRENT_MIGRATIONS } from '../../src/storage/migrations.js';
+
+export const FIXTURE_IDENTITY_ID = 'identity-known';
+export const FIXTURE_MISSING_IDENTITY_ID = 'identity-missing';
+export const FIXTURE_ATTEMPT_COUNT = 205;
+export const FIXTURE_PREPARED_AT_MS = 1_700_000_000_000;
+export const FIXTURE_SATURATION_AT_MS = Number.MAX_SAFE_INTEGER - 1;
+export const FIXTURE_FINAL_REQUEST_ID = 'request-final';
+export const FIXTURE_FINAL_BODY = 'fixture final response';
+
+const FIXTURE_SOCKET_PATH = '/tmp/tmt-fixture.sock';
+const FIXTURE_SERVER_ID = 'fixture-server';
+const FIXTURE_SERVER_START_TIME = 'fixture-server-start';
+const FIXTURE_SERVER_PID = 101;
+const FIXTURE_PANE_ID = '%7';
+const FIXTURE_PANE_PID = 202;
+const FIXTURE_RETENTION_EXPIRES_AT_MS = 1_700_604_800_000;
+const FIXTURE_FINAL_SUBMITTED_AT_MS = 1_700_000_000_200;
+const FIXTURE_FINAL_EXPIRES_AT_MS = 1_700_604_800_200;
+
+type FixtureVersion = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+interface FixtureAttempt {
+  readonly attemptId: string;
+  readonly requestId: string;
+  readonly identityId: string | null;
+  readonly originatorKind: 'unknown' | 'explicit' | 'verified';
+  readonly originatorIdentityId: string | null;
+  readonly recipientIdentityId: string | null;
+  readonly preparedAtMs: number;
+  readonly status: 'prepared' | 'sending' | 'sent' | 'uncertain';
+  readonly waitActive: number;
+  readonly preambleEvery: number | null;
+  readonly injectPreamble: number;
+  readonly cadenceReserved: number;
+  readonly messageText: string | null;
+  readonly messageBytes: number | null;
+  readonly messageExpiresAtMs: number | null;
+  readonly attentionRevision: number;
+}
+
+export interface StorageSnapshot {
+  readonly migrations: readonly MigrationSnapshot[];
+  readonly tables: readonly TableSnapshot[];
+}
+
+interface MigrationSnapshot {
+  readonly version: number;
+  readonly name: string;
+}
+
+interface TableSnapshot {
+  readonly name: string;
+  readonly columns: readonly Record<string, unknown>[];
+  readonly indexes: readonly IndexSnapshot[];
+  readonly foreignKeys: readonly Record<string, unknown>[];
+  readonly rows: readonly Record<string, unknown>[];
+}
+
+interface IndexSnapshot {
+  readonly name: string;
+  readonly columns: readonly Record<string, unknown>[];
+  readonly unique: number;
+  readonly origin: string;
+  readonly partial: number;
+}
+
+const PRIMARY_KEY_ORDER: Record<string, readonly string[]> = {
+  _migrations: ['version'],
+  bindings: ['id'],
+  identities: ['id'],
+  identity_preambles: ['identity_id'],
+  preamble_counters: ['identity_id'],
+  request_attempts: ['attempt_id'],
+  request_attention_identities: ['identity_id'],
+  request_responses: ['request_id'],
+  role_profiles: ['identity_id'],
+};
+
+function location(file: string): { globalDir: string; databaseFile: string } {
+  return { globalDir: path.dirname(file), databaseFile: file };
+}
+
+function fixtureVersion(version: number): FixtureVersion {
+  if (!Number.isInteger(version) || version < 0 || version > 8) {
+    throw new Error('Fixture migration version must be between 0 and 8.');
+  }
+  return version as FixtureVersion;
+}
+
+function openPrefix(file: string, version: FixtureVersion): void {
+  const storage = openStorageWithMigrations(location(file), CURRENT_MIGRATIONS.slice(0, version));
+  try {
+    storage.checkpoint('passive');
+  } finally {
+    storage.close();
+  }
+}
+
+function makeAttempts(version: FixtureVersion): FixtureAttempt[] {
+  const attempts: FixtureAttempt[] = [];
+  for (let index = 0; index < FIXTURE_ATTEMPT_COUNT; index += 1) {
+    const attemptId = index === 0 ? '' : `attempt-${String(index).padStart(3, '0')}`;
+    const group = index % 3;
+    const originatorIdentityId =
+      version >= 7
+        ? group === 0
+          ? FIXTURE_IDENTITY_ID
+          : group === 1
+            ? FIXTURE_MISSING_IDENTITY_ID
+            : null
+        : null;
+    const originatorKind =
+      version >= 7 ? (group === 0 ? 'explicit' : group === 1 ? 'verified' : 'unknown') : 'unknown';
+    const preparedAtMs = index === 0 ? FIXTURE_SATURATION_AT_MS : FIXTURE_PREPARED_AT_MS + index;
+    const status = (['prepared', 'sending', 'sent', 'uncertain'] as const)[index % 4]!;
+    const messageText = version >= 7 && group !== 2 ? `prompt-${group}` : null;
+    attempts.push({
+      attemptId,
+      requestId:
+        index === 1 ? FIXTURE_FINAL_REQUEST_ID : `request-${String(index).padStart(3, '0')}`,
+      identityId: version >= 4 && group === 0 ? FIXTURE_IDENTITY_ID : null,
+      originatorKind,
+      originatorIdentityId,
+      recipientIdentityId: version >= 7 && group === 0 ? FIXTURE_IDENTITY_ID : null,
+      preparedAtMs,
+      status,
+      waitActive: status === 'prepared' || status === 'sending' ? 1 : 0,
+      preambleEvery: version >= 4 && group === 0 ? 3 : null,
+      injectPreamble: version >= 4 && group === 0 ? 1 : 0,
+      cadenceReserved: version >= 4 && group === 0 ? 1 : 0,
+      messageText,
+      messageBytes: messageText === null ? null : Buffer.byteLength(messageText),
+      messageExpiresAtMs: messageText === null ? null : FIXTURE_RETENTION_EXPIRES_AT_MS,
+      attentionRevision: 0,
+    });
+  }
+  const groupCounts = new Map<string, number>();
+  for (const attempt of [...attempts].sort(
+    (left, right) =>
+      left.preparedAtMs - right.preparedAtMs || left.requestId.localeCompare(right.requestId)
+  )) {
+    if (attempt.originatorIdentityId === null) continue;
+    const revision = (groupCounts.get(attempt.originatorIdentityId) ?? 0) + 1;
+    groupCounts.set(attempt.originatorIdentityId, revision);
+    const index = attempts.indexOf(attempt);
+    attempts[index] = { ...attempt, attentionRevision: revision };
+  }
+  return attempts;
+}
+
+function seedRows(database: Database.Database, version: FixtureVersion): void {
+  if (version >= 1) {
+    database
+      .prepare(
+        `INSERT INTO identities (id, name, canonical_name, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .run(
+        FIXTURE_IDENTITY_ID,
+        'Known Fixture',
+        'known-fixture',
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-02T00:00:00.000Z'
+      );
+    database
+      .prepare(
+        `INSERT INTO bindings (
+           id, identity_id, transport, pane_id, server_id, socket_path, server_pid,
+           server_start_time, pane_pid, bound_at, last_verified_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        'binding-known',
+        FIXTURE_IDENTITY_ID,
+        'tmux',
+        FIXTURE_PANE_ID,
+        FIXTURE_SERVER_ID,
+        FIXTURE_SOCKET_PATH,
+        FIXTURE_SERVER_PID,
+        FIXTURE_SERVER_START_TIME,
+        FIXTURE_PANE_PID,
+        '2026-01-02T00:00:00.000Z',
+        '2026-01-02T00:00:01.000Z'
+      );
+  }
+  if (version >= 2) {
+    database
+      .prepare('INSERT INTO role_profiles (identity_id, content, updated_at) VALUES (?, ?, ?)')
+      .run(FIXTURE_IDENTITY_ID, 'fixture role profile', '2026-01-02T00:00:02.000Z');
+  }
+  if (version >= 3) {
+    database
+      .prepare('INSERT INTO identity_preambles (identity_id, content, updated_at) VALUES (?, ?, ?)')
+      .run(FIXTURE_IDENTITY_ID, 'fixture preamble', '2026-01-02T00:00:03.000Z');
+  }
+  if (version < 4) return;
+
+  database
+    .prepare(
+      'INSERT INTO preamble_counters (identity_id, reserved_count, updated_at_ms) VALUES (?, ?, ?)'
+    )
+    .run(FIXTURE_IDENTITY_ID, 7, FIXTURE_PREPARED_AT_MS);
+
+  const attempts = makeAttempts(version);
+  const attemptColumns = [
+    'attempt_id',
+    'request_id',
+    'nonce',
+    'identity_id',
+    'server_id',
+    'socket_path',
+    'server_pid',
+    'server_start_time',
+    'pane_id',
+    'pane_pid',
+    'wait_active',
+    'status',
+    'preamble_every',
+    'inject_preamble',
+    'cadence_reserved',
+    'prepared_at_ms',
+    'sending_at_ms',
+    'settled_at_ms',
+    'wait_released_at_ms',
+    ...(version >= 5 ? ['response_submitted_at_ms'] : []),
+    'expires_at_ms',
+    ...(version >= 6 ? ['retention_days', 'retention_expires_at_ms'] : []),
+    ...(version >= 7
+      ? [
+          'originator_kind',
+          'originator_identity_id',
+          'recipient_identity_id',
+          'message_text',
+          'message_bytes',
+          'message_expires_at_ms',
+        ]
+      : []),
+    ...(version >= 8 ? ['attention_revision', 'attention_acknowledged_revision'] : []),
+  ];
+  const insertAttempt = database.prepare(
+    `INSERT INTO request_attempts (${attemptColumns.join(', ')})
+     VALUES (${attemptColumns.map(() => '?').join(', ')})`
+  );
+  const seedAttempt = (attempt: FixtureAttempt): void => {
+    const saturationAnchor = attempt.attemptId === '';
+    const settledAtMs = saturationAnchor
+      ? null
+      : attempt.status === 'sent' || attempt.status === 'uncertain'
+        ? attempt.preparedAtMs + 2
+        : null;
+    const responseSubmittedAtMs = version >= 5 ? responseSubmittedAtFor(attempt) : null;
+    insertAttempt.run(
+      attempt.attemptId,
+      attempt.requestId,
+      `nonce-${attempt.requestId}`,
+      attempt.identityId,
+      FIXTURE_SERVER_ID,
+      FIXTURE_SOCKET_PATH,
+      FIXTURE_SERVER_PID,
+      FIXTURE_SERVER_START_TIME,
+      FIXTURE_PANE_ID,
+      FIXTURE_PANE_PID,
+      attempt.waitActive,
+      attempt.status,
+      attempt.preambleEvery,
+      attempt.injectPreamble,
+      attempt.cadenceReserved,
+      attempt.preparedAtMs,
+      attempt.status === 'prepared' ? null : attempt.preparedAtMs + 1,
+      settledAtMs,
+      attempt.status === 'sent' ? attempt.preparedAtMs + 3 : null,
+      ...(version >= 5 ? [responseSubmittedAtMs] : []),
+      saturationAnchor ? FIXTURE_SATURATION_AT_MS : attempt.preparedAtMs + 3_600_000,
+      ...(version >= 6
+        ? [7, saturationAnchor ? Number.MAX_SAFE_INTEGER : FIXTURE_RETENTION_EXPIRES_AT_MS]
+        : []),
+      ...(version >= 7
+        ? [
+            attempt.originatorKind,
+            attempt.originatorIdentityId,
+            attempt.recipientIdentityId,
+            attempt.messageText,
+            attempt.messageBytes,
+            attempt.messageExpiresAtMs,
+          ]
+        : []),
+      ...(version >= 8 ? [attempt.attentionRevision, attempt.attentionRevision === 1 ? 1 : 0] : [])
+    );
+  };
+  database.transaction(() => {
+    for (const attempt of attempts) seedAttempt(attempt);
+  })();
+
+  if (version >= 5) {
+    const insertResponse = database.prepare(
+      `INSERT INTO request_responses (
+         request_id, attempt_id, server_id, socket_path, server_pid, server_start_time,
+         pane_id, pane_pid, body, body_bytes, submitted_at_ms
+         ${version >= 6 ? ', response_expires_at_ms' : ''}
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?${version >= 6 ? ', ?' : ''})`
+    );
+    database.transaction(() => {
+      for (const attempt of attempts) {
+        const body = responseBodyFor(attempt);
+        insertResponse.run(
+          attempt.requestId,
+          attempt.attemptId,
+          FIXTURE_SERVER_ID,
+          FIXTURE_SOCKET_PATH,
+          FIXTURE_SERVER_PID,
+          FIXTURE_SERVER_START_TIME,
+          FIXTURE_PANE_ID,
+          FIXTURE_PANE_PID,
+          body,
+          Buffer.byteLength(body),
+          responseSubmittedAtFor(attempt),
+          ...(version >= 6 ? [responseExpiresAtFor(attempt)] : [])
+        );
+      }
+    })();
+  }
+  if (version >= 8) {
+    database
+      .prepare(
+        `INSERT INTO request_attention_identities
+           (identity_id, latest_revision, acknowledged_through)
+         VALUES (?, ?, ?), (?, ?, ?)`
+      )
+      .run(
+        FIXTURE_IDENTITY_ID,
+        attempts.filter((attempt) => attempt.originatorIdentityId === FIXTURE_IDENTITY_ID).length,
+        1,
+        FIXTURE_MISSING_IDENTITY_ID,
+        attempts.filter((attempt) => attempt.originatorIdentityId === FIXTURE_MISSING_IDENTITY_ID)
+          .length,
+        0
+      );
+  }
+}
+
+function responseSubmittedAtFor(attempt: FixtureAttempt): number {
+  if (attempt.attemptId === '') return FIXTURE_SATURATION_AT_MS;
+  if (attempt.requestId === FIXTURE_FINAL_REQUEST_ID) return FIXTURE_FINAL_SUBMITTED_AT_MS;
+  return FIXTURE_FINAL_SUBMITTED_AT_MS + Number(attempt.requestId.replace('request-', ''));
+}
+
+function responseBodyFor(attempt: FixtureAttempt): string {
+  return attempt.requestId === FIXTURE_FINAL_REQUEST_ID
+    ? FIXTURE_FINAL_BODY
+    : `fixture response ${attempt.requestId}`;
+}
+
+function responseExpiresAtFor(attempt: FixtureAttempt): number {
+  if (attempt.attemptId === '') return Number.MAX_SAFE_INTEGER;
+  if (attempt.requestId === FIXTURE_FINAL_REQUEST_ID) return FIXTURE_FINAL_EXPIRES_AT_MS;
+  return FIXTURE_FINAL_EXPIRES_AT_MS + Number(attempt.requestId.replace('request-', ''));
+}
+
+/** Create a closed SQLite database at a TypeScript migration prefix. */
+export function seedStoragePrefix(file: string, version: number): void {
+  const prefix = fixtureVersion(version);
+  openPrefix(file, prefix);
+  let database: Database.Database | undefined;
+  try {
+    database = new Database(file);
+    database.pragma('foreign_keys = ON');
+    seedRows(database, prefix);
+  } finally {
+    database?.close();
+  }
+  openPrefix(file, prefix);
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function orderedRows(
+  database: Database.Database,
+  table: string,
+  columns: readonly Record<string, unknown>[]
+): Record<string, unknown>[] {
+  const order = PRIMARY_KEY_ORDER[table] ?? columns.map((column) => String(column.name));
+  const orderBy = order.map((column) => quoteIdentifier(column)).join(', ');
+  const rows = database
+    .prepare(`SELECT * FROM ${quoteIdentifier(table)} ORDER BY ${orderBy}`)
+    .all() as Record<string, unknown>[];
+  return rows.map((row) => {
+    if (table !== '_migrations') return row;
+    const { applied_at: _appliedAt, ...migration } = row;
+    return migration;
+  });
+}
+
+/** Read SQLite structure and rows without comparing sqlite_schema SQL text. */
+export function storageSnapshot(file: string): StorageSnapshot {
+  const database = new Database(file, { readonly: true });
+  try {
+    const migrations = database
+      .prepare('SELECT version, name FROM _migrations ORDER BY version')
+      .all() as MigrationSnapshot[];
+    const tables: TableSnapshot[] = [];
+    const tableNames = database
+      .prepare(
+        "SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT GLOB 'sqlite_*' ORDER BY name"
+      )
+      .all() as Array<{ name: string }>;
+    for (const { name: table } of tableNames) {
+      const columns = database.pragma(`table_info(${quoteIdentifier(table)})`) as Record<
+        string,
+        unknown
+      >[];
+      const indexRows = database.pragma(`index_list(${quoteIdentifier(table)})`) as Array<{
+        name: string;
+        unique: number;
+        origin: string;
+        partial: number;
+      }>;
+      const indexes = indexRows
+        .map((index) => ({
+          name: index.name,
+          unique: index.unique,
+          origin: index.origin,
+          partial: index.partial,
+          columns: database.pragma(`index_xinfo(${quoteIdentifier(index.name)})`) as Record<
+            string,
+            unknown
+          >[],
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name));
+      const foreignKeys = database.pragma(`foreign_key_list(${quoteIdentifier(table)})`) as Record<
+        string,
+        unknown
+      >[];
+      tables.push({
+        name: table,
+        columns,
+        indexes,
+        foreignKeys,
+        rows: orderedRows(database, table, columns),
+      });
+    }
+    return { migrations, tables };
+  } finally {
+    database.close();
+  }
+}

--- a/test/native/storage.test.ts
+++ b/test/native/storage.test.ts
@@ -1,0 +1,369 @@
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { openStorage } from '../../src/storage/sqlite-adapter.js';
+import { resolveCliExecutables } from '../../src/test-support/cli-executable.mjs';
+import {
+  expectError,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+  type Sandbox,
+} from '../../src/test-support/cli-process.js';
+import {
+  FIXTURE_ATTEMPT_COUNT,
+  FIXTURE_FINAL_BODY,
+  FIXTURE_FINAL_REQUEST_ID,
+  FIXTURE_IDENTITY_ID,
+  seedStoragePrefix,
+  storageSnapshot,
+} from './storage-fixture.js';
+
+// A development-only executable, never a hidden SQL command in the installed CLI.
+if (!process.env.TMT_TEST_STORAGE_PROBE) {
+  throw new Error('Select the native storage probe with TMT_TEST_STORAGE_PROBE.');
+}
+const { cli: probe } = resolveCliExecutables({
+  TMT_TEST_CLI: process.env.TMT_TEST_STORAGE_PROBE,
+});
+
+function runStorage(sandbox: Sandbox, file = sandbox.database) {
+  return runCli({ ...sandbox, cli: probe }, [file], { deadlineMs: 10_000 });
+}
+
+function upgradeWithTypeScript(file: string): void {
+  const storage = openStorage(file);
+  try {
+    expect(storage.health().schemaVersion).toBe(8);
+  } finally {
+    storage.close();
+  }
+}
+
+function migrationTimestamps(file: string): string[] {
+  const database = new Database(file, { readonly: true });
+  try {
+    return database
+      .prepare('SELECT applied_at FROM _migrations ORDER BY version')
+      .pluck()
+      .all() as string[];
+  } finally {
+    database.close();
+  }
+}
+
+describe('native SQLite lifecycle compatibility', () => {
+  it.each(Array.from({ length: 9 }, (_, version) => version))(
+    'upgrades closed TypeScript schema %i without changing schema or durable semantics',
+    async (version) => {
+      await withSandbox(async (sandbox) => {
+        const reference = path.join(sandbox.root, 'reference', 'state.db');
+        seedStoragePrefix(reference, version);
+        seedStoragePrefix(sandbox.database, version);
+        const originalTimestamps = migrationTimestamps(sandbox.database);
+        upgradeWithTypeScript(reference);
+
+        const result = await runStorage(sandbox);
+        expect(result.status).toBe(0);
+        expect(parseWholeStdout(result)).toEqual({
+          path: sandbox.database,
+          open: true,
+          schemaVersion: 8,
+          journalMode: 'wal',
+          foreignKeys: true,
+          busyTimeoutMs: 5000,
+          synchronous: 'normal',
+          fts5: true,
+        });
+        const migrated = storageSnapshot(sandbox.database);
+        expect(migrated).toEqual(storageSnapshot(reference));
+        if (version >= 5) {
+          const responses = migrated.tables.find(
+            (table) => table.name === 'request_responses'
+          )!.rows;
+          expect(responses).toHaveLength(FIXTURE_ATTEMPT_COUNT);
+          expect(
+            responses.find((row) => row.request_id === FIXTURE_FINAL_REQUEST_ID)
+          ).toMatchObject({
+            body: FIXTURE_FINAL_BODY,
+            body_bytes: Buffer.byteLength(FIXTURE_FINAL_BODY),
+            response_expires_at_ms: 1_700_604_800_200,
+          });
+          expect(responses.find((row) => row.attempt_id === '')).toHaveProperty(
+            'response_expires_at_ms',
+            Number.MAX_SAFE_INTEGER
+          );
+        }
+        if (version === 7) {
+          const attempts = migrated.tables.find((table) => table.name === 'request_attempts')!.rows;
+          expect(attempts.find((row) => row.attempt_id === '')).toMatchObject({
+            originator_identity_id: FIXTURE_IDENTITY_ID,
+            attention_revision: 69,
+            attention_acknowledged_revision: 0,
+          });
+          expect(attempts.find((row) => row.attempt_id === 'attempt-003')).toHaveProperty(
+            'attention_revision',
+            1
+          );
+        }
+        const timestamps = migrationTimestamps(sandbox.database);
+        expect(timestamps).toHaveLength(8);
+        expect(timestamps.slice(0, version)).toEqual(originalTimestamps);
+        for (const timestamp of timestamps) {
+          expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+        }
+        // Reverse compatibility and repeated opens must preserve finals and attention.
+        upgradeWithTypeScript(sandbox.database);
+        expect((await runStorage(sandbox)).status).toBe(0);
+        expect(storageSnapshot(sandbox.database)).toEqual(migrated);
+        expect(migrationTimestamps(sandbox.database)).toEqual(timestamps);
+      });
+    }
+  );
+
+  it('lets TypeScript reopen and write a database created only by Rust', async () => {
+    await withSandbox(async (sandbox) => {
+      expect((await runStorage(sandbox)).status).toBe(0);
+      upgradeWithTypeScript(sandbox.database);
+      const writer = new Database(sandbox.database);
+      try {
+        writer
+          .prepare('INSERT INTO identities VALUES (?, ?, ?, ?, ?)')
+          .run('roundtrip-id', 'Roundtrip', 'roundtrip', 'created', 'updated');
+      } finally {
+        writer.close();
+      }
+      const before = storageSnapshot(sandbox.database);
+      expect((await runStorage(sandbox)).status).toBe(0);
+      expect(storageSnapshot(sandbox.database)).toEqual(before);
+    });
+  });
+
+  it('converges concurrent native processes on an existing historical WAL database', async () => {
+    await withSandbox(async (sandbox) => {
+      const reference = path.join(sandbox.root, 'reference', 'state.db');
+      seedStoragePrefix(reference, 4);
+      seedStoragePrefix(sandbox.database, 4);
+      upgradeWithTypeScript(reference);
+      // Wait for every bounded child before the sandbox can be removed, even
+      // when an individual launch fails. No child may escape failed assertions.
+      const results = await Promise.allSettled(
+        Array.from({ length: 4 }, () => runStorage(sandbox))
+      );
+      for (const result of results) {
+        expect(result.status).toBe('fulfilled');
+        if (result.status === 'fulfilled') {
+          expect(result.value.status, result.value.stdout).toBe(0);
+          expect(parseWholeStdout(result.value).schemaVersion).toBe(8);
+        }
+      }
+      expect(storageSnapshot(sandbox.database)).toEqual(storageSnapshot(reference));
+    });
+  });
+
+  it('enforces schema constraints and preserves exchange rows when an identity is removed', async () => {
+    await withSandbox(async (sandbox) => {
+      expect((await runStorage(sandbox)).status).toBe(0);
+      const database = new Database(sandbox.database);
+      try {
+        database.pragma('foreign_keys = ON');
+        database.exec(
+          "INSERT INTO identities VALUES ('id', 'Alice', 'alice', 'created', 'updated')"
+        );
+        expect(() =>
+          database.exec(
+            "INSERT INTO identities VALUES ('other', 'ALICE', 'alice', 'created', 'updated')"
+          )
+        ).toThrow(/UNIQUE/);
+        expect(() =>
+          database.exec("INSERT INTO role_profiles VALUES ('missing', 'body', 'updated')")
+        ).toThrow(/FOREIGN KEY/);
+        expect(() => database.exec("INSERT INTO preamble_counters VALUES ('id', -1, 1)")).toThrow(
+          /CHECK/
+        );
+        expect(() =>
+          database.exec("INSERT INTO request_attention_identities VALUES ('id', 1, 2)")
+        ).toThrow(/CHECK/);
+        expect(() =>
+          database.exec(
+            "INSERT INTO request_attention_identities VALUES ('id', 9007199254740992, 0)"
+          )
+        ).toThrow(/CHECK/);
+        database.exec(`
+          INSERT INTO role_profiles VALUES ('id', 'body', 'updated');
+          INSERT INTO request_attempts (
+            attempt_id, request_id, identity_id, server_id, socket_path, server_pid,
+            server_start_time, pane_id, pane_pid, wait_active, status,
+            inject_preamble, cadence_reserved, prepared_at_ms, expires_at_ms,
+            originator_kind, originator_identity_id, attention_revision
+          ) VALUES ('attempt', 'request', 'id', 'server', '/socket', 1, 'start', '%1',
+            2, 0, 'sent', 0, 0, 1, 2, 'explicit', 'id', 1);
+          INSERT INTO request_responses (
+            request_id, attempt_id, server_id, socket_path, server_pid, server_start_time,
+            pane_id, pane_pid, body, body_bytes, submitted_at_ms
+          ) VALUES ('request', 'attempt', 'server', '/socket', 1, 'start', '%1', 2, 'done', 4, 2);
+          INSERT INTO request_attention_identities VALUES ('id', 1, 0);
+          DELETE FROM identities WHERE id = 'id';
+        `);
+        expect(database.prepare('SELECT * FROM role_profiles').all()).toEqual([]);
+        expect(
+          database
+            .prepare(
+              'SELECT identity_id, originator_identity_id, attention_revision FROM request_attempts'
+            )
+            .get()
+        ).toEqual({
+          identity_id: null,
+          originator_identity_id: 'id',
+          attention_revision: 1,
+        });
+        expect(database.prepare('SELECT body, body_bytes FROM request_responses').get()).toEqual({
+          body: 'done',
+          body_bytes: 4,
+        });
+        expect(database.prepare('SELECT * FROM request_attention_identities').get()).toEqual({
+          identity_id: 'id',
+          latest_revision: 1,
+          acknowledged_through: 0,
+        });
+      } finally {
+        database.close();
+      }
+      upgradeWithTypeScript(sandbox.database);
+    });
+  });
+
+  it('rejects a malformed history table without replacing it', async () => {
+    await withSandbox(async (sandbox) => {
+      seedStoragePrefix(sandbox.database, 0);
+      const writer = new Database(sandbox.database);
+      try {
+        writer.exec(
+          'DROP TABLE _migrations; CREATE TABLE _migrations (version TEXT PRIMARY KEY, label TEXT NOT NULL)'
+        );
+      } finally {
+        writer.close();
+      }
+      const result = await runStorage(sandbox);
+      expect(result.status).toBe(1);
+      expectError(result, 'incompatible-schema');
+      const verification = new Database(sandbox.database, { readonly: true });
+      try {
+        expect(verification.pragma('table_info(_migrations)')).toMatchObject([
+          { name: 'version', type: 'TEXT' },
+          { name: 'label', type: 'TEXT' },
+        ]);
+        expect(verification.prepare('SELECT * FROM _migrations').all()).toEqual([]);
+        expect(
+          verification.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all()
+        ).toEqual([{ name: '_migrations' }]);
+      } finally {
+        verification.close();
+      }
+    });
+  });
+
+  it('does not guess migration history for existing domain tables', async () => {
+    await withSandbox(async (sandbox) => {
+      seedStoragePrefix(sandbox.database, 8);
+      const writer = new Database(sandbox.database);
+      let identities: unknown;
+      let responses: unknown;
+      try {
+        identities = writer.prepare('SELECT * FROM identities ORDER BY id').all();
+        responses = writer.prepare('SELECT * FROM request_responses ORDER BY request_id').all();
+        writer.exec('DROP TABLE _migrations');
+      } finally {
+        writer.close();
+      }
+      const result = await runStorage(sandbox);
+      expect(result.status).toBe(1);
+      expect(expectError(result, 'migration').error).toMatchObject({ migrationVersion: 1 });
+      const verification = new Database(sandbox.database, { readonly: true });
+      try {
+        expect(verification.prepare('SELECT * FROM identities ORDER BY id').all()).toEqual(
+          identities
+        );
+        expect(
+          verification.prepare('SELECT * FROM request_responses ORDER BY request_id').all()
+        ).toEqual(responses);
+        // As in TypeScript, history-table initialization may commit, but no
+        // version can be fabricated to repair an unsupported existing schema.
+        expect(verification.prepare('SELECT * FROM _migrations').all()).toEqual([]);
+      } finally {
+        verification.close();
+      }
+    });
+  });
+
+  it.each(['renamed', 'gap', 'future'])(
+    'rejects %s migration history without resetting or rewriting data',
+    async (kind) => {
+      await withSandbox(async (sandbox) => {
+        seedStoragePrefix(sandbox.database, 8);
+        const writer = new Database(sandbox.database);
+        try {
+          if (kind === 'renamed')
+            writer.exec("UPDATE _migrations SET name = 'unknown' WHERE version = 2");
+          else if (kind === 'gap') writer.exec('DELETE FROM _migrations WHERE version = 2');
+          else writer.exec("INSERT INTO _migrations VALUES (9, 'future', 'timestamp')");
+        } finally {
+          writer.close();
+        }
+        const before = storageSnapshot(sandbox.database);
+        const result = await runStorage(sandbox);
+        expect(result.status).toBe(1);
+        expectError(result, 'incompatible-schema');
+        expect(storageSnapshot(sandbox.database)).toEqual(before);
+      });
+    }
+  );
+
+  it('rolls back migration 6 on an invalid historical anchor and recovers after explicit repair', async () => {
+    await withSandbox(async (sandbox) => {
+      seedStoragePrefix(sandbox.database, 5);
+      const writer = new Database(sandbox.database);
+      try {
+        writer.exec('UPDATE request_attempts SET prepared_at_ms = 0');
+      } finally {
+        writer.close();
+      }
+      const before = storageSnapshot(sandbox.database);
+      const result = await runStorage(sandbox);
+      expect(result.status).toBe(1);
+      expect(expectError(result, 'migration').error).toMatchObject({
+        migrationVersion: 6,
+        retryable: false,
+      });
+      expect(storageSnapshot(sandbox.database)).toEqual(before);
+      const repair = new Database(sandbox.database);
+      try {
+        repair.exec('UPDATE request_attempts SET prepared_at_ms = 1700000000000');
+      } finally {
+        repair.close();
+      }
+      expect((await runStorage(sandbox)).status).toBe(0);
+      upgradeWithTypeScript(sandbox.database);
+    });
+  });
+
+  it('reports bounded writer contention and leaves storage usable after lock release', async () => {
+    await withSandbox(async (sandbox) => {
+      seedStoragePrefix(sandbox.database, 8);
+      const before = storageSnapshot(sandbox.database);
+      const writer = new Database(sandbox.database);
+      try {
+        writer.exec('BEGIN IMMEDIATE');
+        const result = await runStorage(sandbox);
+        expect(result.status).toBe(1);
+        expect(expectError(result, 'busy').error).toMatchObject({ retryable: true });
+      } finally {
+        if (writer.inTransaction) writer.exec('ROLLBACK');
+        writer.close();
+      }
+      expect(storageSnapshot(sandbox.database)).toEqual(before);
+      expect((await runStorage(sandbox)).status).toBe(0);
+      expect(storageSnapshot(sandbox.database)).toEqual(before);
+    });
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

Closes #97. Part of #93; #100 identity lifetime/workspace changes remain separate.

- Add the concrete `tmt-adapters` SQLite lifecycle with a single private synchronous connection, bundled rusqlite, classified errors, private files, verified pragmas/FTS5 and fallible cleanup.
- Preserve schema 8 and historical migrations 1–8, including immediate writer transactions, history rechecks, migration rollback, bounded migration-6 backfill and safe-integer saturation.
- Add a development-only lifecycle probe and independent TypeScript/native fixture matrix, reusing the existing bounded process selector. The probe is not installed and exposes no SQL/reset/fault command.
- Extend the existing native CI job and rename the development suite to `pnpm test:native`; maintain code-quality dependency gating. Update architecture and verification guidance.

The npm runtime still uses TypeScript. Native feature commands still explicitly reject unimplemented effects. This does not claim native identity/request parity, a cutover, or release readiness.

## Primary architectural review

Reviewed head: `6ff5da883af4d03c9a824aa01a2465efa43f79f5`.

Personally reviewed the complete adapter, all nine historical SQL resources against the TypeScript migrations, lifecycle/error/cleanup implementation, development probe, fixture builder, every process-test assertion, Cargo graph, CI changes and affected documentation. Core remains independent of concrete IO; raw SQLite handles remain private; no command-owned connection, generic manager, retry loop or parallel persistence authority was introduced. An independent read-only review also found no actionable defect after the documented corrections.

Findings and disposition:

- The initial cold-open test incorrectly required every low-level WAL initializer to succeed. The same race was reproduced in TypeScript. Separate tests now require established-WAL migration convergence and permit only retryable busy on competing cold initialization, with successful recovery, exact migration accounting and integrity checks. No production policy was changed to satisfy the test.
- Expanded fixture finals to 205 rows so both migration-6 pagination loops are exercised, retained historical cadence foreign keys, and added explicit saturation/body/attention assertions.
- Changed the SQL oracle from a known-table allowlist to actual table discovery, preventing extra tables from being silently ignored. Checked original migration timestamps separately rather than normalizing away rewrites.
- Real active-transaction checkpoint failure proves close still rolls back and releases the writer; explicit constraints verify profile cascading cannot erase exchange/provenance/attention data.

## Local verification

- `cargo fmt --all --check`: passed.
- `cargo clippy --locked --all-targets -- -D warnings`: passed.
- Locked Rust tests on 1.97.0 and MSRV 1.88.0: 29 passed each; locked native/probe builds passed.
- Native adapter lifecycle/concurrency suite repeated 20 times: all passed.
- `pnpm test:native` with explicit native CLI/probe descriptors: 24 passed (19 storage, 5 grammar).
- Selected existing public parser contract against native CLI: 8 passed; unrelated feature cases intentionally not selected.
- `pnpm check`: passed.
- `pnpm test:run`: 1,102 passed; statements 95.66%, branches 89.47%, functions 97.55%.
- Full network-isolated Docker suite twice: 104 passed each; one optional benchmark skipped each. Durations 288.55s and 284.15s. These are TypeScript regression runs, not native tmux parity evidence.
- `git diff --check`: passed.

Dependency review: rusqlite 0.40.2 (defaults disabled, bundled only), libsqlite3-sys 0.38.2; added licenses MIT/MIT-or-Apache-2.0; actual locked MSRV build verified. All nine relevant historical RustSec entries have patched ranges covering locked versions at advisory DB revision `5a0ebedfe8bdd2e295b171f4162f8c977bcad9a5`. This dated review is not a permanent security guarantee.

No user tmux, global configuration, installed executable, release tag or published artifact was changed. Merge only after all CI checks pass on this reviewed head; no bypass or reduced checks.
