### PR TITLE
feat(native): add bounded tmux evidence adapter

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -894,7 +894,8 @@ failure semantics; merely introducing an interface is not an architectural fix.
 remain TypeScript. `tmt-core` owns numeric and settings policy, while `tmt-cli`
 owns one Clap grammar, typed requests, presentation, configuration composition
 and explicit no-effects rejection for unimplemented commands. `tmt-adapters`
-owns the schema 8 SQLite lifecycle under #97 and configuration files under #103;
+owns the schema 8 SQLite lifecycle under #97, configuration files under #103,
+and bounded Unix tmux evidence under #105;
 neither core nor typed requests depend on concrete IO.
 
 Help and completion use a filtered projection of the same grammar, excluding
@@ -942,11 +943,48 @@ does not contain a competing settings validator, and core imports no JSON or IO
 library. This shared boundary is available to subsequent native use cases;
 configuration operations never acquire the storage or tmux adapters.
 Precedence and source accounting live in core `ResolvedSettings`, not the file
-adapter. Config decoding alone normalizes arbitrary JSON numbers to the prior
-runtime's IEEE-754/stringification semantics; it never rewrites retained reply
+adapter. Config and pane metadata reuse `json_document` to normalize arbitrary
+JSON numbers to the prior runtime's IEEE-754/stringification semantics; this
+explicit editable-document boundary never rewrites retained reply
 bodies. Ordered JSON maps minimize edit churn. XDG and derived file paths are
 normalized lexically without requiring discarded components to exist or
 resolving user symlinks.
+
+The native `process` adapter owns argv-only execution, concurrent stdin/stdout/
+stderr communication, independent output caps and monotonic deadlines. It uses
+`subprocess` communication while retaining the process-group owner, with explicit
+kill/reap and a separate one-second cleanup budget. No detached reader threads,
+shell interpolation or async runtime are introduced. An exceptional unreaped
+child is detached only to avoid an unbounded destructor and is reported as
+failed cleanup, never successful termination. Group signals are not sent after
+the leader has been reaped. On Darwin, a zombie-only group may return EPERM;
+only read-only confirmation of group absence after reaping clears that error.
+
+Native `tmux` composes this runner for target resolution, caller ancestry,
+coherent scoped snapshots and metadata read/modify/write. `tmt-core::endpoint`
+owns observation types and ID validity, not registration. Caller and snapshot
+wire parsing share strict decimal safe-integer decoding; unlike permissive
+JavaScript Number conversion, signs, exponents and hexadecimal fields are not
+accepted as process evidence. Actual tmux/ps output uses decimal fields.
+Missing and malformed caller evidence fails closed; complete context uses one
+small query, while ancestry and its pane query share a one-second deadline.
+Scoped reads never expand an empty scope, and linked/grouped rows are validated
+before deduplication. Only reliable recorded-PID absence establishes death.
+Known-socket probes never initialize or overwrite foreign server metadata.
+
+Expected unavailable caller/target evidence and uncertain probes retain their
+optional/unknown results, but failed subprocess cleanup propagates as an error.
+It cannot trigger fallback server initialization or be hidden by best-effort
+observation. Metadata reads remain fatal before writes; unknown siblings survive
+marker replacement/clear. There is no native binding transaction, retirement,
+badge or message transport in this adapter slice.
+
+The non-installed `tmux-probe` example exposes only narrow adapter operations
+and counts runner calls. The existing Docker fixture selects it through the
+shared executable descriptor. The same pinned Debian image builds native
+artifacts, runs adapter unit tests under `--init`, and executes real private-tmux
+scenarios with mock agents and no network. These are adapter integration tests,
+not evidence that unported native identity/talk commands work.
 
 The [Rust rewrite decision](RUST-REWRITE.md) records the proposed native package
 boundaries, compatibility/test matrix, data coexistence gates and dependency

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -62,7 +62,7 @@ Use the [development skill](.agents/skills/tmt-dev/SKILL.md) to apply them.
 
 Native Rust uses edition 2024, rustfmt, snake_case module files, explicit typed
 requests and standard `Result` boundaries. Keep Clap and output in `tmt-cli`,
-pure validity rules/use cases in `tmt-core`, and concrete effects in the future
+pure validity rules/use cases in `tmt-core`, and concrete effects in the
 `tmt-adapters` package. Follow the declared MSRV and committed lockfile; do not
 silence warnings to avoid correcting a touched implementation. Unit tests stay
 with their owner; shared process scenarios reuse the repository test harness.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,6 +36,8 @@ help/version/completion, typed grammar and the existing `config` command.
 Other effectful commands still explicitly fail.
 The separate storage adapter implements schema 8 lifecycle compatibility, tested
 through a development-only probe rather than an installed command.
+The Unix tmux evidence adapter is likewise exercised through a non-installed
+`tmux-probe` example; native identity commands are not implemented by that probe.
 Use the exact toolchain from `rust/rust-toolchain.toml` and run from `rust/`:
 
 ```bash
@@ -44,6 +46,7 @@ cargo clippy --locked --all-targets -- -D warnings
 cargo test --locked
 cargo build --locked
 cargo build --locked --example storage-probe
+cargo build --locked --example tmux-probe
 cargo +1.88.0 build --locked
 ```
 
@@ -88,6 +91,22 @@ current RustSec advisories when changing Cargo.lock. `tmt-core` must remain free
 of CLI/concrete-IO dependencies. `tmt-adapters` owns the concrete SQLite lifecycle;
 keep its raw connection private. See RUST-REWRITE for the dependency
 decision and explicit exceptions under #100.
+
+The Docker image builds Linux adapter test artifacts in a pinned Rust/Debian
+stage matching the runtime image's libc. It runs native adapter unit tests under
+the existing wrapper's `--init --network none` before Vitest. This lets orphaned
+fixture children be reaped by init; running those lifecycle tests in a Docker
+build shell is not equivalent. The native toolchain is not copied to the final
+test image. Keep the same wrapper, private sockets and finally-based cleanup.
+
+`test/e2e/native-tmux.e2e.test.ts` requires `TMT_TEST_TMUX_PROBE`, set by that
+image to the narrow development example. It feeds the descriptor into the
+existing fixture selector, never silently substituting TypeScript. Its caller,
+snapshot, target, metadata and known-server cases are adapter integration, not
+public native CLI parity. The probe requires fixture socket environment as an
+accidental-host-use guard, not an authorization boundary. Never run its tmux
+operations against a host server. Process fixtures use finite children even
+on failure and never signal a recycled PID after observed reaping.
 
 For runtime-rewrite work, read [RUST-REWRITE.md](RUST-REWRITE.md) for the proposed
 boundaries and parity gates. The optional [performance baseline](PERFORMANCE-BASELINE.md)

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -1,6 +1,7 @@
 # Rust rewrite preparation
 
-Status: native grammar (#96), schema 8 lifecycle (#97) and configuration (#103)
+Status: native grammar (#96), schema 8 lifecycle (#97), configuration (#103)
+and bounded tmux evidence (#105)
 are implemented in the development preview, not a shipped Rust runtime.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
@@ -51,7 +52,8 @@ is by responsibility, not a mechanical copy of every TypeScript file.
 
 The `rust/` workspace contains `tmt-core` (numeric and settings policy),
 `tmt-cli` (grammar, typed invocation translation and output), and `tmt-adapters`
-(schema 8 SQLite lifecycle under #97 and configuration files under #103). The npm entry points still execute TypeScript. No command silently
+(schema 8 SQLite lifecycle under #97, configuration files under #103 and Unix
+tmux evidence under #105). The npm entry points still execute TypeScript. No command silently
 delegates from native to Node.
 
 The preview implements help, version, Bash/Zsh completion and the existing
@@ -76,7 +78,8 @@ Configuration decoding enables serde_json's `arbitrary_precision` so valid
 large exponents reach the compatibility boundary, then normalizes numbers to
 the reference runtime's IEEE-754/JSON.stringify semantics (non-finite opaque
 values become null when edited; known invalid fields still fail). This policy
-is config-only, not a global reply/body transformation. `preserve_order` avoids
+is shared by config and editable pane metadata under #105, not a global
+reply/body transformation. `preserve_order` avoids
 reordering ordinary user objects on targeted writes. The added locked graph is
 indexmap 2.14.2, hashbrown 0.17.1 and equivalent 1.0.2, with MIT/Apache-2.0 choices
 and declared MSRVs at or below 1.85. RustSec RUSTSEC-2024-0402 is patched before
@@ -102,7 +105,8 @@ locked builds on both versions are required. The selected released dependencies
 are Clap 4.6.6, clap_complete 4.6.9 and serde_json 1.0.151. Clap disables defaults,
 enabling only std/help/usage/error-context/suggestions/string; the string feature
 supports projecting grammar metadata without a duplicate command inventory.
-No derive, color, async runtime or process dependency is introduced yet.
+The original grammar slice introduced no derive, color, async runtime or process
+dependency; #105 adds the bounded process dependencies described below.
 Published manifests for the original grammar graph declare MSRVs at or below 1.85; licenses
 are MIT/Apache-2.0 compatible alternatives, with unicode-ident also carrying
 Unicode-3.0. RustSec database revision
@@ -129,6 +133,52 @@ busy timeout; this preserves the existing storage boundary, not an all-openers
 success guarantee. See [SQLite busy-handler behavior](https://sqlite.org/c3ref/busy_handler.html).
 
 ### Execution and resource ownership
+
+#105 implements one Unix runner using `subprocess` 1.2.1 for simultaneous pipe
+communication, `nix` 0.31.3 with only signal/process features for typed OS
+operations, and UUID 1.26.0 for v4 server IDs (pure parsing in core; generation
+in adapters). The standard library's safe `CommandExt::process_group` is
+available, but does not itself provide concurrent bounded pipe communication.
+Using a narrow maintained primitive avoids another hand-written poll loop or
+an async runtime. The workspace still forbids authored unsafe code.
+
+The complete lockfile adds 24 packages, but only seven additions are active in
+the inspected Linux/macOS graphs: subprocess, nix, uuid, getrandom 0.4.3,
+libc 0.2.189, cfg-if 1.0.4 and build-time cfg_aliases 0.2.2. The other 17 are
+target-only Windows/WASM/UEFI entries, not a linked async runtime on Unix.
+All additions offer MIT or Apache-2.0 licenses; r-efi also offers LGPL as an
+alternative, which is not selected. Declared MSRVs do not exceed 1.88; some
+manifests omit them, so actual locked MSRV compilation remains required.
+The inspected RustSec snapshot is the revision recorded above: nix's
+RUSTSEC-2021-0119 affects old getgrouplist implementations and is patched before
+0.31.3; that API is outside the enabled features. No other added package had an
+advisory entry in that dated snapshot. This is neither a permanent security
+guarantee nor verification of untested Windows/WASM/UEFI runtime targets.
+
+Retain the `Job` from `Exec::start`; detached `Exec::communicate` and consuming
+timeout convenience methods do not satisfy ownership/cleanup requirements.
+Custom bounded stream sinks classify overflow and never return successful
+partial output. Communication and process exit share the remaining deadline;
+EOF alone is not completion. Failure kills the owned group and waits with a
+separate one-second cleanup budget; cleanup failures retain their cause and
+propagate through optional caller/target and live/dead/unknown probe boundaries.
+They cannot authorize metadata fallback writes. A fallback destructor is bounded
+but does not replace explicit error reporting.
+
+Darwin can return EPERM for a zombie-only group. The adapter reaps its owned
+leader and clears that error only if a read-only group probe returns ESRCH;
+live, denied or unknown groups remain failures. It never signals the numeric
+group again after reaping. This follows the zombie filtering in Apple's
+[XNU group-signal implementation](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/kern_sig.c).
+The tests exercise overflow, ignored termination, inherited output descriptors,
+EOF-before-exit and simultaneous input/output pressure with observable cleanup.
+
+Native endpoint and caller protocols share strict decimal wire parsing. Synthetic
+hex/exponent/signed PID fields previously accepted by Number coercion are now
+rejected; real tmux/ps decimal output is preserved. This is a fail-closed evidence
+boundary, not a broader identity namespace or lifetime policy change. The
+development-only probe and Docker scenarios do not implement identity commands,
+badge presentation, message delivery, or runtime cutover.
 
 Start with synchronous use cases and SQLite, without Tokio in ordinary CLI startup.
 Polling is bounded and does not require an async framework. The command lifetime

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "cc"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +29,18 @@ dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
@@ -84,6 +102,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +159,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +191,30 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -147,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rusqlite"
 version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +258,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
@@ -209,6 +315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +331,16 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subprocess"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c2982c58b661c6509861bd3383870b6918030606e8b5afb0ade14b4a3cff12"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "syn"
@@ -235,9 +357,12 @@ dependencies = [
 name = "tmt-adapters"
 version = "5.0.0-alpha.1"
 dependencies = [
+ "nix",
  "rusqlite",
  "serde_json",
+ "subprocess",
  "tmt-core",
+ "uuid",
 ]
 
 [[package]]
@@ -254,6 +379,9 @@ dependencies = [
 [[package]]
 name = "tmt-core"
 version = "5.0.0-alpha.1"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -262,10 +390,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zmij"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,6 +16,9 @@ clap = { version = "=4.6.6", default-features = false, features = ["std", "help"
 clap_complete = { version = "=4.6.9", default-features = false }
 serde_json = { version = "=1.0.151", features = ["arbitrary_precision", "preserve_order"] }
 rusqlite = { version = "=0.40.2", default-features = false, features = ["bundled"] }
+subprocess = "=1.2.1"
+nix = { version = "=0.31.3", default-features = false, features = ["signal", "process"] }
+uuid = { version = "=1.26.0", default-features = false, features = ["std"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -10,6 +10,11 @@ publish.workspace = true
 tmt-core.workspace = true
 rusqlite.workspace = true
 serde_json.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+
+[target.'cfg(unix)'.dependencies]
+subprocess.workspace = true
+nix.workspace = true
 
 [lints]
 workspace = true

--- a/rust/crates/tmt-adapters/examples/tmux-probe.rs
+++ b/rust/crates/tmt-adapters/examples/tmux-probe.rs
@@ -1,0 +1,277 @@
+//! Development-only tmux adapter probe for isolated E2E fixtures.
+//! This is not a supported tmt command and is never an installed artifact.
+
+use std::{
+    ffi::OsString,
+    io::{self, Write},
+    process::ExitCode,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use tmt_adapters::{
+    process::{CommandOutput, CommandRequest, CommandRunner, UnixCommandRunner},
+    tmux::{CallerEnvironment, OperationOptions, Tmux, TmuxError},
+};
+use tmt_core::endpoint::{
+    BindingMarker, EndpointProbe, EndpointSnapshot, PaneObservation, ServerEvidence,
+    valid_process_id,
+};
+
+const USAGE: &str = "Usage: tmux-probe [--json] caller | snapshot [pane-id ...] | server | probe <socket> <pid> [pane-id ...] | probe-server <socket> <pid> | target <target> | set-marker <pane> <name> <canonical-name> <identity-id> <binding-id> <server-id> <pane-pid> | clear-marker <pane> <binding-id>";
+
+#[derive(Debug)]
+enum ProbeError {
+    Environment,
+    Usage(&'static str),
+    Tmux(TmuxError),
+}
+
+impl ProbeError {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::Environment => "ENVIRONMENT_ERROR",
+            Self::Usage(_) => "USAGE_ERROR",
+            Self::Tmux(_) => "TMUX_ERROR",
+        }
+    }
+
+    fn message(&self) -> String {
+        match self {
+            Self::Environment => "TMT_E2E_SOCKET must be set for the isolated probe.".into(),
+            Self::Usage(message) => (*message).into(),
+            Self::Tmux(error) => error.to_string(),
+        }
+    }
+}
+
+impl From<TmuxError> for ProbeError {
+    fn from(error: TmuxError) -> Self {
+        Self::Tmux(error)
+    }
+}
+
+struct CountingRunner {
+    inner: UnixCommandRunner,
+    count: Arc<AtomicUsize>,
+}
+
+impl CommandRunner for CountingRunner {
+    fn execute(
+        &self,
+        request: CommandRequest<'_>,
+    ) -> Result<CommandOutput, tmt_adapters::process::CommandError> {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.inner.execute(request)
+    }
+}
+
+fn marker_json(marker: Option<&BindingMarker>) -> serde_json::Value {
+    marker.map_or(serde_json::Value::Null, |marker| {
+        serde_json::json!({
+            "name": marker.name,
+            "canonicalName": marker.canonical_name,
+            "identityId": marker.identity_id,
+            "bindingId": marker.binding_id,
+            "serverId": marker.server_id,
+            "panePid": marker.pane_pid,
+        })
+    })
+}
+
+fn server_json(server: &ServerEvidence) -> serde_json::Value {
+    serde_json::json!({
+        "serverId": server.server_id,
+        "socketPath": server.socket_path,
+        "serverPid": server.server_pid,
+        "serverStartTime": server.server_start_time,
+    })
+}
+
+fn pane_json(pane: &PaneObservation) -> serde_json::Value {
+    serde_json::json!({
+        "id": pane.id,
+        "target": pane.target,
+        "cwd": pane.cwd,
+        "command": pane.command,
+        "panePid": pane.pane_pid,
+        "suggestedName": pane.suggested_name,
+        "marker": marker_json(pane.marker.as_ref()),
+    })
+}
+
+fn snapshot_json(snapshot: &EndpointSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "server": server_json(&snapshot.server),
+        "panes": snapshot.panes.iter().map(pane_json).collect::<Vec<_>>(),
+    })
+}
+
+fn probe_json(probe: EndpointProbe) -> serde_json::Value {
+    match probe {
+        EndpointProbe::Live(snapshot) => serde_json::json!({
+            "status": "live",
+            "snapshot": snapshot_json(&snapshot),
+        }),
+        EndpointProbe::Dead => serde_json::json!({"status": "dead"}),
+        EndpointProbe::Unknown => serde_json::json!({"status": "unknown"}),
+    }
+}
+
+fn parse_pid(text: &str) -> Result<u64, ProbeError> {
+    let pid = text
+        .parse::<u64>()
+        .map_err(|_| ProbeError::Usage("PID must be a positive safe integer."))?;
+    if !valid_process_id(pid) {
+        return Err(ProbeError::Usage("PID must be a positive safe integer."));
+    }
+    Ok(pid)
+}
+
+fn options<'a>(pane_ids: &'a [String]) -> OperationOptions<'a> {
+    OperationOptions {
+        deadline: None,
+        pane_ids: (!pane_ids.is_empty()).then_some(pane_ids),
+    }
+}
+
+fn run(args: &[String], tmux: &Tmux<CountingRunner>) -> Result<serde_json::Value, ProbeError> {
+    let Some(mode) = args.first().map(String::as_str) else {
+        return Err(ProbeError::Usage(USAGE));
+    };
+    match mode {
+        "caller" if args.len() == 1 => Ok(serde_json::json!({
+            "pane": tmux.caller_pane(&CallerEnvironment::current())?,
+        })),
+        "snapshot" => {
+            let pane_ids = args[1..].to_vec();
+            let snapshot = tmux.snapshot(options(&pane_ids))?;
+            Ok(snapshot_json(&snapshot))
+        }
+        "server" if args.len() == 1 => {
+            let pane_ids = Vec::new();
+            let snapshot = tmux.snapshot(OperationOptions {
+                pane_ids: Some(&pane_ids),
+                ..Default::default()
+            })?;
+            Ok(snapshot_json(&snapshot))
+        }
+        "probe" if args.len() >= 3 => {
+            let socket = &args[1];
+            if socket.is_empty() {
+                return Err(ProbeError::Usage("probe requires a nonempty socket."));
+            }
+            let recorded_pid = parse_pid(&args[2])?;
+            let pane_ids = args[3..].to_vec();
+            let probe = tmux.probe(socket, recorded_pid, options(&pane_ids))?;
+            Ok(probe_json(probe))
+        }
+        "probe-server" if args.len() == 3 => {
+            let socket = &args[1];
+            if socket.is_empty() {
+                return Err(ProbeError::Usage(
+                    "probe-server requires a nonempty socket.",
+                ));
+            }
+            let recorded_pid = parse_pid(&args[2])?;
+            let pane_ids = Vec::new();
+            let probe = tmux.probe(
+                socket,
+                recorded_pid,
+                OperationOptions {
+                    pane_ids: Some(&pane_ids),
+                    ..Default::default()
+                },
+            )?;
+            Ok(probe_json(probe))
+        }
+        "target" if args.len() == 2 => Ok(serde_json::json!({
+            "pane": tmux.resolve_target(&args[1], OperationOptions::default())?,
+        })),
+        "set-marker" if args.len() == 8 => {
+            let marker = BindingMarker {
+                name: args[2].clone(),
+                canonical_name: args[3].clone(),
+                identity_id: args[4].clone(),
+                binding_id: args[5].clone(),
+                server_id: args[6].clone(),
+                pane_pid: parse_pid(&args[7])?,
+            };
+            tmux.set_marker(&args[1], &marker, OperationOptions::default())?;
+            Ok(serde_json::json!({"changed": true}))
+        }
+        "clear-marker" if args.len() == 3 => {
+            let changed =
+                tmux.clear_marker(&args[1], Some(&args[2]), OperationOptions::default())?;
+            Ok(serde_json::json!({"changed": changed}))
+        }
+        _ => Err(ProbeError::Usage(USAGE)),
+    }
+}
+
+fn main() -> ExitCode {
+    if !matches!(std::env::var_os("TMT_E2E_SOCKET"), Some(value) if !value.is_empty()) {
+        let document = serde_json::json!({
+            "error": {"code": "ENVIRONMENT_ERROR", "message": ProbeError::Environment.message()},
+            "commandCount": 0,
+        });
+        let _ = writeln!(io::stdout().lock(), "{document}");
+        return ExitCode::FAILURE;
+    }
+
+    let raw_args = std::env::args_os().skip(1).collect::<Vec<OsString>>();
+    let mut args = Vec::with_capacity(raw_args.len());
+    for arg in raw_args {
+        let Ok(arg) = arg.into_string() else {
+            let document = serde_json::json!({
+                "error": {"code": "USAGE_ERROR", "message": "Arguments must be valid UTF-8."},
+                "commandCount": 0,
+            });
+            let _ = writeln!(io::stdout().lock(), "{document}");
+            return ExitCode::FAILURE;
+        };
+        args.push(arg);
+    }
+    if args.first().is_some_and(|arg| arg == "--json") {
+        args.remove(0);
+    }
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let tmux = Tmux::new(CountingRunner {
+        inner: UnixCommandRunner,
+        count: Arc::clone(&count),
+    });
+    let document = match run(&args, &tmux) {
+        Ok(result) => {
+            let mut object = match result {
+                serde_json::Value::Object(object) => object,
+                _ => {
+                    let error = ProbeError::Usage("Probe result must be a JSON object.");
+                    serde_json::Map::from_iter([(
+                        "error".into(),
+                        serde_json::json!({"code": error.code(), "message": error.message()}),
+                    )])
+                }
+            };
+            object.insert(
+                "commandCount".into(),
+                serde_json::json!(count.load(Ordering::Relaxed)),
+            );
+            serde_json::Value::Object(object)
+        }
+        Err(error) => serde_json::json!({
+            "error": {"code": error.code(), "message": error.message()},
+            "commandCount": count.load(Ordering::Relaxed),
+        }),
+    };
+    if writeln!(io::stdout().lock(), "{document}").is_err() {
+        return ExitCode::FAILURE;
+    }
+    if document.get("error").is_some() {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}

--- a/rust/crates/tmt-adapters/src/config/document.rs
+++ b/rust/crates/tmt-adapters/src/config/document.rs
@@ -102,42 +102,14 @@ fn shape(value: &Value, path: &Path, scope: Scope) -> Result<(), ConfigError> {
 }
 
 pub(super) fn read(path: &Path, scope: Scope) -> Result<Value, ConfigError> {
-    let mut value = if path.exists() {
+    let value = if path.exists() {
         let content = fs::read_to_string(path).map_err(|error| ConfigError::parse(path, error))?;
-        serde_json::from_str(&content).map_err(|error| ConfigError::parse(path, error))?
+        crate::json_document::parse(&content).map_err(|error| ConfigError::parse(path, error))?
     } else {
         json!({})
     };
-    normalize_numbers(&mut value);
     shape(&value, path, scope)?;
     Ok(value)
-}
-
-fn normalize_numbers(value: &mut Value) {
-    match value {
-        Value::Number(number) => {
-            // JSON.parse uses IEEE-754 for every number, including opaque
-            // fields. JSON.stringify subsequently writes non-finite values as
-            // null. Known numeric settings reject that null during projection.
-            // arbitrary_precision lets the decoder reach this policy even for
-            // a valid JSON exponent outside f64's representable range.
-            *value = number
-                .as_f64()
-                .and_then(|number| {
-                    if number.fract() == 0.0 && number >= 0.0 && number < u64::MAX as f64 {
-                        Some(serde_json::Number::from(number as u64))
-                    } else if number.fract() == 0.0 && number < 0.0 && number >= i64::MIN as f64 {
-                        Some(serde_json::Number::from(number as i64))
-                    } else {
-                        serde_json::Number::from_f64(number)
-                    }
-                })
-                .map_or(Value::Null, Value::Number);
-        }
-        Value::Array(values) => values.iter_mut().for_each(normalize_numbers),
-        Value::Object(values) => values.values_mut().for_each(normalize_numbers),
-        _ => {}
-    }
 }
 
 pub(super) fn project(

--- a/rust/crates/tmt-adapters/src/json_document.rs
+++ b/rust/crates/tmt-adapters/src/json_document.rs
@@ -1,0 +1,35 @@
+//! Compatibility for editable JSON documents formerly owned by JavaScript.
+//! Call explicitly for config and pane metadata, never retained response bodies.
+
+use serde_json::Value;
+
+pub(crate) fn parse(text: &str) -> Result<Value, serde_json::Error> {
+    let mut value = serde_json::from_str(text)?;
+    normalize_numbers(&mut value);
+    Ok(value)
+}
+
+fn normalize_numbers(value: &mut Value) {
+    match value {
+        Value::Number(number) => {
+            // JSON.parse uses IEEE-754 even for opaque values. JSON.stringify
+            // writes non-finite values as null. arbitrary_precision lets valid
+            // exponents outside f64 reach this policy rather than fail decoding.
+            *value = number
+                .as_f64()
+                .and_then(|number| {
+                    if number.fract() == 0.0 && number >= 0.0 && number < u64::MAX as f64 {
+                        Some(serde_json::Number::from(number as u64))
+                    } else if number.fract() == 0.0 && number < 0.0 && number >= i64::MIN as f64 {
+                        Some(serde_json::Number::from(number as i64))
+                    } else {
+                        serde_json::Number::from_f64(number)
+                    }
+                })
+                .map_or(Value::Null, Value::Number);
+        }
+        Value::Array(values) => values.iter_mut().for_each(normalize_numbers),
+        Value::Object(values) => values.values_mut().for_each(normalize_numbers),
+        _ => {}
+    }
+}

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -1,4 +1,15 @@
 //! Concrete native adapters. Application policy must not depend on this crate.
 
 pub mod config;
+mod json_document;
+#[cfg(unix)]
+pub mod process;
 pub mod storage;
+#[cfg(unix)]
+pub mod tmux;
+
+#[cfg(test)]
+mod test_support;
+
+#[cfg(all(test, unix))]
+mod process_tests;

--- a/rust/crates/tmt-adapters/src/process.rs
+++ b/rust/crates/tmt-adapters/src/process.rs
@@ -1,0 +1,305 @@
+//! Bounded Unix child ownership shared by tmux and caller ancestry discovery.
+//! The communication primitive multiplexes pipes; this boundary owns deadlines,
+//! per-stream limits, failure classification, and explicit termination/reaping.
+
+use nix::{
+    errno::Errno,
+    sys::signal::{Signal, killpg},
+    unistd::Pid,
+};
+use std::{
+    ffi::{OsStr, OsString},
+    fmt,
+    io::{self, Write},
+    time::{Duration, Instant},
+};
+use subprocess::{Exec, ExecExt, Job, JobExt, Redirection};
+
+const CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
+
+pub struct CommandRequest<'a> {
+    pub program: &'a OsStr,
+    pub args: &'a [OsString],
+    pub input: &'a [u8],
+    pub deadline: Instant,
+    pub max_output_bytes: usize,
+}
+
+#[derive(Debug)]
+pub struct CommandOutput {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandFailure {
+    Spawn,
+    Timeout,
+    OutputLimit,
+    Io,
+    Exit {
+        code: Option<u32>,
+        signal: Option<i32>,
+    },
+}
+
+#[derive(Debug)]
+pub struct CommandError {
+    pub kind: CommandFailure,
+    pub cleanup_error: Option<io::Error>,
+    cause: Option<io::Error>,
+}
+
+impl CommandError {
+    pub(crate) fn new(kind: CommandFailure) -> Self {
+        Self {
+            kind,
+            cleanup_error: None,
+            cause: None,
+        }
+    }
+
+    fn io(kind: CommandFailure, cause: io::Error) -> Self {
+        Self {
+            cause: Some(cause),
+            ..Self::new(kind)
+        }
+    }
+
+    pub fn raw_os_error(&self) -> Option<i32> {
+        self.cause.as_ref().and_then(io::Error::raw_os_error)
+    }
+
+    pub fn cleanup_failed(&self) -> bool {
+        self.cleanup_error.is_some()
+    }
+}
+
+impl fmt::Display for CommandError {
+    fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Neither argv nor subprocess output belongs in public adapter errors.
+        write!(output, "External command failed: {:?}", self.kind)?;
+        if self.cleanup_failed() {
+            write!(output, " (cleanup failed)")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for CommandError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.cause.as_ref().map(|cause| cause as _)
+    }
+}
+
+pub trait CommandRunner {
+    fn execute(&self, request: CommandRequest<'_>) -> Result<CommandOutput, CommandError>;
+}
+
+pub struct UnixCommandRunner;
+
+impl CommandRunner for UnixCommandRunner {
+    fn execute(&self, request: CommandRequest<'_>) -> Result<CommandOutput, CommandError> {
+        remaining(request.deadline)?;
+        let job = Exec::cmd(request.program)
+            .args(request.args.iter().cloned())
+            .stdin(request.input.to_vec())
+            .stdout(Redirection::Pipe)
+            .stderr(Redirection::Pipe)
+            .setpgid()
+            .start()
+            .map_err(|cause| CommandError::io(CommandFailure::Spawn, cause))?;
+        let mut owned = OwnedJob {
+            job,
+            finished: false,
+        };
+        match communicate(&mut owned.job, request.deadline, request.max_output_bytes) {
+            Ok(output) => {
+                owned.finished = true;
+                Ok(output)
+            }
+            Err(mut error) => {
+                error.cleanup_error = owned.cleanup().err();
+                Err(error)
+            }
+        }
+    }
+}
+
+fn remaining(deadline: Instant) -> Result<Duration, CommandError> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| CommandError::new(CommandFailure::Timeout))
+}
+
+fn communicate(
+    job: &mut Job,
+    deadline: Instant,
+    max_output_bytes: usize,
+) -> Result<CommandOutput, CommandError> {
+    let mut stdout = CappedOutput::new(max_output_bytes);
+    let mut stderr = CappedOutput::new(max_output_bytes);
+    {
+        // Keep the Job. Exec::communicate detaches; consuming convenience
+        // timeout methods can instead block inside Process::drop on failure.
+        let mut communication = job
+            .communicate()
+            .map_err(|cause| CommandError::io(CommandFailure::Io, cause))?
+            .limit_time(remaining(deadline)?);
+        if let Err(cause) = communication.read_to(&mut stdout, &mut stderr) {
+            let kind = if stdout.exceeded || stderr.exceeded {
+                CommandFailure::OutputLimit
+            } else if cause.kind() == io::ErrorKind::TimedOut {
+                CommandFailure::Timeout
+            } else {
+                CommandFailure::Io
+            };
+            return Err(CommandError::io(kind, cause));
+        }
+    }
+    // EOF is not process completion: a child can close both pipes then hang.
+    // Conversely, do not reap the leader while a descendant holds its pipes:
+    // retaining the leader lets failure cleanup safely signal its group.
+    let status = job
+        .wait_timeout(remaining(deadline)?)
+        .map_err(|cause| CommandError::io(CommandFailure::Io, cause))?
+        .ok_or_else(|| CommandError::new(CommandFailure::Timeout))?;
+    if !status.success() {
+        return Err(CommandError::new(CommandFailure::Exit {
+            code: status.code(),
+            signal: status.signal(),
+        }));
+    }
+    Ok(CommandOutput {
+        stdout: stdout.bytes,
+        stderr: stderr.bytes,
+    })
+}
+
+struct CappedOutput {
+    bytes: Vec<u8>,
+    limit: usize,
+    exceeded: bool,
+}
+
+impl CappedOutput {
+    fn new(limit: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            limit,
+            exceeded: false,
+        }
+    }
+}
+
+impl Write for CappedOutput {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if bytes.len() > self.limit.saturating_sub(self.bytes.len()) {
+            self.exceeded = true;
+            return Err(io::Error::other("External command output limit exceeded"));
+        }
+        self.bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct OwnedJob {
+    job: Job,
+    finished: bool,
+}
+
+impl OwnedJob {
+    fn cleanup(&mut self) -> io::Result<()> {
+        let signal = self.job.send_signal_group(Signal::SIGKILL as i32);
+        let waited = self.job.wait_timeout(CLEANUP_TIMEOUT);
+        // An exceptional OS cleanup failure must not turn into an unbounded
+        // blocking destructor. No reader threads were spawned by this adapter.
+        // Detachment here is reported as failed cleanup, never success.
+        if !matches!(waited, Ok(Some(_))) {
+            self.job.detach();
+        }
+        self.finished = true;
+        match waited {
+            Ok(Some(_)) => confirm_group_termination(signal, || {
+                let pid = i32::try_from(self.job.pid()).map_err(|_| Errno::EINVAL)?;
+                // Read-only, after reaping. Never signal a numeric process group
+                // again once its leader may have been recycled by the kernel.
+                killpg(Pid::from_raw(pid), None)
+            }),
+            Ok(None) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "External command could not be reaped within the cleanup budget",
+            )),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn confirm_group_termination(
+    signal: io::Result<()>,
+    inspect: impl FnOnce() -> Result<(), Errno>,
+) -> io::Result<()> {
+    match signal {
+        Err(error) if error.raw_os_error() == Some(Errno::ESRCH as i32) => Ok(()),
+        // Darwin may return EPERM when a group contains only a zombie leader.
+        // Reaping that leader is not sufficient proof: another member could
+        // actually deny signals. Only observed group absence clears the error.
+        Err(error) if error.raw_os_error() == Some(Errno::EPERM as i32) => {
+            if inspect() == Err(Errno::ESRCH) {
+                Ok(())
+            } else {
+                Err(error)
+            }
+        }
+        result => result,
+    }
+}
+
+impl Drop for OwnedJob {
+    fn drop(&mut self) {
+        if !self.finished {
+            // Unwind fallback only. Operational paths call cleanup explicitly
+            // so they can preserve the primary error and expose cleanup failure.
+            let _ = self.cleanup();
+        }
+    }
+}
+
+#[cfg(test)]
+mod cleanup_policy_tests {
+    use super::*;
+
+    #[test]
+    fn permission_failure_requires_observed_group_absence() {
+        for observation in [Ok(()), Err(Errno::EPERM), Err(Errno::EIO)] {
+            let error = confirm_group_termination(
+                Err(io::Error::from_raw_os_error(Errno::EPERM as i32)),
+                || observation,
+            )
+            .unwrap_err();
+            assert_eq!(error.raw_os_error(), Some(Errno::EPERM as i32));
+        }
+        assert!(
+            confirm_group_termination(
+                Err(io::Error::from_raw_os_error(Errno::EPERM as i32)),
+                || Err(Errno::ESRCH),
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn successful_or_missing_groups_do_not_need_an_extra_probe() {
+        for signal in [
+            Ok(()),
+            Err(io::Error::from_raw_os_error(Errno::ESRCH as i32)),
+        ] {
+            assert!(confirm_group_termination(signal, || panic!("unexpected probe")).is_ok());
+        }
+    }
+}

--- a/rust/crates/tmt-adapters/src/process_tests.rs
+++ b/rust/crates/tmt-adapters/src/process_tests.rs
@@ -1,0 +1,360 @@
+use crate::process::{
+    CommandError, CommandFailure, CommandOutput, CommandRequest, CommandRunner, UnixCommandRunner,
+};
+use crate::test_support::TestDirectory;
+use nix::{
+    errno::Errno,
+    sys::signal::{Signal, kill},
+    unistd::Pid,
+};
+use std::{
+    ffi::{OsStr, OsString},
+    fs,
+    path::{Path, PathBuf},
+    thread,
+    time::{Duration, Instant},
+};
+
+const SHELL: &str = "/bin/sh";
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const CLEANUP_WAIT: Duration = Duration::from_secs(2);
+
+fn shell_args(script: &'static str, extra: &[OsString]) -> Vec<OsString> {
+    let mut args = vec![
+        OsString::from("-c"),
+        OsString::from(script),
+        OsString::from("fixture"),
+    ];
+    args.extend_from_slice(extra);
+    args
+}
+
+fn execute_shell(
+    runner: &UnixCommandRunner,
+    args: &[OsString],
+    input: &[u8],
+    timeout: Duration,
+    max_output_bytes: usize,
+) -> Result<CommandOutput, CommandError> {
+    runner.execute(CommandRequest {
+        program: OsStr::new(SHELL),
+        args,
+        input,
+        deadline: Instant::now() + timeout,
+        max_output_bytes,
+    })
+}
+
+fn execute_expired(
+    runner: &UnixCommandRunner,
+    args: &[OsString],
+) -> Result<CommandOutput, CommandError> {
+    runner.execute(CommandRequest {
+        program: OsStr::new(SHELL),
+        args,
+        input: &[],
+        deadline: Instant::now(),
+        max_output_bytes: 1024,
+    })
+}
+
+fn path_arg(path: &Path) -> OsString {
+    path.as_os_str().to_owned()
+}
+
+fn read_pid(path: &Path) -> Pid {
+    let value = fs::read_to_string(path).expect("fixture wrote a child PID");
+    let raw = value
+        .trim()
+        .parse::<i32>()
+        .expect("fixture PID is an integer");
+    assert!(raw > 0, "fixture PID must be positive");
+    Pid::from_raw(raw)
+}
+
+fn wait_for_pid(path: &Path) -> Pid {
+    let deadline = Instant::now() + CLEANUP_WAIT;
+    loop {
+        if path.is_file() {
+            return read_pid(path);
+        }
+        assert!(Instant::now() < deadline, "fixture did not write its PID");
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn assert_pid_gone(pid: Pid, cleanup: &mut PidCleanup) {
+    let deadline = Instant::now() + CLEANUP_WAIT;
+    loop {
+        match kill(pid, Option::<Signal>::None) {
+            Err(Errno::ESRCH) => {
+                cleanup.armed = false;
+                return;
+            }
+            Ok(()) => {}
+            Err(error) => panic!("could not inspect fixture PID {pid}: {error}"),
+        }
+        assert!(
+            Instant::now() < deadline,
+            "fixture PID {pid} was not reaped"
+        );
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+struct PidCleanup {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl Drop for PidCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let Ok(value) = fs::read_to_string(&self.path) else {
+            return;
+        };
+        let Ok(raw) = value.trim().parse::<i32>() else {
+            return;
+        };
+        if raw <= 0 {
+            return;
+        }
+        // These fixtures self-terminate after five seconds even if the runner
+        // is broken. Never send a signal using an already-reaped numeric PID:
+        // it could now belong to an unrelated process. Wait only, boundedly.
+        let deadline = Instant::now() + Duration::from_secs(6);
+        while kill(Pid::from_raw(raw), Option::<Signal>::None) != Err(Errno::ESRCH)
+            && Instant::now() < deadline
+        {
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+}
+
+#[test]
+fn executes_literal_argv_and_stdin_with_separate_output_streams() {
+    let runner = UnixCommandRunner;
+    let args = shell_args(
+        r#"printf 'arg1=[%s]\narg2=[%s]\narg3=[%s]\n' "$1" "$2" "$3"; printf 'stderr=[%s]\n' "$4" >&2; read -r line; printf 'stdin=[%s]\n' "$line""#,
+        &[
+            OsString::from("$(printf hacked); alpha beta"),
+            OsString::from("a'b\"c;*"),
+            OsString::from("! literal --json"),
+            OsString::from("--message=--json"),
+        ],
+    );
+
+    let output = execute_shell(
+        &runner,
+        &args,
+        b"input value\n",
+        Duration::from_secs(2),
+        1024,
+    )
+    .expect("literal command succeeds");
+
+    assert_eq!(
+        output.stdout,
+        b"arg1=[$(printf hacked); alpha beta]\narg2=[a'b\"c;*]\narg3=[! literal --json]\nstdin=[input value]\n"
+    );
+    assert_eq!(output.stderr, b"stderr=[--message=--json]\n");
+}
+
+#[test]
+fn classifies_nonzero_signal_and_spawn_failures() {
+    let runner = UnixCommandRunner;
+    let cases = [
+        ("nonzero", "exit 7", Some(7), None),
+        ("signal", "kill -TERM $$", None, Some(15)),
+    ];
+
+    for (name, script, expected_code, expected_signal) in cases {
+        let args = shell_args(script, &[]);
+        let error =
+            execute_shell(&runner, &args, &[], Duration::from_secs(2), 1024).expect_err(name);
+        assert!(
+            !error.cleanup_failed(),
+            "{name} failure should not require failed cleanup"
+        );
+        assert_eq!(
+            error.kind,
+            CommandFailure::Exit {
+                code: expected_code,
+                signal: expected_signal,
+            },
+            "{name} exit classification"
+        );
+    }
+
+    let missing = OsStr::new("/definitely/missing/tmt-fixture-command");
+    let error = runner
+        .execute(CommandRequest {
+            program: missing,
+            args: &[],
+            input: &[],
+            deadline: Instant::now() + Duration::from_secs(2),
+            max_output_bytes: 1024,
+        })
+        .expect_err("missing program must fail to spawn");
+    assert_eq!(error.kind, CommandFailure::Spawn);
+}
+
+#[test]
+fn enforces_each_output_stream_limit_and_accepts_exact_boundaries() {
+    let runner = UnixCommandRunner;
+    let exact_args = shell_args(
+        r#"printf '%s' "$1"; printf '%s' "$2" >&2"#,
+        &[OsString::from("12345678"), OsString::from("abcdefgh")],
+    );
+    let exact = execute_shell(&runner, &exact_args, &[], Duration::from_secs(2), 8)
+        .expect("exact per-stream output boundary succeeds");
+    assert_eq!(exact.stdout, b"12345678");
+    assert_eq!(exact.stderr, b"abcdefgh");
+
+    let cases = [
+        (
+            "stdout",
+            r#"printf '%s' "$1""#,
+            vec![OsString::from("123456789")],
+        ),
+        (
+            "stderr",
+            r#"printf '%s' "$1" >&2"#,
+            vec![OsString::from("123456789")],
+        ),
+    ];
+    for (name, script, extra) in cases {
+        let args = shell_args(script, &extra);
+        let error = execute_shell(&runner, &args, &[], Duration::from_secs(2), 8)
+            .expect_err("one stream over the cap must fail");
+        assert_eq!(error.kind, CommandFailure::OutputLimit, "{name} cap");
+        assert!(!error.cleanup_failed(), "{name} cleanup: {error:?}");
+    }
+}
+
+#[test]
+fn drains_simultaneous_pipe_pressure_without_deadlock() {
+    let runner = UnixCommandRunner;
+    let count = 70_000usize;
+    let args = shell_args(
+        r#"i=0; while [ "$i" -lt "$1" ]; do printf O; printf E >&2; i=$((i + 1)); done"#,
+        &[OsString::from(count.to_string())],
+    );
+
+    let output = execute_shell(&runner, &args, &[], Duration::from_secs(5), count)
+        .expect("both full output pipes should drain");
+    assert_eq!(output.stdout.len(), count);
+    assert_eq!(output.stderr.len(), count);
+    assert!(output.stdout.iter().all(|byte| *byte == b'O'));
+    assert!(output.stderr.iter().all(|byte| *byte == b'E'));
+}
+
+#[test]
+fn drains_substantial_stdin_while_stdout_and_stderr_are_under_pressure() {
+    let runner = UnixCommandRunner;
+    let count = 70_000usize;
+    let mut input = Vec::with_capacity(128 * 1024);
+    for _ in 0..128 {
+        input.extend(std::iter::repeat_n(b'I', 1024));
+        input.push(b'\n');
+    }
+    let args = shell_args(
+        r#"i=0; while [ "$i" -lt "$1" ]; do printf O; printf E >&2; i=$((i + 1)); done; n=0; while IFS= read -r line; do [ "$line" = "$2" ] || exit 8; n=$((n + 1)); done; [ "$n" -eq 128 ] || exit 9; printf D; printf F >&2"#,
+        &[
+            OsString::from(count.to_string()),
+            OsString::from("I".repeat(1024)),
+        ],
+    );
+
+    let output = execute_shell(&runner, &args, &input, Duration::from_secs(5), count + 1)
+        .expect("both output pipes and substantial stdin should drain");
+    assert_eq!(output.stdout.len(), count + 1);
+    assert_eq!(output.stderr.len(), count + 1);
+    assert_eq!(output.stdout.last(), Some(&b'D'));
+    assert_eq!(output.stderr.last(), Some(&b'F'));
+    assert!(output.stdout[..count].iter().all(|byte| *byte == b'O'));
+    assert!(output.stderr[..count].iter().all(|byte| *byte == b'E'));
+}
+
+#[test]
+fn rejects_expired_deadline_before_spawning() {
+    let directory = TestDirectory::new();
+    let marker = directory.path.join("spawned");
+    let args = shell_args(r#"printf spawned > "$1""#, &[path_arg(&marker)]);
+
+    let error = execute_expired(&UnixCommandRunner, &args).expect_err("expired deadline");
+    assert_eq!(error.kind, CommandFailure::Timeout);
+    assert!(!marker.exists(), "expired deadline must prevent spawn");
+}
+
+#[test]
+fn kills_and_reaps_term_ignoring_child_with_bounded_cleanup() {
+    let directory = TestDirectory::new();
+    let pid_path = directory.path.join("child.pid");
+    let mut cleanup = PidCleanup {
+        path: pid_path.clone(),
+        armed: true,
+    };
+    let args = shell_args(
+        r#"printf '%s' "$$" > "$1"; trap '' TERM; exec sleep 5"#,
+        &[path_arg(&pid_path)],
+    );
+
+    let error = execute_shell(&UnixCommandRunner, &args, &[], Duration::from_secs(1), 1024)
+        .expect_err("TERM-ignoring child must hit the deadline");
+    assert_eq!(error.kind, CommandFailure::Timeout);
+    assert!(
+        !error.cleanup_failed(),
+        "child cleanup should be observable: {error:?}"
+    );
+    let pid = wait_for_pid(&pid_path);
+    assert_pid_gone(pid, &mut cleanup);
+}
+
+#[test]
+fn treats_closed_output_as_eof_but_still_waits_for_running_child() {
+    let directory = TestDirectory::new();
+    let pid_path = directory.path.join("closed-output.pid");
+    let mut cleanup = PidCleanup {
+        path: pid_path.clone(),
+        armed: true,
+    };
+    let args = shell_args(
+        r#"printf '%s' "$$" > "$1"; exec 1>/dev/null 2>/dev/null; exec sleep 5"#,
+        &[path_arg(&pid_path)],
+    );
+
+    let error = execute_shell(&UnixCommandRunner, &args, &[], Duration::from_secs(1), 1024)
+        .expect_err("closed output must not imply process completion");
+    assert_eq!(error.kind, CommandFailure::Timeout);
+    assert!(!error.cleanup_failed(), "running child cleanup: {error:?}");
+    let pid = wait_for_pid(&pid_path);
+    assert_pid_gone(pid, &mut cleanup);
+}
+
+#[test]
+fn kills_descendant_that_retains_pipes_after_leader_exit() {
+    let directory = TestDirectory::new();
+    let pid_path = directory.path.join("descendant.pid");
+    let mut cleanup = PidCleanup {
+        path: pid_path.clone(),
+        armed: true,
+    };
+    let descendant = r#"trap '' TERM; exec sleep 5"#;
+    let args = shell_args(
+        r#"/bin/sh -c "$1" descendant & child=$!; printf '%s' "$child" > "$2"; exit 0"#,
+        &[OsString::from(descendant), path_arg(&pid_path)],
+    );
+
+    let error = execute_shell(&UnixCommandRunner, &args, &[], Duration::from_secs(1), 1024)
+        .expect_err("retained descendant pipe must hit the deadline");
+    assert_eq!(error.kind, CommandFailure::Timeout);
+    assert!(
+        !error.cleanup_failed(),
+        "process-group cleanup should succeed"
+    );
+    let pid = wait_for_pid(&pid_path);
+    assert_pid_gone(pid, &mut cleanup);
+}

--- a/rust/crates/tmt-adapters/src/storage/tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/tests.rs
@@ -1,35 +1,21 @@
-use std::{
-    fs,
-    path::PathBuf,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::{fs, path::PathBuf};
+
+use crate::test_support::TestDirectory;
 
 use super::*;
 
 struct Fixture {
-    directory: PathBuf,
+    directory: TestDirectory,
     database: PathBuf,
 }
 
 impl Fixture {
     fn new() -> Self {
-        static NEXT: AtomicU64 = AtomicU64::new(0);
-        let directory = std::env::temp_dir().join(format!(
-            "tmt-native-storage-{}-{}",
-            std::process::id(),
-            NEXT.fetch_add(1, Ordering::Relaxed)
-        ));
-        fs::create_dir(&directory).expect("create unique test directory");
+        let directory = TestDirectory::new();
         Self {
-            database: directory.join("state").join("tmux-team.db"),
+            database: directory.path.join("state").join("tmux-team.db"),
             directory,
         }
-    }
-}
-
-impl Drop for Fixture {
-    fn drop(&mut self) {
-        fs::remove_dir_all(&self.directory).expect("remove isolated storage fixture");
     }
 }
 
@@ -148,7 +134,7 @@ fn open_errors_preserve_existing_files() {
         b"unrelated file"
     );
 
-    let corrupt = fixture.directory.join("corrupt.db");
+    let corrupt = fixture.directory.path.join("corrupt.db");
     fs::write(&corrupt, b"not a SQLite database").unwrap();
     let error = Storage::open(&corrupt)
         .err()

--- a/rust/crates/tmt-adapters/src/test_support.rs
+++ b/rust/crates/tmt-adapters/src/test_support.rs
@@ -1,0 +1,42 @@
+use std::{
+    fs,
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+/// One invocation-owned filesystem fixture shared by native adapter tests.
+pub(crate) struct TestDirectory {
+    pub path: PathBuf,
+}
+
+impl TestDirectory {
+    pub fn new() -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "tmt-native-adapter-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        // Refuse to reuse an existing directory; cleanup owns only this creation.
+        fs::create_dir(&path).expect("create unique adapter test directory");
+        Self { path }
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_dir_all(&self.path) {
+            if std::thread::panicking() {
+                eprintln!(
+                    "Could not remove adapter fixture {}: {error}",
+                    self.path.display()
+                );
+            } else {
+                panic!(
+                    "Could not remove adapter fixture {}: {error}",
+                    self.path.display()
+                );
+            }
+        }
+    }
+}

--- a/rust/crates/tmt-adapters/src/tmux/caller.rs
+++ b/rust/crates/tmt-adapters/src/tmux/caller.rs
@@ -1,0 +1,192 @@
+use super::evidence::wire_integer as number;
+use super::{CommandRunner, OPERATION_TIMEOUT, Tmux, TmuxError, TmuxFailure};
+use std::{
+    collections::{HashMap, HashSet},
+    ffi::OsString,
+    time::Instant,
+};
+use tmt_core::{endpoint::valid_pane_id, limits::MAX_JS_SAFE_INTEGER};
+
+const SEPARATOR: &str = "__TMT_CALLER_PANE_4f1c__";
+const MAX_DEPTH: usize = 64;
+const DISCOVERY_MAX_OUTPUT: usize = 64 * 1024;
+const VERIFY_MAX_OUTPUT: usize = 4096;
+
+/// Invocation-owned observations; tests never mutate process-global variables.
+pub struct CallerEnvironment {
+    pub tmux: Option<OsString>,
+    pub pane: Option<OsString>,
+    pub process_id: u64,
+}
+
+impl CallerEnvironment {
+    pub fn current() -> Self {
+        Self {
+            tmux: std::env::var_os("TMUX"),
+            pane: std::env::var_os("TMUX_PANE"),
+            process_id: u64::from(std::process::id()),
+        }
+    }
+}
+
+struct Context<'a> {
+    socket: &'a str,
+    server_pid: u64,
+}
+
+fn context(text: &str) -> Option<Context<'_>> {
+    let mut parts = text.rsplitn(3, ',');
+    let session = parts.next()?;
+    let pid = parts.next()?;
+    let socket = parts.next()?;
+    // Session is syntactic evidence only, not a numeric OS process target.
+    if socket.is_empty() || session.is_empty() || !session.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+    Some(Context {
+        socket,
+        server_pid: number(pid).filter(|pid| *pid > 0)?,
+    })
+}
+
+pub(super) fn resolve<R: CommandRunner>(
+    tmux: &Tmux<R>,
+    environment: &CallerEnvironment,
+) -> Result<String, TmuxError> {
+    // Invalid supplied bytes are explicit invalid evidence, not absence that
+    // permits discovery to bind an unrelated ambient pane.
+    let tmux_text = match &environment.tmux {
+        Some(value) => value.to_str().ok_or_else(unavailable)?,
+        None => "",
+    };
+    let pane = match &environment.pane {
+        Some(value) => value.to_str().ok_or_else(unavailable)?,
+        None => "",
+    };
+    if !pane.is_empty() && !valid_pane_id(pane) {
+        return Err(unavailable());
+    }
+    let context = if tmux_text.is_empty() {
+        None
+    } else {
+        Some(context(tmux_text).ok_or_else(unavailable)?)
+    };
+    let deadline = Instant::now() + OPERATION_TIMEOUT;
+    if !pane.is_empty()
+        && let Some(context) = &context
+    {
+        let format = ["#{pane_id}", "#{socket_path}", "#{pid}"].join(SEPARATOR);
+        let output = tmux.run(
+            "tmux",
+            vec![
+                "display-message".into(),
+                "-p".into(),
+                "-t".into(),
+                pane.into(),
+                format,
+            ],
+            deadline,
+            VERIFY_MAX_OUTPUT,
+            TmuxFailure::Command,
+        )?;
+        let text = output.trim();
+        let fields: Vec<_> = text.split(SEPARATOR).collect();
+        return (!text.contains('\n')
+            && fields.len() == 3
+            && fields[0] == pane
+            && fields[1] == context.socket
+            && fields[2] == context.server_pid.to_string())
+        .then(|| pane.into())
+        .ok_or_else(unavailable);
+    }
+    let ancestry = ancestry(tmux, environment.process_id, deadline)?;
+    let mut args = context
+        .as_ref()
+        .map_or_else(Vec::new, |context| vec!["-S".into(), context.socket.into()]);
+    let format = ["#{pane_id}", "#{pane_pid}", "#{socket_path}", "#{pid}"].join(SEPARATOR);
+    args.extend(["list-panes".into(), "-a".into(), "-F".into(), format]);
+    let output = tmux.run(
+        "tmux",
+        args,
+        deadline,
+        DISCOVERY_MAX_OUTPUT,
+        TmuxFailure::Command,
+    )?;
+    if Instant::now() >= deadline {
+        return Err(unavailable());
+    }
+    let mut unique: HashMap<&str, Vec<&str>> = HashMap::new();
+    for line in output.trim().lines().filter(|line| !line.is_empty()) {
+        let fields: Vec<_> = line.split(SEPARATOR).collect();
+        if fields.len() != 4
+            || !valid_pane_id(fields[0])
+            || number(fields[1]).filter(|pid| *pid > 0).is_none()
+            || fields[2].is_empty()
+            || number(fields[3]).filter(|pid| *pid > 0).is_none()
+        {
+            return Err(unavailable());
+        }
+        if let Some(previous) = unique.insert(fields[0], fields.clone())
+            && previous != fields
+        {
+            return Err(unavailable());
+        }
+    }
+    let mut candidates = unique.values().filter(|fields| {
+        number(fields[1]).is_some_and(|pid| ancestry.contains(&pid))
+            && (pane.is_empty() || pane == fields[0])
+            && context.as_ref().is_none_or(|context| {
+                fields[2] == context.socket && fields[3] == context.server_pid.to_string()
+            })
+    });
+    let candidate = candidates.next().ok_or_else(unavailable)?;
+    if candidates.next().is_some() {
+        return Err(unavailable());
+    }
+    Ok(candidate[0].into())
+}
+
+fn unavailable() -> TmuxError {
+    TmuxError::evidence("Caller pane evidence is unavailable")
+}
+
+fn ancestry<R: CommandRunner>(
+    tmux: &Tmux<R>,
+    first: u64,
+    deadline: Instant,
+) -> Result<HashSet<u64>, TmuxError> {
+    let mut ancestry = HashSet::new();
+    let mut pid = first;
+    for _ in 0..MAX_DEPTH {
+        if pid == 0 || pid > MAX_JS_SAFE_INTEGER || !ancestry.insert(pid) {
+            return Err(unavailable());
+        }
+        let output = tmux.run(
+            "ps",
+            vec![
+                "-o".into(),
+                "pid=,ppid=".into(),
+                "-p".into(),
+                pid.to_string(),
+            ],
+            deadline,
+            DISCOVERY_MAX_OUTPUT,
+            TmuxFailure::Command,
+        )?;
+        let lines: Vec<_> = output.trim().lines().collect();
+        if lines.len() != 1 {
+            return Err(unavailable());
+        }
+        let fields: Vec<_> = lines[0].split_whitespace().collect();
+        if fields.len() != 2 || number(fields[0]) != Some(pid) {
+            return Err(unavailable());
+        }
+        let parent = number(fields[1]).ok_or_else(unavailable)?;
+        if parent == 0 {
+            return Ok(ancestry);
+        }
+        pid = parent;
+    }
+    Err(unavailable())
+}

--- a/rust/crates/tmt-adapters/src/tmux/evidence.rs
+++ b/rust/crates/tmt-adapters/src/tmux/evidence.rs
@@ -1,0 +1,179 @@
+use std::collections::{HashMap, HashSet};
+use tmt_core::endpoint::{
+    EndpointSnapshot, PaneObservation, ServerEvidence, valid_pane_id, valid_process_id,
+    valid_server_id,
+};
+
+use super::{TmuxError, metadata};
+
+pub(super) const SEPARATOR: &str = "__TMT_FIELD_4f1c__";
+
+pub(super) fn server_format() -> String {
+    [
+        "#{@tmux-team.server-id}",
+        "#{socket_path}",
+        "#{pid}",
+        "#{start_time}",
+    ]
+    .join(SEPARATOR)
+}
+
+pub(super) fn endpoint_format() -> String {
+    [
+        server_format(),
+        [
+            "#{pane_id}",
+            "#{session_name}:#{window_index}.#{pane_index}",
+            "#{pane_current_path}",
+            "#{pane_current_command}",
+            "#{pane_pid}",
+            "#{session_attached}",
+            "#{@tmux-team.agent}",
+        ]
+        .join(SEPARATOR),
+    ]
+    .join(SEPARATOR)
+}
+
+fn rows(output: &str) -> Vec<Vec<&str>> {
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.split(SEPARATOR).collect())
+        .collect()
+}
+
+/// tmux and ps emit decimal integer fields. Do not accept JavaScript's broader
+/// Number coercions (hex, exponents or signs) as process evidence.
+pub(super) fn wire_integer(text: &str) -> Option<u64> {
+    if text.is_empty() || !text.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    text.parse()
+        .ok()
+        .filter(|value| tmt_core::limits::is_valid_js_safe_integer(*value))
+}
+
+fn positive_id(text: &str) -> Option<u64> {
+    wire_integer(text).filter(|value| valid_process_id(*value))
+}
+
+fn server(rows: &[Vec<&str>], expected: Option<&str>) -> Result<ServerEvidence, TmuxError> {
+    let first = rows
+        .first()
+        .filter(|row| row.len() >= 4)
+        .ok_or_else(|| TmuxError::evidence("tmux server evidence is empty"))?;
+    let server_pid = positive_id(first[2]).ok_or_else(|| {
+        TmuxError::evidence("tmux endpoint snapshot contains inconsistent server evidence")
+    })?;
+    if !valid_server_id(first[0])
+        || first[1].is_empty()
+        || first[3].is_empty()
+        || expected.is_some_and(|id| id != first[0])
+        || rows.iter().any(|row| row.get(..4) != first.get(..4))
+    {
+        return Err(TmuxError::evidence(
+            "tmux endpoint snapshot contains inconsistent server evidence",
+        ));
+    }
+    Ok(ServerEvidence {
+        server_id: first[0].into(),
+        socket_path: first[1].into(),
+        server_pid,
+        server_start_time: first[3].into(),
+    })
+}
+
+pub(super) fn parse_server(
+    output: &str,
+    expected: Option<&str>,
+) -> Result<ServerEvidence, TmuxError> {
+    server(&rows(output), expected)
+}
+
+pub(super) fn parse_snapshot(
+    output: &str,
+    expected: Option<&str>,
+) -> Result<EndpointSnapshot, TmuxError> {
+    let rows = rows(output);
+    let server = server(&rows, expected)?;
+    let mut indexes: HashMap<&str, usize> = HashMap::new();
+    let mut observations: Vec<(PaneObservation, String, bool)> = Vec::new();
+    for fields in rows {
+        if fields.len() < 11 {
+            return Err(TmuxError::evidence(
+                "tmux endpoint snapshot contains inconsistent server evidence",
+            ));
+        }
+        let pane_pid = positive_id(fields[8])
+            .filter(|_| valid_pane_id(fields[4]))
+            .ok_or_else(|| {
+                TmuxError::evidence("tmux endpoint snapshot contains incomplete pane evidence")
+            })?;
+        let raw_metadata = fields[10..].join(SEPARATOR);
+        let attached = positive_id(fields[9]).is_some();
+        let text = |value: &str| (!value.is_empty()).then(|| value.to_string());
+        let pane = PaneObservation {
+            id: fields[4].into(),
+            target: text(fields[5]),
+            cwd: text(fields[6]),
+            command: fields[7].into(),
+            pane_pid,
+            suggested_name: suggested_name(fields[7]),
+            marker: metadata::marker(&metadata::decode(&raw_metadata)),
+        };
+        if let Some(index) = indexes.get(fields[4]) {
+            let previous = &mut observations[*index];
+            // Validate before deduplication. A malformed or conflicting linked
+            // row must never disappear behind an earlier valid presentation.
+            if previous.0.pane_pid != pane_pid || previous.1 != raw_metadata {
+                return Err(TmuxError::evidence(
+                    "tmux endpoint snapshot contains conflicting pane evidence",
+                ));
+            }
+            if attached && !previous.2 {
+                *previous = (pane, raw_metadata, attached);
+            }
+        } else {
+            indexes.insert(fields[4], observations.len());
+            observations.push((pane, raw_metadata, attached));
+        }
+    }
+    Ok(EndpointSnapshot {
+        server,
+        panes: observations.into_iter().map(|(pane, _, _)| pane).collect(),
+    })
+}
+
+fn suggested_name(command: &str) -> Option<String> {
+    let command = command.to_lowercase();
+    ["claude", "codex", "gemini", "aider", "cursor"]
+        .into_iter()
+        .find(|name| command.contains(name))
+        .map(str::to_owned)
+}
+
+pub(super) fn scoped_ids(ids: Option<&[String]>) -> Result<Option<Vec<&str>>, TmuxError> {
+    ids.map(|ids| {
+        let mut scoped = Vec::new();
+        let mut seen = HashSet::new();
+        for id in ids {
+            if !valid_pane_id(id) {
+                return Err(TmuxError::evidence(
+                    "tmux pane scope contains an invalid pane ID",
+                ));
+            }
+            if seen.insert(id.as_str()) {
+                scoped.push(id.as_str());
+            }
+        }
+        Ok(scoped)
+    })
+    .transpose()
+}
+
+pub(super) fn pane_filter(ids: &[&str]) -> String {
+    let mut expressions = ids.iter().map(|id| format!("#{{==:#{{pane_id}},{id}}}"));
+    let first = expressions.next().expect("nonempty validated pane scope");
+    expressions.fold(first, |combined, next| format!("#{{||:{combined},{next}}}"))
+}

--- a/rust/crates/tmt-adapters/src/tmux/evidence_tests.rs
+++ b/rust/crates/tmt-adapters/src/tmux/evidence_tests.rs
@@ -1,0 +1,488 @@
+use super::{evidence, metadata};
+use serde_json::{Value, json};
+use tmt_core::{
+    endpoint::{BindingMarker, EndpointSnapshot, ServerEvidence},
+    limits::MAX_JS_SAFE_INTEGER,
+};
+
+const SERVER_ID: &str = "123e4567-e89b-42d3-a456-426614174000";
+const SOCKET: &str = "/tmp/tmux.sock";
+const START_TIME: &str = "1700000000";
+const SERVER_PID: &str = "321";
+const PANE_PID: &str = "654";
+
+fn server_row(server_id: &str, socket: &str, pid: &str, start_time: &str) -> String {
+    [server_id, socket, pid, start_time].join(evidence::SEPARATOR)
+}
+
+fn endpoint_row(
+    server_id: &str,
+    server_pid: &str,
+    pane_id: &str,
+    target: &str,
+    pane_pid: &str,
+    attached: &str,
+    metadata: &str,
+) -> String {
+    [
+        server_id, SOCKET, server_pid, START_TIME, pane_id, target, "/repo", "codex", pane_pid,
+        attached, metadata,
+    ]
+    .join(evidence::SEPARATOR)
+}
+
+fn valid_endpoint_row() -> String {
+    endpoint_row(
+        SERVER_ID,
+        SERVER_PID,
+        "%9",
+        "main:1.0",
+        PANE_PID,
+        "0",
+        r#"{"version":1}"#,
+    )
+}
+
+fn assert_evidence_error<T: std::fmt::Debug>(result: Result<T, super::TmuxError>, label: &str) {
+    let error = result.expect_err(label);
+    assert_eq!(error.kind, super::TmuxFailure::Evidence, "{label}");
+}
+
+fn marker() -> BindingMarker {
+    BindingMarker {
+        name: "Alice".into(),
+        canonical_name: "alice".into(),
+        identity_id: "identity-1".into(),
+        binding_id: "binding-1".into(),
+        server_id: SERVER_ID.into(),
+        pane_pid: 654,
+    }
+}
+
+#[test]
+fn accepts_strict_v4_server_evidence_and_expected_identity() {
+    let output = format!(
+        "{}\n\n",
+        server_row(SERVER_ID, SOCKET, SERVER_PID, START_TIME)
+    );
+    let expected = ServerEvidence {
+        server_id: SERVER_ID.into(),
+        socket_path: SOCKET.into(),
+        server_pid: 321,
+        server_start_time: START_TIME.into(),
+    };
+
+    assert_eq!(
+        evidence::parse_server(&output, Some(SERVER_ID)).unwrap(),
+        expected
+    );
+    assert_eq!(evidence::parse_server(&output, None).unwrap(), expected);
+}
+
+#[test]
+fn rejects_empty_truncated_mismatched_and_non_v4_server_evidence() {
+    let cases = [
+        ("empty", "".to_owned(), None),
+        (
+            "truncated",
+            [SERVER_ID, SOCKET, SERVER_PID].join(evidence::SEPARATOR),
+            None,
+        ),
+        (
+            "invalid UUID",
+            server_row("not-a-server-id", SOCKET, SERVER_PID, START_TIME),
+            None,
+        ),
+        (
+            "version 1 UUID",
+            server_row(
+                "123e4567-e89b-12d3-a456-426614174000",
+                SOCKET,
+                SERVER_PID,
+                START_TIME,
+            ),
+            None,
+        ),
+        (
+            "zero PID",
+            server_row(SERVER_ID, SOCKET, "0", START_TIME),
+            None,
+        ),
+        (
+            "fractional PID",
+            server_row(SERVER_ID, SOCKET, "321.5", START_TIME),
+            None,
+        ),
+        (
+            "unsafe PID",
+            server_row(SERVER_ID, SOCKET, "9007199254740992", START_TIME),
+            None,
+        ),
+        (
+            "empty socket",
+            server_row(SERVER_ID, "", SERVER_PID, START_TIME),
+            None,
+        ),
+        (
+            "empty start time",
+            server_row(SERVER_ID, SOCKET, SERVER_PID, ""),
+            None,
+        ),
+        (
+            "unexpected server ID",
+            server_row(SERVER_ID, SOCKET, SERVER_PID, START_TIME),
+            Some("123e4567-e89b-42d3-a456-426614174001"),
+        ),
+    ];
+
+    for (label, output, expected) in cases {
+        assert_evidence_error(evidence::parse_server(&output, expected), label);
+    }
+
+    let mixed = format!(
+        "{}\n{}\n",
+        server_row(SERVER_ID, SOCKET, SERVER_PID, START_TIME),
+        server_row(SERVER_ID, SOCKET, "999", START_TIME)
+    );
+    assert_evidence_error(evidence::parse_server(&mixed, None), "mixed server rows");
+}
+
+#[test]
+fn rejects_empty_truncated_and_incomplete_snapshot_rows() {
+    assert_evidence_error(evidence::parse_snapshot("", None), "empty snapshot");
+
+    let truncated = valid_endpoint_row()
+        .split(evidence::SEPARATOR)
+        .take(10)
+        .collect::<Vec<_>>()
+        .join(evidence::SEPARATOR);
+    assert_evidence_error(
+        evidence::parse_snapshot(&truncated, None),
+        "truncated endpoint row",
+    );
+
+    for (label, row) in [
+        (
+            "missing pane ID",
+            endpoint_row(
+                SERVER_ID,
+                SERVER_PID,
+                "",
+                "main:1.0",
+                PANE_PID,
+                "0",
+                r#"{"version":1}"#,
+            ),
+        ),
+        (
+            "zero pane PID",
+            endpoint_row(
+                SERVER_ID,
+                SERVER_PID,
+                "%9",
+                "main:1.0",
+                "0",
+                "0",
+                r#"{"version":1}"#,
+            ),
+        ),
+        (
+            "unsafe pane PID",
+            endpoint_row(
+                SERVER_ID,
+                SERVER_PID,
+                "%9",
+                "main:1.0",
+                "9007199254740992",
+                "0",
+                r#"{"version":1}"#,
+            ),
+        ),
+    ] {
+        assert_evidence_error(evidence::parse_snapshot(&row, None), label);
+    }
+}
+
+#[test]
+fn deduplicates_scoped_ids_and_builds_nested_tmux_filter() {
+    let ids = vec!["%9".to_owned(), "%9".to_owned(), "%10".to_owned()];
+    assert_eq!(
+        evidence::scoped_ids(Some(&ids)).unwrap(),
+        Some(vec!["%9", "%10"])
+    );
+    assert_eq!(evidence::scoped_ids(None).unwrap(), None);
+    assert_eq!(
+        evidence::pane_filter(&["%9", "%10"]),
+        "#{||:#{==:#{pane_id},%9},#{==:#{pane_id},%10}}"
+    );
+
+    let invalid = vec!["%9".to_owned(), "not-a-pane".to_owned()];
+    assert_evidence_error(
+        evidence::scoped_ids(Some(&invalid)),
+        "invalid pane scope precheck",
+    );
+}
+
+#[test]
+fn prefers_attached_presentation_for_grouped_pane_rows() {
+    let detached = endpoint_row(
+        SERVER_ID,
+        SERVER_PID,
+        "%9",
+        "detached:1.0",
+        PANE_PID,
+        "0",
+        r#"{"version":1}"#,
+    );
+    let attached = endpoint_row(
+        SERVER_ID,
+        SERVER_PID,
+        "%9",
+        "attached:2.0",
+        PANE_PID,
+        "2",
+        r#"{"version":1}"#,
+    );
+
+    let snapshot = evidence::parse_snapshot(&format!("{detached}\n{attached}\n"), None).unwrap();
+    assert_eq!(snapshot.panes.len(), 1);
+    assert_eq!(snapshot.panes[0].id, "%9");
+    assert_eq!(snapshot.panes[0].target.as_deref(), Some("attached:2.0"));
+    assert_eq!(snapshot.panes[0].suggested_name.as_deref(), Some("codex"));
+}
+
+#[test]
+fn validates_conflicting_grouped_rows_before_deduplication() {
+    let valid = endpoint_row(
+        SERVER_ID,
+        SERVER_PID,
+        "%9",
+        "attached:1.0",
+        PANE_PID,
+        "2",
+        r#"{"version":1}"#,
+    );
+    let cases = [
+        (
+            "different pane PID",
+            endpoint_row(
+                SERVER_ID,
+                SERVER_PID,
+                "%9",
+                "linked:1.0",
+                "999",
+                "0",
+                r#"{"version":1}"#,
+            ),
+        ),
+        (
+            "different metadata",
+            endpoint_row(
+                SERVER_ID,
+                SERVER_PID,
+                "%9",
+                "linked:1.0",
+                PANE_PID,
+                "0",
+                r#"{"version":1,"opaque":true}"#,
+            ),
+        ),
+        (
+            "different server PID",
+            endpoint_row(
+                SERVER_ID,
+                "999",
+                "%9",
+                "linked:1.0",
+                PANE_PID,
+                "0",
+                r#"{"version":1}"#,
+            ),
+        ),
+        (
+            "invalid pane ID",
+            endpoint_row(
+                SERVER_ID,
+                SERVER_PID,
+                "not-a-pane",
+                "linked:1.0",
+                PANE_PID,
+                "0",
+                r#"{"version":1}"#,
+            ),
+        ),
+        (
+            "truncated row",
+            valid
+                .split(evidence::SEPARATOR)
+                .take(10)
+                .collect::<Vec<_>>()
+                .join(evidence::SEPARATOR),
+        ),
+    ];
+
+    for (label, conflicting) in cases {
+        for (first, second) in [(&valid, &conflicting), (&conflicting, &valid)] {
+            let output = format!("{first}\n{second}\n");
+            assert_evidence_error(evidence::parse_snapshot(&output, None), label);
+        }
+    }
+}
+
+#[test]
+fn preserves_metadata_containing_the_field_separator() {
+    let metadata = json!({
+        "version": 1,
+        "opaque": evidence::SEPARATOR,
+        "globalIdentity": {
+            "name": "Alice",
+            "canonicalName": "alice",
+            "identityId": "identity-1",
+            "bindingId": "binding-1",
+            "serverId": SERVER_ID,
+            "panePid": 654,
+        },
+    })
+    .to_string();
+    let first = endpoint_row(
+        SERVER_ID, SERVER_PID, "%9", "main:1.0", PANE_PID, "0", &metadata,
+    );
+    let second = endpoint_row(
+        SERVER_ID,
+        SERVER_PID,
+        "%9",
+        "linked:7.0",
+        PANE_PID,
+        "0",
+        &metadata,
+    );
+
+    let snapshot = evidence::parse_snapshot(&format!("{first}\n{second}\n"), None).unwrap();
+    assert_eq!(snapshot.panes[0].marker, Some(marker()));
+}
+
+#[test]
+fn decodes_only_version_one_object_metadata_and_defaults_malformed_envelopes() {
+    for (label, text) in [
+        ("invalid JSON", "not-json"),
+        ("null", "null"),
+        ("array", "[]"),
+        ("scalar", "true"),
+        ("missing version", "{}"),
+        ("wrong version", r#"{"version":2,"opaque":true}"#),
+    ] {
+        assert_eq!(metadata::decode(text), json!({"version": 1}), "{label}");
+    }
+
+    assert_eq!(
+        metadata::decode(r#"{"version":1.0,"opaque":true}"#)["opaque"],
+        true
+    );
+}
+
+#[test]
+fn normalizes_js_numbers_before_extracting_marker_pid() {
+    let base = |pane_pid: &str| {
+        format!(
+            r#"{{"version":1,"globalIdentity":{{"name":"Alice","canonicalName":"alice","identityId":"identity-1","bindingId":"binding-1","serverId":"{SERVER_ID}","panePid":{pane_pid}}}}}"#
+        )
+    };
+    let cases = [
+        ("integer", "654", Some(654)),
+        ("integer-valued decimal", "654.0", Some(654)),
+        (
+            "safe integer maximum",
+            "9007199254740991",
+            Some(MAX_JS_SAFE_INTEGER),
+        ),
+        ("unsafe integer", "9007199254740992", None),
+        ("fractional", "654.5", None),
+        ("zero", "0", None),
+        ("negative", "-1", None),
+        ("string", "\"654\"", None),
+    ];
+
+    for (label, pane_pid, expected) in cases {
+        let document = metadata::decode(&base(pane_pid));
+        assert_eq!(
+            metadata::marker(&document).map(|value| value.pane_pid),
+            expected,
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn extracts_marker_only_when_all_identity_strings_are_nonempty() {
+    let mut document = metadata::decode(
+        r#"{"version":1,"globalIdentity":{"name":"Alice","canonicalName":"alice","identityId":"identity-1","bindingId":"binding-1","serverId":"123e4567-e89b-42d3-a456-426614174000","panePid":654}}"#,
+    );
+    assert_eq!(metadata::marker(&document), Some(marker()));
+
+    document["globalIdentity"]["name"] = Value::String("  ".into());
+    assert_eq!(metadata::marker(&document), None);
+}
+
+#[test]
+fn replaces_marker_without_dropping_opaque_metadata() {
+    let mut document = json!({
+        "version": 1,
+        "workspaces": {"/repo": {"name": "legacy"}},
+        "opaque": [true, 3],
+        "globalIdentity": {"name": "Old"},
+    });
+    metadata::replace(&mut document, &marker());
+
+    assert_eq!(document["version"], 1);
+    assert_eq!(document["workspaces"]["/repo"]["name"], "legacy");
+    assert_eq!(document["opaque"], json!([true, 3]));
+    assert_eq!(metadata::marker(&document), Some(marker()));
+}
+
+#[test]
+fn clears_matching_marker_and_preserves_opaque_siblings() {
+    let mut document = json!({
+        "version": 1,
+        "future": {"flag": true},
+        "globalIdentity": {
+            "name": "Alice",
+            "bindingId": "binding-1",
+        },
+    });
+    assert!(metadata::clear(&mut document, Some("binding-1")));
+    assert_eq!(document, json!({"version": 1, "future": {"flag": true}}));
+
+    assert!(!metadata::clear(&mut document, Some("binding-1")));
+    assert!(!metadata::clear(&mut document, None));
+}
+
+#[test]
+fn clear_respects_false_like_malformed_marker_values() {
+    for (label, value) in [
+        ("null", Value::Null),
+        ("false", Value::Bool(false)),
+        ("zero", json!(0)),
+        ("empty string", json!("")),
+    ] {
+        let mut document = json!({"version": 1, "globalIdentity": value});
+        assert!(!metadata::clear(&mut document, None), "{label}");
+        assert!(
+            document.get("globalIdentity").is_some(),
+            "{label} preserved"
+        );
+    }
+
+    let mut object_marker = json!({"version": 1, "globalIdentity": {"opaque": true}});
+    assert!(metadata::clear(&mut object_marker, None));
+    assert_eq!(object_marker, json!({"version": 1}));
+}
+
+#[test]
+fn snapshot_retains_server_and_pane_observations_as_typed_values() {
+    let snapshot: EndpointSnapshot = evidence::parse_snapshot(&valid_endpoint_row(), None).unwrap();
+    assert_eq!(snapshot.server.server_id, SERVER_ID);
+    assert_eq!(snapshot.server.server_pid, 321);
+    assert_eq!(snapshot.panes[0].pane_pid, 654);
+    assert_eq!(snapshot.panes[0].target.as_deref(), Some("main:1.0"));
+    assert_eq!(snapshot.panes[0].cwd.as_deref(), Some("/repo"));
+}

--- a/rust/crates/tmt-adapters/src/tmux/io_tests.rs
+++ b/rust/crates/tmt-adapters/src/tmux/io_tests.rs
@@ -1,0 +1,325 @@
+use super::*;
+use crate::process::CommandOutput;
+use std::{cell::RefCell, collections::VecDeque, io};
+
+const SERVER_ID: &str = "123e4567-e89b-42d3-a456-426614174000";
+
+#[derive(Debug)]
+struct Invocation {
+    program: String,
+    args: Vec<String>,
+    deadline: Instant,
+    max_output_bytes: usize,
+}
+
+#[derive(Default)]
+struct ScriptedRunner {
+    results: RefCell<VecDeque<Result<CommandOutput, CommandError>>>,
+    calls: RefCell<Vec<Invocation>>,
+}
+
+impl ScriptedRunner {
+    fn new(results: impl IntoIterator<Item = Result<&'static str, CommandError>>) -> Self {
+        Self {
+            results: RefCell::new(
+                results
+                    .into_iter()
+                    .map(|result| {
+                        result.map(|text| CommandOutput {
+                            stdout: text.as_bytes().to_vec(),
+                            stderr: Vec::new(),
+                        })
+                    })
+                    .collect(),
+            ),
+            ..Self::default()
+        }
+    }
+}
+
+impl CommandRunner for ScriptedRunner {
+    fn execute(&self, request: CommandRequest<'_>) -> Result<CommandOutput, CommandError> {
+        assert!(request.input.is_empty());
+        self.calls.borrow_mut().push(Invocation {
+            program: request.program.to_str().unwrap().into(),
+            args: request
+                .args
+                .iter()
+                .map(|value| value.to_str().unwrap().into())
+                .collect(),
+            deadline: request.deadline,
+            max_output_bytes: request.max_output_bytes,
+        });
+        self.results
+            .borrow_mut()
+            .pop_front()
+            .expect("unexpected extra subprocess")
+    }
+}
+
+fn failure(cleanup_failed: bool) -> CommandError {
+    let mut error = CommandError::new(CommandFailure::Timeout);
+    if cleanup_failed {
+        error.cleanup_error = Some(io::Error::from_raw_os_error(Errno::EPERM as i32));
+    }
+    error
+}
+
+fn full_environment() -> CallerEnvironment {
+    CallerEnvironment {
+        tmux: Some("/tmp/private.sock,321,0".into()),
+        pane: Some("%9".into()),
+        process_id: 900,
+    }
+}
+
+#[test]
+fn complete_caller_evidence_uses_one_small_query_without_ancestry() {
+    let tmux = Tmux::new(ScriptedRunner::new([Ok(
+        "%9__TMT_CALLER_PANE_4f1c__/tmp/private.sock__TMT_CALLER_PANE_4f1c__321\n",
+    )]));
+    assert_eq!(
+        tmux.caller_pane(&full_environment()).unwrap().as_deref(),
+        Some("%9")
+    );
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].program, "tmux");
+    assert_eq!(&calls[0].args[..4], ["display-message", "-p", "-t", "%9"]);
+    assert_eq!(calls[0].max_output_bytes, 4096);
+}
+
+#[test]
+fn malformed_explicit_environment_and_scopes_never_spawn() {
+    let tmux = Tmux::new(ScriptedRunner::default());
+    for (context, pane) in [("bad", "%9"), ("/tmp/private.sock,321,0", "main:0.0")] {
+        let environment = CallerEnvironment {
+            tmux: Some(context.into()),
+            pane: Some(pane.into()),
+            process_id: 900,
+        };
+        assert_eq!(tmux.caller_pane(&environment).unwrap(), None);
+    }
+    let panes = vec!["%9".into(), "#{pane_id}".into()];
+    let error = tmux
+        .snapshot(OperationOptions {
+            pane_ids: Some(&panes),
+            ..Default::default()
+        })
+        .unwrap_err();
+    assert_eq!(error.kind, TmuxFailure::Evidence);
+    assert!(tmux.runner.calls.borrow().is_empty());
+}
+
+#[test]
+fn ancestry_and_snapshot_share_one_deadline_and_reject_ambient_panes() {
+    let tmux = Tmux::new(ScriptedRunner::new([
+        Ok("900 700\n"),
+        Ok("700 0\n"),
+        Ok(
+            "%9__TMT_CALLER_PANE_4f1c__800__TMT_CALLER_PANE_4f1c__/tmp/private.sock__TMT_CALLER_PANE_4f1c__321\n",
+        ),
+    ]));
+    let environment = CallerEnvironment {
+        tmux: None,
+        pane: None,
+        process_id: 900,
+    };
+    assert_eq!(tmux.caller_pane(&environment).unwrap(), None);
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].program, "ps");
+    assert_eq!(calls[0].args, ["-o", "pid=,ppid=", "-p", "900"]);
+    assert_eq!(calls[1].args, ["-o", "pid=,ppid=", "-p", "700"]);
+    assert_eq!(calls[2].program, "tmux");
+    assert!(calls.iter().all(|call| call.deadline == calls[0].deadline));
+    assert!(calls.iter().all(|call| call.max_output_bytes == 64 * 1024));
+}
+
+#[test]
+fn unavailable_observations_do_not_hide_failed_cleanup() {
+    for failed_cleanup in [false, true] {
+        let tmux = Tmux::new(ScriptedRunner::new([Err(failure(failed_cleanup))]));
+        let caller = tmux.caller_pane(&full_environment());
+        if failed_cleanup {
+            assert!(caller.unwrap_err().cleanup_failed());
+        } else {
+            assert_eq!(caller.unwrap(), None);
+        }
+
+        let tmux = Tmux::new(ScriptedRunner::new([Err(failure(failed_cleanup))]));
+        let target = tmux.resolve_target("10.3", OperationOptions::default());
+        if failed_cleanup {
+            assert!(target.unwrap_err().cleanup_failed());
+        } else {
+            assert_eq!(target.unwrap(), None);
+        }
+
+        let tmux = Tmux::new(ScriptedRunner::new([Err(failure(failed_cleanup))]));
+        let probe = tmux.probe(
+            "/tmp/private.sock",
+            u64::from(std::process::id()),
+            OperationOptions::default(),
+        );
+        if failed_cleanup {
+            assert!(probe.unwrap_err().cleanup_failed());
+        } else {
+            assert!(matches!(probe.unwrap(), EndpointProbe::Unknown));
+        }
+    }
+}
+
+#[test]
+fn ancestry_requires_one_coherent_candidate_after_grouped_row_deduplication() {
+    const MATCH: &str = "%9__TMT_CALLER_PANE_4f1c__700__TMT_CALLER_PANE_4f1c__/tmp/private.sock__TMT_CALLER_PANE_4f1c__321";
+    const OTHER: &str = "%10__TMT_CALLER_PANE_4f1c__900__TMT_CALLER_PANE_4f1c__/tmp/private.sock__TMT_CALLER_PANE_4f1c__321";
+    for (rows, expected) in [
+        (format!("{MATCH}\n{MATCH}\n"), Some("%9")),
+        (format!("{MATCH}\n{OTHER}\n"), None),
+        (format!("{MATCH}\n{}\n", MATCH.replace("700", "800")), None),
+        (format!("{}\n{MATCH}\n", MATCH.replace("700", "800")), None),
+    ] {
+        let runner = ScriptedRunner::new([Ok("900 700\n"), Ok("700 0\n")]);
+        runner.results.borrow_mut().push_back(Ok(CommandOutput {
+            stdout: rows.into_bytes(),
+            stderr: Vec::new(),
+        }));
+        let tmux = Tmux::new(runner);
+        let environment = CallerEnvironment {
+            tmux: None,
+            pane: None,
+            process_id: 900,
+        };
+        assert_eq!(tmux.caller_pane(&environment).unwrap().as_deref(), expected);
+        assert_eq!(tmux.runner.calls.borrow().len(), 3);
+    }
+}
+
+#[test]
+fn partial_caller_evidence_cannot_override_explicit_socket_or_pane() {
+    for environment in [
+        CallerEnvironment {
+            tmux: Some("/different.sock,321,0".into()),
+            pane: None,
+            process_id: 900,
+        },
+        CallerEnvironment {
+            tmux: None,
+            pane: Some("%10".into()),
+            process_id: 900,
+        },
+    ] {
+        let tmux = Tmux::new(ScriptedRunner::new([
+            Ok("900 700\n"),
+            Ok("700 0\n"),
+            Ok(
+                "%9__TMT_CALLER_PANE_4f1c__700__TMT_CALLER_PANE_4f1c__/tmp/private.sock__TMT_CALLER_PANE_4f1c__321\n",
+            ),
+        ]));
+        assert_eq!(tmux.caller_pane(&environment).unwrap(), None);
+        let calls = tmux.runner.calls.borrow();
+        assert_eq!(calls.len(), 3);
+        if environment.tmux.is_some() {
+            assert_eq!(&calls[2].args[..2], ["-S", "/different.sock"]);
+        }
+    }
+}
+
+#[test]
+fn ancestry_cycle_stops_before_any_pane_query() {
+    let tmux = Tmux::new(ScriptedRunner::new([Ok("900 700\n"), Ok("700 900\n")]));
+    let environment = CallerEnvironment {
+        tmux: None,
+        pane: None,
+        process_id: 900,
+    };
+    assert_eq!(tmux.caller_pane(&environment).unwrap(), None);
+    assert!(
+        tmux.runner
+            .calls
+            .borrow()
+            .iter()
+            .all(|call| call.program == "ps")
+    );
+}
+
+#[test]
+fn server_initialization_stops_after_cleanup_failure() {
+    let tmux = Tmux::new(ScriptedRunner::new([Err(failure(true))]));
+    assert!(
+        tmux.snapshot(OperationOptions::default())
+            .unwrap_err()
+            .cleanup_failed()
+    );
+    assert_eq!(
+        tmux.runner.calls.borrow().len(),
+        1,
+        "failed cleanup cannot trigger a metadata mutation"
+    );
+}
+
+#[test]
+fn expired_operation_budget_prevents_even_the_first_query() {
+    let tmux = Tmux::new(ScriptedRunner::default());
+    let error = tmux
+        .snapshot(OperationOptions {
+            deadline: Some(Instant::now()),
+            pane_ids: None,
+        })
+        .unwrap_err();
+    assert_eq!(error.cause.unwrap().kind, CommandFailure::Timeout);
+    assert!(tmux.runner.calls.borrow().is_empty());
+}
+
+#[test]
+fn failed_metadata_read_never_authorizes_a_write() {
+    let tmux = Tmux::new(ScriptedRunner::new([Err(failure(false))]));
+    let error = tmux
+        .clear_marker("%9", None, OperationOptions::default())
+        .unwrap_err();
+    assert_eq!(error.kind, TmuxFailure::MetadataRead);
+    assert_eq!(
+        error.to_string(),
+        "Could not read pane metadata (ETIMEDOUT)."
+    );
+    assert_eq!(tmux.runner.calls.borrow().len(), 1);
+}
+
+#[test]
+fn nonmatching_clear_preserves_metadata_without_a_write() {
+    let tmux = Tmux::new(ScriptedRunner::new([Ok(
+        r#"{"version":1,"globalIdentity":{"bindingId":"other"},"opaque":true}"#,
+    )]));
+    assert!(
+        !tmux
+            .clear_marker("%9", Some("mine"), OperationOptions::default())
+            .unwrap()
+    );
+    assert_eq!(tmux.runner.calls.borrow().len(), 1);
+}
+
+#[test]
+fn empty_scope_reads_server_only_and_never_enumerates_panes() {
+    let tmux = Tmux::new(ScriptedRunner::new([
+        Ok(SERVER_ID),
+        Ok(
+            "123e4567-e89b-42d3-a456-426614174000__TMT_FIELD_4f1c__/tmp/private.sock__TMT_FIELD_4f1c__321__TMT_FIELD_4f1c__1700000000\n",
+        ),
+    ]));
+    let snapshot = tmux
+        .snapshot(OperationOptions {
+            pane_ids: Some(&[]),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(snapshot.panes.is_empty());
+    assert_eq!(snapshot.server.server_id, SERVER_ID);
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[1].args[0], "display-message");
+    assert!(
+        calls
+            .iter()
+            .all(|call| !call.args.iter().any(|arg| arg == "list-panes"))
+    );
+}

--- a/rust/crates/tmt-adapters/src/tmux/metadata.rs
+++ b/rust/crates/tmt-adapters/src/tmux/metadata.rs
@@ -1,0 +1,78 @@
+use serde_json::{Value, json};
+use tmt_core::endpoint::{BindingMarker, valid_process_id};
+
+pub(super) fn decode(text: &str) -> Value {
+    crate::json_document::parse(text)
+        .ok()
+        .filter(|value| {
+            value.is_object() && value.get("version").and_then(Value::as_u64) == Some(1)
+        })
+        .unwrap_or_else(|| json!({"version": 1}))
+}
+
+pub(super) fn marker(document: &Value) -> Option<BindingMarker> {
+    let value = document.get("globalIdentity")?.as_object()?;
+    let text = |name| {
+        value
+            .get(name)?
+            .as_str()
+            .filter(|text| !text.trim().is_empty())
+            .map(str::to_owned)
+    };
+    let pane_pid = value
+        .get("panePid")?
+        .as_u64()
+        .filter(|pid| valid_process_id(*pid))?;
+    Some(BindingMarker {
+        name: text("name")?,
+        canonical_name: text("canonicalName")?,
+        identity_id: text("identityId")?,
+        binding_id: text("bindingId")?,
+        server_id: text("serverId")?,
+        pane_pid,
+    })
+}
+
+pub(super) fn replace(document: &mut Value, marker: &BindingMarker) {
+    document["globalIdentity"] = json!({
+        "name": marker.name,
+        "canonicalName": marker.canonical_name,
+        "identityId": marker.identity_id,
+        "bindingId": marker.binding_id,
+        "serverId": marker.server_id,
+        "panePid": marker.pane_pid,
+    });
+}
+
+pub(super) fn clear(document: &mut Value, binding_id: Option<&str>) -> bool {
+    let Some(marker) = document.get("globalIdentity") else {
+        return false;
+    };
+    // Preserve the reference clear contract for malformed false-like markers;
+    // arrays/objects still count as present, but never match a supplied ID.
+    let present = match marker {
+        Value::Null => false,
+        Value::Bool(value) => *value,
+        Value::Number(value) => value.as_f64().is_some_and(|value| value != 0.0),
+        Value::String(value) => !value.is_empty(),
+        _ => true,
+    };
+    if !present
+        || binding_id.is_some_and(|id| marker.get("bindingId").and_then(Value::as_str) != Some(id))
+    {
+        return false;
+    }
+    document
+        .as_object_mut()
+        .expect("decoded metadata object")
+        .remove("globalIdentity");
+    true
+}
+
+pub(super) fn has_fields(document: &Value) -> bool {
+    document
+        .as_object()
+        .expect("decoded metadata object")
+        .keys()
+        .any(|name| name != "version")
+}

--- a/rust/crates/tmt-adapters/src/tmux/mod.rs
+++ b/rust/crates/tmt-adapters/src/tmux/mod.rs
@@ -1,0 +1,450 @@
+//! Concrete tmux evidence/metadata IO. Identity transactions, reconciliation and
+//! retirement remain application policy; uncertain observations are not death.
+
+mod caller;
+mod evidence;
+mod metadata;
+
+#[cfg(test)]
+mod evidence_tests;
+#[cfg(test)]
+mod io_tests;
+
+pub use caller::CallerEnvironment;
+
+use crate::process::{
+    CommandError, CommandFailure, CommandRequest, CommandRunner, UnixCommandRunner,
+};
+use nix::{errno::Errno, sys::signal::kill, unistd::Pid};
+use std::{
+    ffi::{OsStr, OsString},
+    fmt,
+    time::{Duration, Instant},
+};
+use tmt_core::endpoint::{
+    BindingMarker, EndpointProbe, EndpointSnapshot, ServerEvidence, valid_process_id,
+    valid_server_id,
+};
+
+const OPERATION_TIMEOUT: Duration = Duration::from_secs(1);
+const OPERATION_MAX_OUTPUT: usize = 1024 * 1024;
+const SERVER_ID_OPTION: &str = "@tmux-team.server-id";
+const AGENT_METADATA_OPTION: &str = "@tmux-team.agent";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TmuxFailure {
+    Evidence,
+    Command,
+    MetadataRead,
+    MetadataWrite,
+}
+
+#[derive(Debug)]
+pub struct TmuxError {
+    pub kind: TmuxFailure,
+    message: &'static str,
+    cause: Option<CommandError>,
+}
+
+impl TmuxError {
+    fn evidence(message: &'static str) -> Self {
+        Self {
+            kind: TmuxFailure::Evidence,
+            message,
+            cause: None,
+        }
+    }
+
+    fn command(kind: TmuxFailure, cause: CommandError) -> Self {
+        let message = match kind {
+            TmuxFailure::MetadataRead => "Could not read pane metadata",
+            TmuxFailure::MetadataWrite => "Could not write pane metadata",
+            _ => "Could not execute tmux operation",
+        };
+        Self {
+            kind,
+            message,
+            cause: Some(cause),
+        }
+    }
+
+    pub fn cleanup_failed(&self) -> bool {
+        self.cause
+            .as_ref()
+            .is_some_and(CommandError::cleanup_failed)
+    }
+}
+
+impl fmt::Display for TmuxError {
+    fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(output, "{}", self.message)?;
+        if let Some(cause) = &self.cause {
+            let code = match cause.kind {
+                CommandFailure::Timeout => Some("ETIMEDOUT"),
+                CommandFailure::OutputLimit => Some("ENOBUFS"),
+                _ => match cause.raw_os_error().map(Errno::from_raw) {
+                    Some(Errno::EACCES) => Some("EACCES"),
+                    Some(Errno::EPERM) => Some("EPERM"),
+                    Some(Errno::ENOENT) => Some("ENOENT"),
+                    _ => None,
+                },
+            };
+            if let Some(code) = code {
+                write!(output, " ({code})")?;
+            } else if let CommandFailure::Exit {
+                code: Some(code @ 1..=255),
+                ..
+            } = cause.kind
+            {
+                write!(output, " (tmux exit {code})")?;
+            } else if let CommandFailure::Exit {
+                signal: Some(signal),
+                ..
+            } = cause.kind
+            {
+                match signal {
+                    9 => write!(output, " (SIGKILL)")?,
+                    15 => write!(output, " (SIGTERM)")?,
+                    _ => {}
+                }
+            }
+            if cause.cleanup_failed() {
+                write!(output, " (cleanup failed)")?;
+            }
+        }
+        write!(output, ".")
+    }
+}
+
+impl std::error::Error for TmuxError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.cause.as_ref().map(|cause| cause as _)
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct OperationOptions<'a> {
+    pub deadline: Option<Instant>,
+    pub pane_ids: Option<&'a [String]>,
+}
+
+pub struct Tmux<R = UnixCommandRunner> {
+    runner: R,
+}
+
+impl Default for Tmux {
+    fn default() -> Self {
+        Self::new(UnixCommandRunner)
+    }
+}
+
+impl<R: CommandRunner> Tmux<R> {
+    pub fn new(runner: R) -> Self {
+        Self { runner }
+    }
+
+    fn execute(
+        &self,
+        args: Vec<String>,
+        options: OperationOptions<'_>,
+        stage: TmuxFailure,
+    ) -> Result<String, TmuxError> {
+        let deadline = options.deadline.map_or_else(
+            || Instant::now() + OPERATION_TIMEOUT,
+            |deadline| deadline.min(Instant::now() + OPERATION_TIMEOUT),
+        );
+        self.run("tmux", args, deadline, OPERATION_MAX_OUTPUT, stage)
+    }
+
+    fn run(
+        &self,
+        program: &str,
+        args: Vec<String>,
+        deadline: Instant,
+        max_output_bytes: usize,
+        stage: TmuxFailure,
+    ) -> Result<String, TmuxError> {
+        if Instant::now() >= deadline {
+            return Err(TmuxError::command(
+                stage,
+                CommandError::new(CommandFailure::Timeout),
+            ));
+        }
+        let args: Vec<OsString> = args.into_iter().map(OsString::from).collect();
+        let output = self
+            .runner
+            .execute(CommandRequest {
+                program: OsStr::new(program),
+                args: &args,
+                input: &[],
+                deadline,
+                max_output_bytes,
+            })
+            .map_err(|cause| TmuxError::command(stage, cause))?;
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    pub fn caller_pane(
+        &self,
+        environment: &CallerEnvironment,
+    ) -> Result<Option<String>, TmuxError> {
+        optional_observation(caller::resolve(self, environment))
+    }
+
+    fn server_evidence(
+        &self,
+        socket: Option<&str>,
+        expected: Option<&str>,
+        options: OperationOptions<'_>,
+    ) -> Result<ServerEvidence, TmuxError> {
+        let mut args = socket_args(socket);
+        args.extend([
+            "display-message".into(),
+            "-p".into(),
+            evidence::server_format(),
+        ]);
+        evidence::parse_server(
+            &self.execute(args, options, TmuxFailure::Command)?,
+            expected,
+        )
+    }
+
+    fn ensure_server_id(&self, options: OperationOptions<'_>) -> Result<String, TmuxError> {
+        let read = || {
+            self.execute(
+                vec![
+                    "show-options".into(),
+                    "-s".into(),
+                    "-v".into(),
+                    SERVER_ID_OPTION.into(),
+                ],
+                options,
+                TmuxFailure::Command,
+            )
+        };
+        let value = match read() {
+            Ok(value) => value,
+            Err(error) if error.cleanup_failed() => return Err(error),
+            Err(_) => {
+                self.execute(
+                    vec![
+                        "set-option".into(),
+                        "-s".into(),
+                        "-o".into(),
+                        SERVER_ID_OPTION.into(),
+                        uuid::Uuid::new_v4().to_string(),
+                    ],
+                    options,
+                    TmuxFailure::Command,
+                )?;
+                read()?
+            }
+        };
+        let value = value.trim();
+        if !valid_server_id(value) {
+            return Err(TmuxError::evidence("tmux server identity is unavailable"));
+        }
+        Ok(value.into())
+    }
+
+    pub fn snapshot(&self, options: OperationOptions<'_>) -> Result<EndpointSnapshot, TmuxError> {
+        let scope = evidence::scoped_ids(options.pane_ids)?;
+        let expected = self.ensure_server_id(options)?;
+        if scope.as_ref().is_some_and(Vec::is_empty) {
+            return Ok(EndpointSnapshot {
+                server: self.server_evidence(None, Some(&expected), options)?,
+                panes: Vec::new(),
+            });
+        }
+        let output = self.execute(
+            list_args(None, scope.as_deref()),
+            options,
+            TmuxFailure::Command,
+        )?;
+        if !output.trim().is_empty() {
+            return evidence::parse_snapshot(&output, Some(&expected));
+        }
+        if scope.is_none() {
+            return Err(TmuxError::evidence("tmux endpoint snapshot is empty"));
+        }
+        Ok(EndpointSnapshot {
+            server: self.server_evidence(None, Some(&expected), options)?,
+            panes: Vec::new(),
+        })
+    }
+
+    pub fn probe(
+        &self,
+        socket: &str,
+        recorded_pid: u64,
+        options: OperationOptions<'_>,
+    ) -> Result<EndpointProbe, TmuxError> {
+        if socket.is_empty() || !valid_process_id(recorded_pid) {
+            return Ok(EndpointProbe::Unknown);
+        }
+        let Ok(scope) = evidence::scoped_ids(options.pane_ids) else {
+            return Ok(EndpointProbe::Unknown);
+        };
+        if scope.as_ref().is_some_and(Vec::is_empty) {
+            return match self.server_evidence(Some(socket), None, options) {
+                Ok(server) if server.socket_path == socket => {
+                    Ok(EndpointProbe::Live(EndpointSnapshot {
+                        server,
+                        panes: Vec::new(),
+                    }))
+                }
+                Err(error) if error.cleanup_failed() => Err(error),
+                Err(_) => Ok(probe_death(recorded_pid)),
+                _ => Ok(EndpointProbe::Unknown),
+            };
+        }
+        let output = match self.execute(
+            list_args(Some(socket), scope.as_deref()),
+            options,
+            TmuxFailure::Command,
+        ) {
+            Ok(output) => output,
+            Err(error) if error.cleanup_failed() => return Err(error),
+            Err(_) => return Ok(probe_death(recorded_pid)),
+        };
+        let observed = if !output.trim().is_empty() {
+            evidence::parse_snapshot(&output, None)
+        } else if scope.is_some() {
+            self.server_evidence(Some(socket), None, options)
+                .map(|server| EndpointSnapshot {
+                    server,
+                    panes: Vec::new(),
+                })
+        } else {
+            Err(TmuxError::evidence("tmux endpoint snapshot is empty"))
+        };
+        match observed {
+            Ok(snapshot) if snapshot.server.socket_path == socket => {
+                Ok(EndpointProbe::Live(snapshot))
+            }
+            Err(error) if error.cleanup_failed() => Err(error),
+            _ => Ok(EndpointProbe::Unknown),
+        }
+    }
+
+    pub fn resolve_target(
+        &self,
+        target: &str,
+        options: OperationOptions<'_>,
+    ) -> Result<Option<String>, TmuxError> {
+        let output = optional_observation(self.execute(
+            vec![
+                "display-message".into(),
+                "-p".into(),
+                "-t".into(),
+                target.into(),
+                "#{pane_id}".into(),
+            ],
+            options,
+            TmuxFailure::Command,
+        ))?;
+        let Some(output) = output else {
+            return Ok(None);
+        };
+        let id = output.trim();
+        Ok(tmt_core::endpoint::valid_pane_id(id).then(|| id.into()))
+    }
+
+    fn read_metadata(
+        &self,
+        pane: &str,
+        options: OperationOptions<'_>,
+    ) -> Result<serde_json::Value, TmuxError> {
+        let output = self.execute(
+            vec![
+                "show-options".into(),
+                "-q".into(),
+                "-p".into(),
+                "-t".into(),
+                pane.into(),
+                "-v".into(),
+                AGENT_METADATA_OPTION.into(),
+            ],
+            options,
+            TmuxFailure::MetadataRead,
+        )?;
+        Ok(metadata::decode(&output))
+    }
+
+    fn write_metadata(
+        &self,
+        pane: &str,
+        document: &serde_json::Value,
+        options: OperationOptions<'_>,
+    ) -> Result<(), TmuxError> {
+        let mut args = vec!["set-option".into(), "-p".into()];
+        if !metadata::has_fields(document) {
+            args.push("-u".into());
+        }
+        args.extend(["-t".into(), pane.into(), AGENT_METADATA_OPTION.into()]);
+        if metadata::has_fields(document) {
+            args.push(document.to_string());
+        }
+        self.execute(args, options, TmuxFailure::MetadataWrite)
+            .map(|_| ())
+    }
+
+    pub fn set_marker(
+        &self,
+        pane: &str,
+        marker: &BindingMarker,
+        options: OperationOptions<'_>,
+    ) -> Result<(), TmuxError> {
+        let mut document = self.read_metadata(pane, options)?;
+        metadata::replace(&mut document, marker);
+        self.write_metadata(pane, &document, options)
+    }
+
+    pub fn clear_marker(
+        &self,
+        pane: &str,
+        binding_id: Option<&str>,
+        options: OperationOptions<'_>,
+    ) -> Result<bool, TmuxError> {
+        let mut document = self.read_metadata(pane, options)?;
+        if !metadata::clear(&mut document, binding_id) {
+            return Ok(false);
+        }
+        self.write_metadata(pane, &document, options)?;
+        Ok(true)
+    }
+}
+
+/// Expected unavailable evidence is best-effort; failed resource cleanup is
+/// exceptional and must reach the invocation owner, never become "not found".
+fn optional_observation<T>(result: Result<T, TmuxError>) -> Result<Option<T>, TmuxError> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(error) if error.cleanup_failed() => Err(error),
+        Err(_) => Ok(None),
+    }
+}
+
+fn probe_death(recorded_pid: u64) -> EndpointProbe {
+    let Ok(pid) = i32::try_from(recorded_pid) else {
+        return EndpointProbe::Unknown;
+    };
+    match kill(Pid::from_raw(pid), None) {
+        Err(Errno::ESRCH) => EndpointProbe::Dead,
+        _ => EndpointProbe::Unknown,
+    }
+}
+
+fn socket_args(socket: Option<&str>) -> Vec<String> {
+    socket.map_or_else(Vec::new, |socket| vec!["-S".into(), socket.into()])
+}
+
+fn list_args(socket: Option<&str>, scope: Option<&[&str]>) -> Vec<String> {
+    let mut args = socket_args(socket);
+    args.extend(["list-panes".into(), "-a".into()]);
+    if let Some(ids) = scope.filter(|ids| !ids.is_empty()) {
+        args.extend(["-f".into(), evidence::pane_filter(ids)]);
+    }
+    args.extend(["-F".into(), evidence::endpoint_format()]);
+    args
+}

--- a/rust/crates/tmt-core/Cargo.toml
+++ b/rust/crates/tmt-core/Cargo.toml
@@ -8,3 +8,6 @@ publish.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+uuid.workspace = true

--- a/rust/crates/tmt-core/src/endpoint.rs
+++ b/rust/crates/tmt-core/src/endpoint.rs
@@ -1,0 +1,63 @@
+//! Endpoint observations are evidence, not identity registration or permission.
+//! Adapters decode wire formats; application policy decides binding/retirement.
+
+use crate::limits::MAX_JS_SAFE_INTEGER;
+
+pub fn valid_pane_id(value: &str) -> bool {
+    value.strip_prefix('%').is_some_and(|digits| {
+        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
+pub fn valid_process_id(value: u64) -> bool {
+    value > 0 && value <= MAX_JS_SAFE_INTEGER
+}
+
+pub fn valid_server_id(value: &str) -> bool {
+    value.len() == 36
+        && uuid::Uuid::parse_str(value).is_ok_and(|uuid| {
+            uuid.get_version_num() == 4 && uuid.get_variant() == uuid::Variant::RFC4122
+        })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerEvidence {
+    pub server_id: String,
+    pub socket_path: String,
+    pub server_pid: u64,
+    pub server_start_time: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindingMarker {
+    pub name: String,
+    pub canonical_name: String,
+    pub identity_id: String,
+    pub binding_id: String,
+    pub server_id: String,
+    pub pane_pid: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaneObservation {
+    pub id: String,
+    pub target: Option<String>,
+    pub cwd: Option<String>,
+    pub command: String,
+    pub pane_pid: u64,
+    pub suggested_name: Option<String>,
+    pub marker: Option<BindingMarker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EndpointSnapshot {
+    pub server: ServerEvidence,
+    pub panes: Vec<PaneObservation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EndpointProbe {
+    Live(EndpointSnapshot),
+    Dead,
+    Unknown,
+}

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared native-domain contracts for tmux-team.
 
+pub mod endpoint;
 pub mod limits;
 pub mod settings;
 

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,3 +1,13 @@
+FROM rust:1.97.0-bookworm@sha256:8fa55b2f3ddf97471ab6a767bfa3f37e6bad0986ba823e75fea57e2a2a5c3073 AS native-tests
+WORKDIR /native
+COPY rust/ ./
+RUN cargo build --locked --example tmux-probe \
+  && cargo test --locked --no-run -p tmt-adapters \
+  && mkdir /native-artifacts \
+  && cp target/debug/examples/tmux-probe /native-artifacts/tmux-probe \
+  && find target/debug/deps -maxdepth 1 -type f -name 'tmt_adapters-*' -executable \
+    -exec cp {} /native-artifacts/adapter-tests \;
+
 FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
 
 ARG TMUX_VERSION=3.3a-3
@@ -12,5 +22,9 @@ WORKDIR /workspace
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
+COPY --from=native-tests /native-artifacts/ /opt/tmt-tests/
+ENV TMT_TEST_TMUX_PROBE='{"executable":"/opt/tmt-tests/tmux-probe","args":[]}'
 
-CMD ["pnpm", "exec", "vitest", "run", "--config", "test/e2e/vitest.config.ts"]
+# Run process lifecycle tests under the wrapper's --init, not a build-stage
+# shell that may retain orphan zombies. Both suites share network isolation.
+CMD ["sh", "-c", "/opt/tmt-tests/adapter-tests && exec pnpm exec vitest run --config test/e2e/vitest.config.ts"]

--- a/test/e2e/native-tmux.e2e.test.ts
+++ b/test/e2e/native-tmux.e2e.test.ts
@@ -1,0 +1,293 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  withE2EFixture,
+  type CliResult,
+  type E2EFixture,
+  type E2EFixtureOptions,
+} from './harness.js';
+import { readRealTmuxCli, releaseRealTmuxCli, spawnRealTmuxCli } from './real-tmux-caller.js';
+
+interface Snapshot {
+  server: { serverId: string; socketPath: string; serverPid: number; serverStartTime: string };
+  panes: { id: string; panePid: number; target: string; marker: unknown }[];
+}
+
+interface Counted {
+  commandCount: number;
+}
+
+function fixtureOptions(): E2EFixtureOptions {
+  const probe = process.env.TMT_TEST_TMUX_PROBE;
+  if (!probe) throw new Error('Native tmux E2E requires the Docker-built adapter probe.');
+  // The existing selector validates the descriptor before fixture allocation.
+  return { mode: 'input-log', executableEnv: { TMT_TEST_CLI: probe } };
+}
+
+function successful<T>(result: CliResult<T>): T {
+  expect(result.code, result.stderr || result.stdout).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.json).toBeDefined();
+  return result.json as T;
+}
+
+describe.sequential('native tmux adapter integration (not identity CLI parity)', () => {
+  it('cleans the native-selected fixture after an intentional scenario failure', async () => {
+    const fixtures: E2EFixture[] = [];
+    await expect(
+      withE2EFixture(async (fixture) => {
+        fixtures.push(fixture);
+        successful(await fixture.runJsonCli(['snapshot']));
+        throw new Error('intentional native adapter scenario failure');
+      }, fixtureOptions())
+    ).rejects.toThrow('intentional native adapter scenario failure');
+    expect(fixtures).toHaveLength(1);
+    for (const fixture of fixtures) {
+      expect(fs.existsSync(fixture.root)).toBe(false);
+      expect(fs.existsSync(fixture.socketRoot)).toBe(false);
+      expect(fixture.serverProcessIsRunning()).toBe(false);
+      expect(fixture.mockProcessIsRunning()).toBe(false);
+    }
+  });
+  it.each([
+    { name: 'complete', stripTmux: false, stripPane: false },
+    { name: 'missing-pane', stripTmux: false, stripPane: true },
+    { name: 'missing-tmux', stripTmux: true, stripPane: false },
+    { name: 'missing-both', stripTmux: true, stripPane: true },
+  ])(
+    'verifies real descendant caller evidence: $name',
+    async (context) => {
+      await withE2EFixture(async (fixture) => {
+        const real = await spawnRealTmuxCli(fixture, ['caller'], context);
+        const peer = await fixture.createMockPane('ambient-peer');
+        fixture.tmux(['select-pane', '-t', peer.pane]);
+        await releaseRealTmuxCli(fixture, real);
+        const result = readRealTmuxCli<Counted & { pane: string }>(real);
+        expect(result.code).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(result.stdout.pane).toBe(real.pane);
+        expect(result.stdout.commandCount).toBeGreaterThan(0);
+        if (context.name === 'complete') expect(result.stdout.commandCount).toBe(1);
+        expect(fixture.paneMetadata(real.pane)).toBe('');
+        expect(fixture.paneMetadata(peer.pane)).toBe('');
+        expect(fs.existsSync(path.join(fixture.globalDir, 'tmux-team.db'))).toBe(false);
+      }, fixtureOptions());
+    },
+    20_000
+  );
+
+  it('rejects malformed and conflicting context without choosing the active pane', async () => {
+    await withE2EFixture(async (fixture) => {
+      const malformed = successful(
+        await fixture.runJsonCli<Counted & { pane: null }>(['caller'], {
+          caller: { tmux: 'invalid', pane: fixture.pane },
+        })
+      );
+      expect(malformed).toEqual({ pane: null, commandCount: 0 });
+      const conflict = successful(
+        await fixture.runJsonCli<Counted & { pane: null }>(['caller'], {
+          caller: { tmux: `/unrelated/socket,${fixture.serverPid},0` },
+        })
+      );
+      expect(conflict).toEqual({ pane: null, commandCount: 1 });
+      const outside = successful(
+        await fixture.runJsonCli<Counted & { pane: null }>(['caller'], { outsideTmux: true })
+      );
+      expect(outside.pane).toBeNull();
+      expect(outside.commandCount).toBeGreaterThan(1);
+    }, fixtureOptions());
+  });
+
+  it('keeps scoped and empty snapshots bounded in a mostly-unbound server', async () => {
+    await withE2EFixture(async (fixture) => {
+      for (let index = 0; index < 30; index++) {
+        fixture.tmux(['new-window', '-d', '-t', 'e2e:', '-n', `unbound-${index}`, 'sleep', '300']);
+      }
+      const initial = successful(await fixture.runJsonCli<Snapshot & Counted>(['snapshot']));
+      expect(initial.panes).toHaveLength(31);
+      expect(initial.panes.every((pane) => pane.marker === null)).toBe(true);
+      const full = successful(await fixture.runJsonCli<Snapshot & Counted>(['snapshot']));
+      expect(full.commandCount).toBe(2);
+      const scoped = successful(
+        await fixture.runJsonCli<Snapshot & Counted>(['snapshot', fixture.pane])
+      );
+      expect(scoped.commandCount).toBe(2);
+      expect(scoped.panes.map((pane) => pane.id)).toEqual([fixture.pane]);
+      const empty = successful(await fixture.runJsonCli<Snapshot & Counted>(['server']));
+      expect(empty.commandCount).toBe(2);
+      expect(empty.panes).toEqual([]);
+      const missing = successful(
+        await fixture.runJsonCli<Snapshot & Counted>(['snapshot', '%999999'])
+      );
+      expect(missing.commandCount).toBe(3);
+      expect(missing.panes).toEqual([]);
+      expect(missing.server).toEqual(full.server);
+      const target = successful(
+        await fixture.runJsonCli<Counted & { pane: string }>([
+          'target',
+          fixture.paneTarget(fixture.pane),
+        ])
+      );
+      expect(target).toEqual({ pane: fixture.pane, commandCount: 1 });
+    }, fixtureOptions());
+  }, 20_000);
+
+  it.each(['grouped', 'linked'] as const)(
+    'deduplicates %s rows and prefers a real attached target',
+    async (mode) => {
+      await withE2EFixture(async (fixture) => {
+        if (mode === 'grouped') fixture.tmux(['new-session', '-d', '-t', 'e2e', '-s', 'second']);
+        else {
+          fixture.tmux(['new-session', '-d', '-s', 'second', 'sleep', '300']);
+          fixture.tmux(['link-window', '-s', 'e2e:0', '-t', 'second:']);
+        }
+        await fixture.attachSessionClient('second');
+        const rows = fixture
+          .tmux([
+            'list-panes',
+            '-a',
+            '-F',
+            '#{pane_id}|#{session_name}:#{window_index}.#{pane_index}|#{session_attached}',
+          ])
+          .trim()
+          .split('\n')
+          .map((line) => line.split('|'))
+          .filter(([id]) => id === fixture.pane);
+        expect(rows).toHaveLength(2);
+        expect(rows[0]?.[2]).toBe('0');
+        const attached = rows.find((row) => Number(row[2]) > 0);
+        expect(attached).toBeDefined();
+        for (const args of [['snapshot'], ['snapshot', fixture.pane]]) {
+          const snapshot = successful(await fixture.runJsonCli<Snapshot & Counted>(args));
+          const panes = snapshot.panes.filter((pane) => pane.id === fixture.pane);
+          expect(panes).toHaveLength(1);
+          expect(panes[0]).toMatchObject({ panePid: fixture.panePid, target: attached?.[1] });
+        }
+      }, fixtureOptions());
+    },
+    20_000
+  );
+
+  it('preserves opaque metadata and only clears the selected binding marker', async () => {
+    await withE2EFixture(async (fixture) => {
+      const snapshot = successful(await fixture.runJsonCli<Snapshot>(['server']));
+      const opaque = { version: 1, future: { literal: '__TMT_FIELD_4f1c__', enabled: true } };
+      fixture.tmux([
+        'set-option',
+        '-p',
+        '-t',
+        fixture.pane,
+        '@tmux-team.agent',
+        JSON.stringify(opaque),
+      ]);
+      const published = successful(
+        await fixture.runJsonCli<Counted & { changed: boolean }>([
+          'set-marker',
+          fixture.pane,
+          'Alice',
+          'alice',
+          'identity-1',
+          'binding-1',
+          snapshot.server.serverId,
+          String(fixture.panePid),
+        ])
+      );
+      expect(published).toEqual({ changed: true, commandCount: 2 });
+      const expected = {
+        ...opaque,
+        globalIdentity: {
+          name: 'Alice',
+          canonicalName: 'alice',
+          identityId: 'identity-1',
+          bindingId: 'binding-1',
+          serverId: snapshot.server.serverId,
+          panePid: fixture.panePid,
+        },
+      };
+      expect(JSON.parse(fixture.paneMetadata())).toEqual(expected);
+      const observed = successful(await fixture.runJsonCli<Snapshot>(['snapshot', fixture.pane]));
+      expect(observed.panes[0]?.marker).toEqual(expected.globalIdentity);
+      const before = fixture.paneMetadata();
+      expect(successful(await fixture.runJsonCli(['clear-marker', fixture.pane, 'wrong']))).toEqual(
+        { changed: false, commandCount: 1 }
+      );
+      expect(fixture.paneMetadata()).toBe(before);
+      expect(
+        successful(await fixture.runJsonCli(['clear-marker', fixture.pane, 'binding-1']))
+      ).toEqual({ changed: true, commandCount: 2 });
+      expect(JSON.parse(fixture.paneMetadata())).toEqual(opaque);
+      // tmux show-options -q may treat a missing pane as empty metadata. An
+      // already-absent marker is an idempotent no-op, not proof of an IO error.
+      expect(
+        successful(await fixture.runJsonCli(['clear-marker', '%999999', 'binding-1']))
+      ).toEqual({ changed: false, commandCount: 1 });
+      const failedWrite = await fixture.runJsonCli([
+        'set-marker',
+        '%999999',
+        'Alice',
+        'alice',
+        'identity-1',
+        'binding-1',
+        snapshot.server.serverId,
+        String(fixture.panePid),
+      ]);
+      expect(failedWrite.code).toBe(1);
+      expect(failedWrite.json).toMatchObject({
+        error: {
+          code: 'TMUX_ERROR',
+          message: expect.stringContaining('Could not write pane metadata'),
+        },
+      });
+      const failedRead = await fixture.runJsonCli(['clear-marker', fixture.pane, 'binding-1'], {
+        withoutTmux: true,
+      });
+      expect(failedRead.code).toBe(1);
+      expect(failedRead.json).toMatchObject({
+        error: {
+          code: 'TMUX_ERROR',
+          message: expect.stringContaining('Could not read pane metadata'),
+        },
+        commandCount: 1,
+      });
+      expect(JSON.parse(fixture.paneMetadata())).toEqual(opaque);
+      expect(fs.existsSync(path.join(fixture.globalDir, 'tmux-team.db'))).toBe(false);
+    }, fixtureOptions());
+  });
+
+  it('distinguishes live, inaccessible and reaped foreign servers without mutating them', async () => {
+    await withE2EFixture(async (local) => {
+      let deadSocket = '';
+      let deadPid = 0;
+      await withE2EFixture(async (foreign) => {
+        const expected = successful(await foreign.runJsonCli<Snapshot>(['snapshot']));
+        const probe = successful(
+          await local.runJsonCli<Counted & { status: string; snapshot: Snapshot }>([
+            'probe',
+            foreign.socketPath,
+            String(foreign.serverPid),
+          ])
+        );
+        expect(probe.status).toBe('live');
+        expect(probe.commandCount).toBe(1);
+        expect(probe.snapshot).toEqual({ server: expected.server, panes: expected.panes });
+        expect(probe.snapshot.server.socketPath).not.toBe(local.socketPath);
+        const unknown = successful(
+          await local.runJsonCli<Counted & { status: string }>([
+            'probe',
+            `${foreign.socketPath}.missing`,
+            String(foreign.serverPid),
+          ])
+        );
+        expect(unknown).toEqual({ status: 'unknown', commandCount: 1 });
+        expect(foreign.paneMetadata()).toBe('');
+        deadSocket = foreign.socketPath;
+        deadPid = foreign.serverPid;
+      }, fixtureOptions());
+      const dead = successful(
+        await local.runJsonCli<Counted & { status: string }>(['probe', deadSocket, String(deadPid)])
+      );
+      expect(dead).toEqual({ status: 'dead', commandCount: 1 });
+    }, fixtureOptions());
+  });
+});


### PR DESCRIPTION
## Scope

Closes #105. Part of #93; #100 owns identity lifetime/workspace policy and #106 owns the future compact receipt amendment.

Implement the native Unix tmux evidence boundary without changing the installed TypeScript runtime or claiming native identity/talk parity:

- One bounded argv-only process runner with concurrent pipe communication, per-stream caps, monotonic deadlines and explicit process-group termination/reaping.
- Strict caller environment/ancestry, coherent scoped/grouped endpoint snapshots, known-socket live/dead/unknown probes, bounded target resolution and opaque metadata preservation.
- Shared editable-JSON compatibility for config and metadata, and shared tmux/ps integer-wire parsing; no second identity registry or response layer.
- Non-installed adapter probe and native scenarios in the existing Docker fixture. One pinned Rust build stage, with Linux adapter tests running under the wrapper's existing init/network isolation before Vitest.

## Architecture and primary review

Primary reviewed commit: `1dab732d4b25248df2994c5698a2806331671364`.

The primary personally inspected every changed implementation/test/document, the TypeScript tmux/caller/metadata reference, process dependency ownership APIs, relevant config/storage fixtures, executable selector, Docker wrapper and real-descendant harness. A separate bounded review corroborated the resource/caller/evidence boundaries; it did not replace primary acceptance.

Findings and dispositions:

1. Optional observations initially hid cleanup failures. Caller/target and probes now preserve expected unavailable results but propagate exceptional cleanup errors, and server initialization cannot proceed after failed cleanup.
2. Overflow testing exposed Darwin EPERM for zombie-only groups. Clear that error only after owned-leader reaping and read-only proof of group absence; never signal the numeric group after reap. Live/denied/unknown observations retain the failure.
3. Cleanup fixtures must not signal already-reaped numeric PIDs. Fixtures now naturally expire, with read-only bounded absence assertions. Input-pressure tests verify exact input rather than only reaching EOF; separate tests cover closed output before process exit.
4. `tmux show-options -q` can return empty metadata for a missing pane. The Docker scenario distinguishes idempotent absent-marker clear from genuine failed reads/writes, and independently checks unrelated metadata/state preservation.
5. Caller and endpoint numeric decoding initially duplicated the same wire rule. They now share it. The explicit compatibility refinement rejects synthetic signed/hex/exponent PID fields; actual tmux/ps decimal output is preserved.

Architecture impact: concrete resource ownership, endpoint observation types, shared editable JSON and test-artifact composition changed. ARCHITECTURE.md, CONVENTIONS.md, DEVELOPMENT.md and RUST-REWRITE.md are updated in this PR. No binding transactions, retirement, badge, message transport, daemon, MCP, public installation, or runtime cutover are introduced.

Dependency review covers exact locked published manifests/features/licenses and both toolchains. There are seven active Unix additions; other lock additions are target-only Windows/WASM/UEFI dependencies. The dated RustSec snapshot and its limitation are recorded in RUST-REWRITE.md; no permanent security guarantee is claimed.

## Verification

- [x] Primary reviewed every changed file and relevant callers/tests.
- [x] Exact local commands and results recorded below.
- [x] All 11 CI checks passed on this exact reviewed head before authorized merge (run 34119886643, attempt 1).

From `rust/`:

- `cargo fmt --all --check` — passed.
- `cargo clippy --locked --all-targets -- -D warnings` — passed.
- `cargo test --locked` — 78 passed (44 adapters, 14 CLI, 20 core).
- `cargo +1.88.0 test --locked` — same 78 passed.
- `cargo build --locked` and `cargo build --locked --examples` — passed.

Repository checks:

- `pnpm check` — passed, no lint warnings/errors.
- `pnpm test:run` — 1,102 tests / 70 files passed; coverage 95.66% statements/lines, 89.47% branches, 97.55% functions.
- Explicit native `TMT_TEST_CLI` plus `TMT_TEST_STORAGE_PROBE`, `pnpm test:native` — 39 passed.
- Documented unchanged native-selected parser subset — 8 passed; documented config subset — 6 passed. Other effectful CLI scenarios are not claimed as native parity.
- `pnpm test:e2e`, twice — 115 passed and one optional benchmark skipped on each run (286.50s / 287.44s); Linux adapter unit tests 44 passed in each container. Both runs completed with exit 0 through the existing image/fixture cleanup wrapper.
- The initial Docker development run deliberately remains recorded as failed (one incorrect missing-pane test expectation); it is not counted as a passing cleanup gate.

Native Docker coverage includes real stripped/partial-env descendants with another active pane, malformed/conflicting and outside context, mostly-unbound large sessions, explicit empty/missing scopes, real grouped/linked/attached sessions, preserved metadata and failed reads/writes, two private servers and verified death, plus intentional scenario-failure cleanup.

## Project lifecycle

- English issue #105 contains scope, dependency/resource decisions and progress/evidence.
- Dedicated branch/worktree: `feat/105-native-tmux` / `tmt-105-native-tmux`.
- Parent #93 distinguishes delivered configuration/storage from this adapter and later identity/request work. #106 is recorded separately; receipt behavior is unchanged here.
- Submit one CI candidate after local gates; merge only with all checks green on the reviewed head. Clean the worktree only after clean, pushed, recorded delivery. No package publication or global installation.
