### PR TITLE
feat(native): implement shared configuration boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         run: |
           pnpm test:native
           pnpm exec vitest run src/cli-contract.test.ts -t 'reports JSON parse errors|rejects ignored options|validates invalid options|keeps JSON leaf|does not treat|keeps a literal|does not reinterpret|rejects JSON mode for text-only'
+          pnpm exec vitest run src/config-cli-contract.test.ts -t 'accepts omitted|accepts safe|keeps unknown|rejects decimal|repairs a targeted|allows zero'
 
   unit-tests:
     name: Unit tests

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -891,10 +891,11 @@ failure semantics; merely introducing an interface is not an architectural fix.
 ### Native grammar preview
 
 `rust/` contains a development-only native CLI under #96; installed entry points
-remain TypeScript. `tmt-core` owns pure numeric limits, while `tmt-cli` owns one
-Clap grammar, typed requests, presentation and explicit no-effects rejection for
-unimplemented commands. `tmt-adapters` owns the schema 8 SQLite lifecycle under
-#97; neither core nor typed requests depend on concrete IO.
+remain TypeScript. `tmt-core` owns numeric and settings policy, while `tmt-cli`
+owns one Clap grammar, typed requests, presentation, configuration composition
+and explicit no-effects rejection for unimplemented commands. `tmt-adapters`
+owns the schema 8 SQLite lifecycle under #97 and configuration files under #103;
+neither core nor typed requests depend on concrete IO.
 
 Help and completion use a filtered projection of the same grammar, excluding
 hidden rejection syntax and unrelated inherited options. Parser errors choose
@@ -930,6 +931,22 @@ public CLI command or alternate storage implementation. Shared bounded subproces
 tests compare closed TypeScript schema-prefix fixtures and independent SQL
 observations, reverse-reopen with TypeScript and exercise failure recovery.
 These tests establish storage compatibility, not native request/identity parity.
+
+The native `config` command uses core-owned typed values, defaults, editing scope
+and local-clear rules. Its filesystem adapter owns global/XDG/legacy and upward
+local-path discovery, JSON container validation, known-setting projection and
+raw edits preserving opaque fields. A targeted repair validates shape, edits
+only the intended field, then validates all remaining known values before write.
+Loaded sources and resolved settings come from the same projection. CLI code
+does not contain a competing settings validator, and core imports no JSON or IO
+library. This shared boundary is available to subsequent native use cases;
+configuration operations never acquire the storage or tmux adapters.
+Precedence and source accounting live in core `ResolvedSettings`, not the file
+adapter. Config decoding alone normalizes arbitrary JSON numbers to the prior
+runtime's IEEE-754/stringification semantics; it never rewrites retained reply
+bodies. Ordered JSON maps minimize edit churn. XDG and derived file paths are
+normalized lexically without requiring discarded components to exist or
+resolving user symlinks.
 
 The [Rust rewrite decision](RUST-REWRITE.md) records the proposed native package
 boundaries, compatibility/test matrix, data coexistence gates and dependency

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,8 @@ pnpm dev -- --help
 ### Native development preview
 
 The `rust/` workspace is not the installed runtime yet. It implements only
-help/version/completion and typed grammar; effectful commands explicitly fail.
+help/version/completion, typed grammar and the existing `config` command.
+Other effectful commands still explicitly fail.
 The separate storage adapter implements schema 8 lifecycle compatibility, tested
 through a development-only probe rather than an installed command.
 Use the exact toolchain from `rust/rust-toolchain.toml` and run from `rust/`:
@@ -69,7 +70,17 @@ existing parser-only public contract subset through the same selection:
 TMT_TEST_CLI='{"executable":"/absolute/checkout/rust/target/debug/tmt","args":[]}' \
   pnpm exec vitest run src/cli-contract.test.ts \
   -t 'reports JSON parse errors|rejects ignored options|validates invalid options|keeps JSON leaf|does not treat|keeps a literal|does not reinterpret|rejects JSON mode for text-only'
+
+TMT_TEST_CLI='{"executable":"/absolute/checkout/rust/target/debug/tmt","args":[]}' \
+  pnpm exec vitest run src/config-cli-contract.test.ts \
+  -t 'accepts omitted|accepts safe|keeps unknown|rejects decimal|repairs a targeted|allows zero'
 ```
+
+The selected config cases exercise the original public CLI contract unchanged.
+Other cases in that file still require native list/reply/result implementations;
+their exclusion is not parity evidence. The native suite separately exercises
+configuration validation through `config show`, path discovery, scoped edits,
+no-op clear and file preservation, without starting SQLite or tmux.
 
 Keep Cargo workspace version synchronized with the package version while both
 runtimes coexist. Check the resolved dependency graph's licenses, MSRVs and

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -1,7 +1,8 @@
 # Rust rewrite preparation
 
-Status: native grammar preview implemented under [#96](https://github.com/wkh237/tmux-team/issues/96),
-not a shipped Rust runtime. Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
+Status: native grammar (#96), schema 8 lifecycle (#97) and configuration (#103)
+are implemented in the development preview, not a shipped Rust runtime.
+Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
 The compatibility reference is TypeScript main `cb53533f3a9f19a1a2ab95af59dda20df419200b`
 (v5.0.0-alpha.1). [ARCHITECTURE.md](ARCHITECTURE.md) remains the current implementation map.
@@ -48,16 +49,40 @@ is by responsibility, not a mechanical copy of every TypeScript file.
 
 ### Implemented native preview
 
-The `rust/` workspace contains `tmt-core` (pure numeric policy),
+The `rust/` workspace contains `tmt-core` (numeric and settings policy),
 `tmt-cli` (grammar, typed invocation translation and output), and `tmt-adapters`
-(schema 8 SQLite lifecycle under #97). The npm entry points still execute TypeScript. No command silently
+(schema 8 SQLite lifecycle under #97 and configuration files under #103). The npm entry points still execute TypeScript. No command silently
 delegates from native to Node.
 
-The preview implements help, version and Bash/Zsh completion. All recognized
-effectful commands return `NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
+The preview implements help, version, Bash/Zsh completion and the existing
+`config` command. Other recognized effectful commands return
+`NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
 storage, tmux or input acquisition. Text-only commands reject JSON. Native
 `name`/`this`/`add` parse temporary defaults and save flags; `rm`/`remove` parse
 explicit force. This is not evidence that native lifecycle operations work.
+
+#103 makes settings an invocation-owned shared boundary rather than a rule set
+inside each CLI handler. Core owns typed defaults, scalar bounds, setting scope
+and clear policy; the adapter discovers existing paths, validates/project raw
+JSON and preserves opaque fields during edits. CLI composition renders reports
+after file operations. Config never opens SQLite or contacts tmux. Targeted
+repair validates container shape before editing, then validates remaining known
+values before writing; it does not pre-load unrelated invalid runtime settings.
+Negative numeric config operands reach semantic validation, while unknown flags
+remain parser errors. No JSON identity registry or new configuration setting is
+introduced by this port.
+
+Configuration decoding enables serde_json's `arbitrary_precision` so valid
+large exponents reach the compatibility boundary, then normalizes numbers to
+the reference runtime's IEEE-754/JSON.stringify semantics (non-finite opaque
+values become null when edited; known invalid fields still fail). This policy
+is config-only, not a global reply/body transformation. `preserve_order` avoids
+reordering ordinary user objects on targeted writes. The added locked graph is
+indexmap 2.14.2, hashbrown 0.17.1 and equivalent 1.0.2, with MIT/Apache-2.0 choices
+and declared MSRVs at or below 1.85. RustSec RUSTSEC-2024-0402 is patched before
+the selected hashbrown version; the other two packages had no entries at the
+recorded advisory revision. Structured CLI JSON contracts do not require byte
+equality of whitespace or numeric spelling between serializers.
 
 One Clap registration tree owns recognition and allowed options. Its public
 projection removes hidden rejection syntax and inherited-but-unrelated options

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -60,6 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +82,22 @@ name = "find-msvc-tools"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "itoa"
@@ -172,6 +194,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -224,6 +247,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "serde_json",
+ "tmt-adapters",
  "tmt-core",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,9 +11,10 @@ publish = false
 
 [workspace.dependencies]
 tmt-core = { path = "crates/tmt-core" }
+tmt-adapters = { path = "crates/tmt-adapters" }
 clap = { version = "=4.6.6", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions", "string"] }
 clap_complete = { version = "=4.6.9", default-features = false }
-serde_json = "=1.0.151"
+serde_json = { version = "=1.0.151", features = ["arbitrary_precision", "preserve_order"] }
 rusqlite = { version = "=0.40.2", default-features = false, features = ["bundled"] }
 
 [workspace.lints.rust]

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -9,8 +9,6 @@ publish.workspace = true
 [dependencies]
 tmt-core.workspace = true
 rusqlite.workspace = true
-
-[dev-dependencies]
 serde_json.workspace = true
 
 [lints]

--- a/rust/crates/tmt-adapters/src/config/document.rs
+++ b/rust/crates/tmt-adapters/src/config/document.rs
@@ -1,0 +1,253 @@
+use serde_json::{Map, Value, json};
+use std::{fs, path::Path};
+use tmt_core::settings::{Scalar, Setting, SettingKey, Settings};
+
+use super::{ConfigError, Scope};
+
+struct Field {
+    key: SettingKey,
+    container: Option<&'static str>,
+    property: &'static str,
+}
+
+const GLOBAL_FIELDS: [Field; 8] = [
+    Field {
+        key: SettingKey::PreambleMode,
+        container: None,
+        property: "preambleMode",
+    },
+    Field {
+        key: SettingKey::RetentionDays,
+        container: Some("exchange"),
+        property: "retentionDays",
+    },
+    Field {
+        key: SettingKey::PaneBadge,
+        container: Some("ui"),
+        property: "paneBadge",
+    },
+    Field {
+        key: SettingKey::Timeout,
+        container: Some("defaults"),
+        property: "timeout",
+    },
+    Field {
+        key: SettingKey::PollInterval,
+        container: Some("defaults"),
+        property: "pollInterval",
+    },
+    Field {
+        key: SettingKey::CaptureLines,
+        container: Some("defaults"),
+        property: "captureLines",
+    },
+    Field {
+        key: SettingKey::PreambleEvery,
+        container: Some("defaults"),
+        property: "preambleEvery",
+    },
+    Field {
+        key: SettingKey::PasteEnterDelayMs,
+        container: Some("defaults"),
+        property: "pasteEnterDelayMs",
+    },
+];
+const LOCAL_FIELDS: [Field; 3] = [
+    Field {
+        key: SettingKey::PreambleMode,
+        container: Some("$config"),
+        property: "preambleMode",
+    },
+    Field {
+        key: SettingKey::PreambleEvery,
+        container: Some("$config"),
+        property: "preambleEvery",
+    },
+    Field {
+        key: SettingKey::PasteEnterDelayMs,
+        container: Some("$config"),
+        property: "pasteEnterDelayMs",
+    },
+];
+
+fn fields(scope: Scope) -> &'static [Field] {
+    match scope {
+        Scope::Global => &GLOBAL_FIELDS,
+        Scope::Local => &LOCAL_FIELDS,
+    }
+}
+
+fn object<'a>(
+    value: &'a Value,
+    path: &Path,
+    field: &str,
+) -> Result<&'a Map<String, Value>, ConfigError> {
+    value
+        .as_object()
+        .ok_or_else(|| ConfigError::validation(path, field, "a non-null object"))
+}
+
+fn shape(value: &Value, path: &Path, scope: Scope) -> Result<(), ConfigError> {
+    let root = object(value, path, "<root>")?;
+    let containers: &[&str] = match scope {
+        Scope::Global => &["defaults", "exchange", "ui"],
+        Scope::Local => &["$config"],
+    };
+    for name in containers {
+        if let Some(value) = root.get(*name) {
+            object(value, path, name)?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn read(path: &Path, scope: Scope) -> Result<Value, ConfigError> {
+    let mut value = if path.exists() {
+        let content = fs::read_to_string(path).map_err(|error| ConfigError::parse(path, error))?;
+        serde_json::from_str(&content).map_err(|error| ConfigError::parse(path, error))?
+    } else {
+        json!({})
+    };
+    normalize_numbers(&mut value);
+    shape(&value, path, scope)?;
+    Ok(value)
+}
+
+fn normalize_numbers(value: &mut Value) {
+    match value {
+        Value::Number(number) => {
+            // JSON.parse uses IEEE-754 for every number, including opaque
+            // fields. JSON.stringify subsequently writes non-finite values as
+            // null. Known numeric settings reject that null during projection.
+            // arbitrary_precision lets the decoder reach this policy even for
+            // a valid JSON exponent outside f64's representable range.
+            *value = number
+                .as_f64()
+                .and_then(|number| {
+                    if number.fract() == 0.0 && number >= 0.0 && number < u64::MAX as f64 {
+                        Some(serde_json::Number::from(number as u64))
+                    } else if number.fract() == 0.0 && number < 0.0 && number >= i64::MIN as f64 {
+                        Some(serde_json::Number::from(number as i64))
+                    } else {
+                        serde_json::Number::from_f64(number)
+                    }
+                })
+                .map_or(Value::Null, Value::Number);
+        }
+        Value::Array(values) => values.iter_mut().for_each(normalize_numbers),
+        Value::Object(values) => values.values_mut().for_each(normalize_numbers),
+        _ => {}
+    }
+}
+
+pub(super) fn project(
+    value: &Value,
+    path: &Path,
+    scope: Scope,
+) -> Result<Vec<Setting>, ConfigError> {
+    shape(value, path, scope)?;
+    let mut settings = Vec::new();
+    for field in fields(scope) {
+        let container = field.container.map_or(Some(value), |name| value.get(name));
+        let Some(value) = container.and_then(|container| container.get(field.property)) else {
+            continue;
+        };
+        let scalar = match value {
+            Value::String(text) => Scalar::Text(text),
+            Value::Number(number) => number.as_f64().map_or(Scalar::Invalid, Scalar::Number),
+            _ => Scalar::Invalid,
+        };
+        let setting = Setting::validate(field.key, scalar).ok_or_else(|| {
+            let label = field.container.map_or_else(
+                || field.property.to_string(),
+                |container| format!("{container}.{}", field.property),
+            );
+            ConfigError::validation(path, &label, field.key.expected())
+        })?;
+        settings.push(setting);
+    }
+    Ok(settings)
+}
+
+fn setting_value(setting: Setting) -> Value {
+    match setting {
+        Setting::PreambleMode(value) => json!(value.as_str()),
+        Setting::PaneBadge(value) => json!(value.as_str()),
+        Setting::CaptureLines(value)
+        | Setting::PreambleEvery(value)
+        | Setting::RetentionDays(value) => json!(value),
+        Setting::Timeout(value)
+        | Setting::PollInterval(value)
+        | Setting::PasteEnterDelayMs(value) => {
+            // JSON.stringify emits integral numbers without a fractional suffix.
+            if value.fract() == 0.0 && value >= 0.0 && value <= u64::MAX as f64 {
+                json!(value as u64)
+            } else {
+                json!(value)
+            }
+        }
+    }
+}
+
+pub(super) fn set(value: &mut Value, setting: Setting, scope: Scope) -> Result<(), ConfigError> {
+    let field = fields(scope)
+        .iter()
+        .find(|field| field.key == setting.key())
+        .ok_or_else(|| ConfigError::internal("Unsupported configuration scope"))?;
+    // read() validated all relevant containers before this mutation.
+    let root = value.as_object_mut().expect("validated configuration root");
+    let target = if let Some(container) = field.container {
+        let initial = if container == "defaults" {
+            let defaults = Settings::default();
+            json!({
+                "timeout": defaults.timeout as u64,
+                "pollInterval": defaults.poll_interval as u64,
+                "captureLines": defaults.capture_lines,
+                "preambleEvery": defaults.preamble_every,
+                "pasteEnterDelayMs": defaults.paste_enter_delay_ms as u64,
+            })
+        } else {
+            json!({})
+        };
+        root.entry(container)
+            .or_insert(initial)
+            .as_object_mut()
+            .expect("validated configuration container")
+    } else {
+        root
+    };
+    target.insert(field.property.into(), setting_value(setting));
+    Ok(())
+}
+
+/// Return false only for a key-specific clear with no local container. The
+/// reference command does not create a file in that no-op case.
+pub(super) fn clear(value: &mut Value, key: Option<&str>) -> bool {
+    let root = value.as_object_mut().expect("validated configuration root");
+    if let Some(key) = key {
+        let Some(settings) = root.get_mut("$config") else {
+            return false;
+        };
+        let settings = settings.as_object_mut().expect("validated local settings");
+        settings.remove(key);
+        if settings.is_empty() {
+            root.remove("$config");
+        }
+    } else {
+        root.remove("$config");
+    }
+    true
+}
+
+pub(super) fn write(path: &Path, value: &Value, scope: Scope) -> Result<(), ConfigError> {
+    project(value, path, scope)?;
+    if scope == Scope::Global
+        && let Some(parent) = path.parent()
+    {
+        fs::create_dir_all(parent).map_err(|error| ConfigError::internal(error.to_string()))?;
+    }
+    let mut content = serde_json::to_string_pretty(value)
+        .map_err(|error| ConfigError::internal(error.to_string()))?;
+    content.push('\n');
+    fs::write(path, content).map_err(|error| ConfigError::internal(error.to_string()))
+}

--- a/rust/crates/tmt-adapters/src/config/mod.rs
+++ b/rust/crates/tmt-adapters/src/config/mod.rs
@@ -1,0 +1,91 @@
+//! Configuration filesystem boundary. One raw-document implementation preserves
+//! opaque user fields while shared core policy validates every known setting.
+
+mod document;
+mod paths;
+
+pub use paths::ConfigPaths;
+use std::{fmt, path::Path};
+pub use tmt_core::settings::Scope;
+use tmt_core::settings::{LocalClear, ResolvedSettings, Setting};
+
+#[derive(Debug)]
+pub struct ConfigError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl ConfigError {
+    fn internal(message: impl Into<String>) -> Self {
+        Self {
+            code: "INTERNAL_ERROR",
+            message: message.into(),
+        }
+    }
+
+    fn validation(path: &Path, field: &str, expected: &str) -> Self {
+        Self {
+            code: "CONFIG_ERROR",
+            message: format!(
+                "Invalid configuration in {} ({field}): must be {expected}.",
+                path.display()
+            ),
+        }
+    }
+
+    fn parse(path: &Path, cause: impl fmt::Display) -> Self {
+        Self {
+            code: "CONFIG_ERROR",
+            message: format!("Invalid JSON in {}: {cause}", path.display()),
+        }
+    }
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+pub struct ConfigFiles {
+    pub paths: ConfigPaths,
+}
+
+impl ConfigFiles {
+    pub fn load(&self) -> Result<ResolvedSettings, ConfigError> {
+        let read_layer = |scope| {
+            let path = self.path(scope);
+            let document = document::read(path, scope)?;
+            document::project(&document, path, scope)
+        };
+        Ok(ResolvedSettings::from_layers(
+            read_layer(Scope::Global)?,
+            read_layer(Scope::Local)?,
+        ))
+    }
+
+    pub fn set(&self, setting: Setting, scope: Scope) -> Result<(), ConfigError> {
+        let path = self.path(scope);
+        let mut value = document::read(path, scope)?;
+        document::set(&mut value, setting, scope)?;
+        document::write(path, &value, scope)
+    }
+
+    pub fn clear_local(&self, clear: LocalClear) -> Result<(), ConfigError> {
+        let path = self.path(Scope::Local);
+        let mut value = document::read(path, Scope::Local)?;
+        if document::clear(&mut value, clear.key()) {
+            document::write(path, &value, Scope::Local)?;
+        }
+        Ok(())
+    }
+
+    fn path(&self, scope: Scope) -> &Path {
+        match scope {
+            Scope::Global => &self.paths.global_config,
+            Scope::Local => &self.paths.local_config,
+        }
+    }
+}

--- a/rust/crates/tmt-adapters/src/config/paths.rs
+++ b/rust/crates/tmt-adapters/src/config/paths.rs
@@ -1,0 +1,91 @@
+use std::{
+    env,
+    path::{Component, Path, PathBuf},
+};
+
+use super::ConfigError;
+
+#[derive(Debug, Clone)]
+pub struct ConfigPaths {
+    pub global_dir: PathBuf,
+    pub global_config: PathBuf,
+    pub local_config: PathBuf,
+    pub database: PathBuf,
+}
+
+impl ConfigPaths {
+    pub fn discover() -> Result<Self, ConfigError> {
+        let cwd = env::current_dir().map_err(|error| ConfigError::internal(error.to_string()))?;
+        let home = env::home_dir()
+            .ok_or_else(|| ConfigError::internal("Cannot determine the home directory"))?;
+        Ok(Self::resolve(
+            &cwd,
+            &home,
+            env::var_os("TMUX_TEAM_HOME")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+                .as_deref(),
+            env::var_os("XDG_CONFIG_HOME")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+                .as_deref(),
+        ))
+    }
+
+    /// Inputs are invocation-owned; tests need not mutate process-wide variables.
+    pub fn resolve(cwd: &Path, home: &Path, explicit: Option<&Path>, xdg: Option<&Path>) -> Self {
+        let global_dir = if let Some(explicit) = explicit {
+            explicit.to_path_buf()
+        } else if let Some(xdg) = xdg {
+            normalize(&xdg.join("tmux-team"))
+        } else {
+            let preferred = normalize(&home.join(".config/tmux-team"));
+            let legacy = normalize(&home.join(".tmux-team"));
+            if preferred.exists() {
+                if legacy.join("config.json").exists() && !preferred.join("config.json").exists() {
+                    legacy
+                } else {
+                    preferred
+                }
+            } else if legacy.exists() {
+                legacy
+            } else {
+                preferred
+            }
+        };
+        let local_config = cwd
+            .ancestors()
+            .map(|directory| directory.join("tmux-team.json"))
+            .find(|candidate| candidate.exists())
+            .unwrap_or_else(|| cwd.join("tmux-team.json"));
+        Self {
+            global_config: normalize(&global_dir.join("config.json")),
+            database: normalize(&global_dir.join("tmux-team.db")),
+            global_dir,
+            local_config,
+        }
+    }
+}
+
+/// Lexical normalization matches path.join without requiring the destination
+/// (or a discarded parent component) to exist. Do not canonicalize symlinks.
+fn normalize(path: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if matches!(result.components().next_back(), Some(Component::Normal(_))) {
+                    result.pop();
+                } else if !result.has_root() {
+                    result.push("..");
+                }
+            }
+            component => result.push(component.as_os_str()),
+        }
+    }
+    if result.as_os_str().is_empty() {
+        result.push(".");
+    }
+    result
+}

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -1,3 +1,4 @@
 //! Concrete native adapters. Application policy must not depend on this crate.
 
+pub mod config;
 pub mod storage;

--- a/rust/crates/tmt-cli/Cargo.toml
+++ b/rust/crates/tmt-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 tmt-core.workspace = true
+tmt-adapters.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 serde_json.workspace = true

--- a/rust/crates/tmt-cli/src/config_command.rs
+++ b/rust/crates/tmt-cli/src/config_command.rs
@@ -1,0 +1,200 @@
+//! Thin configuration command composition and presentation. Policy and raw
+//! document mutation remain in the shared core and filesystem adapter.
+
+use crate::invocation::{ConfigRequest, OutputMode};
+use serde_json::json;
+use std::io::{self, Write};
+use tmt_adapters::config::{ConfigError, ConfigFiles, ConfigPaths, Scope};
+use tmt_core::settings::{LocalClear, ResolvedSettings, Setting, SettingKey};
+
+struct Failure {
+    code: &'static str,
+    message: String,
+}
+
+impl From<ConfigError> for Failure {
+    fn from(error: ConfigError) -> Self {
+        Self {
+            code: error.code,
+            message: error.message,
+        }
+    }
+}
+
+impl From<String> for Failure {
+    fn from(message: String) -> Self {
+        Self {
+            code: "ERROR",
+            message,
+        }
+    }
+}
+
+enum Report {
+    Show {
+        loaded: ResolvedSettings,
+        paths: ConfigPaths,
+    },
+    Changed(String),
+}
+
+fn run(request: ConfigRequest) -> Result<Report, Failure> {
+    let files = ConfigFiles {
+        paths: ConfigPaths::discover()?,
+    };
+    match request {
+        ConfigRequest::Show => Ok(Report::Show {
+            loaded: files.load()?,
+            paths: files.paths,
+        }),
+        ConfigRequest::Set { key, value, global } => {
+            let scope = if global { Scope::Global } else { Scope::Local };
+            files.set(Setting::edit(&key, &value, scope)?, scope)?;
+            let destination = if global {
+                "global config"
+            } else {
+                "local config (repo override)"
+            };
+            Ok(Report::Changed(format!(
+                "Set {key}={value} in {destination}"
+            )))
+        }
+        ConfigRequest::Clear { key } => {
+            files.clear_local(LocalClear::parse(key.as_deref())?)?;
+            Ok(Report::Changed(key.map_or_else(
+                || "Cleared all local config overrides".into(),
+                |key| format!("Cleared local override for {key}"),
+            )))
+        }
+    }
+}
+
+pub fn execute(request: ConfigRequest, mode: OutputMode) -> io::Result<u8> {
+    let report = match run(request) {
+        Ok(report) => report,
+        Err(error) => return crate::failure(mode, error.code, &error.message),
+    };
+    let mut output = io::stdout().lock();
+    match report {
+        Report::Changed(message) => {
+            if mode.json {
+                writeln!(output, "{{\"ok\":true}}")?;
+            } else {
+                writeln!(output, "✓ {message}")?;
+            }
+        }
+        Report::Show { loaded, paths } => {
+            if mode.json {
+                writeln!(output, "{}", show_json(&loaded, &paths))?;
+            } else {
+                show_text(&mut output, &loaded, &paths)?;
+            }
+        }
+    }
+    Ok(0)
+}
+
+fn show_json(loaded: &ResolvedSettings, paths: &ConfigPaths) -> serde_json::Value {
+    let settings = &loaded.settings;
+    json!({
+        "resolved": {
+            "preambleMode": settings.preamble_mode.as_str(),
+            "preambleEvery": settings.preamble_every,
+            "pasteEnterDelayMs": settings.paste_enter_delay_ms,
+            "defaults": {
+                "timeout": settings.timeout,
+                "pollInterval": settings.poll_interval,
+                "captureLines": settings.capture_lines,
+                "preambleEvery": settings.preamble_every,
+                "pasteEnterDelayMs": settings.paste_enter_delay_ms,
+            },
+            "exchange": { "retentionDays": settings.retention_days },
+            "ui": { "paneBadge": settings.pane_badge.as_str() },
+        },
+        "sources": {
+            "preambleMode": loaded.source(SettingKey::PreambleMode),
+            "preambleEvery": loaded.source(SettingKey::PreambleEvery),
+            "pasteEnterDelayMs": loaded.source(SettingKey::PasteEnterDelayMs),
+            "exchange": { "retentionDays": loaded.source(SettingKey::RetentionDays) },
+            "ui": { "paneBadge": loaded.source(SettingKey::PaneBadge) },
+        },
+        "paths": { "global": paths.global_config, "local": paths.local_config },
+    })
+}
+
+fn show_text(
+    output: &mut impl Write,
+    loaded: &ResolvedSettings,
+    paths: &ConfigPaths,
+) -> io::Result<()> {
+    let settings = &loaded.settings;
+    let rows = [
+        (
+            "preambleMode",
+            settings.preamble_mode.as_str().to_string(),
+            loaded.source(SettingKey::PreambleMode),
+        ),
+        (
+            "preambleEvery",
+            settings.preamble_every.to_string(),
+            loaded.source(SettingKey::PreambleEvery),
+        ),
+        (
+            "pasteEnterDelayMs",
+            settings.paste_enter_delay_ms.to_string(),
+            loaded.source(SettingKey::PasteEnterDelayMs),
+        ),
+        ("defaults.timeout", settings.timeout.to_string(), "global"),
+        (
+            "defaults.pollInterval",
+            settings.poll_interval.to_string(),
+            "global",
+        ),
+        (
+            "defaults.captureLines",
+            settings.capture_lines.to_string(),
+            "global",
+        ),
+        (
+            "exchange.retentionDays",
+            settings.retention_days.to_string(),
+            loaded.source(SettingKey::RetentionDays),
+        ),
+        (
+            "ui.paneBadge",
+            settings.pane_badge.as_str().to_string(),
+            loaded.source(SettingKey::PaneBadge),
+        ),
+    ];
+    let key_width = rows.iter().map(|row| row.0.len()).max().unwrap_or(3).max(3);
+    let value_width = rows.iter().map(|row| row.1.len()).max().unwrap_or(5).max(5);
+    let source_width = rows
+        .iter()
+        .map(|row| row.2.len() + 2)
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    writeln!(output, "ℹ Current configuration:\n")?;
+    writeln!(
+        output,
+        "  {:key_width$} {:value_width$} {:source_width$}",
+        "Key", "Value", "Source"
+    )?;
+    writeln!(
+        output,
+        "  {} {} {}",
+        "─".repeat(key_width),
+        "─".repeat(value_width),
+        "─".repeat(source_width)
+    )?;
+    for (key, value, source) in rows {
+        writeln!(
+            output,
+            "  {key:key_width$} {value:value_width$} {:source_width$}",
+            format!("({source})")
+        )?;
+    }
+    writeln!(output, "ℹ \nPaths:")?;
+    writeln!(output, "ℹ   Global: {}", paths.global_config.display())?;
+    writeln!(output, "ℹ   Local:  {}", paths.local_config.display())
+}

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -99,7 +99,7 @@ pub fn grammar() -> Command {
                 .subcommand(
                     with_options(general("set", "Set a setting"), &["global"])
                         .arg(operand("key", true))
-                        .arg(operand("value", true)),
+                        .arg(operand("value", true).allow_negative_numbers(true)),
                 )
                 .subcommand(general("clear", "Clear a local setting").arg(operand("key", false))),
         )

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod config_command;
 mod diagnostics;
 mod grammar;
 mod invocation;
@@ -30,7 +31,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: effectful commands are not implemented yet.\n"
+                "Native development preview: configuration is available; identity and transport commands are not implemented yet.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -55,6 +56,10 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
                     "Use 'tmt completion bash' or 'tmt completion zsh' to generate a shell script."
                 )?;
             }
+        }
+        Invocation::Config(request) => {
+            drop(stdout);
+            return config_command::execute(request, parsed.mode);
         }
         _ => {
             drop(stdout);

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -9,6 +9,24 @@ fn args(values: &[&str]) -> Vec<OsString> {
     values.iter().map(OsString::from).collect()
 }
 
+#[test]
+fn negative_config_values_reach_setting_validation_without_accepting_unknown_flags() {
+    let invocation = parsed(&["config", "set", "preambleEvery", "-1", "--json"]);
+    assert_eq!(
+        invocation.invocation,
+        Invocation::Config(crate::invocation::ConfigRequest::Set {
+            key: "preambleEvery".into(),
+            value: "-1".into(),
+            global: false,
+        })
+    );
+    assert!(invocation.mode.json);
+    assert_eq!(
+        parse_error(&["config", "set", "preambleEvery", "--unknown", "--json"]).code,
+        "USAGE_ERROR"
+    );
+}
+
 fn parsed(values: &[&str]) -> Parsed {
     parse(&args(values)).unwrap_or_else(|error| {
         panic!("expected {:?} to parse, got {error:?}", values);

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -1,3 +1,7 @@
 //! Shared native-domain contracts for tmux-team.
 
 pub mod limits;
+pub mod settings;
+
+#[cfg(test)]
+mod settings_tests;

--- a/rust/crates/tmt-core/src/settings.rs
+++ b/rust/crates/tmt-core/src/settings.rs
@@ -1,0 +1,342 @@
+//! Configuration policy shared by invocation setup and editing. JSON, paths,
+//! files, and presentation belong to adapters rather than this module.
+
+use crate::limits::{
+    MAX_CAPTURE_LINES, MAX_JS_SAFE_INTEGER, is_valid_observer_timeout_seconds,
+    is_valid_timer_delay_ms,
+};
+
+pub const DEFAULT_RETENTION_DAYS: u64 = 90;
+pub const MAX_RETENTION_DAYS: u64 = 3650;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    Global,
+    Local,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalClear {
+    All,
+    Setting(SettingKey),
+    ObsoleteMode,
+}
+
+impl LocalClear {
+    pub fn parse(key: Option<&str>) -> Result<Self, String> {
+        let Some(name) = key else {
+            return Ok(Self::All);
+        };
+        if name == "mode" {
+            return Ok(Self::ObsoleteMode);
+        }
+        let key = SettingKey::editable(name)?;
+        if key.global_only() {
+            return Err(format!(
+                "{name} is global-only and has no local override to clear."
+            ));
+        }
+        Ok(Self::Setting(key))
+    }
+
+    pub fn key(self) -> Option<&'static str> {
+        match self {
+            Self::All => None,
+            Self::Setting(key) => Some(key.name()),
+            Self::ObsoleteMode => Some("mode"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreambleMode {
+    Always,
+    Disabled,
+}
+
+impl PreambleMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Always => "always",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneBadge {
+    On,
+    Off,
+}
+
+impl PaneBadge {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::On => "on",
+            Self::Off => "off",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingKey {
+    PreambleMode,
+    Timeout,
+    PollInterval,
+    CaptureLines,
+    PreambleEvery,
+    PasteEnterDelayMs,
+    RetentionDays,
+    PaneBadge,
+}
+
+pub const EDITABLE_KEYS: [SettingKey; 5] = [
+    SettingKey::PreambleMode,
+    SettingKey::PaneBadge,
+    SettingKey::PreambleEvery,
+    SettingKey::PasteEnterDelayMs,
+    SettingKey::RetentionDays,
+];
+
+impl SettingKey {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::PreambleMode => "preambleMode",
+            Self::Timeout => "timeout",
+            Self::PollInterval => "pollInterval",
+            Self::CaptureLines => "captureLines",
+            Self::PreambleEvery => "preambleEvery",
+            Self::PasteEnterDelayMs => "pasteEnterDelayMs",
+            Self::RetentionDays => "exchange.retentionDays",
+            Self::PaneBadge => "ui.paneBadge",
+        }
+    }
+
+    pub fn expected(self) -> &'static str {
+        match self {
+            Self::PreambleMode => "'always' or 'disabled'",
+            Self::Timeout => "a finite positive number no greater than 86400",
+            Self::PollInterval => "a finite positive number",
+            Self::CaptureLines => "an integer from 0 through 2147483647",
+            Self::PreambleEvery => "a safe non-negative integer",
+            Self::PasteEnterDelayMs => "a finite number from 0 through 2147483647",
+            Self::RetentionDays => "an integer from 1 through 3650",
+            Self::PaneBadge => "'on' or 'off'",
+        }
+    }
+
+    pub fn global_only(self) -> bool {
+        matches!(self, Self::RetentionDays | Self::PaneBadge)
+    }
+
+    pub fn editable(name: &str) -> Result<Self, String> {
+        EDITABLE_KEYS
+            .into_iter()
+            .find(|key| key.name() == name)
+            .ok_or_else(|| {
+                format!(
+                    "Invalid key: {name}. Valid keys: {}",
+                    EDITABLE_KEYS.map(Self::name).join(", ")
+                )
+            })
+    }
+}
+
+/// The boundary accepts only scalar kinds needed by policy. Null, arrays,
+/// objects and booleans become Invalid without making core depend on JSON.
+pub enum Scalar<'a> {
+    Text(&'a str),
+    Number(f64),
+    Invalid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Setting {
+    PreambleMode(PreambleMode),
+    Timeout(f64),
+    PollInterval(f64),
+    CaptureLines(u64),
+    PreambleEvery(u64),
+    PasteEnterDelayMs(f64),
+    RetentionDays(u64),
+    PaneBadge(PaneBadge),
+}
+
+fn unsigned_integer(value: f64, maximum: u64) -> bool {
+    value.is_finite() && value >= 0.0 && value.fract() == 0.0 && value <= maximum as f64
+}
+
+impl Setting {
+    pub fn edit(name: &str, value: &str, scope: Scope) -> Result<Self, String> {
+        let key = SettingKey::editable(name)?;
+        if scope == Scope::Local && key.global_only() {
+            return Err(format!(
+                "{name} can only be set in global config with --global."
+            ));
+        }
+        Self::parse_edit(key, value)
+    }
+
+    pub fn validate(key: SettingKey, value: Scalar<'_>) -> Option<Self> {
+        match (key, value) {
+            (SettingKey::PreambleMode, Scalar::Text("always")) => {
+                Some(Self::PreambleMode(PreambleMode::Always))
+            }
+            (SettingKey::PreambleMode, Scalar::Text("disabled")) => {
+                Some(Self::PreambleMode(PreambleMode::Disabled))
+            }
+            (SettingKey::PaneBadge, Scalar::Text("on")) => Some(Self::PaneBadge(PaneBadge::On)),
+            (SettingKey::PaneBadge, Scalar::Text("off")) => Some(Self::PaneBadge(PaneBadge::Off)),
+            (SettingKey::Timeout, Scalar::Number(value))
+                if is_valid_observer_timeout_seconds(value) =>
+            {
+                Some(Self::Timeout(value))
+            }
+            (SettingKey::PollInterval, Scalar::Number(value))
+                if value.is_finite() && value > 0.0 =>
+            {
+                Some(Self::PollInterval(value))
+            }
+            (SettingKey::CaptureLines, Scalar::Number(value))
+                if unsigned_integer(value, MAX_CAPTURE_LINES) =>
+            {
+                Some(Self::CaptureLines(value as u64))
+            }
+            (SettingKey::PreambleEvery, Scalar::Number(value))
+                if unsigned_integer(value, MAX_JS_SAFE_INTEGER) =>
+            {
+                Some(Self::PreambleEvery(value as u64))
+            }
+            (SettingKey::PasteEnterDelayMs, Scalar::Number(value))
+                if is_valid_timer_delay_ms(value) =>
+            {
+                Some(Self::PasteEnterDelayMs(value))
+            }
+            (SettingKey::RetentionDays, Scalar::Number(value))
+                if unsigned_integer(value, MAX_RETENTION_DAYS) && value >= 1.0 =>
+            {
+                Some(Self::RetentionDays(value as u64))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn parse_edit(key: SettingKey, text: &str) -> Result<Self, String> {
+        let scalar = if matches!(key, SettingKey::PreambleMode | SettingKey::PaneBadge) {
+            Scalar::Text(text)
+        } else {
+            if text.is_empty() || !text.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err(format!(
+                    "Invalid value for {}: {text}. Must be a non-negative integer.",
+                    key.name()
+                ));
+            }
+            let number = text.parse::<f64>().unwrap_or(f64::INFINITY);
+            if !unsigned_integer(number, MAX_JS_SAFE_INTEGER) {
+                return Err(format!(
+                    "Invalid value for {}: {text}. Must be a supported non-negative integer.",
+                    key.name()
+                ));
+            }
+            Scalar::Number(number)
+        };
+        Self::validate(key, scalar).ok_or_else(|| {
+            let expected = match key {
+                SettingKey::PreambleMode => "Valid values: always, disabled",
+                SettingKey::PaneBadge => "Valid values: on, off",
+                _ => "Must be a supported non-negative integer.",
+            };
+            format!("Invalid value for {}: {text}. {expected}", key.name())
+        })
+    }
+
+    pub fn key(self) -> SettingKey {
+        match self {
+            Self::PreambleMode(_) => SettingKey::PreambleMode,
+            Self::Timeout(_) => SettingKey::Timeout,
+            Self::PollInterval(_) => SettingKey::PollInterval,
+            Self::CaptureLines(_) => SettingKey::CaptureLines,
+            Self::PreambleEvery(_) => SettingKey::PreambleEvery,
+            Self::PasteEnterDelayMs(_) => SettingKey::PasteEnterDelayMs,
+            Self::RetentionDays(_) => SettingKey::RetentionDays,
+            Self::PaneBadge(_) => SettingKey::PaneBadge,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Settings {
+    pub preamble_mode: PreambleMode,
+    pub timeout: f64,
+    pub poll_interval: f64,
+    pub capture_lines: u64,
+    pub preamble_every: u64,
+    pub paste_enter_delay_ms: f64,
+    pub retention_days: u64,
+    pub pane_badge: PaneBadge,
+}
+
+pub struct ResolvedSettings {
+    pub settings: Settings,
+    sources: Vec<(SettingKey, Scope)>,
+}
+
+impl ResolvedSettings {
+    pub fn from_layers(global: Vec<Setting>, local: Vec<Setting>) -> Self {
+        let mut resolved = Self {
+            settings: Settings::default(),
+            sources: Vec::new(),
+        };
+        for (scope, settings) in [(Scope::Global, global), (Scope::Local, local)] {
+            for setting in settings {
+                resolved.sources.push((setting.key(), scope));
+                resolved.settings.apply(setting);
+            }
+        }
+        resolved
+    }
+
+    pub fn source(&self, key: SettingKey) -> &'static str {
+        match self
+            .sources
+            .iter()
+            .rev()
+            .find(|(candidate, _)| *candidate == key)
+            .map(|(_, scope)| scope)
+        {
+            Some(Scope::Global) => "global",
+            Some(Scope::Local) => "local",
+            None => "default",
+        }
+    }
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            preamble_mode: PreambleMode::Always,
+            timeout: 180.0,
+            poll_interval: 1.0,
+            capture_lines: 100,
+            preamble_every: 3,
+            paste_enter_delay_ms: 500.0,
+            retention_days: DEFAULT_RETENTION_DAYS,
+            pane_badge: PaneBadge::Off,
+        }
+    }
+}
+
+impl Settings {
+    pub fn apply(&mut self, setting: Setting) {
+        match setting {
+            Setting::PreambleMode(value) => self.preamble_mode = value,
+            Setting::Timeout(value) => self.timeout = value,
+            Setting::PollInterval(value) => self.poll_interval = value,
+            Setting::CaptureLines(value) => self.capture_lines = value,
+            Setting::PreambleEvery(value) => self.preamble_every = value,
+            Setting::PasteEnterDelayMs(value) => self.paste_enter_delay_ms = value,
+            Setting::RetentionDays(value) => self.retention_days = value,
+            Setting::PaneBadge(value) => self.pane_badge = value,
+        }
+    }
+}

--- a/rust/crates/tmt-core/src/settings_tests.rs
+++ b/rust/crates/tmt-core/src/settings_tests.rs
@@ -1,0 +1,330 @@
+use super::limits::{MAX_CAPTURE_LINES, MAX_JS_SAFE_INTEGER, MAX_TIMER_DELAY_MS};
+use super::settings::{
+    DEFAULT_RETENTION_DAYS, EDITABLE_KEYS, LocalClear, PaneBadge, PreambleMode, ResolvedSettings,
+    Scalar, Scope, Setting, SettingKey, Settings,
+};
+
+#[test]
+fn defaults_are_canonical_and_isolated() {
+    assert_eq!(DEFAULT_RETENTION_DAYS, 90);
+    let mut first = Settings::default();
+    let second = Settings::default();
+
+    first.timeout = 42.0;
+    first.retention_days = 1;
+
+    assert_eq!(second.timeout, 180.0);
+    assert_eq!(second.poll_interval, 1.0);
+    assert_eq!(second.capture_lines, 100);
+    assert_eq!(second.preamble_every, 3);
+    assert_eq!(second.paste_enter_delay_ms, 500.0);
+    assert_eq!(second.retention_days, DEFAULT_RETENTION_DAYS);
+    assert_eq!(second.preamble_mode, PreambleMode::Always);
+    assert_eq!(second.pane_badge, PaneBadge::Off);
+    assert_ne!(first, second);
+}
+
+#[test]
+fn resolved_layers_share_precedence_and_source_accounting() {
+    let resolved = ResolvedSettings::from_layers(
+        vec![Setting::PreambleEvery(7), Setting::RetentionDays(30)],
+        vec![Setting::PreambleEvery(0)],
+    );
+    assert_eq!(resolved.settings.preamble_every, 0);
+    assert_eq!(resolved.settings.retention_days, 30);
+    assert_eq!(resolved.source(SettingKey::PreambleEvery), "local");
+    assert_eq!(resolved.source(SettingKey::RetentionDays), "global");
+    assert_eq!(resolved.source(SettingKey::PaneBadge), "default");
+}
+
+#[test]
+fn editing_scope_and_obsolete_clear_policy_are_shared_outside_the_cli() {
+    assert_eq!(
+        Setting::edit("ui.paneBadge", "on", Scope::Global).unwrap(),
+        Setting::PaneBadge(PaneBadge::On)
+    );
+    assert!(Setting::edit("ui.paneBadge", "on", Scope::Local).is_err());
+    assert!(Setting::edit("exchange.retentionDays", "90", Scope::Local).is_err());
+    assert!(Setting::edit("mode", "legacy", Scope::Local).is_err());
+    assert_eq!(LocalClear::parse(None).unwrap(), LocalClear::All);
+    assert_eq!(
+        LocalClear::parse(Some("mode")).unwrap(),
+        LocalClear::ObsoleteMode
+    );
+    assert_eq!(
+        LocalClear::parse(Some("preambleEvery")).unwrap().key(),
+        Some("preambleEvery")
+    );
+    assert!(LocalClear::parse(Some("exchange.retentionDays")).is_err());
+    assert!(LocalClear::parse(Some("ui.paneBadge")).is_err());
+    assert!(LocalClear::parse(Some("unknown")).is_err());
+}
+
+#[test]
+fn editable_keys_are_limited_to_supported_set() {
+    let valid = [
+        "preambleMode",
+        "ui.paneBadge",
+        "preambleEvery",
+        "pasteEnterDelayMs",
+        "exchange.retentionDays",
+    ];
+    for name in valid {
+        let key = SettingKey::editable(name).unwrap_or_else(|error| {
+            panic!("expected {name} to be editable, got {error}");
+        });
+        assert!(EDITABLE_KEYS.contains(&key), "{name}");
+    }
+
+    for name in ["timeout", "pollInterval", "captureLines", "unknown", "mode"] {
+        assert!(SettingKey::editable(name).is_err(), "{name}");
+    }
+}
+
+#[test]
+fn enum_settings_accept_only_documented_values() {
+    let cases = [
+        (
+            SettingKey::PreambleMode,
+            Scalar::Text("always"),
+            Some(Setting::PreambleMode(PreambleMode::Always)),
+        ),
+        (
+            SettingKey::PreambleMode,
+            Scalar::Text("disabled"),
+            Some(Setting::PreambleMode(PreambleMode::Disabled)),
+        ),
+        (
+            SettingKey::PaneBadge,
+            Scalar::Text("on"),
+            Some(Setting::PaneBadge(PaneBadge::On)),
+        ),
+        (
+            SettingKey::PaneBadge,
+            Scalar::Text("off"),
+            Some(Setting::PaneBadge(PaneBadge::Off)),
+        ),
+    ];
+    for (key, value, expected) in cases {
+        assert_eq!(Setting::validate(key, value), expected);
+    }
+
+    for (key, value) in [
+        (SettingKey::PreambleMode, "always "),
+        (SettingKey::PreambleMode, "on"),
+        (SettingKey::PaneBadge, "ON"),
+        (SettingKey::PaneBadge, "disabled"),
+    ] {
+        assert!(
+            Setting::validate(key, Scalar::Text(value)).is_none(),
+            "{key:?}={value:?}"
+        );
+    }
+}
+
+#[test]
+fn loaded_fractional_delay_is_valid_but_cli_edit_requires_integer_text() {
+    assert_eq!(
+        Setting::validate(SettingKey::PasteEnterDelayMs, Scalar::Number(0.5),),
+        Some(Setting::PasteEnterDelayMs(0.5))
+    );
+    assert!(Setting::parse_edit(SettingKey::PasteEnterDelayMs, "0.5").is_err());
+    assert_eq!(
+        Setting::parse_edit(SettingKey::PasteEnterDelayMs, "0")
+            .expect("zero is a valid integer edit"),
+        Setting::PasteEnterDelayMs(0.0)
+    );
+    assert_eq!(
+        Setting::parse_edit(
+            SettingKey::PasteEnterDelayMs,
+            &MAX_TIMER_DELAY_MS.to_string()
+        )
+        .expect("maximum delay is a valid integer edit"),
+        Setting::PasteEnterDelayMs(MAX_TIMER_DELAY_MS)
+    );
+}
+
+#[test]
+fn timing_settings_require_positive_finite_values_with_their_bounds() {
+    for (key, value, expected) in [
+        (SettingKey::Timeout, 1.0, Some(Setting::Timeout(1.0))),
+        (
+            SettingKey::Timeout,
+            86_400.0,
+            Some(Setting::Timeout(86_400.0)),
+        ),
+        (
+            SettingKey::PollInterval,
+            f64::MIN_POSITIVE,
+            Some(Setting::PollInterval(f64::MIN_POSITIVE)),
+        ),
+        (
+            SettingKey::PollInterval,
+            f64::MAX,
+            Some(Setting::PollInterval(f64::MAX)),
+        ),
+    ] {
+        assert_eq!(Setting::validate(key, Scalar::Number(value)), expected);
+    }
+
+    for (key, value) in [
+        (SettingKey::Timeout, 0.0),
+        (SettingKey::Timeout, -0.001),
+        (SettingKey::Timeout, 86_400.001),
+        (SettingKey::Timeout, f64::NAN),
+        (SettingKey::Timeout, f64::INFINITY),
+        (SettingKey::PollInterval, 0.0),
+        (SettingKey::PollInterval, -0.001),
+        (SettingKey::PollInterval, f64::NAN),
+        (SettingKey::PollInterval, f64::NEG_INFINITY),
+    ] {
+        assert!(
+            Setting::validate(key, Scalar::Number(value)).is_none(),
+            "{key:?}={value:?}"
+        );
+    }
+}
+
+#[test]
+fn integer_settings_enforce_safe_and_feature_specific_bounds() {
+    for (key, value, expected) in [
+        (
+            SettingKey::CaptureLines,
+            0.0,
+            Some(Setting::CaptureLines(0)),
+        ),
+        (
+            SettingKey::CaptureLines,
+            MAX_CAPTURE_LINES as f64,
+            Some(Setting::CaptureLines(MAX_CAPTURE_LINES)),
+        ),
+        (
+            SettingKey::PreambleEvery,
+            0.0,
+            Some(Setting::PreambleEvery(0)),
+        ),
+        (
+            SettingKey::PreambleEvery,
+            MAX_JS_SAFE_INTEGER as f64,
+            Some(Setting::PreambleEvery(MAX_JS_SAFE_INTEGER)),
+        ),
+        (
+            SettingKey::RetentionDays,
+            1.0,
+            Some(Setting::RetentionDays(1)),
+        ),
+        (
+            SettingKey::RetentionDays,
+            3650.0,
+            Some(Setting::RetentionDays(3650)),
+        ),
+    ] {
+        assert_eq!(Setting::validate(key, Scalar::Number(value)), expected);
+    }
+
+    for (key, value) in [
+        (SettingKey::CaptureLines, -1.0),
+        (SettingKey::CaptureLines, 1.5),
+        (SettingKey::CaptureLines, MAX_CAPTURE_LINES as f64 + 1.0),
+        (SettingKey::PreambleEvery, -1.0),
+        (SettingKey::PreambleEvery, 1.5),
+        (SettingKey::PreambleEvery, MAX_JS_SAFE_INTEGER as f64 + 1.0),
+        (SettingKey::RetentionDays, 0.0),
+        (SettingKey::RetentionDays, 1.5),
+        (SettingKey::RetentionDays, 3651.0),
+        (SettingKey::RetentionDays, f64::INFINITY),
+    ] {
+        assert!(
+            Setting::validate(key, Scalar::Number(value)).is_none(),
+            "{key:?}={value:?}"
+        );
+    }
+}
+
+#[test]
+fn invalid_scalars_are_rejected_without_coercion() {
+    for key in [
+        SettingKey::PreambleMode,
+        SettingKey::Timeout,
+        SettingKey::CaptureLines,
+        SettingKey::PaneBadge,
+    ] {
+        assert!(Setting::validate(key, Scalar::Invalid).is_none(), "{key:?}");
+    }
+
+    for key in [SettingKey::Timeout, SettingKey::CaptureLines] {
+        assert!(Setting::parse_edit(key, "").is_err(), "{key:?}");
+        assert!(Setting::parse_edit(key, "true").is_err(), "{key:?}");
+        assert!(Setting::parse_edit(key, "null").is_err(), "{key:?}");
+    }
+}
+
+#[test]
+fn parse_edit_uses_strict_integer_syntax_and_exact_enum_values() {
+    assert_eq!(
+        Setting::parse_edit(SettingKey::PreambleEvery, "0").unwrap(),
+        Setting::PreambleEvery(0)
+    );
+    assert_eq!(
+        Setting::parse_edit(SettingKey::PreambleEvery, &MAX_JS_SAFE_INTEGER.to_string()).unwrap(),
+        Setting::PreambleEvery(MAX_JS_SAFE_INTEGER)
+    );
+    assert_eq!(
+        Setting::parse_edit(SettingKey::RetentionDays, "3650").unwrap(),
+        Setting::RetentionDays(3650)
+    );
+    assert_eq!(
+        Setting::parse_edit(SettingKey::PreambleMode, "disabled").unwrap(),
+        Setting::PreambleMode(PreambleMode::Disabled)
+    );
+    assert_eq!(
+        Setting::parse_edit(SettingKey::PaneBadge, "on").unwrap(),
+        Setting::PaneBadge(PaneBadge::On)
+    );
+
+    for (key, text) in [
+        (SettingKey::PreambleEvery, "-1"),
+        (SettingKey::PreambleEvery, "1.5"),
+        (SettingKey::PreambleEvery, "9007199254740992"),
+        (SettingKey::RetentionDays, "0"),
+        (SettingKey::RetentionDays, "3651"),
+        (SettingKey::PaneBadge, "ON"),
+        (SettingKey::PreambleMode, "enabled"),
+    ] {
+        assert!(Setting::parse_edit(key, text).is_err(), "{key:?}={text:?}");
+    }
+}
+
+#[test]
+fn apply_has_last_write_precedence_across_all_setting_kinds() {
+    let mut settings = Settings::default();
+    for setting in [
+        Setting::PreambleMode(PreambleMode::Disabled),
+        Setting::Timeout(86_400.0),
+        Setting::PollInterval(2.5),
+        Setting::CaptureLines(MAX_CAPTURE_LINES),
+        Setting::PreambleEvery(MAX_JS_SAFE_INTEGER),
+        Setting::PasteEnterDelayMs(0.5),
+        Setting::RetentionDays(1),
+        Setting::PaneBadge(PaneBadge::On),
+        Setting::Timeout(30.0),
+        Setting::RetentionDays(3650),
+        Setting::PaneBadge(PaneBadge::Off),
+    ] {
+        settings.apply(setting);
+    }
+
+    assert_eq!(
+        settings,
+        Settings {
+            preamble_mode: PreambleMode::Disabled,
+            timeout: 30.0,
+            poll_interval: 2.5,
+            capture_lines: MAX_CAPTURE_LINES,
+            preamble_every: MAX_JS_SAFE_INTEGER,
+            paste_enter_delay_ms: 0.5,
+            retention_days: 3650,
+            pane_badge: PaneBadge::Off,
+        }
+    );
+}

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -83,7 +83,6 @@ describe('native grammar preview process contract', () => {
         ['talk', 'worker', 'hello'],
         ['check', '%14'],
         ['identity', 'create', 'saved'],
-        ['config'],
         ['init'],
         ['role', 'show'],
         ['preamble'],

--- a/test/native/config.test.ts
+++ b/test/native/config.test.ts
@@ -1,0 +1,278 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  fileSnapshot,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+} from '../../src/test-support/cli-process.js';
+
+if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
+
+describe('native configuration process boundary', () => {
+  it('retains JavaScript numeric semantics and insertion order in opaque fields', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.mkdirSync(sandbox.globalDir, { recursive: true });
+      const bytes =
+        '{"zFuture":9007199254740993,"aFuture":{"values":[1e400,-1e400,-0,3]},"preambleMode":"always"}';
+      fs.writeFileSync(sandbox.globalConfig, bytes);
+      const shown = await runCli(sandbox, ['config', '--json']);
+      expect(shown.status).toBe(0);
+      expect(parseWholeStdout(shown)).toMatchObject({ resolved: { preambleMode: 'always' } });
+      expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(bytes);
+      const edited = await runCli(sandbox, [
+        'config',
+        'set',
+        'preambleMode',
+        'disabled',
+        '--global',
+        '--json',
+      ]);
+      expect(edited.status).toBe(0);
+      const expected = JSON.parse(bytes);
+      expected.preambleMode = 'disabled';
+      expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(
+        `${JSON.stringify(expected, null, 2)}\n`
+      );
+      fs.writeFileSync(sandbox.globalConfig, '{"defaults":{"timeout":1e400}}');
+      const invalid = await runCli(sandbox, ['config', '--json']);
+      expect(invalid.status).toBe(1);
+      expect(expectError(invalid, 'CONFIG_ERROR').error).toMatchObject({
+        message: expect.stringContaining('(defaults.timeout)'),
+      });
+    });
+  });
+
+  it('normalizes XDG parent components without requiring discarded directories', async () => {
+    await withSandbox(async (sandbox) => {
+      sandbox.env.XDG_CONFIG_HOME = path.join(sandbox.root, 'missing') + '/../resolved';
+      const shown = await runCli(sandbox, ['config', '--json']);
+      expect(shown.status).toBe(0);
+      const config = path.join(sandbox.root, 'resolved', 'tmux-team', 'config.json');
+      expect(parseWholeStdout(shown)).toMatchObject({ paths: { global: config } });
+      expect(
+        (await runCli(sandbox, ['config', 'set', 'ui.paneBadge', 'on', '--global', '--json']))
+          .status
+      ).toBe(0);
+      expect(JSON.parse(fs.readFileSync(config, 'utf8'))).toEqual({ ui: { paneBadge: 'on' } });
+      expect(fs.existsSync(path.join(sandbox.root, 'missing'))).toBe(false);
+    });
+  });
+
+  it('normalizes HOME before selecting an existing legacy configuration', async () => {
+    await withSandbox(async (sandbox) => {
+      sandbox.env.HOME = path.join(sandbox.root, 'missing') + '/../resolved-home';
+      delete sandbox.env.XDG_CONFIG_HOME;
+      const config = path.join(sandbox.root, 'resolved-home', '.tmux-team', 'config.json');
+      fs.mkdirSync(path.dirname(config), { recursive: true });
+      fs.writeFileSync(config, '{"ui":{"paneBadge":"on"}}');
+      const before = fileSnapshot(sandbox.root);
+      const shown = await runCli(sandbox, ['config', '--json']);
+      expect(shown.status).toBe(0);
+      expect(parseWholeStdout(shown)).toMatchObject({
+        paths: { global: config },
+        resolved: { ui: { paneBadge: 'on' } },
+      });
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect(fs.existsSync(path.join(sandbox.root, 'missing'))).toBe(false);
+    });
+  });
+
+  it('preserves a file blocking the configuration directory on write failure', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.mkdirSync(sandbox.xdgConfigHome, { recursive: true });
+      fs.writeFileSync(sandbox.globalDir, 'unrelated user file');
+      const before = fileSnapshot(sandbox.root);
+      const result = await runCli(sandbox, [
+        'config',
+        'set',
+        'ui.paneBadge',
+        'on',
+        '--global',
+        '--json',
+      ]);
+      expect(result.status).toBe(1);
+      expectError(result, 'INTERNAL_ERROR');
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+    });
+  });
+
+  it('validates known settings and containers before projecting overrides', async () => {
+    for (const [global, local] of [
+      [null, {}],
+      [[], {}],
+      [{ defaults: null }, {}],
+      [{ exchange: [] }, {}],
+      [{ ui: { paneBadge: true } }, {}],
+      [{ defaults: { timeout: '180' } }, {}],
+      [{ defaults: { pollInterval: 0 } }, {}],
+      [{ defaults: { captureLines: 0.5 } }, {}],
+      [{ exchange: { retentionDays: 3651 } }, {}],
+      [{ defaults: { preambleEvery: null } }, { $config: { preambleEvery: 3 } }],
+      [{}, { $config: [] }],
+      [{}, { $config: { pasteEnterDelayMs: null } }],
+    ]) {
+      await withSandbox(async (sandbox) => {
+        fs.mkdirSync(sandbox.globalDir, { recursive: true });
+        fs.writeFileSync(sandbox.globalConfig, JSON.stringify(global));
+        fs.writeFileSync(sandbox.localConfig, JSON.stringify(local));
+        const before = fileSnapshot(sandbox.root);
+        const result = await runCli(sandbox, ['config', 'show', '--json']);
+        expect(result.status).toBe(1);
+        expectError(result, 'CONFIG_ERROR');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+        expect(fs.existsSync(sandbox.database)).toBe(false);
+      });
+    }
+  });
+
+  it('reports malformed JSON without replacing or repairing it', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.writeFileSync(sandbox.localConfig, '{ not json');
+      const before = fileSnapshot(sandbox.root);
+      const result = await runCli(sandbox, ['config', 'set', 'preambleEvery', '4', '--json']);
+      expect(result.status).toBe(1);
+      expect(expectError(result, 'CONFIG_ERROR').error).toMatchObject({
+        message: expect.stringContaining(sandbox.localConfig),
+      });
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+    });
+  });
+
+  it('keeps global-only settings out of local edits and ignores opaque local copies', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.writeFileSync(
+        sandbox.localConfig,
+        JSON.stringify({
+          $config: { exchange: { retentionDays: 1 }, ui: { paneBadge: 'on' }, future: true },
+        })
+      );
+      const before = fileSnapshot(sandbox.root);
+      for (const args of [
+        ['config', 'set', 'exchange.retentionDays', '1'],
+        ['config', 'set', 'ui.paneBadge', 'on'],
+        ['config', 'clear', 'exchange.retentionDays'],
+        ['config', 'clear', 'ui.paneBadge'],
+      ]) {
+        const result = await runCli(sandbox, [...args, '--json']);
+        expect(result.status).toBe(1);
+        expectError(result, 'ERROR');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+      }
+      const shown = await runCli(sandbox, ['config', '--json']);
+      expect(shown.status).toBe(0);
+      expect(parseWholeStdout(shown)).toMatchObject({
+        resolved: { exchange: { retentionDays: 90 }, ui: { paneBadge: 'off' } },
+      });
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+    });
+  });
+
+  it('distinguishes absent-container clear, clear-all and obsolete-key repair', async () => {
+    await withSandbox(async (sandbox) => {
+      const before = fileSnapshot(sandbox.root);
+      const missing = await runCli(sandbox, ['config', 'clear', 'preambleEvery', '--json']);
+      expect(missing.status).toBe(0);
+      expect(parseWholeStdout(missing)).toEqual({ ok: true });
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect((await runCli(sandbox, ['config', 'clear', '--json'])).status).toBe(0);
+      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({});
+      fs.writeFileSync(
+        sandbox.localConfig,
+        JSON.stringify({
+          keep: 'data',
+          $config: { mode: 'legacy' },
+        })
+      );
+      expect((await runCli(sandbox, ['config', 'clear', 'mode', '--json'])).status).toBe(0);
+      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({ keep: 'data' });
+    });
+  });
+
+  it('finds the nearest ancestor settings file and edits that file only', async () => {
+    await withSandbox(async (sandbox) => {
+      const nested = path.join(sandbox.cwd, 'child', 'nested');
+      fs.mkdirSync(nested, { recursive: true });
+      fs.writeFileSync(sandbox.localConfig, JSON.stringify({ $config: { preambleEvery: 8 } }));
+      const child = { ...sandbox, cwd: nested };
+      const shown = await runCli(child, ['config', '--json']);
+      expect(shown.status).toBe(0);
+      expect(parseWholeStdout(shown)).toMatchObject({
+        resolved: { preambleEvery: 8 },
+        sources: { preambleEvery: 'local' },
+        paths: { local: fs.realpathSync(sandbox.localConfig) },
+      });
+      expect((await runCli(child, ['config', 'set', 'preambleEvery', '9', '--json'])).status).toBe(
+        0
+      );
+      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+        $config: { preambleEvery: 9 },
+      });
+      expect(fs.readdirSync(nested)).toEqual([]);
+      expect(fs.existsSync(sandbox.database)).toBe(false);
+    });
+  });
+
+  it.each(['new', 'legacy-empty', 'legacy-config', 'both-config', 'xdg-empty'])(
+    'preserves %s global directory selection without creating state',
+    async (scenario) => {
+      await withSandbox(async (sandbox) => {
+        delete sandbox.env.XDG_CONFIG_HOME;
+        const xdg = path.join(sandbox.home, '.config', 'tmux-team');
+        const legacy = path.join(sandbox.home, '.tmux-team');
+        if (scenario !== 'new') fs.mkdirSync(legacy, { recursive: true });
+        if (
+          scenario === 'legacy-config' ||
+          scenario === 'both-config' ||
+          scenario === 'xdg-empty'
+        ) {
+          fs.writeFileSync(path.join(legacy, 'config.json'), '{}');
+        }
+        if (scenario === 'both-config' || scenario === 'xdg-empty')
+          fs.mkdirSync(xdg, { recursive: true });
+        if (scenario === 'both-config') fs.writeFileSync(path.join(xdg, 'config.json'), '{}');
+        const before = fileSnapshot(sandbox.root);
+        const shown = await runCli(sandbox, ['config', '--json']);
+        expect(shown.status).toBe(0);
+        const expected = scenario === 'new' || scenario === 'both-config' ? xdg : legacy;
+        expect(parseWholeStdout(shown)).toMatchObject({
+          paths: { global: path.join(expected, 'config.json') },
+        });
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+      });
+    }
+  );
+
+  it('honors the explicit directory override within the isolated process group', async () => {
+    await withSandbox(async (sandbox) => {
+      const override = path.join(sandbox.root, "custom root's files");
+      // The common launcher intentionally removes ambient TMUX_TEAM_HOME.
+      // env introduces this explicit fixture-only value inside its bounded child
+      // group; no shell expansion or production environment bypass is added.
+      const selected = {
+        ...sandbox,
+        cli: {
+          executable: '/usr/bin/env',
+          args: [`TMUX_TEAM_HOME=${override}`, sandbox.cli.executable, ...sandbox.cli.args],
+        },
+      };
+      const result = await runCli(selected, [
+        'config',
+        'set',
+        'ui.paneBadge',
+        'on',
+        '--global',
+        '--json',
+      ]);
+      expect(result.status).toBe(0);
+      expect(parseWholeStdout(result)).toEqual({ ok: true });
+      expect(JSON.parse(fs.readFileSync(path.join(override, 'config.json'), 'utf8'))).toEqual({
+        ui: { paneBadge: 'on' },
+      });
+      expect(fs.existsSync(sandbox.globalDir)).toBe(false);
+      expect(fs.existsSync(path.join(override, 'tmux-team.db'))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #103. Implements the existing configuration command in the development-only Rust preview; installed npm commands remain TypeScript.

- Centralize typed defaults, bounds, edit scope, clear policy, precedence and source accounting in `tmt-core`.
- Add one configuration filesystem adapter for explicit/XDG/legacy and ancestor-local paths, validated raw JSON projection and targeted edits preserving unrelated fields.
- Compose native `config` show/set/clear without acquiring SQLite or tmux. Keep other effects explicitly unimplemented.
- Extend the existing selected-process harness and CI with native config scenarios and six unchanged shared config contract cases.
- Update architecture, developer instructions, dependency review and the explicit rewrite parity boundary.

## Primary architecture review

Reviewed the complete production/test diff, relevant TypeScript configuration contracts and callers, and delegated core tests. Core owns policy without JSON/IO dependencies; adapters own concrete documents and paths; CLI owns invocation translation and presentation. No competing settings representation, validator, runtime fallback or identity registry was introduced.

Review findings resolved before this candidate:

- Move precedence/source accounting and edit/clear policy to core instead of leaving policy in adapter/CLI.
- Preserve JS numeric semantics in opaque config fields via config-only normalization; large valid JSON exponents must not make otherwise valid old files unreadable. Preserve ordinary insertion order on targeted edits. No reply-body normalization.
- Normalize XDG/HOME and derived file paths lexically before lookup, without requiring discarded components to exist or resolving symlinks.
- Route negative numeric config operands to semantic validation while still rejecting unknown flags.

Independent follow-up review found no remaining concrete correctness or architectural defects. Structured CLI JSON preserves parsed values; whitespace and numeric spelling are not byte-level invariants.

## Local verification

- Rust 1.97: locked format, clippy across workspace/all targets with warnings denied, 41 tests, native binary/probe builds.
- MSRV Rust 1.88: 41 tests passed.
- Native selected-process suite: 39 passed (15 config, 19 storage, 5 grammar).
- Existing selected public parser contracts: 8 passed; existing selected config contracts: 6 passed.
- `pnpm check`: passed, zero warnings/errors.
- Existing TypeScript suite: 1,102 tests passed across 70 files; coverage 95.66% statements, 89.47% branches, 97.55% functions.
- Full isolated local Docker E2E: 104 passed, one optional benchmark skipped; 286.51 seconds. These regressions still exercise the installed TypeScript runtime, not native tmux parity.
- `git diff --check`: passed.

Four shared config-suite cases require unported native list/reply/result commands. They remain explicit parent parity gates; native `config show` independently covers configuration-validation concerns. No tests were removed to claim those commands work.

## Delivery boundaries

This does not deliver native identities, transport, requests, installation/update, release publication or runtime cutover. #100 still owns the temporary-by-default / explicit-save / restored-remove amendment. Merge only after all CI checks pass on the reviewed candidate.
