### PR TITLE
feat(native): expose storage-only identity commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -892,7 +892,7 @@ failure semantics; merely introducing an interface is not an architectural fix.
 
 `rust/` contains a development-only native CLI under #96; installed entry points
 remain TypeScript. `tmt-core` owns numeric and settings policy, while `tmt-cli`
-owns one Clap grammar, typed requests, presentation, configuration composition
+owns one Clap grammar, typed requests, presentation, configuration and storage-only identity composition
 and explicit no-effects rejection for unimplemented commands. `tmt-adapters`
 owns the SQLite lifecycle under #97 and native schema 9 under #108, configuration files under #103,
 and bounded Unix tmux evidence under #105;
@@ -913,7 +913,8 @@ non-retired identities, including saved offline entries, and show lifetime
 separately from active/offline/unknown presence. Unverified evidence cannot retire
 a temporary identity or release a saved name. Visibility does not extend routing.
 The storage-only identity record foundation under #111 supplies shared creation,
-promotion and non-retired selection; command wiring, binding retirement and these
+promotion and non-retired selection; #113 wires storage-only create/show/list.
+Binding command wiring, retirement and these
 presence-listing changes are not yet implemented. The durable-global invariants elsewhere in
 this map still describe the shipped TypeScript runtime, not the amended future
 native lifecycle. See [RUST-REWRITE.md](RUST-REWRITE.md) for transition boundaries.
@@ -954,8 +955,27 @@ creation owner before its separate publication transaction, not fork the policy.
 Non-retired selection uses schema 9's index and deterministic BINARY ordering.
 Tombstones are excluded and replacement names receive fresh UUIDs; no profile,
 binding, request, cadence or attention row is changed by creation/promotion.
-Retirement authorization, live presence and public command activation remain
-in #109, not in this storage-only foundation.
+Retirement authorization and live presence remain in #109, not in this
+storage-only foundation.
+
+Native `identity_command` composes the existing typed request, ConfigPaths and
+one invocation-owned Storage handle. It never loads configuration contents or
+constructs tmux. Create requests Saved through the same core creation owner;
+show and ordered list use the existing non-retired selector. Its explicit public
+projection adds lifetime to UUID/name/canonical name, without timestamps or
+endpoint evidence. Human output names lifetime rather than claiming presence.
+Semantic name validation follows storage acquisition, matching standalone TS
+ordering; invalid names can initialize the database but cannot create rows.
+
+Native `output` owns shared status-aware failure presentation for parsing,
+configuration and identity commands. The identity command retains its report
+until explicit close has run, even on operation failure. Failed cleanup replaces
+only success with CLEANUP_ERROR and an effects warning; the pending identity and
+raw storage causes are not serialized. Existing primary codes, status and causes
+survive cleanup failure. Missing identities return NAME_NOT_FOUND/3; unexpected
+storage/path failures use bounded IDENTITY_ERROR/1. RAII remains the fallback,
+not the ordinary close path. No general service container, second error writer
+or new resource framework is introduced by this slice.
 
 Native migration 9 adds `lifetime` (default `saved` for existing identities) and
 nullable `retired_at_ms` to that same identity table. A partial unique index

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,15 +32,16 @@ pnpm dev -- --help
 ### Native development preview
 
 The `rust/` workspace is not the installed runtime yet. It implements only
-help/version/completion, typed grammar and the existing `config` command.
+help/version/completion, typed grammar, the existing `config` command and
+storage-only `identity create/show/list` under #113.
 Other effectful commands still explicitly fail.
 The separate storage adapter upgrades historical schemas 0–8 to native schema 9,
 tested through a development-only probe rather than an installed command.
 Use isolated test databases only: installed TypeScript cannot reopen schema 9.
-Native identity commands and retirement are still unimplemented.
+Native pane binding, presence listing and retirement are still unimplemented.
 The #111 internal record service supports temporary/saved creation, same-UUID
 promotion and non-retired selection, tested against real isolated SQLite. It
-does not activate the public identity commands or establish live presence.
+supplies the public storage-only commands but does not establish live presence.
 The Unix tmux evidence adapter is likewise exercised through a non-installed
 `tmux-probe` example; native identity commands are not implemented by that probe.
 Use the exact toolchain from `rust/rust-toolchain.toml` and run from `rust/`:
@@ -112,6 +113,17 @@ do not substitute compiler-owned casing tables or case folding. Identity-record
 tests invoke the actual service and repository on private SQLite fixtures,
 observe dependent rows independently, and synchronize competing connections
 before creation. Their evidence is storage policy, not public CLI/tmux parity.
+
+`test/native/identity.test.ts` separately exercises the public native
+create/show/list commands across bounded processes and working directories.
+Use independent SQL only to seed temporary/retired states that the public native
+binding commands cannot produce yet, and to inspect preserved records. Do not
+initialize schema 9 through the TypeScript Storage owner. Test exact public
+lifetime projections, missing-name status 3, invalid-name status 1, malformed
+unrelated configuration isolation, and calibrated no-tmux guards. CLI cleanup
+precedence is tested in `output.rs`; real SQLite close/rollback/contention tests
+remain adapter evidence. Native reads omit retired records and never reconcile
+bindings; these tests are not proof of tmux presence or retirement authorization.
 
 The Docker image builds Linux adapter test artifacts in a pinned Rust/Debian
 stage matching the runtime image's libc. It runs native adapter unit tests under

--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ Claude Code can invoke it as `/tmux-team`; no marketplace or separate `/team`
 command is needed. See the [installation guide](skills/README.md) if you have
 an older command or plugin installed.
 
+## Native rewrite development
+
+The Rust executable is an isolated development preview, not the installer above.
+It currently supports configuration and storage-only `identity create/show/list`;
+pane binding and messaging still require the TypeScript runtime. Do not point
+the native preview at existing user data: its schema upgrade is forward-only.
+See [development and verification](DEVELOPMENT.md#native-development-preview).
+
 ## License
 
 MIT

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -1,7 +1,8 @@
 # Rust rewrite preparation
 
 Status: native grammar (#96), storage lifecycle (#97) with native identity schema 9 (#108), configuration (#103)
-and bounded tmux evidence (#105)
+and bounded tmux evidence (#105), shared identity records (#111), and
+storage-only identity commands (#113)
 are implemented in the development preview, not a shipped Rust runtime.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
@@ -60,7 +61,8 @@ tmux evidence under #105). The npm entry points still execute TypeScript. No com
 delegates from native to Node.
 
 The preview implements help, version, Bash/Zsh completion and the existing
-`config` command. Other recognized effectful commands return
+`config` command plus storage-only `identity create/show/list` (#113).
+Other recognized effectful commands return
 `NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
 storage, tmux or input acquisition. Text-only commands reject JSON. Native
 `name`/`this`/`add` parse temporary defaults and save flags; `rm`/`remove` parse
@@ -165,8 +167,16 @@ storage adapter provides an immediate transaction and concrete UUID/UTC timestam
 generation. Idempotent reuse preserves the original display name and timestamps,
 save never changes UUID, and temporary requests never downgrade saved rows.
 Non-retired selection excludes tombstones without erasing historical ownership.
-This does not activate native identity commands, binding, removal or presence;
-#109 retains their public input/output and Docker gates.
+This foundation alone does not activate commands. #113 composes public native
+`identity create/show/list` over it with one invocation-owned connection and
+explicit close before output. Create is saved, canonical reuse/promotion keeps
+the UUID, and show/list include lifetime without probing tmux or reading unrelated
+settings. JSON excludes internal timestamps, retirement and binding evidence.
+Missing show names return NAME_NOT_FOUND/3; semantic invalid names return
+INVALID_NAME/1. Storage acquisition precedes semantic validation, while grammar
+errors still precede effects. Cleanup failure replaces only success with an
+effects warning; primary errors survive. #109 retains binding, removal, presence
+and their real-tmux gates. Installed npm still uses TypeScript/schema 8.
 
 Name normalization uses pinned `icu_normalizer`, `icu_casemap` and
 `icu_locale_core` 2.3.0, with defaults disabled and compiled data only for the

--- a/rust/crates/tmt-cli/src/config_command.rs
+++ b/rust/crates/tmt-cli/src/config_command.rs
@@ -2,31 +2,21 @@
 //! document mutation remain in the shared core and filesystem adapter.
 
 use crate::invocation::{ConfigRequest, OutputMode};
+use crate::output::Failure;
 use serde_json::json;
 use std::io::{self, Write};
 use tmt_adapters::config::{ConfigError, ConfigFiles, ConfigPaths, Scope};
 use tmt_core::settings::{LocalClear, ResolvedSettings, Setting, SettingKey};
 
-struct Failure {
-    code: &'static str,
-    message: String,
-}
-
 impl From<ConfigError> for Failure {
     fn from(error: ConfigError) -> Self {
-        Self {
-            code: error.code,
-            message: error.message,
-        }
+        Self::new(error.code, error.message.clone(), 1).caused_by(error)
     }
 }
 
 impl From<String> for Failure {
     fn from(message: String) -> Self {
-        Self {
-            code: "ERROR",
-            message,
-        }
+        Self::new("ERROR", message, 1)
     }
 }
 
@@ -72,7 +62,7 @@ fn run(request: ConfigRequest) -> Result<Report, Failure> {
 pub fn execute(request: ConfigRequest, mode: OutputMode) -> io::Result<u8> {
     let report = match run(request) {
         Ok(report) => report,
-        Err(error) => return crate::failure(mode, error.code, &error.message),
+        Err(error) => return error.publish(mode),
     };
     let mut output = io::stdout().lock();
     match report {

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -143,11 +143,13 @@ pub fn grammar() -> Command {
             )),
         )
         .subcommand(
-            storage("identity", "Manage saved identities")
+            storage("identity", "Manage identity records without probing tmux")
                 .subcommand_required(true)
-                .subcommand(storage("create", "Create a saved identity").arg(operand("name", true)))
+                .subcommand(
+                    storage("create", "Create or save an identity").arg(operand("name", true)),
+                )
                 .subcommand(storage("show", "Show an identity").arg(operand("name", true)))
-                .subcommand(storage("list", "List saved identities")),
+                .subcommand(storage("list", "List non-retired identities")),
         )
         .subcommand(
             with_options(general("role", "Manage role profiles"), &["identity"])

--- a/rust/crates/tmt-cli/src/identity_command.rs
+++ b/rust/crates/tmt-cli/src/identity_command.rs
@@ -1,0 +1,140 @@
+//! Storage-only command composition. Identity policy and SQL remain in their
+//! existing core/service and adapter owners; this layer projects public output.
+
+use crate::{
+    invocation::{IdentityRequest, OutputMode},
+    output::{Failure, after_cleanup},
+};
+use serde_json::{Value, json};
+use std::{
+    error::Error,
+    io::{self, Write},
+};
+use tmt_adapters::{
+    config::ConfigPaths,
+    storage::{Storage, StorageError},
+};
+use tmt_core::identity::{self, Identity, IdentityError, IdentityReader, Lifetime};
+
+enum Report {
+    Created(identity::CreatedIdentity),
+    Shown(Identity),
+    Listed(Vec<Identity>),
+}
+
+fn unavailable(error: impl Error + 'static) -> Failure {
+    Failure::new(
+        "IDENTITY_ERROR",
+        "Could not complete the identity operation.",
+        1,
+    )
+    .caused_by(error)
+}
+
+fn identity_failure(error: IdentityError<StorageError>) -> Failure {
+    match error {
+        IdentityError::InvalidName(error) => {
+            Failure::new("INVALID_NAME", error.to_string(), 1).caused_by(error)
+        }
+        IdentityError::Repository(error) => unavailable(error),
+    }
+}
+
+fn run(request: IdentityRequest) -> Result<Report, Failure> {
+    // Path discovery does not load settings. Open only for this implemented
+    // capability; unported commands never reach storage or tmux construction.
+    let paths = ConfigPaths::discover().map_err(unavailable)?;
+    let mut storage = Storage::open(paths.database).map_err(unavailable)?;
+    let pending = operation(&mut storage, request);
+    after_cleanup(pending, || storage.close())
+}
+
+fn operation(storage: &mut Storage, request: IdentityRequest) -> Result<Report, Failure> {
+    match request {
+        IdentityRequest::Create(name) => {
+            identity::create_or_resolve(storage, &name, Lifetime::Saved)
+                .map(Report::Created)
+                .map_err(identity_failure)
+        }
+        IdentityRequest::Show(name) => identity::find_by_name(storage, &name)
+            .map_err(identity_failure)?
+            .map(Report::Shown)
+            .ok_or_else(|| {
+                Failure::new(
+                    "NAME_NOT_FOUND",
+                    format!("Identity '{name}' was not found."),
+                    3,
+                )
+            }),
+        IdentityRequest::List => storage
+            .list_identities()
+            .map(Report::Listed)
+            .map_err(unavailable),
+    }
+}
+
+pub fn execute(request: IdentityRequest, mode: OutputMode) -> io::Result<u8> {
+    let report = match run(request) {
+        Ok(report) => report,
+        Err(error) => return error.publish(mode),
+    };
+    let mut stdout = io::stdout().lock();
+    if mode.json {
+        let document = match report {
+            Report::Created(result) => {
+                json!({"identity": public_identity(&result.identity), "created": result.created})
+            }
+            Report::Shown(identity) => json!({"identity": public_identity(&identity)}),
+            Report::Listed(identities) => {
+                json!({"identities": identities.iter().map(public_identity).collect::<Vec<_>>()})
+            }
+        };
+        writeln!(stdout, "{document}")?;
+    } else {
+        match report {
+            Report::Created(result) => {
+                let action = if result.created {
+                    "Created"
+                } else {
+                    "Already exists:"
+                };
+                writeln!(
+                    stdout,
+                    "{action} saved identity '{}' ({}).",
+                    result.identity.name, result.identity.id
+                )?;
+            }
+            Report::Shown(identity) => {
+                writeln!(stdout, "NAME\tLIFETIME\tCANONICAL NAME\tID")?;
+                writeln!(
+                    stdout,
+                    "{}\t{}\t{}\t{}",
+                    identity.name,
+                    identity.lifetime.as_str(),
+                    identity.canonical_name,
+                    identity.id
+                )?;
+            }
+            Report::Listed(identities) if identities.is_empty() => {
+                writeln!(stdout, "No identities found.")?
+            }
+            Report::Listed(identities) => {
+                writeln!(stdout, "NAME\tLIFETIME\tID")?;
+                for identity in identities {
+                    writeln!(
+                        stdout,
+                        "{}\t{}\t{}",
+                        identity.name,
+                        identity.lifetime.as_str(),
+                        identity.id
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(0)
+}
+
+fn public_identity(identity: &Identity) -> Value {
+    json!({"id": identity.id, "name": identity.name, "canonicalName": identity.canonical_name, "lifetime": identity.lifetime.as_str()})
+}

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -1,7 +1,9 @@
 mod config_command;
 mod diagnostics;
 mod grammar;
+mod identity_command;
 mod invocation;
+mod output;
 mod parser;
 
 use std::io::{self, Write};
@@ -31,7 +33,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration is available; identity and transport commands are not implemented yet.\n"
+                "Native development preview: configuration and storage-only identity create/show/list are available; pane binding and transport commands are not implemented yet. Use isolated test state only.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -61,6 +63,10 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
             drop(stdout);
             return config_command::execute(request, parsed.mode);
         }
+        Invocation::Identity(request) => {
+            drop(stdout);
+            return identity_command::execute(request, parsed.mode);
+        }
         _ => {
             drop(stdout);
             return failure(
@@ -73,12 +79,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
     Ok(0)
 }
 
-fn failure(mode: OutputMode, code: &str, message: &str) -> io::Result<u8> {
-    if mode.json {
-        let document = serde_json::json!({"error": {"code": code, "message": message}});
-        writeln!(io::stdout().lock(), "{document}")?;
-    } else {
-        writeln!(io::stderr().lock(), "{message}")?;
-    }
-    Ok(1)
+fn failure(mode: OutputMode, code: &'static str, message: &str) -> io::Result<u8> {
+    // Parse and existing configuration failures retain their exit-1 contract.
+    output::Failure::new(code, message, 1).publish(mode)
 }

--- a/rust/crates/tmt-cli/src/output.rs
+++ b/rust/crates/tmt-cli/src/output.rs
@@ -1,0 +1,137 @@
+//! Shared failure presentation and close-before-publication ordering.
+
+use crate::invocation::OutputMode;
+use std::{
+    error::Error,
+    fmt,
+    io::{self, Write},
+};
+
+#[derive(Debug)]
+pub struct Failure {
+    pub code: &'static str,
+    pub message: String,
+    pub status: u8,
+    cause: Option<Box<dyn Error>>,
+}
+
+impl Failure {
+    pub fn new(code: &'static str, message: impl Into<String>, status: u8) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            status,
+            cause: None,
+        }
+    }
+
+    pub fn caused_by(mut self, cause: impl Error + 'static) -> Self {
+        self.cause = Some(Box::new(cause));
+        self
+    }
+
+    pub fn publish(&self, mode: OutputMode) -> io::Result<u8> {
+        if mode.json {
+            let document =
+                serde_json::json!({"error": {"code": self.code, "message": self.message}});
+            writeln!(io::stdout().lock(), "{document}")?;
+        } else {
+            writeln!(io::stderr().lock(), "{}", self.message)?;
+        }
+        Ok(self.status)
+    }
+}
+
+impl fmt::Display for Failure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for Failure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause.as_deref()
+    }
+}
+
+/// Cleanup runs even when the operation failed. A committed operation is not
+/// rolled back by failed cleanup; discard its pending success projection and
+/// preserve an existing primary failure, including its status and cause.
+pub fn after_cleanup<T, E: Error + 'static>(
+    pending: Result<T, Failure>,
+    cleanup: impl FnOnce() -> Result<(), E>,
+) -> Result<T, Failure> {
+    let cleanup = cleanup();
+    match pending {
+        Err(primary) => Err(primary),
+        Ok(report) => cleanup.map(|()| report).map_err(|error| {
+            Failure::new(
+                "CLEANUP_ERROR",
+                "Could not clean up command resources. Effects may already have occurred.",
+                1,
+            )
+            .caused_by(error)
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn cleanup_runs_once_before_a_success_can_be_published() {
+        let calls = Cell::new(0);
+        let report = after_cleanup(Ok("pending identity"), || {
+            calls.set(calls.get() + 1);
+            Ok::<_, io::Error>(())
+        })
+        .unwrap();
+        assert_eq!(calls.get(), 1);
+        assert_eq!(report, "pending identity");
+    }
+
+    #[test]
+    fn cleanup_failure_discards_the_success_without_exposing_its_data_or_cause() {
+        let failure = after_cleanup(Ok("private identity data"), || {
+            Err(io::Error::other("private storage cause"))
+        })
+        .unwrap_err();
+        assert_eq!(failure.code, "CLEANUP_ERROR");
+        assert_eq!(failure.status, 1);
+        assert!(
+            failure
+                .message
+                .contains("Effects may already have occurred")
+        );
+        assert!(!failure.message.contains("private"));
+        assert_eq!(
+            failure.source().unwrap().to_string(),
+            "private storage cause"
+        );
+    }
+
+    #[test]
+    fn primary_failure_survives_successful_and_failed_cleanup() {
+        for fail_cleanup in [false, true] {
+            let calls = Cell::new(0);
+            let primary = Failure::new("NAME_NOT_FOUND", "Missing identity", 3)
+                .caused_by(io::Error::other("primary cause"));
+            let failure = after_cleanup::<(), _>(Err(primary), || {
+                calls.set(calls.get() + 1);
+                if fail_cleanup {
+                    Err(io::Error::other("cleanup cause"))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+            assert_eq!(calls.get(), 1);
+            assert_eq!(failure.code, "NAME_NOT_FOUND");
+            assert_eq!(failure.message, "Missing identity");
+            assert_eq!(failure.status, 3);
+            assert_eq!(failure.source().unwrap().to_string(), "primary cause");
+        }
+    }
+}

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -61,6 +61,8 @@ describe('native grammar preview process contract', () => {
       expect(help.status).toBe(0);
       expect(help.stderr).toBe('');
       expect(help.stdout).toContain('Native development preview');
+      expect(help.stdout).toContain('storage-only identity create/show/list are available');
+      expect(help.stdout).toContain('Manage identity records without probing tmux');
       expect(help.stdout).toContain('temporary unless saved');
       expect(help.stdout).toContain('rm');
       expect(help.stdout).not.toContain('--wait');
@@ -82,7 +84,6 @@ describe('native grammar preview process contract', () => {
         ['list'],
         ['talk', 'worker', 'hello'],
         ['check', '%14'],
-        ['identity', 'create', 'saved'],
         ['init'],
         ['role', 'show'],
         ['preamble'],

--- a/test/native/identity.test.ts
+++ b/test/native/identity.test.ts
@@ -1,0 +1,557 @@
+import Database from 'better-sqlite3';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  expectJsonSuccess,
+  parseWholeStdout,
+  runCli,
+  type Sandbox,
+  withSandbox,
+} from '../../src/test-support/cli-process.js';
+
+if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
+
+type Identity = {
+  readonly id: string;
+  readonly name: string;
+  readonly canonicalName: string;
+  readonly lifetime: 'temporary' | 'saved';
+};
+
+const TEMPORARY_ID = '11111111-1111-4111-8111-111111111111';
+const TEMPORARY_BINDING_ID = '11111111-1111-4111-8111-111111111112';
+const TEMPORARY_SERVER_ID = '11111111-1111-4111-8111-111111111113';
+const RETIRED_ID = '22222222-2222-4222-8222-222222222222';
+const RETIRED_BINDING_ID = '22222222-2222-4222-8222-222222222223';
+const RETIRED_SERVER_ID = '22222222-2222-4222-8222-222222222224';
+
+function assertIdentity(value: unknown): asserts value is Identity {
+  expect(value).toEqual({
+    id: expect.any(String),
+    name: expect.any(String),
+    canonicalName: expect.any(String),
+    lifetime: expect.stringMatching(/^(temporary|saved)$/),
+  });
+  expect(Object.keys(value as object).sort()).toEqual(['canonicalName', 'id', 'lifetime', 'name']);
+  expect((value as Identity).id).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  );
+}
+
+function documentIdentity(result: Awaited<ReturnType<typeof runCli>>): Identity {
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe('');
+  const document = parseWholeStdout(result) as { identity?: unknown };
+  assertIdentity(document.identity);
+  return document.identity;
+}
+
+async function initializeSchema(sandbox: Sandbox): Promise<void> {
+  expectJsonSuccess(await runCli(sandbox, ['identity', 'list', '--json']), { identities: [] });
+  expect(existsSync(sandbox.database)).toBe(true);
+}
+
+function withDatabase<T>(file: string, callback: (database: Database.Database) => T): T {
+  const database = new Database(file);
+  try {
+    database.pragma('foreign_keys = ON');
+    return callback(database);
+  } finally {
+    database.close();
+  }
+}
+
+function seedIdentity(
+  database: Database.Database,
+  identity: {
+    readonly id: string;
+    readonly name: string;
+    readonly canonicalName: string;
+    readonly lifetime: 'temporary' | 'saved';
+    readonly retiredAtMs?: number;
+  }
+): void {
+  database
+    .prepare(
+      `INSERT INTO identities
+         (id, name, canonical_name, created_at, updated_at, lifetime, retired_at_ms)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      identity.id,
+      identity.name,
+      identity.canonicalName,
+      '2026-01-01T00:00:00.000Z',
+      '2026-01-02T00:00:00.000Z',
+      identity.lifetime,
+      identity.retiredAtMs ?? null
+    );
+}
+
+function seedDependents(database: Database.Database, identityId: string, suffix: string): void {
+  database
+    .prepare('INSERT INTO role_profiles (identity_id, content, updated_at) VALUES (?, ?, ?)')
+    .run(identityId, `role-${suffix}`, '2026-01-03T00:00:00.000Z');
+  database
+    .prepare('INSERT INTO identity_preambles (identity_id, content, updated_at) VALUES (?, ?, ?)')
+    .run(identityId, `preamble-${suffix}`, '2026-01-04T00:00:00.000Z');
+  database
+    .prepare(
+      `INSERT INTO bindings (
+         id, identity_id, transport, pane_id, server_id, socket_path, server_pid,
+         server_start_time, pane_pid, bound_at, last_verified_at
+       ) VALUES (?, ?, 'tmux', ?, ?, ?, 101, ?, 202, ?, ?)`
+    )
+    .run(
+      suffix === 'temporary' ? TEMPORARY_BINDING_ID : RETIRED_BINDING_ID,
+      identityId,
+      `%${suffix === 'temporary' ? '12' : '13'}`,
+      suffix === 'temporary' ? TEMPORARY_SERVER_ID : RETIRED_SERVER_ID,
+      `/tmp/${suffix}.sock`,
+      `start-${suffix}`,
+      '2026-01-05T00:00:00.000Z',
+      '2026-01-06T00:00:00.000Z'
+    );
+}
+
+function dependentSnapshot(
+  database: Database.Database,
+  identityId: string
+): {
+  readonly role: unknown;
+  readonly preamble: unknown;
+  readonly binding: unknown;
+} {
+  return {
+    role: database
+      .prepare('SELECT identity_id, content, updated_at FROM role_profiles WHERE identity_id = ?')
+      .get(identityId),
+    preamble: database
+      .prepare(
+        'SELECT identity_id, content, updated_at FROM identity_preambles WHERE identity_id = ?'
+      )
+      .get(identityId),
+    binding: database
+      .prepare(
+        `SELECT id, identity_id, transport, pane_id, server_id, socket_path, server_pid,
+                server_start_time, pane_pid, bound_at, last_verified_at
+           FROM bindings WHERE identity_id = ?`
+      )
+      .get(identityId),
+  };
+}
+
+function installTmuxTripwire(sandbox: Sandbox): string {
+  const directory = path.join(sandbox.root, 'task-owned-tripwire');
+  const logPath = path.join(sandbox.root, 'tmux-invocations.log');
+  mkdirSync(directory);
+  const executable = path.join(directory, 'tmux');
+  writeFileSync(
+    executable,
+    '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TMT_IDENTITY_TMUX_LOG"\nexit 97\n'
+  );
+  chmodSync(executable, 0o755);
+  sandbox.env.PATH = `${directory}${path.delimiter}${process.env.PATH ?? ''}`;
+  sandbox.env.TMT_IDENTITY_TMUX_LOG = logPath;
+  return logPath;
+}
+
+async function calibrateTmuxTripwire(sandbox: Sandbox): Promise<string> {
+  const logPath = installTmuxTripwire(sandbox);
+  const tripwire = await runCli(
+    {
+      ...sandbox,
+      cli: { executable: '/usr/bin/env', args: ['tmux'] },
+    },
+    [],
+    { deadlineMs: 2_000 }
+  );
+  expect(tripwire.status).toBe(97);
+  expect(tripwire.stderr).toBe('');
+  expect(readFileSync(logPath, 'utf8')).toBe('\n');
+  return logPath;
+}
+
+describe('native durable identity process boundary', () => {
+  it('keeps create/show/list exact across restarts and directories', async () => {
+    await withSandbox(async (sandbox) => {
+      const globalConfig = '{ unrelated malformed global config';
+      const localConfig = '{ unrelated malformed local config';
+      mkdirSync(sandbox.globalDir, { recursive: true });
+      writeFileSync(sandbox.globalConfig, globalConfig);
+      writeFileSync(sandbox.localConfig, localConfig);
+
+      const createdResult = await runCli(sandbox, ['identity', 'create', '  Alice  ', '--json']);
+      expect(createdResult.status).toBe(0);
+      expect(createdResult.stderr).toBe('');
+      const created = documentIdentity(createdResult);
+      expect(created).toMatchObject({
+        name: 'Alice',
+        canonicalName: 'alice',
+        lifetime: 'saved',
+      });
+      expect(parseWholeStdout(createdResult)).toEqual({ identity: created, created: true });
+
+      const nested = path.join(sandbox.cwd, 'nested', 'directory');
+      mkdirSync(nested, { recursive: true });
+      const otherDirectory = { ...sandbox, cwd: nested };
+      const repeated = await runCli(otherDirectory, ['identity', 'create', 'ALICE', '--json']);
+      expectJsonSuccess(repeated, { identity: created, created: false });
+      expectJsonSuccess(await runCli(otherDirectory, ['identity', 'show', 'alice', '--json']), {
+        identity: created,
+      });
+      expectJsonSuccess(await runCli(sandbox, ['identity', 'list', '--json']), {
+        identities: [created],
+      });
+      expect(readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalConfig);
+      expect(readFileSync(sandbox.localConfig, 'utf8')).toBe(localConfig);
+    });
+  });
+
+  it('reuses Unicode canonical names and exposes only the public identity fields', async () => {
+    await withSandbox(async (sandbox) => {
+      const firstResult = await runCli(sandbox, ['identity', 'create', 'Ｇｅｍｉｎｉ', '--json']);
+      const first = documentIdentity(firstResult);
+      expect(first).toEqual({
+        id: first.id,
+        name: 'Ｇｅｍｉｎｉ',
+        canonicalName: 'gemini',
+        lifetime: 'saved',
+      });
+      expect(parseWholeStdout(firstResult)).toEqual({ identity: first, created: true });
+
+      const repeatedResult = await runCli(sandbox, ['identity', 'create', 'GEMINI', '--json']);
+      expectJsonSuccess(repeatedResult, { identity: first, created: false });
+      const shownResult = await runCli(sandbox, ['identity', 'show', 'ＧＥＭＩＮＩ', '--json']);
+      expectJsonSuccess(shownResult, { identity: first });
+      expect(
+        Object.keys((parseWholeStdout(shownResult) as { identity: object }).identity).sort()
+      ).toEqual(['canonicalName', 'id', 'lifetime', 'name']);
+    });
+  });
+
+  it('promotes a temporary row in place while retaining bindings, roles, and preambles', async () => {
+    await withSandbox(async (sandbox) => {
+      await initializeSchema(sandbox);
+      const temporary = {
+        id: TEMPORARY_ID,
+        name: 'Temporary Name',
+        canonicalName: 'temporary name',
+        lifetime: 'temporary' as const,
+      };
+      const before = withDatabase(sandbox.database, (database) => {
+        seedIdentity(database, temporary);
+        seedDependents(database, temporary.id, 'temporary');
+        return {
+          identity: database.prepare('SELECT * FROM identities WHERE id = ?').get(temporary.id),
+          dependents: dependentSnapshot(database, temporary.id),
+        };
+      });
+
+      const promoted = await runCli(sandbox, ['identity', 'create', 'TEMPORARY NAME', '--json']);
+      expectJsonSuccess(promoted, {
+        identity: { ...temporary, lifetime: 'saved' },
+        created: false,
+      });
+      const afterPromotion = withDatabase(sandbox.database, (database) => ({
+        identity: database.prepare('SELECT * FROM identities WHERE id = ?').get(temporary.id),
+        dependents: dependentSnapshot(database, temporary.id),
+      }));
+      expect(afterPromotion.identity).toEqual({
+        ...(before.identity as Record<string, unknown>),
+        lifetime: 'saved',
+        updated_at: expect.any(String),
+      });
+      expect((afterPromotion.identity as Record<string, unknown>).updated_at).not.toBe(
+        (before.identity as Record<string, unknown>).updated_at
+      );
+      expect(afterPromotion.dependents).toEqual(before.dependents);
+      const repeated = await runCli(sandbox, ['identity', 'create', 'temporary name', '--json']);
+      expectJsonSuccess(repeated, {
+        identity: { ...temporary, lifetime: 'saved' },
+        created: false,
+      });
+      expect(
+        withDatabase(sandbox.database, (database) =>
+          database.prepare('SELECT * FROM identities WHERE id = ?').get(temporary.id)
+        )
+      ).toEqual(afterPromotion.identity);
+    });
+  });
+
+  it('omits retired identities and gives a reused name a fresh UUID without dependent rows', async () => {
+    await withSandbox(async (sandbox) => {
+      await initializeSchema(sandbox);
+      const retired = {
+        id: RETIRED_ID,
+        name: 'Reusable',
+        canonicalName: 'reusable',
+        lifetime: 'saved' as const,
+        retiredAtMs: 1_700_000_000_000,
+      };
+      const before = withDatabase(sandbox.database, (database) => {
+        seedIdentity(database, retired);
+        seedDependents(database, retired.id, 'retired');
+        return {
+          identity: database.prepare('SELECT * FROM identities WHERE id = ?').get(retired.id),
+          dependents: dependentSnapshot(database, retired.id),
+        };
+      });
+
+      const listedBefore = await runCli(sandbox, ['identity', 'list', '--json']);
+      expectJsonSuccess(listedBefore, { identities: [] });
+      const missingBeforeReuse = await runCli(sandbox, ['identity', 'show', 'REUSABLE', '--json']);
+      expect(missingBeforeReuse.status).toBe(3);
+      expectError(missingBeforeReuse, 'NAME_NOT_FOUND');
+      const replacementResult = await runCli(sandbox, ['identity', 'create', 'REUSABLE', '--json']);
+      const replacement = documentIdentity(replacementResult);
+      expect(replacement).toMatchObject({
+        name: 'REUSABLE',
+        canonicalName: retired.canonicalName,
+        lifetime: 'saved',
+      });
+      expect(replacement.id).not.toBe(retired.id);
+      expect(parseWholeStdout(replacementResult)).toEqual({
+        identity: replacement,
+        created: true,
+      });
+      expect(
+        withDatabase(sandbox.database, (database) => ({
+          old: database.prepare('SELECT * FROM identities WHERE id = ?').get(retired.id),
+          oldDependents: dependentSnapshot(database, retired.id),
+          newDependents: dependentSnapshot(database, replacement.id),
+        }))
+      ).toEqual({
+        old: before.identity,
+        oldDependents: before.dependents,
+        newDependents: { role: undefined, preamble: undefined, binding: undefined },
+      });
+      expectJsonSuccess(await runCli(sandbox, ['identity', 'list', '--json']), {
+        identities: [replacement],
+      });
+    });
+  });
+
+  it('uses canonical SQLite BINARY order for saved and temporary rows', async () => {
+    await withSandbox(async (sandbox) => {
+      const names = ['Zulu', 'Apple', 'Ä', 'zebra'];
+      const identities = new Map<string, Identity>();
+      for (const name of names) {
+        const result = await runCli(sandbox, ['identity', 'create', name, '--json']);
+        const identity = documentIdentity(result);
+        identities.set(identity.canonicalName, identity);
+      }
+
+      const temporary = {
+        id: '33333333-3333-4333-8333-333333333333',
+        name: 'Temporary Row',
+        canonicalName: 'temporary row',
+        lifetime: 'temporary' as const,
+      };
+      withDatabase(sandbox.database, (database) => {
+        seedIdentity(database, temporary);
+      });
+      const listed = await runCli(sandbox, ['identity', 'list', '--json']);
+      expectJsonSuccess(listed, {
+        identities: [
+          identities.get('apple'),
+          temporary,
+          identities.get('zebra'),
+          identities.get('zulu'),
+          identities.get('ä'),
+        ],
+      });
+    });
+  });
+
+  it('does not invoke tmux, read malformed unrelated config, or leak extra fields', async () => {
+    await withSandbox(async (sandbox) => {
+      const globalConfig = '{ malformed global config';
+      const localConfig = '{ malformed local config';
+      mkdirSync(sandbox.globalDir, { recursive: true });
+      writeFileSync(sandbox.globalConfig, globalConfig);
+      writeFileSync(sandbox.localConfig, localConfig);
+      const logPath = await calibrateTmuxTripwire(sandbox);
+      const calibratedLog = readFileSync(logPath, 'utf8');
+
+      const created = await runCli(sandbox, ['identity', 'create', 'No Tmux', '--json']);
+      expect(created.status).toBe(0);
+      expect(readFileSync(logPath, 'utf8')).toBe(calibratedLog);
+      const identity = documentIdentity(created);
+      const before = withDatabase(sandbox.database, (database) => {
+        seedDependents(database, identity.id, 'temporary');
+        return dependentSnapshot(database, identity.id);
+      });
+      expectJsonSuccess(await runCli(sandbox, ['identity', 'show', 'no tmux', '--json']), {
+        identity,
+      });
+      expect(readFileSync(logPath, 'utf8')).toBe(calibratedLog);
+      expectJsonSuccess(await runCli(sandbox, ['identity', 'list', '--json']), {
+        identities: [identity],
+      });
+      expect(readFileSync(logPath, 'utf8')).toBe(calibratedLog);
+      expect(
+        withDatabase(sandbox.database, (database) => dependentSnapshot(database, identity.id))
+      ).toEqual(before);
+      expect(readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalConfig);
+      expect(readFileSync(sandbox.localConfig, 'utf8')).toBe(localConfig);
+      expect(Object.keys(parseWholeStdout(created)).sort()).toEqual(['created', 'identity']);
+      expect(
+        Object.keys((parseWholeStdout(created) as { identity: object }).identity).sort()
+      ).toEqual(['canonicalName', 'id', 'lifetime', 'name']);
+    });
+  });
+
+  it('honors a sandbox-contained explicit path override across directories', async () => {
+    await withSandbox(async (sandbox) => {
+      const override = path.join(sandbox.root, "custom root's files");
+      const selected: Sandbox = {
+        ...sandbox,
+        cli: {
+          executable: '/usr/bin/env',
+          args: [`TMUX_TEAM_HOME=${override}`, sandbox.cli.executable, ...sandbox.cli.args],
+        },
+      };
+      const nested = path.join(sandbox.cwd, 'override', 'child');
+      mkdirSync(nested, { recursive: true });
+      const child = { ...selected, cwd: nested };
+      const created = documentIdentity(
+        await runCli(selected, ['identity', 'create', 'Override', '--json'])
+      );
+      expect(existsSync(path.join(override, 'tmux-team.db'))).toBe(true);
+      expect(existsSync(sandbox.database)).toBe(false);
+      expectJsonSuccess(await runCli(child, ['identity', 'show', 'override', '--json']), {
+        identity: created,
+      });
+      expectJsonSuccess(await runCli(child, ['identity', 'list', '--json']), {
+        identities: [created],
+      });
+    });
+  });
+
+  it('keeps semantic validation and missing-name lookup bounded and distinct', async () => {
+    await withSandbox(async (sandbox) => {
+      for (const operation of ['create', 'show']) {
+        for (const name of ['', ' \uFEFF ', 'bad\u007f', '%12', '10.3']) {
+          const result = await runCli(sandbox, ['identity', operation, name, '--json']);
+          expect(result.status, `${operation} ${JSON.stringify(name)}`).toBe(1);
+          expectError(result, 'INVALID_NAME');
+        }
+      }
+      expectJsonSuccess(await runCli(sandbox, ['identity', 'list', '--json']), { identities: [] });
+
+      const missing = await runCli(sandbox, ['identity', 'show', 'Missing', '--json']);
+      expect(missing.status).toBe(3);
+      expect(missing.stderr).toBe('');
+      expect(parseWholeStdout(missing)).toEqual({
+        error: { code: 'NAME_NOT_FOUND', message: "Identity 'Missing' was not found." },
+      });
+    });
+  });
+
+  it('rejects grammar errors before opening storage', async () => {
+    await withSandbox(async (sandbox) => {
+      const syntax = await runCli(sandbox, ['identity', 'create', 'Alice', 'extra', '--json']);
+      expect(syntax.status).toBe(1);
+      expect(syntax.stderr).toBe('');
+      expectError(syntax, 'USAGE_ERROR');
+      expect(existsSync(sandbox.database)).toBe(false);
+    });
+  });
+
+  it('maps corrupt and blocked storage to a bounded generic error', async () => {
+    await withSandbox(async (sandbox) => {
+      mkdirSync(sandbox.globalDir, { recursive: true });
+      writeFileSync(sandbox.database, 'not a sqlite database');
+      const corrupt = await runCli(sandbox, ['identity', 'list', '--json']);
+      expect(corrupt.status).toBe(1);
+      expectError(corrupt, 'IDENTITY_ERROR', 'Could not complete the identity operation.');
+      expect(readFileSync(sandbox.database, 'utf8')).toBe('not a sqlite database');
+    });
+
+    await withSandbox(async (sandbox) => {
+      mkdirSync(sandbox.xdgConfigHome, { recursive: true });
+      writeFileSync(sandbox.globalDir, 'directory blocker');
+      const blocked = await runCli(sandbox, ['identity', 'list', '--json']);
+      expect(blocked.status).toBe(1);
+      expectError(blocked, 'IDENTITY_ERROR', 'Could not complete the identity operation.');
+      expect(readFileSync(sandbox.globalDir, 'utf8')).toBe('directory blocker');
+    });
+  });
+
+  it('keeps human output explicit for empty, create, show, and list cases', async () => {
+    await withSandbox(async (sandbox) => {
+      const emptyHuman = await runCli(sandbox, ['identity', 'list']);
+      expect(emptyHuman.status).toBe(0);
+      expect(emptyHuman.stdout).toBe('No identities found.\n');
+      expect(emptyHuman.stderr).toBe('');
+
+      const human = await runCli(sandbox, ['identity', 'create', 'Human']);
+      expect(human.status).toBe(0);
+      expect(human.stdout).toContain("Created saved identity 'Human'");
+      expect(human.stdout).toContain('saved');
+      expect(human.stderr).toBe('');
+      const repeatedHuman = await runCli(sandbox, ['identity', 'create', 'human']);
+      expect(repeatedHuman.status).toBe(0);
+      expect(repeatedHuman.stdout).toContain("Already exists: saved identity 'Human'");
+      expect(repeatedHuman.stderr).toBe('');
+      const humanShow = await runCli(sandbox, ['identity', 'show', 'human']);
+      expect(humanShow.status).toBe(0);
+      expect(humanShow.stdout).toContain('NAME\tLIFETIME\tCANONICAL NAME\tID');
+      expect(humanShow.stdout).toContain('Human\tsaved\thuman\t');
+      expect(humanShow.stderr).toBe('');
+      const missingHuman = await runCli(sandbox, ['identity', 'show', 'missing']);
+      expect(missingHuman.status).toBe(3);
+      expect(missingHuman.stdout).toBe('');
+      expect(missingHuman.stderr).toBe("Identity 'missing' was not found.\n");
+      const humanList = await runCli(sandbox, ['identity', 'list']);
+      expect(humanList.status).toBe(0);
+      expect(humanList.stdout).toContain('NAME\tLIFETIME\tID');
+      expect(humanList.stdout).toContain('Human\tsaved\t');
+      expect(humanList.stderr).toBe('');
+    });
+  });
+
+  it('rejects an unsupported future migration without mutating history or rows', async () => {
+    await withSandbox(async (sandbox) => {
+      await initializeSchema(sandbox);
+      const created = documentIdentity(
+        await runCli(sandbox, ['identity', 'create', 'History Fixture', '--json'])
+      );
+      const before = withDatabase(sandbox.database, (database) => ({
+        history: database
+          .prepare('SELECT version, name, applied_at FROM _migrations ORDER BY version')
+          .all(),
+        identities: database.prepare('SELECT * FROM identities ORDER BY id').all(),
+      }));
+      withDatabase(sandbox.database, (database) => {
+        database
+          .prepare('INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, ?)')
+          .run(10, 'unsupported future migration', '2026-01-07T00:00:00.000Z');
+      });
+      const result = await runCli(sandbox, ['identity', 'show', created.canonicalName, '--json']);
+      expect(result.status).toBe(1);
+      expectError(result, 'IDENTITY_ERROR', 'Could not complete the identity operation.');
+      expect(
+        withDatabase(sandbox.database, (database) => ({
+          history: database
+            .prepare('SELECT version, name, applied_at FROM _migrations ORDER BY version')
+            .all(),
+          identities: database.prepare('SELECT * FROM identities ORDER BY id').all(),
+        }))
+      ).toEqual({
+        history: [
+          ...before.history,
+          {
+            version: 10,
+            name: 'unsupported future migration',
+            applied_at: '2026-01-07T00:00:00.000Z',
+          },
+        ],
+        identities: before.identities,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Scope

- Closes #113; bounded public-command slice under #109, #100 and #93.
- Activate native `identity create/show/list` over the existing shared identity records. Creation is saved, temporary promotion keeps the UUID, and reads omit retired records without claiming presence.
- Add shared status-aware failure output and explicit close-before-publication. Keep all other unported command families effect-free.
- No dependency/schema change, tmux binding integration, release, global installation or user-state migration.

## Architecture and review

- Architecture impact: native CLI composition now acquires one Storage handle through existing ConfigPaths, invokes the core identity owner, closes before output and projects only public identity fields. Shared failure presentation replaces the old main/config-specific shape; it does not add a service container, alternate repository, selector or SQL in handlers.
- Reused/inspected: typed IdentityRequest and Clap grammar, core identity/name policy, private Storage and identity transaction adapter, ConfigPaths/config error mapping, TS standalone command and shared bounded CLI sandbox/descriptor.
- Public behavior: saved create/reuse/promotion; BINARY-ordered temporary/saved identity list; no timestamps, endpoint or presence leaks. Missing show name exits 3, invalid semantic name exits 1; storage/path errors remain bounded generic IDENTITY_ERROR. Primary failure survives cleanup failure; failed cleanup replaces only success with CLEANUP_ERROR and an effects warning.
- Primary reviewer: Codex. Personally reviewed every production, test and documentation diff plus the above callers/owners. Luna authored only the bounded process tests; primary reviewed and strengthened them before acceptance.
- Findings corrected before push: tests originally compared only partial identity/history fields and calibrated no-tmux behavior only for creation. Final tests preserve complete identity timestamps and dependent fields, retain the unsupported version-10 history row, use valid UUIDv4 fixtures and test all three storage-only commands. Primary added existing-binding preservation under the calibrated tmux tripwire and blank/control/pane-shaped invalid names for create/show. A hand-built duplicate sandbox was removed; error/human scenarios were separated. Help no longer misleadingly describes all identity records as saved.
- Reviewed commit: `223fed2d4449899478084613f4613d4628b2a01e`.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge.

Local evidence (verbose logs retained under `/private/tmp/tmt-113-*`):

CI run [34139198468](https://github.com/wkh237/tmux-team/actions/runs/34139198468), attempt 1: all 11 checks succeeded on reviewed head `223fed2d4449899478084613f4613d4628b2a01e`; merge state CLEAN. No rerun, protection bypass or relaxed gate.

- `cargo fmt --all --check`, `cargo clippy --locked --all-targets -- -D warnings`: passed.
- `cargo test --locked` and `cargo +1.88.0 test --locked`: 105 tests each (62 adapters, 26 core, 17 CLI).
- Locked bins/examples builds on Rust 1.97.0 and 1.88.0: passed. Cargo.lock unchanged.
- `pnpm check` plus explicit README formatting check: passed.
- `pnpm test:run`: 1,102 tests / 70 files; coverage 95.66% statements/lines, 89.47% branches, 97.55% functions.
- Explicit native descriptor plus storage probe, `pnpm test:native`: 56 tests / 4 files, including 12 new native identity process cases. No TS fallback.
- Unchanged shared parser subset: 8 passed; shared config subset: 6 passed. Excluded cases are not claimed as parity.
- `pnpm test:e2e` through the existing private-tmux/mock-agent, `--init --network none` Docker wrapper, twice: 115 passed plus one optional benchmark skip each, 292.33s / 283.11s; both wrappers exited 0. Each also passed 62 Linux native adapter tests. Both task-owned images/containers were independently confirmed absent afterward. This is regression evidence for the unchanged installed TS runtime and native adapters, not native binding/transport parity.

## Project lifecycle

- Updated ARCHITECTURE, DEVELOPMENT, RUST-REWRITE and README to describe the implemented native preview accurately. Grammar-derived help/completion follows the same owner.
- Installed canonical skill unchanged intentionally: npm still ships TypeScript, whose commands/contracts are unchanged. Adding unshipped native lifecycle instructions there would be misleading. #109 owns the remaining amended lifecycle guidance and integration gates.
- #109 retains name/this/add/whoami/unbind/rm, global presence listing, retirement and badge integration; #106 retains compact receipts, and #82 distribution. This PR does not complete the Rust rewrite or permit old/new writers on schema 9.
- Delivered as `b5c609a4e4a937e5dc2ddb5ba2d856655faf87c7`. The clean/pushed worktree `/Users/benhsieh/dev/tmt-113-native-identity-cli` and local/remote `feat/113-native-identity-cli` branch were safely removed after verifying tree equality with merged main. Shared main dependencies were preserved; main is clean and synchronized. No user state was touched.
