### PR TITLE
feat(native): add shared identity records and name policy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -912,8 +912,9 @@ directory-based discovery filter is planned. Native `ls` is planned to list all
 non-retired identities, including saved offline entries, and show lifetime
 separately from active/offline/unknown presence. Unverified evidence cannot retire
 a temporary identity or release a saved name. Visibility does not extend routing.
-Identity repositories, retirement, promotion and these listing changes are not
-yet implemented. The durable-global invariants elsewhere in
+The storage-only identity record foundation under #111 supplies shared creation,
+promotion and non-retired selection; command wiring, binding retirement and these
+presence-listing changes are not yet implemented. The durable-global invariants elsewhere in
 this map still describe the shipped TypeScript runtime, not the amended future
 native lifecycle. See [RUST-REWRITE.md](RUST-REWRITE.md) for transition boundaries.
 
@@ -932,6 +933,29 @@ JavaScript-safe saturating timestamps; this is not today's configuration policy.
 Close always releases the connection even if checkpoint fails, preserving the
 primary error. Cold WAL transitions can return retryable contention, as in the
 TypeScript adapter; no new retry loop is hidden in this lifecycle layer.
+
+Native `core::names` is the sole identity-key and pane-target classifier. It
+preserves ECMAScript whitespace, NFKC and locale-neutral lowercase, with trimmed
+display names and the existing control/pane-shaped rejection. Fixed ICU4X 2.3
+normalization/casing data prevents the compiler's Unicode version from changing
+canonical keys. This is not case folding or a locale-sensitive name registry.
+The pinned Node 22.23.2 reference uses Unicode 17.0; dependency updates must
+recheck parity. Stored canonical keys and timestamps are never renormalized.
+
+Native `core::identity` owns lifetime and storage-only create-or-resolve policy.
+Its reader and transaction-scoped writer ports are implemented by
+`storage::identities` over the existing private connection. Canonical lookup and
+creation/promotion share an immediate transaction; only one concurrent caller
+can report creation. Save promotes temporary rows in place, while ordinary
+reuse never downgrades saved rows or rewrites names/timestamps. UUID generation
+and UTC millisecond timestamps belong to the concrete adapter. The service
+neither opens/closes storage nor probes tmux. Binding must call this same
+creation owner before its separate publication transaction, not fork the policy.
+Non-retired selection uses schema 9's index and deterministic BINARY ordering.
+Tombstones are excluded and replacement names receive fresh UUIDs; no profile,
+binding, request, cadence or attention row is changed by creation/promotion.
+Retirement authorization, live presence and public command activation remain
+in #109, not in this storage-only foundation.
 
 Native migration 9 adds `lifetime` (default `saved` for existing identities) and
 nullable `retired_at_ms` to that same identity table. A partial unique index

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,6 +38,9 @@ The separate storage adapter upgrades historical schemas 0–8 to native schema 
 tested through a development-only probe rather than an installed command.
 Use isolated test databases only: installed TypeScript cannot reopen schema 9.
 Native identity commands and retirement are still unimplemented.
+The #111 internal record service supports temporary/saved creation, same-UUID
+promotion and non-retired selection, tested against real isolated SQLite. It
+does not activate the public identity commands or establish live presence.
 The Unix tmux evidence adapter is likewise exercised through a non-installed
 `tmux-probe` example; native identity commands are not implemented by that probe.
 Use the exact toolchain from `rust/rust-toolchain.toml` and run from `rust/`:
@@ -101,6 +104,14 @@ current RustSec advisories when changing Cargo.lock. `tmt-core` must remain free
 of CLI/concrete-IO dependencies. `tmt-adapters` owns the concrete SQLite lifecycle;
 keep its raw connection private. See RUST-REWRITE for the dependency
 decision and explicit exceptions under #100.
+
+Name-policy goldens cover the pinned Node 22.23.2 reference (Unicode 17.0,
+ICU 78.2), including ECMAScript BOM/NEL differences, contextual lowercase and
+pane-shaped names. Run the same core tests on both supported Rust toolchains;
+do not substitute compiler-owned casing tables or case folding. Identity-record
+tests invoke the actual service and repository on private SQLite fixtures,
+observe dependent rows independently, and synchronize competing connections
+before creation. Their evidence is storage policy, not public CLI/tmux parity.
 
 The Docker image builds Linux adapter test artifacts in a pinned Rust/Debian
 stage matching the runtime image's libc. It runs native adapter unit tests under

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -138,8 +138,8 @@ so actual Rust 1.88 locked compilation remains the acceptance evidence.
 
 Historical migrations 1–8 remain unchanged. Native migrations retain their names,
 column/index/foreign-key definitions and seven-day migration backfill rather
-than applying today's retention configuration retroactively. The private
-connection exposes only lifecycle operations until repositories are ported.
+than applying today's retention configuration retroactively. The raw connection
+stays private; #111 composes the first identity repository over this lifecycle.
 A non-installed `storage-probe` example allows bounded cross-runtime tests of
 the real adapter, without adding arbitrary SQL or fault flags to public syntax.
 Cold concurrent WAL transitions can report retryable busy errors even with a
@@ -158,6 +158,40 @@ on all normal success/error paths. The source definition must match the frozen
 historical identity table apart from whitespace; custom columns, constraints,
 indexes or triggers are rejected instead of silently removed. No ORM, alternate
 registry or dependency is added.
+
+#111 adds the storage-only identity creation/selection owner over that schema.
+Core validates names and decides creation or in-place promotion; the existing
+storage adapter provides an immediate transaction and concrete UUID/UTC timestamp
+generation. Idempotent reuse preserves the original display name and timestamps,
+save never changes UUID, and temporary requests never downgrade saved rows.
+Non-retired selection excludes tombstones without erasing historical ownership.
+This does not activate native identity commands, binding, removal or presence;
+#109 retains their public input/output and Docker gates.
+
+Name normalization uses pinned `icu_normalizer`, `icu_casemap` and
+`icu_locale_core` 2.3.0, with defaults disabled and compiled data only for the
+first two. The locale type supplies the explicit root/und language; no locale
+discovery occurs. NFKC followed by default lowercase matches the measured pinned
+Node 22.23.2 Unicode 17.0/ICU 78.2 reference. ECMAScript whitespace is explicit
+because Rust trim includes NEL and excludes BOM. A smaller
+unicode-normalization plus standard-library lowercase combination was rejected
+because compiler-owned casing tables may differ between MSRV and current Rust.
+Case folding would merge additional names and is not compatible. Do not
+renormalize existing database keys during dependency or compiler upgrades.
+Published ICU4X manifests declare Rust 1.88 and Unicode-3.0; binary distribution
+must retain the associated Unicode permission notice under #82. See
+[normalizer](https://docs.rs/crate/icu_normalizer/2.3.0/source/Cargo.toml) and
+[case mapping](https://docs.rs/crate/icu_casemap/2.3.0/source/Cargo.toml).
+The lock adds 25 packages, including Unicode data/provider/zero-copy support
+and procedural-macro tooling; this is a deliberate footprint tradeoff, not a
+claim of zero-cost normalization. Their published licenses offer Unicode-3.0,
+MIT or Apache-2.0 and declared MSRVs do not exceed 1.88; some omit MSRV, so
+locked builds remain required. At advisory revision
+`faedffd5118c1835e13cca3babb6059afb1eb8d0`, zerovec's RUSTSEC-2024-0347 and
+zerovec-derive's RUSTSEC-2024-0346 are patched before the selected 0.11.8/0.11.6.
+The other added package names had no entries in that dated snapshot. Baked
+data manifests record ICU release-78.1rc/CLDR 48.2.1; no data download occurs
+at CLI startup. Repeat the graph/advisory review on dependency updates.
 
 ### Execution and resource ownership
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -78,6 +78,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +154,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "icu_casemap"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2edfd120d8445de853cf53a1abec916f638f933a70a6f4bf8f7e2d7b7f884e9"
+dependencies = [
+ "icu_casemap_data",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties",
+ "icu_provider",
+ "potential_utf",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_casemap_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059fcda0fc8d33effc6633a8cf0d8a3c17caf7d7c91918fba9918744f501e4e8"
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "serde",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "serde",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +307,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +347,17 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "serde_core",
+ "writeable",
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -272,6 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -291,7 +429,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -327,6 +465,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +488,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
@@ -351,6 +506,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec",
 ]
 
 [[package]]
@@ -380,6 +557,9 @@ dependencies = [
 name = "tmt-core"
 version = "5.0.0-alpha.1"
 dependencies = [
+ "icu_casemap",
+ "icu_locale_core",
+ "icu_normalizer",
  "uuid",
 ]
 
@@ -388,6 +568,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -438,7 +624,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
@@ -472,6 +658,91 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "serde",
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
 
 [[package]]
 name = "zmij"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,6 +19,9 @@ rusqlite = { version = "=0.40.2", default-features = false, features = ["bundled
 subprocess = "=1.2.1"
 nix = { version = "=0.31.3", default-features = false, features = ["signal", "process"] }
 uuid = { version = "=1.26.0", default-features = false, features = ["std"] }
+icu_normalizer = { version = "=2.3.0", default-features = false, features = ["compiled_data"] }
+icu_casemap = { version = "=2.3.0", default-features = false, features = ["compiled_data"] }
+icu_locale_core = { version = "=2.3.0", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/rust/crates/tmt-adapters/src/storage/identities.rs
+++ b/rust/crates/tmt-adapters/src/storage/identities.rs
@@ -1,0 +1,111 @@
+//! Identity SQL shares the invocation-owned connection and schema history.
+
+use rusqlite::{Connection, OptionalExtension, Row, TransactionBehavior, params};
+use tmt_core::{
+    identity::{Identity, IdentityReader, IdentityRepository, IdentityWriter, Lifetime},
+    names::ValidatedName,
+};
+
+use super::{Storage, StorageError, StorageErrorCode, errors::classify};
+
+const COLUMNS: &str = "id, name, canonical_name, lifetime, created_at, updated_at";
+
+struct IdentityRecords<'a>(&'a Connection);
+
+fn identity_row(row: &Row<'_>) -> rusqlite::Result<Identity> {
+    let lifetime = match row.get::<_, String>(3)?.as_str() {
+        "temporary" => Lifetime::Temporary,
+        "saved" => Lifetime::Saved,
+        _ => return Err(rusqlite::Error::InvalidQuery),
+    };
+    Ok(Identity {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        canonical_name: row.get(2)?,
+        lifetime,
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
+impl IdentityReader for IdentityRecords<'_> {
+    type Error = StorageError;
+
+    fn find_identity(&self, canonical_name: &str) -> Result<Option<Identity>, Self::Error> {
+        self.0
+            .query_row(
+                &format!("SELECT {COLUMNS} FROM identities WHERE canonical_name = ? AND retired_at_ms IS NULL"),
+                [canonical_name],
+                identity_row,
+            )
+            .optional()
+            .map_err(|error| classify(error, "Find identity"))
+    }
+
+    fn list_identities(&self) -> Result<Vec<Identity>, Self::Error> {
+        let mut statement = self.0.prepare(&format!(
+            "SELECT {COLUMNS} FROM identities WHERE retired_at_ms IS NULL ORDER BY canonical_name COLLATE BINARY"
+        )).map_err(|error| classify(error, "Prepare identity list"))?;
+        statement
+            .query_map([], identity_row)
+            .and_then(|rows| rows.collect())
+            .map_err(|error| classify(error, "List identities"))
+    }
+}
+
+impl IdentityWriter for IdentityRecords<'_> {
+    fn insert_identity(
+        &mut self,
+        name: &ValidatedName,
+        lifetime: Lifetime,
+    ) -> Result<Identity, Self::Error> {
+        self.0.query_row(
+            &format!("INSERT INTO identities (id, name, canonical_name, lifetime, created_at, updated_at) \
+                VALUES (?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) RETURNING {COLUMNS}"),
+            params![uuid::Uuid::new_v4().to_string(), name.display_name(), name.canonical_name(), lifetime.as_str()],
+            identity_row,
+        ).map_err(|error| classify(error, "Create identity"))
+    }
+
+    fn save_identity(&mut self, identity: &Identity) -> Result<Identity, Self::Error> {
+        self.0.query_row(
+            &format!("UPDATE identities SET lifetime = 'saved', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') \
+                WHERE id = ? AND retired_at_ms IS NULL AND lifetime = 'temporary' RETURNING {COLUMNS}"),
+            [&identity.id], identity_row,
+        ).map_err(|error| classify(error, "Save identity"))
+    }
+}
+
+impl IdentityReader for Storage {
+    type Error = StorageError;
+
+    fn find_identity(&self, canonical_name: &str) -> Result<Option<Identity>, Self::Error> {
+        IdentityRecords(self.connection()?).find_identity(canonical_name)
+    }
+
+    fn list_identities(&self) -> Result<Vec<Identity>, Self::Error> {
+        IdentityRecords(self.connection()?).list_identities()
+    }
+}
+
+impl IdentityRepository for Storage {
+    fn with_identity_transaction<T>(
+        &mut self,
+        operation: impl FnOnce(&mut dyn IdentityWriter<Error = Self::Error>) -> Result<T, Self::Error>,
+    ) -> Result<T, Self::Error> {
+        let connection = self.connection.as_mut().ok_or_else(|| {
+            StorageError::new(StorageErrorCode::Closed, "Storage is already closed")
+        })?;
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| classify(error, "Begin identity transaction"))?;
+        let result = operation(&mut IdentityRecords(&transaction))?;
+        transaction
+            .commit()
+            .map_err(|error| classify(error, "Commit identity transaction"))?;
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-adapters/src/storage/identities/tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/identities/tests.rs
@@ -1,0 +1,652 @@
+use std::{
+    path::PathBuf,
+    sync::mpsc::{self, RecvTimeoutError},
+    thread,
+    time::Duration,
+};
+
+use crate::test_support::TestDirectory;
+use rusqlite::{Connection, params, types::Value};
+use tmt_core::identity::{
+    CreatedIdentity, IdentityError, IdentityReader, IdentityRepository, Lifetime,
+    create_or_resolve, find_by_name,
+};
+use tmt_core::names::validate_name;
+
+use super::super::*;
+
+struct Fixture {
+    _directory: TestDirectory,
+    database: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = TestDirectory::new();
+        Self {
+            database: directory.path.join("state").join("tmux-team.db"),
+            _directory: directory,
+        }
+    }
+
+    fn open(&self) -> Storage {
+        Storage::open(&self.database).unwrap()
+    }
+}
+
+type DependentSnapshot = Vec<(&'static str, Vec<Vec<Value>>)>;
+
+fn snapshot_dependent_rows(connection: &Connection, identity_id: &str) -> DependentSnapshot {
+    const TABLES: [(&str, &str); 7] = [
+        (
+            "role_profiles",
+            "SELECT * FROM role_profiles WHERE identity_id = ? ORDER BY identity_id",
+        ),
+        (
+            "identity_preambles",
+            "SELECT * FROM identity_preambles WHERE identity_id = ? ORDER BY identity_id",
+        ),
+        (
+            "preamble_counters",
+            "SELECT * FROM preamble_counters WHERE identity_id = ? ORDER BY identity_id",
+        ),
+        (
+            "bindings",
+            "SELECT * FROM bindings WHERE identity_id = ? ORDER BY identity_id, id",
+        ),
+        (
+            "request_attempts",
+            "SELECT * FROM request_attempts WHERE identity_id = ? ORDER BY identity_id, attempt_id",
+        ),
+        (
+            "request_responses",
+            "SELECT request_responses.* FROM request_responses
+             JOIN request_attempts ON request_attempts.attempt_id = request_responses.attempt_id
+             WHERE request_attempts.identity_id = ? ORDER BY request_responses.request_id",
+        ),
+        (
+            "request_attention_identities",
+            "SELECT * FROM request_attention_identities WHERE identity_id = ? ORDER BY identity_id",
+        ),
+    ];
+    TABLES
+        .into_iter()
+        .map(|(table, query)| {
+            let mut statement = connection.prepare(query).unwrap();
+            let rows = statement
+                .query_map([identity_id], |row| {
+                    (0..row.as_ref().column_count())
+                        .map(|index| row.get(index))
+                        .collect::<rusqlite::Result<Vec<Value>>>()
+                })
+                .unwrap()
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .unwrap();
+            (table, rows)
+        })
+        .collect()
+}
+
+fn seed_dependents(connection: &Connection, identity_id: &str) {
+    let attempt_id = format!("attempt-{identity_id}");
+    let request_id = format!("request-{identity_id}");
+    connection
+        .execute(
+            "INSERT INTO role_profiles VALUES (?, 'role body', 'role-time')",
+            params![identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO identity_preambles VALUES (?, 'preamble body', 'preamble-time')",
+            params![identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO preamble_counters VALUES (?, 12, 123456789)",
+            params![identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO bindings VALUES ('binding', ?, 'tmux', '%1', 'server', '/tmp/socket', 11, 'server-time', 12, 'bound-time', 'verified-time')",
+            params![identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO request_attempts (
+                attempt_id, request_id, identity_id, server_id, socket_path, server_pid,
+                server_start_time, pane_id, pane_pid, wait_active, status, preamble_every,
+                inject_preamble, cadence_reserved, prepared_at_ms, expires_at_ms,
+                retention_days, retention_expires_at_ms, originator_kind, originator_identity_id,
+                recipient_identity_id, message_text, message_bytes, message_expires_at_ms,
+                attention_revision, attention_acknowledged_revision
+             ) VALUES (?, ?, ?, 'server', '/tmp/socket', 11, 'server-time', '%1', 12, 0,
+                'sent', 3, 1, 1, 100, 200, 7, 300, 'explicit', ?, ?,
+                'prompt body', 11, 400, 7, 5)",
+            params![
+                attempt_id,
+                request_id,
+                identity_id,
+                identity_id,
+                identity_id,
+            ],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO request_responses (
+                request_id, attempt_id, server_id, socket_path, server_pid,
+                server_start_time, pane_id, pane_pid, body, body_bytes, submitted_at_ms,
+                response_expires_at_ms
+             ) VALUES (?, ?, 'server', '/tmp/socket', 11, 'server-time', '%1', 12,
+                'response body', 13, 150, 500)",
+            params![request_id, attempt_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO request_attention_identities VALUES (?, 7, 5)",
+            params![identity_id],
+        )
+        .unwrap();
+}
+
+fn assert_uuid_v4(value: &str) {
+    let uuid = uuid::Uuid::parse_str(value).expect("identity ID must be a UUID");
+    assert_eq!(value.len(), 36);
+    assert_eq!(uuid.to_string(), value);
+    assert_eq!(uuid.get_version_num(), 4);
+}
+
+fn assert_utc_millisecond_timestamp(value: &str) {
+    assert_eq!(
+        value.len(),
+        24,
+        "timestamp must use UTC milliseconds: {value}"
+    );
+    for (index, character) in value.chars().enumerate() {
+        if [4, 7, 10, 13, 16, 19, 23].contains(&index) {
+            continue;
+        }
+        assert!(
+            character.is_ascii_digit(),
+            "timestamp must be numeric: {value}"
+        );
+    }
+    assert_eq!(&value[4..5], "-");
+    assert_eq!(&value[7..8], "-");
+    assert_eq!(&value[10..11], "T");
+    assert_eq!(&value[13..14], ":");
+    assert_eq!(&value[16..17], ":");
+    assert_eq!(&value[19..20], ".");
+    assert_eq!(&value[23..24], "Z");
+}
+
+#[test]
+fn canonical_name_reuse_is_idempotent_and_preserves_the_original_record() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+
+    let first = create_or_resolve(&mut storage, "  Alice  ", Lifetime::Temporary).unwrap();
+    assert!(first.created);
+    assert_uuid_v4(&first.identity.id);
+    assert_utc_millisecond_timestamp(&first.identity.created_at);
+    assert_utc_millisecond_timestamp(&first.identity.updated_at);
+    let second = create_or_resolve(&mut storage, "alice", Lifetime::Temporary).unwrap();
+    assert!(!second.created);
+    assert_eq!(second.identity, first.identity);
+    assert_eq!(
+        storage.list_identities().unwrap(),
+        vec![first.identity.clone()]
+    );
+    assert_eq!(
+        find_by_name(&storage, " ALICE ").unwrap(),
+        Some(first.identity)
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn promotion_reuses_uuid_without_downgrade_or_rewriting_creation_fields() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+
+    let temporary = create_or_resolve(&mut storage, "  Alice  ", Lifetime::Temporary)
+        .unwrap()
+        .identity;
+    seed_dependents(storage.connection().unwrap(), &temporary.id);
+    let dependents_before = snapshot_dependent_rows(storage.connection().unwrap(), &temporary.id);
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE identities SET created_at = ?, updated_at = ? WHERE id = ?",
+            (
+                "2000-01-01T00:00:00.000Z",
+                "2000-01-02T00:00:00.000Z",
+                &temporary.id,
+            ),
+        )
+        .unwrap();
+
+    let saved = create_or_resolve(&mut storage, "alice", Lifetime::Saved).unwrap();
+    assert!(!saved.created);
+    assert_eq!(saved.identity.id, temporary.id);
+    assert_eq!(saved.identity.name, temporary.name);
+    assert_eq!(saved.identity.canonical_name, temporary.canonical_name);
+    assert_eq!(saved.identity.created_at, "2000-01-01T00:00:00.000Z");
+    assert_eq!(saved.identity.lifetime, Lifetime::Saved);
+    assert!(saved.identity.updated_at.as_str() > "2000-01-02T00:00:00.000Z");
+    assert_eq!(
+        snapshot_dependent_rows(storage.connection().unwrap(), &temporary.id),
+        dependents_before
+    );
+
+    let repeated = create_or_resolve(&mut storage, "ALICE", Lifetime::Temporary).unwrap();
+    assert!(!repeated.created);
+    assert_eq!(repeated.identity, saved.identity);
+    storage.close().unwrap();
+}
+
+#[test]
+fn saved_identity_cannot_be_downgraded_to_temporary() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+
+    let saved = create_or_resolve(&mut storage, "Alice", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE identities SET created_at = ?, updated_at = ? WHERE id = ?",
+            (
+                "1999-01-01T00:00:00.000Z",
+                "1999-01-02T00:00:00.000Z",
+                &saved.id,
+            ),
+        )
+        .unwrap();
+
+    let repeated_saved = create_or_resolve(&mut storage, " alice ", Lifetime::Saved).unwrap();
+    assert!(!repeated_saved.created);
+    assert_eq!(repeated_saved.identity.id, saved.id);
+    assert_eq!(repeated_saved.identity.name, saved.name);
+    assert_eq!(repeated_saved.identity.canonical_name, saved.canonical_name);
+    assert_eq!(repeated_saved.identity.lifetime, Lifetime::Saved);
+    assert_eq!(
+        repeated_saved.identity.created_at,
+        "1999-01-01T00:00:00.000Z"
+    );
+    assert_eq!(
+        repeated_saved.identity.updated_at,
+        "1999-01-02T00:00:00.000Z"
+    );
+
+    let reused = create_or_resolve(&mut storage, " alice ", Lifetime::Temporary).unwrap();
+    assert!(!reused.created);
+    assert_eq!(reused.identity, repeated_saved.identity);
+    storage.close().unwrap();
+}
+
+#[test]
+fn list_is_non_retired_and_deterministically_binary_ordered() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    // Non-English letters distinguish binary ordering from locale collation.
+    for name in ["ä", "a2", "a", "é", "aa"] {
+        create_or_resolve(&mut storage, name, Lifetime::Temporary).unwrap();
+    }
+
+    let listed = storage.list_identities().unwrap();
+    let canonical_names = listed
+        .iter()
+        .map(|identity| identity.canonical_name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(canonical_names, ["a", "a2", "aa", "ä", "é"]);
+    storage.close().unwrap();
+}
+
+#[test]
+fn retired_name_is_excluded_and_reuse_gets_a_fresh_uuid_without_dependents() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let original = create_or_resolve(&mut storage, "Alice", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    seed_dependents(storage.connection().unwrap(), &original.id);
+    let dependents_before = snapshot_dependent_rows(storage.connection().unwrap(), &original.id);
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE identities SET retired_at_ms = ? WHERE id = ?",
+            params![1700000000000_i64, original.id],
+        )
+        .unwrap();
+    assert_eq!(
+        snapshot_dependent_rows(storage.connection().unwrap(), &original.id),
+        dependents_before
+    );
+
+    assert!(storage.find_identity("alice").unwrap().is_none());
+    assert!(
+        storage
+            .list_identities()
+            .unwrap()
+            .iter()
+            .all(|identity| identity.id != original.id)
+    );
+
+    let created = create_or_resolve(&mut storage, " alice ", Lifetime::Temporary).unwrap();
+    assert!(created.created);
+    let replacement = created.identity;
+    assert_ne!(replacement.id, original.id);
+    assert_eq!(replacement.lifetime, Lifetime::Temporary);
+    assert!(
+        snapshot_dependent_rows(storage.connection().unwrap(), &replacement.id)
+            .iter()
+            .all(|(_, rows)| rows.is_empty()),
+        "retired identity dependents must not be inherited"
+    );
+    assert_eq!(
+        snapshot_dependent_rows(storage.connection().unwrap(), &original.id),
+        dependents_before
+    );
+    assert_uuid_v4(&replacement.id);
+    assert_utc_millisecond_timestamp(&replacement.created_at);
+    assert_utc_millisecond_timestamp(&replacement.updated_at);
+    storage.close().unwrap();
+}
+
+#[test]
+fn promotion_failure_rolls_back_lifetime_and_timestamps() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let temporary = create_or_resolve(&mut storage, "Alice", Lifetime::Temporary)
+        .unwrap()
+        .identity;
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE identities SET created_at = ?, updated_at = ? WHERE id = ?",
+            (
+                "1980-01-01T00:00:00.000Z",
+                "1980-01-02T00:00:00.000Z",
+                &temporary.id,
+            ),
+        )
+        .unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER reject_identity_promotion
+             BEFORE UPDATE OF lifetime ON identities
+             WHEN NEW.lifetime = 'saved'
+             BEGIN SELECT RAISE(ABORT, 'injected promotion failure'); END;",
+        )
+        .unwrap();
+
+    let error = create_or_resolve(&mut storage, "alice", Lifetime::Saved).unwrap_err();
+    match error {
+        IdentityError::Repository(error) => assert_eq!(error.code, StorageErrorCode::Unknown),
+        IdentityError::InvalidName(error) => panic!("unexpected invalid name: {error}"),
+    }
+    let row: (String, String, String) = storage
+        .connection()
+        .unwrap()
+        .query_row(
+            "SELECT lifetime, created_at, updated_at FROM identities WHERE id = ?",
+            [&temporary.id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        row,
+        (
+            "temporary".into(),
+            "1980-01-01T00:00:00.000Z".into(),
+            "1980-01-02T00:00:00.000Z".into()
+        )
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn transaction_rolls_back_prior_identity_writes_and_releases_writer_lock() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let temporary = create_or_resolve(&mut storage, "Alice", Lifetime::Temporary)
+        .unwrap()
+        .identity;
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE identities SET created_at = ?, updated_at = ? WHERE id = ?",
+            (
+                "1970-01-01T00:00:00.000Z",
+                "1970-01-02T00:00:00.000Z",
+                &temporary.id,
+            ),
+        )
+        .unwrap();
+    let rollback_name = validate_name("RollbackNew").unwrap();
+
+    let error: Result<(), StorageError> = storage.with_identity_transaction(|writer| {
+        writer.save_identity(&temporary)?;
+        writer.insert_identity(&rollback_name, Lifetime::Temporary)?;
+        Err(StorageError::new(
+            StorageErrorCode::Unknown,
+            "injected transaction failure",
+        ))
+    });
+    assert_eq!(error.unwrap_err().code, StorageErrorCode::Unknown);
+
+    let verification = Connection::open(&fixture.database).unwrap();
+    verification
+        .busy_timeout(Duration::from_millis(100))
+        .unwrap();
+    let original: (String, String, String) = verification
+        .query_row(
+            "SELECT lifetime, created_at, updated_at FROM identities WHERE id = ?",
+            [&temporary.id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        original,
+        (
+            "temporary".into(),
+            "1970-01-01T00:00:00.000Z".into(),
+            "1970-01-02T00:00:00.000Z".into()
+        )
+    );
+    let rollback_count: i64 = verification
+        .query_row(
+            "SELECT COUNT(*) FROM identities WHERE canonical_name = 'rollbacknew'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(rollback_count, 0);
+    verification
+        .execute_batch("BEGIN IMMEDIATE; COMMIT;")
+        .unwrap();
+    storage.close().unwrap();
+}
+
+#[test]
+fn commit_contention_rolls_back_creation_and_releases_the_transaction() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    // A rollback-journal reader allows BEGIN IMMEDIATE and INSERT, but blocks
+    // COMMIT. This intentionally changed fixture policy isolates the commit
+    // failure path; production remains WAL with its five-second busy timeout.
+    storage
+        .connection()
+        .unwrap()
+        .pragma_update(None, "journal_mode", "DELETE")
+        .unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .busy_timeout(Duration::from_millis(100))
+        .unwrap();
+    let reader = Connection::open(&fixture.database).unwrap();
+    reader
+        .execute_batch("BEGIN; SELECT COUNT(*) FROM identities;")
+        .unwrap();
+
+    let error = create_or_resolve(&mut storage, "CommitBlocked", Lifetime::Temporary).unwrap_err();
+    let IdentityError::Repository(error) = error else {
+        panic!("expected storage contention")
+    };
+    assert_eq!(error.code, StorageErrorCode::Busy);
+    assert_eq!(error.message, "Commit identity transaction failed");
+    assert!(error.retryable);
+    assert!(storage.connection().unwrap().is_autocommit());
+    reader.execute_batch("ROLLBACK;").unwrap();
+    let count: i64 = reader
+        .query_row("SELECT COUNT(*) FROM identities", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+    reader.execute_batch("BEGIN IMMEDIATE; COMMIT;").unwrap();
+    storage.close().unwrap();
+}
+
+#[test]
+fn closed_storage_reports_closed_errors_through_reads_and_mutations() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    storage.close().unwrap();
+
+    let mutation = create_or_resolve(&mut storage, "Alice", Lifetime::Temporary).unwrap_err();
+    match mutation {
+        IdentityError::Repository(error) => assert_eq!(error.code, StorageErrorCode::Closed),
+        IdentityError::InvalidName(error) => panic!("unexpected invalid name: {error}"),
+    }
+    let lookup = find_by_name(&storage, "Alice").unwrap_err();
+    match lookup {
+        IdentityError::Repository(error) => assert_eq!(error.code, StorageErrorCode::Closed),
+        IdentityError::InvalidName(error) => panic!("unexpected invalid name: {error}"),
+    }
+    assert_eq!(
+        storage.list_identities().unwrap_err().code,
+        StorageErrorCode::Closed
+    );
+}
+
+#[test]
+fn concurrent_connections_create_once_and_keep_one_active_canonical_row() {
+    let fixture = Fixture::new();
+    let _initial = fixture.open();
+    drop(_initial);
+
+    let (ready_tx, ready_rx) = mpsc::sync_channel::<Result<(), String>>(2);
+    let start_channels = (0..2)
+        .map(|_| mpsc::sync_channel::<()>(1))
+        .collect::<Vec<_>>();
+    let start_txs = start_channels
+        .iter()
+        .map(|(sender, _)| sender.clone())
+        .collect::<Vec<_>>();
+    let (result_tx, result_rx) = mpsc::sync_channel::<Result<(bool, String, Lifetime), String>>(2);
+
+    thread::scope(|scope| {
+        for (worker_index, (_, start_rx)) in start_channels.into_iter().enumerate() {
+            let ready_tx = ready_tx.clone();
+            let result_tx = result_tx.clone();
+            let database = fixture.database.clone();
+            scope.spawn(move || {
+                let mut storage = match Storage::open(database) {
+                    Ok(storage) => storage,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(error.to_string()));
+                        return;
+                    }
+                };
+                if ready_tx.send(Ok(())).is_err() {
+                    return;
+                }
+                if start_rx.recv_timeout(Duration::from_secs(5)).is_err() {
+                    let _ = result_tx.send(Err("timed out waiting for start".into()));
+                    return;
+                }
+                let (name, lifetime) = if worker_index == 0 {
+                    ("  Concurrent  ", Lifetime::Temporary)
+                } else {
+                    ("CONCURRENT", Lifetime::Saved)
+                };
+                let outcome = create_or_resolve(&mut storage, name, lifetime)
+                    .map(|CreatedIdentity { identity, created }| {
+                        (created, identity.id, identity.lifetime)
+                    })
+                    .map_err(|error| error.to_string())
+                    .and_then(|outcome| {
+                        storage
+                            .close()
+                            .map(|()| outcome)
+                            .map_err(|error| error.to_string())
+                    });
+                let _ = result_tx.send(outcome);
+            });
+        }
+        drop(ready_tx);
+        drop(result_tx);
+
+        let mut ready = 0;
+        for _ in 0..2 {
+            match ready_rx.recv_timeout(Duration::from_secs(5)) {
+                Ok(Ok(())) => ready += 1,
+                Ok(Err(error)) => panic!("worker failed before synchronization: {error}"),
+                Err(RecvTimeoutError::Timeout) => panic!("worker did not become ready"),
+                Err(RecvTimeoutError::Disconnected) => panic!("all workers exited early"),
+            }
+        }
+        assert_eq!(ready, 2);
+        for start_tx in start_txs {
+            start_tx.send(()).unwrap();
+        }
+
+        let mut outcomes = Vec::new();
+        for _ in 0..ready {
+            outcomes.push(
+                result_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("worker did not return an outcome")
+                    .unwrap(),
+            );
+        }
+        assert_eq!(
+            outcomes.iter().filter(|(created, _, _)| *created).count(),
+            1
+        );
+        assert_eq!(outcomes[0].1, outcomes[1].1);
+    });
+
+    let verification = Connection::open(&fixture.database).unwrap();
+    let active: (i64, i64, String) = verification
+        .query_row(
+            "SELECT COUNT(*), COUNT(DISTINCT canonical_name), MAX(lifetime)
+             FROM identities WHERE retired_at_ms IS NULL",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(active, (1, 1, "saved".into()));
+    let canonical: String = verification
+        .query_row(
+            "SELECT canonical_name FROM identities WHERE retired_at_ms IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(canonical, "concurrent");
+}

--- a/rust/crates/tmt-adapters/src/storage/mod.rs
+++ b/rust/crates/tmt-adapters/src/storage/mod.rs
@@ -1,4 +1,5 @@
 mod errors;
+mod identities;
 mod migrations;
 
 #[cfg(test)]

--- a/rust/crates/tmt-core/Cargo.toml
+++ b/rust/crates/tmt-core/Cargo.toml
@@ -11,3 +11,6 @@ workspace = true
 
 [dependencies]
 uuid.workspace = true
+icu_normalizer.workspace = true
+icu_casemap.workspace = true
+icu_locale_core.workspace = true

--- a/rust/crates/tmt-core/src/identity.rs
+++ b/rust/crates/tmt-core/src/identity.rs
@@ -1,0 +1,126 @@
+//! Storage-only identity policy shared by standalone creation and pane binding.
+
+use crate::names::{NameError, ValidatedName, validate_name};
+use std::{error::Error, fmt};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lifetime {
+    Temporary,
+    Saved,
+}
+
+impl Lifetime {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Temporary => "temporary",
+            Self::Saved => "saved",
+        }
+    }
+}
+
+/// Non-retired identity. Historical timestamps and canonical keys are not
+/// normalized again when read; changing a compiler must not rewrite ownership.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Identity {
+    pub id: String,
+    pub name: String,
+    pub canonical_name: String,
+    pub lifetime: Lifetime,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreatedIdentity {
+    pub identity: Identity,
+    pub created: bool,
+}
+
+/// Read capabilities never infer presence or reconcile bindings.
+pub trait IdentityReader {
+    type Error;
+
+    fn find_identity(&self, canonical_name: &str) -> Result<Option<Identity>, Self::Error>;
+    fn list_identities(&self) -> Result<Vec<Identity>, Self::Error>;
+}
+
+/// Available only inside the repository's immediate transaction. Implementations
+/// generate UUIDs/timestamps and preserve dependent rows; the service owns when
+/// creation or promotion is appropriate.
+pub trait IdentityWriter: IdentityReader {
+    fn insert_identity(
+        &mut self,
+        name: &ValidatedName,
+        lifetime: Lifetime,
+    ) -> Result<Identity, Self::Error>;
+    fn save_identity(&mut self, identity: &Identity) -> Result<Identity, Self::Error>;
+}
+
+pub trait IdentityRepository: IdentityReader {
+    fn with_identity_transaction<T>(
+        &mut self,
+        operation: impl FnOnce(&mut dyn IdentityWriter<Error = Self::Error>) -> Result<T, Self::Error>,
+    ) -> Result<T, Self::Error>;
+}
+
+#[derive(Debug)]
+pub enum IdentityError<E> {
+    InvalidName(NameError),
+    Repository(E),
+}
+
+impl<E: fmt::Display> fmt::Display for IdentityError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidName(error) => error.fmt(formatter),
+            Self::Repository(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl<E: Error + 'static> Error for IdentityError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidName(error) => Some(error),
+            Self::Repository(error) => Some(error),
+        }
+    }
+}
+
+/// This commit precedes binding publication. A later publication failure must
+/// not undo an identity another invocation could already have observed.
+pub fn create_or_resolve<R: IdentityRepository>(
+    repository: &mut R,
+    name: &str,
+    requested_lifetime: Lifetime,
+) -> Result<CreatedIdentity, IdentityError<R::Error>> {
+    let name = validate_name(name).map_err(IdentityError::InvalidName)?;
+    repository
+        .with_identity_transaction(|records| {
+            if let Some(mut identity) = records.find_identity(name.canonical_name())? {
+                if identity.lifetime == Lifetime::Temporary && requested_lifetime == Lifetime::Saved
+                {
+                    identity = records.save_identity(&identity)?;
+                }
+                return Ok(CreatedIdentity {
+                    identity,
+                    created: false,
+                });
+            }
+            Ok(CreatedIdentity {
+                identity: records.insert_identity(&name, requested_lifetime)?,
+                created: true,
+            })
+        })
+        .map_err(IdentityError::Repository)
+}
+
+pub fn find_by_name<R: IdentityReader>(
+    repository: &R,
+    name: &str,
+) -> Result<Option<Identity>, IdentityError<R::Error>> {
+    let name = validate_name(name).map_err(IdentityError::InvalidName)?;
+    repository
+        .find_identity(name.canonical_name())
+        .map_err(IdentityError::Repository)
+}

--- a/rust/crates/tmt-core/src/identity_tests.rs
+++ b/rust/crates/tmt-core/src/identity_tests.rs
@@ -1,0 +1,40 @@
+use crate::identity::*;
+
+struct ForbiddenRepository;
+
+impl IdentityReader for ForbiddenRepository {
+    type Error = std::convert::Infallible;
+
+    fn find_identity(&self, _: &str) -> Result<Option<Identity>, Self::Error> {
+        panic!("invalid input must not read storage")
+    }
+
+    fn list_identities(&self) -> Result<Vec<Identity>, Self::Error> {
+        panic!("invalid input must not list storage")
+    }
+}
+
+impl IdentityRepository for ForbiddenRepository {
+    fn with_identity_transaction<T>(
+        &mut self,
+        _: impl FnOnce(&mut dyn IdentityWriter<Error = Self::Error>) -> Result<T, Self::Error>,
+    ) -> Result<T, Self::Error> {
+        panic!("invalid input must not acquire a transaction")
+    }
+}
+
+#[test]
+fn invalid_names_stop_before_repository_access() {
+    for name in ["", " ", "a\0b", "%14", "session:1.2"] {
+        for lifetime in [Lifetime::Temporary, Lifetime::Saved] {
+            assert!(matches!(
+                create_or_resolve(&mut ForbiddenRepository, name, lifetime),
+                Err(IdentityError::InvalidName(_))
+            ));
+        }
+        assert!(matches!(
+            find_by_name(&ForbiddenRepository, name),
+            Err(IdentityError::InvalidName(_))
+        ));
+    }
+}

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -1,8 +1,12 @@
 //! Shared native-domain contracts for tmux-team.
 
 pub mod endpoint;
+pub mod identity;
 pub mod limits;
+pub mod names;
 pub mod settings;
 
+#[cfg(test)]
+mod identity_tests;
 #[cfg(test)]
 mod settings_tests;

--- a/rust/crates/tmt-core/src/names.rs
+++ b/rust/crates/tmt-core/src/names.rs
@@ -1,0 +1,99 @@
+//! Identity keys follow ECMAScript trim -> NFKC -> default lowercase.
+//! Fixed ICU data avoids compiler-dependent casing of persistent names.
+
+use icu_casemap::CaseMapper;
+use icu_locale_core::LanguageIdentifier;
+use icu_normalizer::ComposingNormalizer;
+use std::{error::Error, fmt};
+
+use crate::endpoint::valid_pane_id;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedName {
+    display_name: String,
+    canonical_name: String,
+}
+
+impl ValidatedName {
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    pub fn canonical_name(&self) -> &str {
+        &self.canonical_name
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NameError {
+    EmptyOrControl,
+    PaneTarget,
+}
+
+impl fmt::Display for NameError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::EmptyOrControl => {
+                "Identity name must not be empty or contain control characters."
+            }
+            Self::PaneTarget => "Identity name must not look like a pane target.",
+        })
+    }
+}
+
+impl Error for NameError {}
+
+// ECMAScript WhiteSpace plus LineTerminator, also used by its regular-expression
+// \s. Rust's is_whitespace differs: it includes NEL and excludes BOM.
+fn ecmascript_space(character: char) -> bool {
+    matches!(character,
+        '\u{0009}'..='\u{000d}' | '\u{0020}' | '\u{00a0}' | '\u{1680}' |
+        '\u{2000}'..='\u{200a}' | '\u{2028}' | '\u{2029}' | '\u{202f}' |
+        '\u{205f}' | '\u{3000}' | '\u{feff}'
+    )
+}
+
+pub fn normalize_name(value: &str) -> String {
+    let trimmed = value.trim_matches(ecmascript_space);
+    let normalized = ComposingNormalizer::new_nfkc().normalize(trimmed);
+    // The root locale is intentional: environment locale must not change keys.
+    CaseMapper::new()
+        .lowercase_to_string(&normalized, &LanguageIdentifier::UNKNOWN)
+        .into_owned()
+}
+
+pub fn is_pane_target(value: &str) -> bool {
+    let canonical = normalize_name(value);
+    if valid_pane_id(&canonical) || window_pane(&canonical) {
+        return true;
+    }
+    canonical.split_once(':').is_some_and(|(session, pane)| {
+        !session.is_empty() && !session.chars().any(ecmascript_space) && window_pane(pane)
+    })
+}
+
+fn window_pane(value: &str) -> bool {
+    value.split_once('.').is_some_and(|(window, pane)| {
+        [window, pane]
+            .into_iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+    })
+}
+
+pub fn validate_name(value: &str) -> Result<ValidatedName, NameError> {
+    let display_name = value.trim_matches(ecmascript_space);
+    if display_name.is_empty() || display_name.chars().any(|c| c < '\u{20}' || c == '\u{7f}') {
+        return Err(NameError::EmptyOrControl);
+    }
+    let canonical_name = normalize_name(value);
+    if is_pane_target(&canonical_name) {
+        return Err(NameError::PaneTarget);
+    }
+    Ok(ValidatedName {
+        display_name: display_name.into(),
+        canonical_name,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-core/src/names/tests.rs
+++ b/rust/crates/tmt-core/src/names/tests.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+#[test]
+fn canonical_keys_preserve_javascript_normalization_and_contextual_lowercase() {
+    // Non-English text is required Unicode compatibility fixture data.
+    for (input, expected) in [
+        (" Ａlice ", "alice"),
+        ("\u{feff}Alice\u{feff}", "alice"),
+        ("\u{85}Alice\u{85}", "\u{85}alice\u{85}"),
+        ("ΟΣ", "ος"),
+        ("ΟΣΑ", "οσα"),
+        ("AΣ\u{301}", "aς\u{301}"),
+        ("AΣ\u{301}A", "aσ\u{301}a"),
+        ("Σ", "σ"),
+        ("İIı", "i\u{307}iı"),
+        ("Straße", "straße"),
+        ("ẞ", "ß"),
+        // Unicode 17 additions catch accidental use of the MSRV compiler's
+        // older casing tables instead of the pinned normalization dependency.
+        ("\u{16ea0}\u{16ea1}", "\u{16ebb}\u{16ebc}"),
+        ("E\u{301}", "é"),
+        ("KÅﬃ", "kåffi"),
+        ("\u{a0}\u{2007}ALICE\u{202f}", "alice"),
+        ("\u{200b}ALICE\u{200b}", "\u{200b}alice\u{200b}"),
+    ] {
+        assert_eq!(normalize_name(input), expected, "input {input:?}");
+    }
+    assert_ne!(
+        normalize_name("Straße"),
+        normalize_name("STRASSE"),
+        "case folding would merge distinct names"
+    );
+}
+
+#[test]
+fn display_names_are_trimmed_but_not_compatibility_normalized() {
+    let name = validate_name("\u{feff} Ａlice \u{2028}").unwrap();
+    assert_eq!(name.display_name(), "Ａlice");
+    assert_eq!(name.canonical_name(), "alice");
+    assert!(
+        validate_name("\u{85}").is_ok(),
+        "NEL is neither ECMAScript whitespace nor a rejected C0 control"
+    );
+}
+
+#[test]
+fn all_ecmascript_spaces_trim_at_edges_but_not_inside_names() {
+    let spaces = [
+        '\u{9}', '\u{a}', '\u{b}', '\u{c}', '\u{d}', ' ', '\u{a0}', '\u{1680}', '\u{2000}',
+        '\u{2001}', '\u{2002}', '\u{2003}', '\u{2004}', '\u{2005}', '\u{2006}', '\u{2007}',
+        '\u{2008}', '\u{2009}', '\u{200a}', '\u{2028}', '\u{2029}', '\u{202f}', '\u{205f}',
+        '\u{3000}', '\u{feff}',
+    ];
+    for space in spaces {
+        assert_eq!(normalize_name(&format!("{space}ALICE{space}")), "alice");
+        assert_eq!(
+            validate_name(&space.to_string()),
+            Err(NameError::EmptyOrControl)
+        );
+        assert!(!is_pane_target(&format!("a{space}b:1.2")));
+    }
+}
+
+#[test]
+fn controls_are_checked_after_trim_not_silently_removed_from_the_middle() {
+    for code in (0..0x20).chain([0x7f]) {
+        let character = char::from_u32(code).unwrap();
+        assert_eq!(
+            validate_name(&format!("a{character}b")),
+            Err(NameError::EmptyOrControl)
+        );
+    }
+    assert_eq!(validate_name("\n Alice\t").unwrap().display_name(), "Alice");
+    assert_eq!(validate_name(""), Err(NameError::EmptyOrControl));
+    assert_eq!(validate_name("\0Alice"), Err(NameError::EmptyOrControl));
+}
+
+#[test]
+fn pane_classification_and_name_rejection_share_exact_target_forms() {
+    for target in [
+        "%14",
+        "10.3",
+        "session:2.1",
+        "％１４",
+        "１０.３",
+        "session：２.１",
+        " %0014 ",
+        "a\u{85}b:2.1",
+    ] {
+        assert!(is_pane_target(target), "{target:?}");
+        assert_eq!(validate_name(target), Err(NameError::PaneTarget));
+    }
+    for name in [
+        "backend",
+        "%",
+        "%1a",
+        "%١",
+        "١.٢",
+        "-1.2",
+        "1.-2",
+        "1.2.3",
+        ":1.2",
+        "a:b:1.2",
+        "a b:1.2",
+        "a\u{feff}b:1.2",
+        "1.",
+        ".2",
+        "repo/branch",
+    ] {
+        assert!(!is_pane_target(name), "{name:?}");
+        assert!(validate_name(name).is_ok(), "{name:?}");
+    }
+}


### PR DESCRIPTION
## Summary

- Add one core identity-name validator and pane-target classifier with fixed Unicode 17 normalization/casing data, preserving the pinned JavaScript reference rather than using compiler-dependent casing.
- Implement shared transactional creation, same-UUID saved promotion and non-retired BINARY-ordered selection over the existing private SQLite connection. Never downgrade saved identities or mutate dependent records.
- Add representative name, persistence, concurrency, rollback and commit-contention tests; maintain architecture and native-preview documentation.

Closes #111. Parent workflow: #109 under #100/#93.

This is an internal foundation, not public native identity activation. Installed TypeScript, binding/removal/presence, request/reply, skills and distribution remain unchanged. Native preview databases remain isolated schema-9 fixtures, not user state.

## Architecture impact

Core owns name and lifetime policy plus narrow reader/transaction-scoped writer ports. The existing Storage adapter owns SQL, UUID/time generation and immediate commit/rollback on its one private connection. No second selector, registry, connection, ORM, schema migration or IO dependency in core.

Updated ARCHITECTURE.md, DEVELOPMENT.md and RUST-REWRITE.md. Installed skill/README behavior is unchanged; #109 owns their update when native commands are integrated. The known raw tmux marker whitespace mismatch is explicitly recorded in #109, not silently accepted as verified binding behavior.

ICU4X direct components are pinned at 2.3.0 with minimal compiled-data features. Primary reviewed the 25 added locked packages, published licenses/MSRVs and RustSec revision faedffd5118c1835e13cca3babb6059afb1eb8d0. Selected zerovec/derive versions include the recorded advisory fixes. #82 records distribution notice requirements. Both supported Rust toolchains are tested; fixed data intentionally trades binary footprint for stable persisted keys.

## Verification

- [x] Rust 1.97 and MSRV 1.88: 102 tests each (62 adapter, 26 core, 14 CLI), locked binaries/examples builds.
- [x] cargo fmt --all --check; cargo clippy --locked --all-targets -- -D warnings.
- [x] pnpm check; TypeScript unit suite: 1,102 tests / 70 files, coverage gates passed.
- [x] Native process suite: 44 tests; unchanged selected shared parser/config contracts: 8 and 6 tests.
- [x] Pinned Node 22.23.2 Docker reference: Unicode 17.0 / ICU 78.2, matching name goldens. A separate Rust 1.88 probe confirms std casing misses the Unicode-17 regression vector.
- [x] Two local Docker regressions through the existing private-tmux/mock-agent, network-isolated wrapper: 115 passed plus one optional benchmark skip each (287.32s / 288.15s), wrapper exit 0. Adapter tests: 61 then 62 after adding the commit-contention test; no production changes between runs. No host tmux or credentials.
- [x] All 11 required CI checks passed on 6872537e4a5f60e0138d36db909fb879f7ce2137; run 34132398583, attempt 1. PR merge state CLEAN; no bypass or rerun.

The Docker suites protect existing TypeScript CLI/native tmux adapter behavior; they do not prove the unported native identity commands. The optional benchmark is not an acceptance test.

## Primary review

Primary personally reviewed every changed source/test/document/manifest/lock diff, surrounding Storage lifecycle, historical schema, TypeScript name/create/binding commit contracts and existing test harness. Reviewed boundaries include Unicode keys, transaction ownership, idempotence/promotion, tombstone selection, dependent-data preservation, error/close behavior and test cleanup.

Findings resolved before submission: partial dependent-field assertions strengthened to all-column snapshots; refusal-only rollback coverage extended to successful writes followed by failure; explicit commit-contention rollback/lock-release test added; stale test timestamp comparison corrected. Independent Luna review supplements this primary review and found no remaining blocking semantic issue. The dependency audit's initial no-advisory claim was corrected by primary against actual patched advisory ranges.

Reviewed commit: 6872537e4a5f60e0138d36db909fb879f7ce2137. No implementation edits after this review.

## Project lifecycle

Dedicated branch/worktree: feat/111-native-identity-records. #109 was refined before implementation; #111 records scope, dependency decisions and start state. No release, publishing, installation or user-state migration. Worktree cleanup follows authorized merge and verified safe handoff.
