### PR TITLE
feat(native): add lossless identity lifetime migration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -894,7 +894,7 @@ failure semantics; merely introducing an interface is not an architectural fix.
 remain TypeScript. `tmt-core` owns numeric and settings policy, while `tmt-cli`
 owns one Clap grammar, typed requests, presentation, configuration composition
 and explicit no-effects rejection for unimplemented commands. `tmt-adapters`
-owns the schema 8 SQLite lifecycle under #97, configuration files under #103,
+owns the SQLite lifecycle under #97 and native schema 9 under #108, configuration files under #103,
 and bounded Unix tmux evidence under #105;
 neither core nor typed requests depend on concrete IO.
 
@@ -933,11 +933,44 @@ Close always releases the connection even if checkpoint fails, preserving the
 primary error. Cold WAL transitions can return retryable contention, as in the
 TypeScript adapter; no new retry loop is hidden in this lifecycle layer.
 
+Native migration 9 adds `lifetime` (default `saved` for existing identities) and
+nullable `retired_at_ms` to that same identity table. A partial unique index
+reserves canonical names only for non-retired rows; old UUID/name metadata can
+survive name reuse. It does not retire rows, remove bindings or profiles, or
+acknowledge exchanges. Actual retirement and cleanup authorization belong to
+the pending identity service, not SQL triggers or a second registry.
+Lifetime and retirement are independent: explicit confirmed removal may also
+retire a saved identity; ordinary pane death must not do so.
+
+Changing the old unconditional unique constraint requires a table rebuild.
+The private opening connection temporarily suspends foreign keys outside the
+immediate migration transaction. The runner rechecks history under the lock,
+validates the historical identity definition, rejects custom identity
+columns/constraints/indexes/triggers, checks existing foreign keys, copies
+the identity table, replaces it, records the migration and checks foreign keys
+again before commit. Enforcement is restored after commit or rollback, before
+any successful handle can escape. A failed opening closes the connection.
+The rebuild never renames the original table first or edits sqlite_schema;
+bindings, role/preamble/cadence rows and request identity references are preserved.
+SQL, record-insertion and commit failure tests verify rollback and enforcement,
+not merely a healthy empty database.
+
+This is a forward-only development boundary: installed TypeScript remains on
+schema 8 and rejects schema 9. Do not use the native preview against user state
+or run old and new writers on the same database. Before distribution, #82/#93
+must provide stopped-writer cutover, consistent backup/recovery and preserved
+old-receipt execution. Replacing a binary does not downgrade a database.
+
 `storage-probe` is a development-only example using that real adapter, not a
 public CLI command or alternate storage implementation. Shared bounded subprocess
 tests compare closed TypeScript schema-prefix fixtures and independent SQL
-observations, reverse-reopen with TypeScript and exercise failure recovery.
-These tests establish storage compatibility, not native request/identity parity.
+observations and exercise failure recovery. Prefixes 0–8 retain historical
+schema/data semantics except the explicit ninth identity amendment; tests assert
+TypeScript rejects the upgraded database without mutation and native reopen is
+idempotent. Independent snapshots retain exact bodies, provenance, horizons and
+attention across the rebuild. The earlier schema-8 reverse-open success is
+superseded by this explicit forward boundary, not silently counted as passing.
+These tests establish migration preservation, not native request/identity parity.
 
 The native `config` command uses core-owned typed values, defaults, editing scope
 and local-clear rules. Its filesystem adapter owns global/XDG/legacy and upward

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -906,8 +906,14 @@ invocations without exposing Clap to application use cases. The binary returns
 an exit status through `main` and does not terminate from a domain operation.
 
 Native syntax includes the approved #100 amendment (`rm`/`remove`, temporary
-binding defaults and `-s`/`--save`). Identity repositories, retirement, workspace selection and
-promotion are not yet implemented. The durable-global invariants elsewhere in
+binding defaults and `-s`/`--save`). Names remain globally unique across temporary
+and saved identities in one database; no project/workspace name isolation or
+directory-based discovery filter is planned. Native `ls` is planned to list all
+non-retired identities, including saved offline entries, and show lifetime
+separately from active/offline/unknown presence. Unverified evidence cannot retire
+a temporary identity or release a saved name. Visibility does not extend routing.
+Identity repositories, retirement, promotion and these listing changes are not
+yet implemented. The durable-global invariants elsewhere in
 this map still describe the shipped TypeScript runtime, not the amended future
 native lifecycle. See [RUST-REWRITE.md](RUST-REWRITE.md) for transition boundaries.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,8 +34,10 @@ pnpm dev -- --help
 The `rust/` workspace is not the installed runtime yet. It implements only
 help/version/completion, typed grammar and the existing `config` command.
 Other effectful commands still explicitly fail.
-The separate storage adapter implements schema 8 lifecycle compatibility, tested
-through a development-only probe rather than an installed command.
+The separate storage adapter upgrades historical schemas 0–8 to native schema 9,
+tested through a development-only probe rather than an installed command.
+Use isolated test databases only: installed TypeScript cannot reopen schema 9.
+Native identity commands and retirement are still unimplemented.
 The Unix tmux evidence adapter is likewise exercised through a non-installed
 `tmux-probe` example; native identity commands are not implemented by that probe.
 Use the exact toolchain from `rust/rust-toolchain.toml` and run from `rust/`:
@@ -61,11 +63,19 @@ TMT_TEST_CLI='{"executable":"/absolute/checkout/rust/target/debug/tmt","args":[]
 This preview-specific suite reuses the shared sandbox and bounded process
 launcher; it does not replace TypeScript or Docker verification. Storage tests
 create and close TypeScript schema-prefix fixtures, migrate through the actual
-Rust adapter, and compare independent SQL schema/data with the TypeScript result.
-They also exercise reverse opens, rollback, history rejection and bounded writer
+Rust adapter, and compare independent SQL schema/data with the TypeScript result,
+allowing only the specified identity-table/index/history amendment. They verify
+saved backfill, name reuse without UUID inheritance, preserved dependent records,
+explicit TypeScript rejection of schema 9 without mutation, native reopen,
+rollback, history rejection and bounded writer
 contention. Neither executable selector may silently fall back to TypeScript.
 The probe accepts only a database path and runs open/health/checkpoint/close;
 it has no arbitrary SQL or failure-injection command and is not packaged.
+Runner-level Rust tests also hold a real rollback-journal reader across migration
+commit and inject record/foreign-key failures after table replacement. Assert
+schema/data rollback and restored connection enforcement; a migration error alone
+does not establish either invariant. Preserve the independent schema-prefix
+fixtures instead of copying the new production migration into the test oracle.
 Also run the
 existing parser-only public contract subset through the same selection:
 

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -15,7 +15,10 @@ Replace the user-facing Node/tsx runtime with a native executable, preserving
 supported v5 command and data contracts. Node may remain developer test tooling.
 The approved native identity amendment [#100](https://github.com/wkh237/tmux-team/issues/100)
 adds temporary-by-default identities, explicit `-s`/`--save`, restored `rm`/`remove`,
-and workspace-scoped everyday discovery. It retains one SQLite identity model;
+and visible lifetime/presence in `ls`. Canonical names remain globally unique
+within one local database across both lifetimes; folders and Git worktrees do
+not establish another namespace or filter discovery. The earlier workspace
+scoping proposal was withdrawn by user clarification. It retains one SQLite identity model;
 promotion keeps the UUID and retirement must preserve retained exchanges.
 This amendment is not implemented by grammar recognition alone. The rewrite
 is not authorization to add memory/offline inbox,
@@ -62,6 +65,17 @@ The preview implements help, version, Bash/Zsh completion and the existing
 storage, tmux or input acquisition. Text-only commands reject JSON. Native
 `name`/`this`/`add` parse temporary defaults and save flags; `rm`/`remove` parse
 explicit force. This is not evidence that native lifecycle operations work.
+
+The planned #100 listing includes all non-retired temporary and saved identities,
+including saved offline identities. It exposes lifetime separately from verified
+presence: `temporary`/`saved` and `active`/`offline`/`unknown`. Unavailable evidence
+is not proof of death; retired temporary identities are omitted, while offline
+saved identities continue to reserve their names. Visibility does not silently
+expand current-server routing or justify unbounded per-identity tmux queries.
+The implementing issue must define exact JSON and failure precedence and test
+cross-directory name collisions, promotion, retirement/reuse, preserved exchanges
+and truthful unknown presence. These are planned native changes, not installed
+TypeScript behavior or a second identity registry.
 
 #103 makes settings an invocation-owned shared boundary rather than a rule set
 inside each CLI handler. Core owns typed defaults, scalar bounds, setting scope

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -1,6 +1,6 @@
 # Rust rewrite preparation
 
-Status: native grammar (#96), schema 8 lifecycle (#97), configuration (#103)
+Status: native grammar (#96), storage lifecycle (#97) with native identity schema 9 (#108), configuration (#103)
 and bounded tmux evidence (#105)
 are implemented in the development preview, not a shipped Rust runtime.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
@@ -55,7 +55,7 @@ is by responsibility, not a mechanical copy of every TypeScript file.
 
 The `rust/` workspace contains `tmt-core` (numeric and settings policy),
 `tmt-cli` (grammar, typed invocation translation and output), and `tmt-adapters`
-(schema 8 SQLite lifecycle under #97, configuration files under #103 and Unix
+(SQLite lifecycle under #97 with schema 9 under #108, configuration files under #103 and Unix
 tmux evidence under #105). The npm entry points still execute TypeScript. No command silently
 delegates from native to Node.
 
@@ -136,7 +136,7 @@ revision, the nine entries for rusqlite, libsqlite3-sys, shlex and smallvec all
 list patched ranges containing the locked versions. Some manifests omit MSRV,
 so actual Rust 1.88 locked compilation remains the acceptance evidence.
 
-Schema 8 remains unchanged. Native migrations retain the historical names,
+Historical migrations 1–8 remain unchanged. Native migrations retain their names,
 column/index/foreign-key definitions and seven-day migration backfill rather
 than applying today's retention configuration retroactively. The private
 connection exposes only lifecycle operations until repositories are ported.
@@ -145,6 +145,19 @@ the real adapter, without adding arbitrary SQL or fault flags to public syntax.
 Cold concurrent WAL transitions can report retryable busy errors even with a
 busy timeout; this preserves the existing storage boundary, not an all-openers
 success guarantee. See [SQLite busy-handler behavior](https://sqlite.org/c3ref/busy_handler.html).
+
+#108 appends native schema 9: the same identity table gains `lifetime` and
+`retired_at_ms`, with a partial unique canonical-name index for non-retired rows.
+Existing rows become saved; their UUIDs, names and timestamps are unchanged.
+The migration does not implement retirement commands or erase dependent state.
+Its reviewed rebuild follows the
+[SQLite generalized ALTER TABLE procedure](https://www.sqlite.org/lang_altertable.html#otheralter):
+temporarily disable foreign keys outside the immediate transaction, preserve
+the table contents, validate foreign keys before commit and restore enforcement
+on all normal success/error paths. The source definition must match the frozen
+historical identity table apart from whitespace; custom columns, constraints,
+indexes or triggers are rejected instead of silently removed. No ORM, alternate
+registry or dependency is added.
 
 ### Execution and resource ownership
 
@@ -332,7 +345,8 @@ the isolated fixture before copying. WAL requires local shared-memory semantics;
 network filesystems are not a new supported deployment.
 [SQLite WAL documentation](https://www.sqlite.org/wal.html).
 
-Required matrix before claiming same-schema coexistence:
+Original schema-8 coexistence matrix (historical plan, superseded by #108's
+forward-only identity amendment below):
 
 1. TS creates and closes data; Rust opens/reads/writes; TS reopens and sees the
    same identity UUID and exact bodies without reset. Repeat in reverse order.
@@ -347,13 +361,22 @@ Required matrix before claiming same-schema coexistence:
 5. Read-only/corrupt/locked storage, private file modes, foreign keys, WAL,
    synchronous NORMAL, FTS5 and close/checkpoint failure classification.
 
-Initial implementation must keep schema 8 unchanged. Binary rollback to baseline
-TS is an acceptance target **only after** this matrix passes, not a guarantee
-today. A later incompatible schema requires its own migration/rollback decision;
-installer binary rollback cannot downgrade a database. Development TS and Rust
-may coexist in separate fixtures until proven compatible. Final cutover removes
-the production TS runtime and redundant transitional adapters; it need not remove
-Node-based test infrastructure or historical data fixtures.
+#97 delivered the unchanged schema-8 storage baseline. #108 intentionally moves
+the native preview to schema 9; baseline TypeScript rejects it. Mixed-runtime
+writers/readers and binary rollback to schema-8 TS are not supported after this
+upgrade. Do not weaken history validation or maintain a second native legacy
+mode just to preserve a transitional test. Native development uses isolated
+fixtures, never a live user database.
+
+Before release, #82/#93 must stop old writers, create a consistent recoverable
+backup and explain that binary rollback is not schema downgrade. Acceptance
+still requires every supported historical prefix, exact retained records,
+native concurrent lifecycle/attention races, and execution of old v1 receipts
+against migrated in-flight and retained requests. #106 owns receipt transition;
+this schema slice proves preservation, not execution. A restored pre-upgrade
+backup cannot include work written after upgrade; recovery must not promise
+lossless downgrade. Final cutover removes the production TS runtime and
+redundant transitional adapters; Node-based tests and historical fixtures may stay.
 
 ## Delivery gates
 

--- a/rust/crates/tmt-adapters/src/storage/identity_lifetime_tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/identity_lifetime_tests.rs
@@ -1,0 +1,356 @@
+use super::*;
+
+// Runner-focused tests use the actual historical migrations. Independent
+// TypeScript-created fixtures and full data/schema oracles live in test/native.
+fn historical_connection() -> Connection {
+    let mut connection = Connection::open_in_memory().unwrap();
+    seed_history(&mut connection);
+    connection
+}
+
+fn seed_history(connection: &mut Connection) {
+    connection
+        .pragma_update(None, "foreign_keys", true)
+        .unwrap();
+    connection.execute_batch("CREATE TABLE _migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL)").unwrap();
+    for (index, migration) in MIGRATIONS[..8].iter().enumerate() {
+        apply_version(connection, index as u32 + 1, migration).unwrap();
+    }
+    connection
+        .execute_batch(
+            "INSERT INTO identities VALUES ('old-id', 'Alice', 'alice', 'created', 'updated');
+         INSERT INTO role_profiles VALUES ('old-id', 'original role', 'role-time');
+         INSERT INTO identity_preambles VALUES ('old-id', 'original preamble', 'preamble-time');
+         INSERT INTO preamble_counters VALUES ('old-id', 12, 123);
+         INSERT INTO request_attention_identities VALUES ('old-id', 9, 4);",
+        )
+        .unwrap();
+}
+
+#[test]
+fn blocked_commit_rolls_back_replacement_and_restores_enforcement() {
+    let directory = crate::test_support::TestDirectory::new();
+    let path = directory.path.join("migration.db");
+    let mut connection = Connection::open(&path).unwrap();
+    seed_history(&mut connection);
+    // Rollback journal makes a real reader prevent COMMIT without preventing
+    // the immediate writer lock. This tests the commit path, not a SQL trigger.
+    connection
+        .busy_timeout(std::time::Duration::from_millis(25))
+        .unwrap();
+    let reader = Connection::open(&path).unwrap();
+    reader
+        .execute_batch("BEGIN; SELECT * FROM identities;")
+        .unwrap();
+    // History is already initialized; hold the reader across the actual ninth
+    // migration rather than blocking the earlier history-initialization commit.
+    let error = apply_identity_lifetime(&mut connection, &MIGRATIONS[8]).unwrap_err();
+    assert_eq!(error.code, StorageErrorCode::Busy);
+    assert_eq!(error.message, "Commit migration failed");
+    assert!(error.retryable);
+    reader.execute_batch("ROLLBACK").unwrap();
+    assert_old_schema_and_data(&connection);
+    assert_enforcement(&connection);
+    apply(&mut connection).unwrap();
+    assert_enforcement(&connection);
+}
+
+fn assert_enforcement(connection: &Connection) {
+    assert!(connection.is_autocommit());
+    let enabled: bool = connection
+        .pragma_query_value(None, "foreign_keys", |row| row.get(0))
+        .unwrap();
+    assert!(enabled);
+    assert!(
+        connection
+            .execute(
+                "INSERT INTO role_profiles VALUES ('absent', 'role', 'time')",
+                []
+            )
+            .is_err()
+    );
+}
+
+fn assert_old_schema_and_data(connection: &Connection) {
+    let version: i64 = connection
+        .query_row("SELECT MAX(version) FROM _migrations", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, 8);
+    let columns: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('identities')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(columns, 5);
+    let replacement: bool = connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE name = 'identities_with_lifetime')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(!replacement);
+    let identity: (String, String, String, String, String) = connection
+        .query_row("SELECT * FROM identities", [], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        })
+        .unwrap();
+    assert_eq!(
+        identity,
+        (
+            "old-id".into(),
+            "Alice".into(),
+            "alice".into(),
+            "created".into(),
+            "updated".into()
+        )
+    );
+    assert_eq!(
+        connection
+            .query_row(
+                "SELECT content FROM role_profiles WHERE identity_id = 'old-id'",
+                [],
+                |row| row.get::<_, String>(0)
+            )
+            .unwrap(),
+        "original role"
+    );
+    assert_eq!(
+        connection
+            .query_row(
+                "SELECT reserved_count FROM preamble_counters WHERE identity_id = 'old-id'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        12
+    );
+    assert_eq!(connection.query_row("SELECT acknowledged_through FROM request_attention_identities WHERE identity_id = 'old-id'", [], |row| row.get::<_, i64>(0)).unwrap(), 4);
+}
+
+#[test]
+fn identity_rebuild_restores_enforcement_after_success_and_reopen() {
+    let mut connection = historical_connection();
+    apply(&mut connection).unwrap();
+    assert_enforcement(&connection);
+    check_foreign_keys(&connection).unwrap();
+    let value: (String, Option<i64>) = connection
+        .query_row(
+            "SELECT lifetime, retired_at_ms FROM identities WHERE id = 'old-id'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(value, ("saved".into(), None));
+    apply(&mut connection).unwrap();
+    assert_enforcement(&connection);
+    assert_eq!(
+        connection
+            .query_row(
+                "SELECT COUNT(*) FROM _migrations WHERE version = 9",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        1
+    );
+}
+
+#[test]
+fn recording_failure_rolls_back_replacement_and_restores_enforcement() {
+    let mut connection = historical_connection();
+    connection
+        .execute_batch(
+            "CREATE TRIGGER reject_ninth BEFORE INSERT ON _migrations WHEN NEW.version = 9
+         BEGIN SELECT RAISE(ABORT, 'fixture record failure'); END;",
+        )
+        .unwrap();
+    let error = apply(&mut connection).unwrap_err();
+    assert_eq!(error.code, StorageErrorCode::Migration);
+    assert_eq!(error.migration_version, Some(9));
+    assert_old_schema_and_data(&connection);
+    assert_enforcement(&connection);
+    connection
+        .execute_batch("DROP TRIGGER reject_ninth")
+        .unwrap();
+    apply(&mut connection).unwrap();
+    assert_enforcement(&connection);
+}
+
+#[test]
+fn post_rebuild_foreign_key_violation_rolls_back_the_entire_migration() {
+    let mut connection = historical_connection();
+    connection
+        .execute_batch(
+            "CREATE TRIGGER damage_ninth AFTER INSERT ON _migrations WHEN NEW.version = 9
+         BEGIN UPDATE role_profiles SET identity_id = 'missing'; END;",
+        )
+        .unwrap();
+    let error = apply(&mut connection).unwrap_err();
+    assert_eq!(error.migration_version, Some(9));
+    assert_old_schema_and_data(&connection);
+    assert_enforcement(&connection);
+    check_foreign_keys(&connection).unwrap();
+}
+
+#[test]
+fn preexisting_foreign_key_damage_is_rejected_not_repaired() {
+    let mut connection = historical_connection();
+    connection
+        .pragma_update(None, "foreign_keys", false)
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO role_profiles VALUES ('missing', 'keep', 'time')",
+            [],
+        )
+        .unwrap();
+    connection
+        .pragma_update(None, "foreign_keys", true)
+        .unwrap();
+    let error = apply(&mut connection).unwrap_err();
+    assert_eq!(error.migration_version, Some(9));
+    assert_old_schema_and_data(&connection);
+    assert_enforcement(&connection);
+    assert_eq!(
+        connection
+            .query_row(
+                "SELECT content FROM role_profiles WHERE identity_id = 'missing'",
+                [],
+                |row| row.get::<_, String>(0)
+            )
+            .unwrap(),
+        "keep"
+    );
+}
+
+#[test]
+fn custom_identity_objects_are_not_silently_removed() {
+    for statement in [
+        "CREATE INDEX custom_identity ON identities(name)",
+        "CREATE TRIGGER custom_identity AFTER INSERT ON identities BEGIN SELECT 1; END",
+    ] {
+        let mut connection = historical_connection();
+        connection.execute_batch(statement).unwrap();
+        let error = apply(&mut connection).unwrap_err();
+        assert_eq!(error.migration_version, Some(9));
+        assert_old_schema_and_data(&connection);
+        assert_enforcement(&connection);
+        let sql: String = connection
+            .query_row(
+                "SELECT sql FROM sqlite_schema WHERE name = 'custom_identity'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(sql, statement);
+    }
+}
+
+#[test]
+fn lifetime_and_retirement_constraints_preserve_name_and_uuid_boundaries() {
+    let mut connection = historical_connection();
+    apply(&mut connection).unwrap();
+    for lifetime in ["temporary", "saved"] {
+        assert!(connection.execute(
+            "INSERT INTO identities (id, name, canonical_name, created_at, updated_at, lifetime) VALUES ('new-id', 'ALICE', 'alice', 'new', 'new', ?)",
+            [lifetime],
+        ).is_err());
+    }
+    for timestamp in ["0", "-1", "1.5", "9007199254740992", "'invalid'"] {
+        assert!(
+            connection
+                .execute(
+                    &format!("UPDATE identities SET retired_at_ms = {timestamp}"),
+                    []
+                )
+                .is_err()
+        );
+    }
+    assert!(
+        connection
+            .execute("UPDATE identities SET lifetime = 'permanent'", [])
+            .is_err()
+    );
+    connection
+        .execute(
+            "UPDATE identities SET retired_at_ms = 123 WHERE id = 'old-id'",
+            [],
+        )
+        .unwrap();
+    connection
+        .execute_batch(
+            "INSERT INTO identities (id, name, canonical_name, created_at, updated_at, lifetime)
+         VALUES ('new-id', 'ALICE', 'alice', 'new', 'new', 'temporary');",
+        )
+        .unwrap();
+    assert!(
+        connection
+            .execute(
+                "UPDATE identities SET retired_at_ms = NULL WHERE id = 'old-id'",
+                []
+            )
+            .is_err()
+    );
+    assert!(
+        connection
+            .execute(
+                "UPDATE identities SET id = 'old-id' WHERE id = 'new-id'",
+                []
+            )
+            .is_err()
+    );
+    for table in [
+        "role_profiles",
+        "identity_preambles",
+        "preamble_counters",
+        "request_attention_identities",
+    ] {
+        let count: i64 = connection
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE identity_id = 'new-id'"),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "name reuse must not inherit {table}");
+    }
+    check_foreign_keys(&connection).unwrap();
+    assert_enforcement(&connection);
+}
+
+#[test]
+fn custom_identity_columns_and_their_contents_are_not_discarded() {
+    let mut connection = historical_connection();
+    connection
+        .execute_batch(
+            "ALTER TABLE identities ADD COLUMN private_note TEXT;
+         UPDATE identities SET private_note = 'user-owned content';",
+        )
+        .unwrap();
+    let error = apply(&mut connection).unwrap_err();
+    assert_eq!(error.migration_version, Some(9));
+    assert_enforcement(&connection);
+    assert_eq!(
+        connection
+            .query_row("SELECT private_note FROM identities", [], |row| row
+                .get::<_, String>(0))
+            .unwrap(),
+        "user-owned content"
+    );
+    assert_eq!(
+        connection
+            .query_row("SELECT MAX(version) FROM _migrations", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        8
+    );
+}

--- a/rust/crates/tmt-adapters/src/storage/migrations.rs
+++ b/rust/crates/tmt-adapters/src/storage/migrations.rs
@@ -3,6 +3,10 @@ use tmt_core::limits::MAX_JS_SAFE_INTEGER;
 
 use super::errors::{StorageError, StorageErrorCode, classify, incompatible};
 
+#[cfg(test)]
+#[path = "identity_lifetime_tests.rs"]
+mod identity_lifetime_tests;
+
 struct Migration {
     name: &'static str,
     sql: &'static str,
@@ -41,6 +45,10 @@ const MIGRATIONS: &[Migration] = &[
         name: "add identity-scoped exchange attention revisions",
         sql: include_str!("schema/008.sql"),
     },
+    Migration {
+        name: "add identity lifetimes and reusable retired names",
+        sql: include_str!("schema/009.sql"),
+    },
 ];
 
 pub(super) fn apply(connection: &mut Connection) -> Result<(), StorageError> {
@@ -56,31 +64,131 @@ pub(super) fn apply(connection: &mut Connection) -> Result<(), StorageError> {
     let current = validate_history(connection)?;
     for (index, migration) in MIGRATIONS.iter().enumerate().skip(current) {
         let version = index as u32 + 1;
-        let transaction = connection
-            .transaction_with_behavior(TransactionBehavior::Immediate)
-            .map_err(|error| classify(error, "Acquire migration lock"))?;
-        let apply_one = (|| {
-            // A concurrent opener may already have applied this version. The
-            // authoritative history check is inside the immediate writer lock.
-            if validate_history(&transaction)? >= version as usize {
-                return Ok(());
-            }
-            transaction
-                .execute_batch(migration.sql)
-                .map_err(|error| classify(error, "Apply migration SQL"))?;
-            if version == 6 {
-                backfill_retention(&transaction)?;
-            }
-            transaction.execute(
-                "INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
-                params![version, migration.name],
-            ).map_err(|error| classify(error, "Record migration"))?;
-            Ok(())
-        })();
-        apply_one.map_err(|error| StorageError::migration(version, error))?;
+        if version == 9 {
+            apply_identity_lifetime(connection, migration)?;
+        } else {
+            apply_version(connection, version, migration)?;
+        }
+    }
+    Ok(())
+}
+
+fn apply_identity_lifetime(
+    connection: &mut Connection,
+    migration: &Migration,
+) -> Result<(), StorageError> {
+    // SQLite requires foreign_keys to change outside a transaction.
+    // The private opening connection cannot escape during this rebuild.
+    let result = set_foreign_keys(connection, false)
+        .map_err(|error| StorageError::migration(9, error))
+        .and_then(|()| apply_version(connection, 9, migration));
+    // apply_version has committed or dropped its transaction before
+    // restoration. Always attempt it, preserving a primary failure.
+    // Attempt restoration even if disabling succeeded but its verification failed.
+    let restore =
+        set_foreign_keys(connection, true).map_err(|error| StorageError::migration(9, error));
+    result.and(restore)
+}
+
+fn apply_version(
+    connection: &mut Connection,
+    version: u32,
+    migration: &Migration,
+) -> Result<(), StorageError> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| classify(error, "Acquire migration lock"))?;
+    let apply_one = (|| {
+        // Another opener may have migrated while this one waited for the lock.
+        if validate_history(&transaction)? >= version as usize {
+            return Ok(());
+        }
+        if version == 9 {
+            validate_identity_source(&transaction)?;
+            check_foreign_keys(&transaction)?;
+        }
         transaction
-            .commit()
-            .map_err(|error| classify(error, "Commit migration"))?;
+            .execute_batch(migration.sql)
+            .map_err(|error| classify(error, "Apply migration SQL"))?;
+        if version == 6 {
+            backfill_retention(&transaction)?;
+        }
+        transaction.execute(
+            "INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+            params![version, migration.name],
+        ).map_err(|error| classify(error, "Record migration"))?;
+        if version == 9 {
+            check_foreign_keys(&transaction)?;
+        }
+        Ok(())
+    })();
+    apply_one.map_err(|error| StorageError::migration(version, error))?;
+    transaction
+        .commit()
+        .map_err(|error| classify(error, "Commit migration"))
+}
+
+fn set_foreign_keys(connection: &Connection, enabled: bool) -> Result<(), StorageError> {
+    connection
+        .pragma_update(None, "foreign_keys", enabled)
+        .map_err(|error| classify(error, "Configure migration foreign keys"))?;
+    let actual: bool = connection
+        .pragma_query_value(None, "foreign_keys", |row| row.get(0))
+        .map_err(|error| classify(error, "Verify migration foreign keys"))?;
+    if actual != enabled {
+        return Err(incompatible(
+            "Migration foreign-key policy did not take effect",
+        ));
+    }
+    Ok(())
+}
+
+fn check_foreign_keys(connection: &Connection) -> Result<(), StorageError> {
+    let mut statement = connection
+        .prepare("PRAGMA foreign_key_check")
+        .map_err(|error| classify(error, "Inspect migration foreign keys"))?;
+    let mut rows = statement
+        .query([])
+        .map_err(|error| classify(error, "Inspect migration foreign keys"))?;
+    if rows
+        .next()
+        .map_err(|error| classify(error, "Read migration foreign keys"))?
+        .is_some()
+    {
+        return Err(incompatible(
+            "Identity migration requires consistent foreign keys",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_identity_source(connection: &Connection) -> Result<(), StorageError> {
+    // Compare only the frozen first CREATE TABLE statement, not arbitrary SQL.
+    // Whitespace differs between historical TS and Rust migration formatting.
+    // Refuse custom columns/constraints rather than discarding their data/rules.
+    let original = MIGRATIONS[0].sql.split(';').next().unwrap_or_default();
+    let actual: String = connection
+        .query_row(
+            "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'identities'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| classify(error, "Inspect identity source schema"))?;
+    if !actual.split_whitespace().eq(original.split_whitespace()) {
+        return Err(incompatible(
+            "Identity migration requires the historical table definition",
+        ));
+    }
+    // Only the two implicit identity indexes are part of schema 8. Never drop
+    // an unrecognized user index or trigger as a side effect of table replacement.
+    let custom: bool = connection.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE tbl_name = 'identities' AND type IN ('index', 'trigger') AND sql IS NOT NULL)",
+        [], |row| row.get(0),
+    ).map_err(|error| classify(error, "Inspect identity schema extensions"))?;
+    if custom {
+        return Err(incompatible(
+            "Identity migration cannot replace custom indexes or triggers",
+        ));
     }
     Ok(())
 }

--- a/rust/crates/tmt-adapters/src/storage/schema/009.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/009.sql
@@ -1,0 +1,20 @@
+CREATE TABLE identities_with_lifetime (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  canonical_name TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  lifetime TEXT NOT NULL DEFAULT 'saved'
+    CHECK (lifetime IN ('temporary', 'saved')),
+  retired_at_ms INTEGER
+    CHECK (retired_at_ms IS NULL OR (
+      typeof(retired_at_ms) = 'integer' AND
+      retired_at_ms > 0 AND retired_at_ms <= 9007199254740991
+    ))
+);
+INSERT INTO identities_with_lifetime (id, name, canonical_name, created_at, updated_at)
+  SELECT id, name, canonical_name, created_at, updated_at FROM identities;
+DROP TABLE identities;
+ALTER TABLE identities_with_lifetime RENAME TO identities;
+CREATE UNIQUE INDEX identities_active_name
+  ON identities (canonical_name) WHERE retired_at_ms IS NULL;

--- a/rust/crates/tmt-adapters/src/storage/tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/tests.rs
@@ -27,7 +27,7 @@ fn open_enforces_connection_features_and_private_files() {
         storage.health().unwrap(),
         StorageHealth {
             path: fixture.database.clone(),
-            schema_version: 8,
+            schema_version: 9,
             journal_mode: "wal",
             foreign_keys: true,
             busy_timeout_ms: 5000,
@@ -88,7 +88,7 @@ fn open_enforces_connection_features_and_private_files() {
 fn failed_checkpoint_still_closes_and_rolls_back_the_active_transaction() {
     let fixture = Fixture::new();
     let mut storage = Storage::open(&fixture.database).unwrap();
-    storage.connection().unwrap().execute_batch("BEGIN IMMEDIATE; INSERT INTO identities VALUES ('uncommitted', 'Test', 'test', 'now', 'now');").unwrap();
+    storage.connection().unwrap().execute_batch("BEGIN IMMEDIATE; INSERT INTO identities (id, name, canonical_name, created_at, updated_at) VALUES ('uncommitted', 'Test', 'test', 'now', 'now');").unwrap();
     assert_eq!(storage.close().unwrap_err().code, StorageErrorCode::Busy);
     assert_eq!(storage.health().unwrap_err().code, StorageErrorCode::Closed);
     storage.close().unwrap();
@@ -153,7 +153,7 @@ fn concurrent_openers_commit_each_migration_only_once() {
     initial.pragma_update(None, "journal_mode", "WAL").unwrap();
     initial.close().unwrap();
     for result in concurrent_opens(&fixture) {
-        assert_eq!(result.unwrap(), 8);
+        assert_eq!(result.unwrap(), 9);
     }
     assert_complete_history(&fixture);
 }
@@ -165,7 +165,7 @@ fn cold_open_race_only_returns_success_or_retryable_contention() {
     for result in concurrent_opens(&fixture) {
         match result {
             Ok(version) => {
-                assert_eq!(version, 8);
+                assert_eq!(version, 9);
                 successful += 1;
             }
             Err(error) => {
@@ -179,7 +179,7 @@ fn cold_open_race_only_returns_success_or_retryable_contention() {
     }
     assert!(successful > 0);
     let mut recovered = Storage::open(&fixture.database).unwrap();
-    assert_eq!(recovered.health().unwrap().schema_version, 8);
+    assert_eq!(recovered.health().unwrap().schema_version, 9);
     recovered.close().unwrap();
     assert_complete_history(&fixture);
 }
@@ -212,7 +212,7 @@ fn assert_complete_history(fixture: &Fixture) {
     let count: i64 = verification
         .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(count, 8);
+    assert_eq!(count, 9);
     let check: String = verification
         .query_row("PRAGMA integrity_check", [], |row| row.get(0))
         .unwrap();

--- a/test/native/storage.test.ts
+++ b/test/native/storage.test.ts
@@ -40,6 +40,18 @@ function upgradeWithTypeScript(file: string): void {
   }
 }
 
+function rejectSchema9WithTypeScript(file: string): void {
+  let error: unknown;
+  let opened: ReturnType<typeof openStorage> | undefined;
+  try {
+    opened = openStorage(file);
+  } catch (thrown) {
+    error = thrown;
+  }
+  opened?.close();
+  expect(error).toMatchObject({ code: 'incompatible-schema' });
+}
+
 function migrationTimestamps(file: string): string[] {
   const database = new Database(file, { readonly: true });
   try {
@@ -52,9 +64,77 @@ function migrationTimestamps(file: string): string[] {
   }
 }
 
+function table(snapshot: ReturnType<typeof storageSnapshot>, name: string) {
+  const found = snapshot.tables.find((candidate) => candidate.name === name);
+  expect(found, `Missing table ${name}`).toBeDefined();
+  return found!;
+}
+
+function expectNativeSchema9(
+  reference: ReturnType<typeof storageSnapshot>,
+  migrated: ReturnType<typeof storageSnapshot>
+): void {
+  expect(migrated.migrations.slice(0, 8)).toEqual(reference.migrations);
+  expect(migrated.migrations).toHaveLength(9);
+  expect(migrated.migrations[8]).toEqual({
+    version: 9,
+    name: 'add identity lifetimes and reusable retired names',
+  });
+  expect(migrated.tables.map(({ name }) => name)).toEqual(reference.tables.map(({ name }) => name));
+
+  const unchangedTables = reference.tables
+    .filter(({ name }) => name !== '_migrations' && name !== 'identities')
+    .map(({ name }) => name);
+  expect(
+    migrated.tables.filter(({ name }) => unchangedTables.includes(name)).map(({ name }) => name)
+  ).toEqual(unchangedTables);
+  for (const name of unchangedTables) expect(table(migrated, name)).toEqual(table(reference, name));
+
+  const oldHistory = table(reference, '_migrations');
+  const newHistory = table(migrated, '_migrations');
+  expect(newHistory.columns).toEqual(oldHistory.columns);
+  expect(newHistory.indexes).toEqual(oldHistory.indexes);
+  expect(newHistory.foreignKeys).toEqual(oldHistory.foreignKeys);
+  expect(newHistory.rows).toEqual([
+    ...oldHistory.rows,
+    { version: 9, name: migrated.migrations[8]!.name },
+  ]);
+
+  const oldIdentities = table(reference, 'identities');
+  const newIdentities = table(migrated, 'identities');
+  expect(newIdentities.columns.slice(0, 5)).toEqual(oldIdentities.columns);
+  expect(newIdentities.columns.slice(5)).toEqual([
+    { cid: 5, name: 'lifetime', type: 'TEXT', notnull: 1, dflt_value: "'saved'", pk: 0 },
+    { cid: 6, name: 'retired_at_ms', type: 'INTEGER', notnull: 0, dflt_value: null, pk: 0 },
+  ]);
+  expect(newIdentities.rows).toEqual(
+    oldIdentities.rows.map((row) => ({ ...row, lifetime: 'saved', retired_at_ms: null }))
+  );
+  expect(newIdentities.foreignKeys).toEqual(oldIdentities.foreignKeys);
+  expect(newIdentities.indexes).toHaveLength(oldIdentities.indexes.length);
+  expect(newIdentities.indexes.find((index) => index.origin === 'pk')).toEqual(
+    oldIdentities.indexes.find((index) => index.origin === 'pk')
+  );
+  const activeNameIndex = newIdentities.indexes.find(
+    (index) =>
+      index.unique === 1 &&
+      index.partial === 1 &&
+      index.columns.some((column) => column.name === 'canonical_name' && column.key === 1)
+  );
+  expect(activeNameIndex).toMatchObject({ name: 'identities_active_name' });
+  expect(
+    newIdentities.indexes.some(
+      (index) =>
+        index.unique === 1 &&
+        index.partial === 0 &&
+        index.columns.some((column) => column.name === 'canonical_name' && column.key === 1)
+    )
+  ).toBe(false);
+}
+
 describe('native SQLite lifecycle compatibility', () => {
   it.each(Array.from({ length: 9 }, (_, version) => version))(
-    'upgrades closed TypeScript schema %i without changing schema or durable semantics',
+    'upgrades closed TypeScript schema %i to schema 9 without changing durable data',
     async (version) => {
       await withSandbox(async (sandbox) => {
         const reference = path.join(sandbox.root, 'reference', 'state.db');
@@ -68,7 +148,7 @@ describe('native SQLite lifecycle compatibility', () => {
         expect(parseWholeStdout(result)).toEqual({
           path: sandbox.database,
           open: true,
-          schemaVersion: 8,
+          schemaVersion: 9,
           journalMode: 'wal',
           foreignKeys: true,
           busyTimeoutMs: 5000,
@@ -76,7 +156,7 @@ describe('native SQLite lifecycle compatibility', () => {
           fts5: true,
         });
         const migrated = storageSnapshot(sandbox.database);
-        expect(migrated).toEqual(storageSnapshot(reference));
+        expectNativeSchema9(storageSnapshot(reference), migrated);
         if (version >= 5) {
           const responses = migrated.tables.find(
             (table) => table.name === 'request_responses'
@@ -107,13 +187,15 @@ describe('native SQLite lifecycle compatibility', () => {
           );
         }
         const timestamps = migrationTimestamps(sandbox.database);
-        expect(timestamps).toHaveLength(8);
+        expect(timestamps).toHaveLength(9);
         expect(timestamps.slice(0, version)).toEqual(originalTimestamps);
         for (const timestamp of timestamps) {
           expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
         }
-        // Reverse compatibility and repeated opens must preserve finals and attention.
-        upgradeWithTypeScript(sandbox.database);
+        // Forward native compatibility has intentionally not been added to TypeScript.
+        const beforeTypeScriptOpen = storageSnapshot(sandbox.database);
+        rejectSchema9WithTypeScript(sandbox.database);
+        expect(storageSnapshot(sandbox.database)).toEqual(beforeTypeScriptOpen);
         expect((await runStorage(sandbox)).status).toBe(0);
         expect(storageSnapshot(sandbox.database)).toEqual(migrated);
         expect(migrationTimestamps(sandbox.database)).toEqual(timestamps);
@@ -121,19 +203,12 @@ describe('native SQLite lifecycle compatibility', () => {
     }
   );
 
-  it('lets TypeScript reopen and write a database created only by Rust', async () => {
+  it('rejects a native schema 9 database from TypeScript without mutation', async () => {
     await withSandbox(async (sandbox) => {
       expect((await runStorage(sandbox)).status).toBe(0);
-      upgradeWithTypeScript(sandbox.database);
-      const writer = new Database(sandbox.database);
-      try {
-        writer
-          .prepare('INSERT INTO identities VALUES (?, ?, ?, ?, ?)')
-          .run('roundtrip-id', 'Roundtrip', 'roundtrip', 'created', 'updated');
-      } finally {
-        writer.close();
-      }
       const before = storageSnapshot(sandbox.database);
+      rejectSchema9WithTypeScript(sandbox.database);
+      expect(storageSnapshot(sandbox.database)).toEqual(before);
       expect((await runStorage(sandbox)).status).toBe(0);
       expect(storageSnapshot(sandbox.database)).toEqual(before);
     });
@@ -142,8 +217,8 @@ describe('native SQLite lifecycle compatibility', () => {
   it('converges concurrent native processes on an existing historical WAL database', async () => {
     await withSandbox(async (sandbox) => {
       const reference = path.join(sandbox.root, 'reference', 'state.db');
-      seedStoragePrefix(reference, 4);
-      seedStoragePrefix(sandbox.database, 4);
+      seedStoragePrefix(reference, 8);
+      seedStoragePrefix(sandbox.database, 8);
       upgradeWithTypeScript(reference);
       // Wait for every bounded child before the sandbox can be removed, even
       // when an individual launch fails. No child may escape failed assertions.
@@ -154,10 +229,10 @@ describe('native SQLite lifecycle compatibility', () => {
         expect(result.status).toBe('fulfilled');
         if (result.status === 'fulfilled') {
           expect(result.value.status, result.value.stdout).toBe(0);
-          expect(parseWholeStdout(result.value).schemaVersion).toBe(8);
+          expect(parseWholeStdout(result.value).schemaVersion).toBe(9);
         }
       }
-      expect(storageSnapshot(sandbox.database)).toEqual(storageSnapshot(reference));
+      expectNativeSchema9(storageSnapshot(reference), storageSnapshot(sandbox.database));
     });
   });
 
@@ -168,13 +243,46 @@ describe('native SQLite lifecycle compatibility', () => {
       try {
         database.pragma('foreign_keys = ON');
         database.exec(
-          "INSERT INTO identities VALUES ('id', 'Alice', 'alice', 'created', 'updated')"
+          "INSERT INTO identities (id, name, canonical_name, created_at, updated_at) VALUES ('id', 'Alice', 'alice', 'created', 'updated')"
         );
+        expect(
+          database.prepare('SELECT lifetime, retired_at_ms FROM identities WHERE id = ?').get('id')
+        ).toEqual({
+          lifetime: 'saved',
+          retired_at_ms: null,
+        });
         expect(() =>
           database.exec(
-            "INSERT INTO identities VALUES ('other', 'ALICE', 'alice', 'created', 'updated')"
+            "INSERT INTO identities (id, name, canonical_name, created_at, updated_at) VALUES ('other', 'ALICE', 'alice', 'created', 'updated')"
           )
         ).toThrow(/UNIQUE/);
+        expect(() =>
+          database.exec(
+            "INSERT INTO identities VALUES ('invalid-lifetime', 'Invalid', 'invalid-lifetime', 'created', 'updated', 'permanent', NULL)"
+          )
+        ).toThrow(/CHECK/);
+        expect(() =>
+          database.exec(
+            "INSERT INTO identities VALUES ('invalid-retired-zero', 'Invalid', 'invalid-retired-zero', 'created', 'updated', 'saved', 0)"
+          )
+        ).toThrow(/CHECK/);
+        expect(() =>
+          database.exec(
+            "INSERT INTO identities VALUES ('invalid-retired-large', 'Invalid', 'invalid-retired-large', 'created', 'updated', 'saved', 9007199254740992)"
+          )
+        ).toThrow(/CHECK/);
+        database.exec(
+          "UPDATE identities SET lifetime = 'temporary', retired_at_ms = 9007199254740991 WHERE id = 'id'"
+        );
+        database.exec(
+          "INSERT INTO identities VALUES ('new-id', 'ALICE', 'alice', 'created-new', 'updated-new', 'saved', NULL)"
+        );
+        expect(
+          database.prepare('SELECT id, lifetime, retired_at_ms FROM identities ORDER BY id').all()
+        ).toEqual([
+          { id: 'id', lifetime: 'temporary', retired_at_ms: Number.MAX_SAFE_INTEGER },
+          { id: 'new-id', lifetime: 'saved', retired_at_ms: null },
+        ]);
         expect(() =>
           database.exec("INSERT INTO role_profiles VALUES ('missing', 'body', 'updated')")
         ).toThrow(/FOREIGN KEY/);
@@ -229,7 +337,180 @@ describe('native SQLite lifecycle compatibility', () => {
       } finally {
         database.close();
       }
-      upgradeWithTypeScript(sandbox.database);
+      rejectSchema9WithTypeScript(sandbox.database);
+    });
+  });
+
+  it('rolls back schema 9 identity replacement when recording the migration fails', async () => {
+    await withSandbox(async (sandbox) => {
+      seedStoragePrefix(sandbox.database, 8);
+      const before = storageSnapshot(sandbox.database);
+      const writer = new Database(sandbox.database);
+      try {
+        writer.exec(`
+          CREATE TRIGGER fail_schema9_history
+          BEFORE INSERT ON _migrations
+          WHEN NEW.version = 9
+          BEGIN
+            SELECT RAISE(ABORT, 'schema 9 history failure');
+          END;
+        `);
+      } finally {
+        writer.close();
+      }
+
+      const failed = await runStorage(sandbox);
+      expect(failed.status).toBe(1);
+      expect(expectError(failed, 'migration').error).toMatchObject({ migrationVersion: 9 });
+      expect(storageSnapshot(sandbox.database)).toEqual(before);
+      const afterFailure = new Database(sandbox.database, { readonly: true });
+      try {
+        expect(
+          afterFailure
+            .prepare("SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = ?")
+            .get('fail_schema9_history')
+        ).toEqual({ name: 'fail_schema9_history' });
+      } finally {
+        afterFailure.close();
+      }
+
+      const repair = new Database(sandbox.database);
+      try {
+        repair.exec('DROP TRIGGER fail_schema9_history');
+      } finally {
+        repair.close();
+      }
+      expect((await runStorage(sandbox)).status).toBe(0);
+      expect(parseWholeStdout(await runStorage(sandbox))).toMatchObject({ schemaVersion: 9 });
+    });
+  });
+
+  it('rejects an invalid old foreign key without replacing the identity table', async () => {
+    await withSandbox(async (sandbox) => {
+      seedStoragePrefix(sandbox.database, 8);
+      const writer = new Database(sandbox.database);
+      try {
+        writer.pragma('foreign_keys = OFF');
+        writer
+          .prepare('INSERT INTO role_profiles (identity_id, content, updated_at) VALUES (?, ?, ?)')
+          .run('missing-old-identity', 'orphan role', 'updated');
+      } finally {
+        writer.close();
+      }
+      const before = storageSnapshot(sandbox.database);
+      const result = await runStorage(sandbox);
+      expect(result.status).toBe(1);
+      expect(expectError(result, 'migration').error).toMatchObject({ migrationVersion: 9 });
+      expect(storageSnapshot(sandbox.database)).toEqual(before);
+    });
+  });
+
+  it('rejects an unexpected identity index without replacing the identity table', async () => {
+    await withSandbox(async (sandbox) => {
+      seedStoragePrefix(sandbox.database, 8);
+      const writer = new Database(sandbox.database);
+      try {
+        writer.exec('CREATE INDEX identities_unexpected_name ON identities(name)');
+      } finally {
+        writer.close();
+      }
+      const before = storageSnapshot(sandbox.database);
+      const result = await runStorage(sandbox);
+      expect(result.status).toBe(1);
+      expect(expectError(result, 'migration').error).toMatchObject({ migrationVersion: 9 });
+      expect(storageSnapshot(sandbox.database)).toEqual(before);
+    });
+  });
+
+  it('preserves old UUID provenance and gives a reused name no dependent rows', async () => {
+    await withSandbox(async (sandbox) => {
+      seedStoragePrefix(sandbox.database, 8);
+      expect((await runStorage(sandbox)).status).toBe(0);
+      const before = storageSnapshot(sandbox.database);
+      const database = new Database(sandbox.database);
+      try {
+        database.pragma('foreign_keys = ON');
+        database
+          .prepare("UPDATE identities SET lifetime = 'temporary', retired_at_ms = ? WHERE id = ?")
+          .run(1_700_000_000_999, FIXTURE_IDENTITY_ID);
+        database
+          .prepare(
+            `INSERT INTO identities (
+               id, name, canonical_name, created_at, updated_at, lifetime, retired_at_ms
+             ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+          )
+          .run(
+            'identity-new',
+            'Known Fixture',
+            'known-fixture',
+            '2026-02-01T00:00:00.000Z',
+            '2026-02-01T00:00:00.000Z',
+            'saved',
+            null
+          );
+
+        expect(
+          database
+            .prepare(
+              `SELECT DISTINCT identity_id, originator_identity_id, recipient_identity_id
+               FROM request_attempts
+               WHERE identity_id = ? OR originator_identity_id = ? OR recipient_identity_id = ?`
+            )
+            .all(FIXTURE_IDENTITY_ID, FIXTURE_IDENTITY_ID, FIXTURE_IDENTITY_ID)
+        ).not.toHaveLength(0);
+        expect(
+          database
+            .prepare(
+              `SELECT COUNT(*) AS count FROM request_attempts
+               WHERE identity_id = ? OR originator_identity_id = ? OR recipient_identity_id = ?`
+            )
+            .get('identity-new', 'identity-new', 'identity-new')
+        ).toEqual({ count: 0 });
+        for (const tableName of [
+          'bindings',
+          'identity_preambles',
+          'preamble_counters',
+          'request_attention_identities',
+          'role_profiles',
+        ]) {
+          expect(
+            database
+              .prepare(`SELECT COUNT(*) AS count FROM ${tableName} WHERE identity_id = ?`)
+              .get('identity-new')
+          ).toEqual({ count: 0 });
+        }
+        expect(
+          database.prepare('SELECT id FROM bindings WHERE identity_id = ?').get(FIXTURE_IDENTITY_ID)
+        ).toEqual({ id: 'binding-known' });
+        expect(
+          database
+            .prepare(
+              'SELECT identity_id FROM request_attempts WHERE originator_identity_id = ? LIMIT 1'
+            )
+            .get(FIXTURE_IDENTITY_ID)
+        ).toEqual({ identity_id: FIXTURE_IDENTITY_ID });
+      } finally {
+        database.close();
+      }
+      const after = storageSnapshot(sandbox.database);
+      expect(after.tables.filter(({ name }) => name !== 'identities')).toEqual(
+        before.tables.filter(({ name }) => name !== 'identities')
+      );
+      const identities = new Database(sandbox.database, { readonly: true });
+      try {
+        expect(
+          identities
+            .prepare(
+              'SELECT id, lifetime, retired_at_ms FROM identities WHERE canonical_name = ? ORDER BY id'
+            )
+            .all('known-fixture')
+        ).toEqual([
+          { id: FIXTURE_IDENTITY_ID, lifetime: 'temporary', retired_at_ms: 1_700_000_000_999 },
+          { id: 'identity-new', lifetime: 'saved', retired_at_ms: null },
+        ]);
+      } finally {
+        identities.close();
+      }
     });
   });
 
@@ -301,12 +582,17 @@ describe('native SQLite lifecycle compatibility', () => {
     async (kind) => {
       await withSandbox(async (sandbox) => {
         seedStoragePrefix(sandbox.database, 8);
+        if (kind === 'future') {
+          const upgraded = await runStorage(sandbox);
+          expect(upgraded.status).toBe(0);
+          expect(parseWholeStdout(upgraded)).toMatchObject({ schemaVersion: 9 });
+        }
         const writer = new Database(sandbox.database);
         try {
           if (kind === 'renamed')
             writer.exec("UPDATE _migrations SET name = 'unknown' WHERE version = 2");
           else if (kind === 'gap') writer.exec('DELETE FROM _migrations WHERE version = 2');
-          else writer.exec("INSERT INTO _migrations VALUES (9, 'future', 'timestamp')");
+          else writer.exec("INSERT INTO _migrations VALUES (10, 'future', 'timestamp')");
         } finally {
           writer.close();
         }
@@ -343,12 +629,14 @@ describe('native SQLite lifecycle compatibility', () => {
         repair.close();
       }
       expect((await runStorage(sandbox)).status).toBe(0);
-      upgradeWithTypeScript(sandbox.database);
+      rejectSchema9WithTypeScript(sandbox.database);
     });
   });
 
   it('reports bounded writer contention and leaves storage usable after lock release', async () => {
     await withSandbox(async (sandbox) => {
+      const reference = path.join(sandbox.root, 'reference', 'state.db');
+      seedStoragePrefix(reference, 8);
       seedStoragePrefix(sandbox.database, 8);
       const before = storageSnapshot(sandbox.database);
       const writer = new Database(sandbox.database);
@@ -363,7 +651,8 @@ describe('native SQLite lifecycle compatibility', () => {
       }
       expect(storageSnapshot(sandbox.database)).toEqual(before);
       expect((await runStorage(sandbox)).status).toBe(0);
-      expect(storageSnapshot(sandbox.database)).toEqual(before);
+      upgradeWithTypeScript(reference);
+      expectNativeSchema9(storageSnapshot(reference), storageSnapshot(sandbox.database));
     });
   }, 15_000);
 });

--- a/test/native/storage.test.ts
+++ b/test/native/storage.test.ts
@@ -514,6 +514,26 @@ describe('native SQLite lifecycle compatibility', () => {
     });
   });
 
+  it('preserves a user table that conflicts with the migration replacement name', async () => {
+    await withSandbox(async (sandbox) => {
+      seedStoragePrefix(sandbox.database, 8);
+      const writer = new Database(sandbox.database);
+      try {
+        writer.exec(`
+          CREATE TABLE identities_with_lifetime (note TEXT NOT NULL);
+          INSERT INTO identities_with_lifetime VALUES ('user-owned content');
+        `);
+      } finally {
+        writer.close();
+      }
+      const before = storageSnapshot(sandbox.database);
+      const result = await runStorage(sandbox);
+      expect(result.status).toBe(1);
+      expect(expectError(result, 'migration').error).toMatchObject({ migrationVersion: 9 });
+      expect(storageSnapshot(sandbox.database)).toEqual(before);
+    });
+  });
+
   it('rejects a malformed history table without replacing it', async () => {
     await withSandbox(async (sandbox) => {
       seedStoragePrefix(sandbox.database, 0);


### PR DESCRIPTION
## Summary

Closes #108. Part of #100 and the native rewrite #93.

- Append native schema 9 with temporary/saved lifetime, retirement metadata and globally unique non-retired names in the existing identity table.
- Preserve historical UUIDs, bindings, profiles, preambles, cadence and all exchange data through a guarded, transactional table rebuild.
- Verify migration rollback, FK restoration, name reuse without history inheritance and explicit schema-9 rejection by the unchanged TypeScript runtime.
- Carry the #100 clarification into maintained docs: no project namespace or directory filtering; planned `ls` shows lifetime separately from presence.

The installed runtime is unchanged. This does not implement native identity commands or claim Rust cutover readiness. The next workflow specification is #109.

## Architecture impact and primary review

Reviewed head: `7119bbac08a6d0c37cd9030d2d36e04a49ea8eef`.

Primary personally reviewed every changed file, the private Storage owner, historical SQL/foreign keys, native fixture/snapshot helpers and the command/runtime boundary. Independent Luna review supplemented, rather than replaced, primary acceptance. There is one migration runner and identity table; raw SQL does not escape into CLI/core. No dependencies or migrations 1–8 changed.

The rebuild temporarily suspends FK enforcement outside an immediate transaction, rechecks history under the writer lock, validates the original identity schema, checks FKs before/after replacement, and always attempts restoration before returning. Custom columns/constraints/indexes/triggers are rejected instead of discarded. Failure to open never exposes a connection. Existing lock/commit busy classification is retained.

Review findings fixed: custom-column data-loss guard, restoration after a failed toggle verification, future-version test versus accidental gap coverage, complete non-identity state preservation assertions, exact new-column/PK metadata, trigger preservation and test-handle cleanup. The commit-failure fixture was corrected to block the ninth migration commit rather than earlier history initialization. Lifetime and retirement are intentionally independent because confirmed removal may retire a saved identity.

ARCHITECTURE, RUST-REWRITE and DEVELOPMENT describe the implemented native schema and remaining preview limitations. Installed skill/README behavior is not changed before native commands exist.

## Compatibility and risk

Schema 9 is forward-only in the native preview. TypeScript schema-8 binaries reject it without mutation. Do not run mixed old/new writers against the same database or use this preview on user state. #82/#93 own stopped-writer cutover, consistent backup/recovery and truthful downgrade behavior; #106 still must prove native execution of old v1 receipts. Record preservation is not receipt execution. No user database, host tmux, global installation or release was touched.

## Verification

- [x] Rust fmt and Clippy (`--locked --all-targets -- -D warnings`).
- [x] Locked Rust tests: 86 passing on 1.97.0 and MSRV 1.88.0 (52 adapter, 14 CLI, 20 core); bins/examples built.
- [x] `pnpm check` on finalized files.
- [x] TypeScript regression suite: 1,102 passing in 70 files; 95.66% statements/lines, 89.46% branches, 97.55% functions.
- [x] `pnpm test:native`: 44 passing, including 24 real storage process scenarios.
- [x] Unchanged shared native parser subset: 8 passing; config subset: 6 passing. Excluded unported-command cases are not parity evidence.
- [x] Final production/Docker revision verified twice locally: 52 native adapter tests and 115 E2E scenarios each, with one optional benchmark skip; 289.69s and 291.08s, wrapper exit 0. A subsequent independently reviewed process-test-only collision case does not alter the production/Docker sources; quality and all native process tests were rerun on the final head.
- [x] All 11 required CI checks passed on the reviewed head in [run 34125284479](https://github.com/wkh237/tmux-team/actions/runs/34125284479), attempt 1; merge state CLEAN. No bypass, rerun or lowered gate. Existing checkout/setup-node v4 Node-20 deprecation annotations are unchanged, not failures from this patch.

Tests compare independent schema/data snapshots from all historical prefixes; exercise real concurrent openers, rollback after table replacement, a real blocked commit, invalid FKs/custom schema, active-name conflicts, retired-name reuse and unchanged provenance/bodies/attention. They do not substitute terminal echo or successful exit codes for durable-state assertions.

## Delivery lifecycle

- Issue #108; branch `feat/108-native-identity-schema`; dedicated worktree.
- The earlier unpushed #100 documentation-only commit is carried into this PR; its source worktree is retained until safe delivery.
- Every commit carries the Codex co-author trailer. After authorized green-head merge, record delivery and clean only verified clean/pushed worktrees.
