### PR TITLE
test(native): enforce architecture and SSOT boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -925,6 +925,40 @@ silently testing TS. The named shared parser-contract subset remains separate
 from full native parity. Native unit tests cover typed grammar and core policy;
 real tmux behavior remains gated by the existing Docker harness as it is ported.
 
+#### Native architecture guards
+
+`rust/crates/tmt-cli/tests/architecture.rs` is a test-only integration gate run
+by ordinary `cargo test --locked` and the existing Native Rust contracts CI job.
+Its collector follows production lib/bin module roots from bounded, offline
+Cargo metadata; its policy and adversarial fixtures live in separate test
+modules. It reuses the process adapter rather than inventing a subprocess runner.
+
+Cargo metadata supplies the actual dependency inventory, including build and
+target-specific edges. Explicit layer allowlists require review for new normal
+or build dependencies and package aliases; dev dependencies are exempt. Canonical
+crate names keep source-layer checks meaningful. The `syn` AST collector follows
+inline and external modules, conservatively scans unknown platform/feature cfg
+branches, and skips only branches proven absent with `test=false`. Missing,
+ambiguous, escaped, malformed, path-remapped or source-included modules fail
+closed rather than silently disappearing from coverage.
+
+Core syntax may use reviewed pure standard-library modules, not filesystem,
+process or terminal output. CLI grammar, parser, diagnostics and typed invocation
+must not import adapters or command handlers. Clap stays in the parsing boundary
+(plus entry-point completion rendering), never command handlers. Public core
+declarations and policy functions, typed invocation declarations and shared
+output types supply reserved names directly from their owners: adapters and
+handlers must reuse them, not define competing same-named types or policy
+functions. Generic `From<String> for Failure` is rejected; command-local error
+mapping must choose its public code and status explicitly.
+
+These are syntactic regression checks, not full Rust name resolution, macro
+expansion or semantic equivalence analysis. Differently named duplicate business
+logic, effects hidden in macros, and behavior reached through permitted APIs
+still require primary review. Comments and literals are not source references.
+Changing a boundary requires updating its policy, positive/negative fixtures
+and this map together, not adding a file exclusion to make the gate green.
+
 The native storage adapter owns one synchronous, private rusqlite connection.
 Opening enforces private files, WAL, foreign keys, the five-second busy timeout,
 NORMAL synchronization and real FTS5 availability. Migrations 1–8 retain their

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -941,6 +941,7 @@ inline and external modules, conservatively scans unknown platform/feature cfg
 branches, and skips only branches proven absent with `test=false`. Missing,
 ambiguous, escaped, malformed, path-remapped or source-included modules fail
 closed rather than silently disappearing from coverage.
+Associated impl/trait items use the same cfg evaluator as ordinary items.
 
 Core syntax may use reviewed pure standard-library modules, not filesystem,
 process or terminal output. CLI grammar, parser, diagnostics and typed invocation
@@ -949,7 +950,8 @@ must not import adapters or command handlers. Clap stays in the parsing boundary
 declarations and policy functions, typed invocation declarations and shared
 output types supply reserved names directly from their owners: adapters and
 handlers must reuse them, not define competing same-named types or policy
-functions. Generic `From<String> for Failure` is rejected; command-local error
+functions. Public declarations in inline modules also seed ownership; methods
+do not reserve free-function names. Generic `From<String> for Failure` is rejected; command-local error
 mapping must choose its public code and status explicitly.
 
 These are syntactic regression checks, not full Rust name resolution, macro

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -67,6 +67,13 @@ pure validity rules/use cases in `tmt-core`, and concrete effects in the
 silence warnings to avoid correcting a touched implementation. Unit tests stay
 with their owner; shared process scenarios reuse the repository test harness.
 
+The native architecture integration test separates module discovery, policy and
+adversarial examples. Extend its reviewed permissions only with a documented
+boundary decision; do not suppress failures with source exclusions or a second
+dependency inventory. Derive shared declaration ownership from production code.
+Keep generic textual errors local to their command's explicit mapping instead
+of adding a crate-wide `From<String>` implementation for shared `Failure`.
+
 Before adding a dependency or abstraction, inspect existing helpers and compare
 the concrete benefit, compatibility/native-install impact, maintenance, license,
 security and operational cost. Record the decision in the issue. A built-in is

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,6 +56,25 @@ cargo build --locked --example tmux-probe
 cargo +1.88.0 build --locked
 ```
 
+The architecture guard is included in `cargo test`; it adds no separate CI job.
+For a focused run from any working directory, after dependencies are available:
+
+```bash
+cargo test --offline --locked --manifest-path /absolute/checkout/rust/Cargo.toml --test architecture
+cargo +1.88.0 test --offline --locked --manifest-path /absolute/checkout/rust/Cargo.toml --test architecture
+```
+
+The guard itself obtains offline, locked Cargo metadata through the existing
+bounded process runner. It needs no tmux server, provider, database or network.
+The integration root validates the real workspace; separate positive/negative
+fixtures validate dependency edges, AST references, shared declaration ownership
+and fail-closed module discovery. When changing this gate, also temporarily
+introduce a real source/dependency violation, observe its specific diagnostic,
+and restore the original files exactly. A stale-lock failure or an unexecuted
+test is not evidence that the architecture policy caught the violation.
+See [the native guard contract](ARCHITECTURE.md#native-architecture-guards)
+for the syntactic limits that still require manual review.
+
 From the repository root, select the built executable explicitly:
 
 ```bash

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -369,7 +369,20 @@ units/concurrency tests are built; do not count them as native evidence. The
 packed storage probe imports TS runtime modules and therefore needs an artifact
 inventory/public-CLI/independent-SQL replacement before native cutover. Retain
 the incompatible-history, concurrency and cleanup assertions it currently proves.
-Grammar/architecture AST guards also need native equivalents, not deletion.
+Native grammar contracts remain in the CLI owner. #115 adds architecture guards
+to ordinary Cargo integration tests: offline dependency edges, production module
+discovery, core purity, parsing/effect separation and owner-derived declaration
+names. The TypeScript guards remain until runtime cutover. This is not semantic
+duplicate detection or full macro/name resolution; see ARCHITECTURE for limits.
+
+The guard uses the already locked `syn` 2.0.119 as a CLI dev dependency with
+`full`, `parsing` and `visit`, default features disabled. It adds no runtime
+dependency or new locked package. A maintained Rust AST parser avoids a second
+handwritten Rust parser; existing `serde_json` and the bounded process adapter
+supply metadata handling. The published manifest declares Rust 1.71 and
+MIT/Apache-2.0 licensing, below this workspace's 1.88 MSRV. RustSec snapshot
+`faedffd5118c1835e13cca3babb6059afb1eb8d0` contains no `syn` advisory; actual
+locked builds/tests on both supported toolchains remain required evidence.
 
 Run the full shared suite per runtime once supported; interim subset selection
 must be explicit in the issue and cannot be represented as full parity. Keep

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -549,6 +549,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "serde_json",
+ "syn 2.0.119",
  "tmt-adapters",
  "tmt-core",
 ]

--- a/rust/crates/tmt-cli/Cargo.toml
+++ b/rust/crates/tmt-cli/Cargo.toml
@@ -17,5 +17,8 @@ clap.workspace = true
 clap_complete.workspace = true
 serde_json.workspace = true
 
+[dev-dependencies]
+syn = { version = "=2.0.119", default-features = false, features = ["full", "parsing", "visit"] }
+
 [lints]
 workspace = true

--- a/rust/crates/tmt-cli/src/config_command.rs
+++ b/rust/crates/tmt-cli/src/config_command.rs
@@ -14,10 +14,8 @@ impl From<ConfigError> for Failure {
     }
 }
 
-impl From<String> for Failure {
-    fn from(message: String) -> Self {
-        Self::new("ERROR", message, 1)
-    }
+fn invalid_setting(message: String) -> Failure {
+    Failure::new("ERROR", message, 1)
 }
 
 enum Report {
@@ -39,7 +37,10 @@ fn run(request: ConfigRequest) -> Result<Report, Failure> {
         }),
         ConfigRequest::Set { key, value, global } => {
             let scope = if global { Scope::Global } else { Scope::Local };
-            files.set(Setting::edit(&key, &value, scope)?, scope)?;
+            files.set(
+                Setting::edit(&key, &value, scope).map_err(invalid_setting)?,
+                scope,
+            )?;
             let destination = if global {
                 "global config"
             } else {
@@ -50,7 +51,7 @@ fn run(request: ConfigRequest) -> Result<Report, Failure> {
             )))
         }
         ConfigRequest::Clear { key } => {
-            files.clear_local(LocalClear::parse(key.as_deref())?)?;
+            files.clear_local(LocalClear::parse(key.as_deref()).map_err(invalid_setting)?)?;
             Ok(Report::Changed(key.map_or_else(
                 || "Cleared all local config overrides".into(),
                 |key| format!("Cleared local override for {key}"),

--- a/rust/crates/tmt-cli/tests/architecture.rs
+++ b/rust/crates/tmt-cli/tests/architecture.rs
@@ -1,0 +1,100 @@
+#[path = "architecture/cases.rs"]
+mod cases;
+#[path = "architecture/policy.rs"]
+mod policy;
+#[path = "architecture/source.rs"]
+mod source;
+
+use std::{
+    collections::BTreeSet,
+    ffi::OsString,
+    path::Path,
+    time::{Duration, Instant},
+};
+use tmt_adapters::process::{CommandRequest, CommandRunner, UnixCommandRunner};
+
+#[test]
+fn workspace_obeys_native_architecture() {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../Cargo.toml");
+    let cargo = std::env::var_os("CARGO").expect("cargo test provides its Cargo executable");
+    let args: Vec<OsString> = [
+        "metadata",
+        "--offline",
+        "--locked",
+        "--no-deps",
+        "--format-version",
+        "1",
+        "--manifest-path",
+    ]
+    .into_iter()
+    .map(Into::into)
+    .chain([manifest.into_os_string()])
+    .collect();
+    let output = UnixCommandRunner
+        .execute(CommandRequest {
+            program: &cargo,
+            args: &args,
+            input: &[],
+            deadline: Instant::now() + Duration::from_secs(10),
+            max_output_bytes: 4 * 1024 * 1024,
+        })
+        .expect("bounded offline Cargo metadata");
+    let metadata: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("Cargo metadata JSON");
+    let mut violations = Vec::new();
+    let mut sources = Vec::new();
+    let packages: BTreeSet<_> = metadata["packages"]
+        .as_array()
+        .expect("Cargo packages")
+        .iter()
+        .map(|p| p["name"].as_str().expect("Cargo package name"))
+        .collect();
+    assert_eq!(
+        packages,
+        BTreeSet::from(["tmt-core", "tmt-adapters", "tmt-cli"]),
+        "Review native package boundaries when changing workspace members"
+    );
+    for package in metadata["packages"].as_array().expect("Cargo packages") {
+        violations.extend(policy::dependency_violations(package));
+        for target in package["targets"].as_array().expect("Cargo targets") {
+            let kind = target["kind"].as_array().expect("Cargo target kinds");
+            if kind.iter().any(|k| k == "lib" || k == "bin") {
+                sources.extend(
+                    source::collect(
+                        package["name"].as_str().unwrap(),
+                        Path::new(target["src_path"].as_str().unwrap()),
+                    )
+                    .expect("collect production source"),
+                );
+            }
+        }
+    }
+    assert!(
+        sources
+            .iter()
+            .any(|s| s.package == "tmt-core" && s.file == "identity.rs")
+    );
+    for (package, file) in [
+        ("tmt-core", "names.rs"),
+        ("tmt-cli", "invocation.rs"),
+        ("tmt-cli", "output.rs"),
+    ] {
+        assert!(
+            sources
+                .iter()
+                .any(|s| s.package == package && s.file == file),
+            "Missing SSOT owner {package}/{file}"
+        );
+    }
+    assert!(
+        sources
+            .iter()
+            .any(|s| s.package == "tmt-cli" && s.file == "identity_command.rs")
+    );
+    violations.extend(policy::source_violations(&sources));
+    assert!(
+        violations.is_empty(),
+        "Native architecture violations:\n{}",
+        violations.join("\n")
+    );
+}

--- a/rust/crates/tmt-cli/tests/architecture/cases.rs
+++ b/rust/crates/tmt-cli/tests/architecture/cases.rs
@@ -225,7 +225,7 @@ fn owner_policy_rejects_nested_and_foreign_declarations() {
                 "mod nested { pub struct Identity; }\n",
             ),
         ],
-        &["tmt-core/other.rs: Identity is owned by tmt-core/identity.rs"],
+        &["tmt-core/other.rs: duplicate owner Identity (already tmt-core/identity.rs)"],
     );
     assert_exact(
         &[
@@ -291,6 +291,61 @@ fn comments_text_and_test_only_items_do_not_trigger_policy() {
             "#,
         )],
         &[],
+    );
+}
+
+#[test]
+fn associated_items_respect_cfg_without_hiding_production_bodies() {
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "methods.rs",
+            r#"
+        pub struct Subject;
+        pub fn inspect() {}
+        impl Subject {
+            pub fn inspect() {}
+            #[cfg(test)]
+            fn test_io() { std::fs::read("fixture"); }
+        }
+        pub trait Reader {
+            #[cfg(all(test, unix))]
+            fn test_io() { std::fs::read("fixture"); }
+        }
+    "#,
+        )],
+        &[],
+    );
+    for text in [
+        "impl Subject { #[cfg(any(test, unix))] fn read() { std::fs::read(\"fixture\"); } }",
+        "trait Reader { #[cfg(not(test))] fn read() { std::fs::read(\"fixture\"); } }",
+    ] {
+        assert_exact(
+            &[syntax("tmt-core", "methods.rs", text)],
+            &["tmt-core/methods.rs: non-pure core reference std::fs::read"],
+        );
+    }
+}
+
+#[test]
+fn public_inline_declarations_seed_ownership_without_reserving_methods() {
+    assert_exact(
+        &[
+            syntax(
+                "tmt-core",
+                "inline.rs",
+                "pub mod domain { pub struct Record; pub fn inspect() {} }",
+            ),
+            syntax(
+                "tmt-adapters",
+                "copy.rs",
+                "pub struct Record; pub fn inspect() {}",
+            ),
+        ],
+        &[
+            "tmt-adapters/copy.rs: Record is owned by tmt-core/inline.rs",
+            "tmt-adapters/copy.rs: inspect is owned by tmt-core/inline.rs",
+        ],
     );
 }
 
@@ -430,6 +485,43 @@ fn collector_reaches_inline_nested_and_external_modules() {
         .collect::<Vec<_>>();
     assert_eq!(files, vec!["lib.rs", "outer.rs", "outer/inner/mod.rs"]);
     assert!(sources.iter().all(|source| source.package == "fixture"));
+}
+
+#[test]
+fn collector_applies_associated_item_cfg_to_nested_modules() {
+    let fixture = FixtureDirectory::new();
+    fixture.write(
+        "lib.rs",
+        r#"
+        struct Subject;
+        impl Subject {
+            #[cfg(test)]
+            fn test_only() { mod missing; }
+        }
+        trait Reader {
+            #[cfg(all(test, unix))]
+            fn test_only() { mod missing; }
+        }
+        mod inline { mod external; }
+    "#,
+    );
+    fixture.write("inline/external.rs", "pub fn found() {}");
+    let sources = source::collect("fixture", &fixture.root().join("lib.rs")).unwrap();
+    assert_eq!(
+        sources.iter().map(|s| s.file.as_str()).collect::<Vec<_>>(),
+        vec!["inline/external.rs", "lib.rs"]
+    );
+    fixture.write(
+        "lib.rs",
+        "impl Subject { #[cfg(any(test, unix))] fn maybe() { mod missing; } }",
+    );
+    let error = source::collect("fixture", &fixture.root().join("lib.rs"))
+        .err()
+        .unwrap();
+    assert!(
+        error.contains("module missing needs exactly one source file"),
+        "{error}"
+    );
 }
 
 #[test]

--- a/rust/crates/tmt-cli/tests/architecture/cases.rs
+++ b/rust/crates/tmt-cli/tests/architecture/cases.rs
@@ -1,0 +1,529 @@
+//! Adversarial and positive examples for the native architecture guards.
+//!
+//! These examples intentionally exercise the public test-only collector and
+//! policy APIs.  The filesystem fixtures are private to this module so the
+//! production adapter test directory cannot become part of the guard's API.
+
+use super::{policy, source};
+use serde_json::{Value, json};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+fn syntax(package: &str, file: &str, text: &str) -> source::Source {
+    source::Source {
+        package: package.into(),
+        file: file.into(),
+        syntax: syn::parse_file(text)
+            .unwrap_or_else(|error| panic!("fixture {package}/{file} must parse: {error}")),
+    }
+}
+
+fn assert_exact(sources: &[source::Source], expected: &[&str]) {
+    let actual = policy::source_violations(sources);
+    let expected = expected
+        .iter()
+        .map(|value| (*value).to_owned())
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn core_rejects_grouped_renamed_reexport_and_qualified_io_references() {
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "storage.rs",
+            "use std::{fs::File, io::Read};\n",
+        )],
+        &[
+            "tmt-core/storage.rs: non-pure core reference std::fs::File",
+            "tmt-core/storage.rs: non-pure core reference std::io::Read",
+        ],
+    );
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "storage.rs",
+            "use std::fs::File as Handle;\n",
+        )],
+        &["tmt-core/storage.rs: non-pure core reference std::fs::File"],
+    );
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "storage.rs",
+            "pub use std::fs::File as Handle;\n",
+        )],
+        &["tmt-core/storage.rs: non-pure core reference std::fs::File"],
+    );
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "storage.rs",
+            "pub fn read() { let _ = std::fs::read_to_string(\"state\"); }\n",
+        )],
+        &["tmt-core/storage.rs: non-pure core reference std::fs::read_to_string"],
+    );
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "nested.rs",
+            "mod nested { use std::fs::File; }\n",
+        )],
+        &["tmt-core/nested.rs: non-pure core reference std::fs::File"],
+    );
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "output.rs",
+            "pub fn report() { println!(\"done\"); std::process::exit(1); }\n",
+        )],
+        &[
+            "tmt-core/output.rs: non-pure core reference println",
+            "tmt-core/output.rs: non-pure core reference std::process::exit",
+        ],
+    );
+    assert_exact(
+        &[syntax("tmt-core", "legacy.rs", "extern crate std;\n")],
+        &["tmt-core/legacy.rs: non-pure core reference std"],
+    );
+}
+
+#[test]
+fn core_allows_grouped_renamed_reexport_and_qualified_pure_std_references() {
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "text.rs",
+            r#"
+                use std::{borrow::Cow, collections::BTreeMap, result::Result as StdResult};
+                pub use std::vec::Vec as List;
+                pub fn names() -> StdResult<List<Cow<'static, str>>, BTreeMap<String, String>> {
+                    let _ = std::option::Option::<String>::None;
+                    let _ = std::result::Result::<(), ()>::Ok(());
+                    // std::fs::File in a comment and a string are not syntax references.
+                    let _text = "std::fs::File";
+                    Ok(Vec::new())
+                }
+                mod nested {
+                    use std::collections::BTreeSet as Set;
+                    pub fn nested_names() -> Set<String> { Set::new() }
+                }
+            "#,
+        )],
+        &[],
+    );
+}
+
+#[test]
+fn adapters_allow_legitimate_grouped_reexports_and_dtos() {
+    assert_exact(
+        &[syntax(
+            "tmt-adapters",
+            "dto.rs",
+            r#"
+                use tmt_core::{identity::Identity as CoreIdentity, names::Name as CoreName};
+                pub use tmt_core::Result as CoreResult;
+                pub struct AdapterDto { pub identity: CoreIdentity, pub name: CoreName }
+                pub fn load() -> CoreResult<AdapterDto> { todo!() }
+            "#,
+        )],
+        &[],
+    );
+}
+
+#[test]
+fn parsing_modules_reject_effects_and_handler_clap() {
+    for (file, text, expected) in [
+        (
+            "grammar.rs",
+            "use tmt_adapters::process::CommandRunner;\n",
+            "tmt-cli/grammar.rs: parsing depends on effects via tmt_adapters::process::CommandRunner",
+        ),
+        (
+            "parser.rs",
+            "use crate::identity_command::execute;\n",
+            "tmt-cli/parser.rs: parsing depends on effects via crate::identity_command::execute",
+        ),
+        (
+            "diagnostics.rs",
+            "use super::config_command::execute;\n",
+            "tmt-cli/diagnostics.rs: parsing depends on effects via super::config_command::execute",
+        ),
+        (
+            "invocation.rs",
+            "use tmt_adapters::storage::Store;\n",
+            "tmt-cli/invocation.rs: parsing depends on effects via tmt_adapters::storage::Store",
+        ),
+    ] {
+        assert_exact(&[syntax("tmt-cli", file, text)], &[expected]);
+    }
+
+    assert_exact(
+        &[syntax(
+            "tmt-cli",
+            "identity_command.rs",
+            "use clap::Parser;\n",
+        )],
+        &["tmt-cli/identity_command.rs: CLI parsing belongs to grammar/parser, not clap::Parser"],
+    );
+}
+
+#[test]
+fn owner_policy_derives_duplicate_types_aliases_traits_and_functions() {
+    let first = syntax(
+        "tmt-core",
+        "identity.rs",
+        r#"
+            pub struct Identity;
+            pub enum State { Ready }
+            pub union Storage { value: u64 }
+            pub type Name = String;
+            pub trait Marker {}
+            pub trait Alias = Send;
+            pub fn identity_name() {}
+        "#,
+    );
+    let second = syntax(
+        "tmt-core",
+        "identity_copy.rs",
+        r#"
+            pub struct Identity;
+            pub enum State { Ready }
+            pub union Storage { value: u64 }
+            pub type Name = String;
+            pub trait Marker {}
+            pub trait Alias = Send;
+            pub fn identity_name() {}
+        "#,
+    );
+    assert_exact(
+        &[first, second],
+        &[
+            "tmt-core/identity_copy.rs: duplicate owner Alias (already tmt-core/identity.rs)",
+            "tmt-core/identity_copy.rs: duplicate owner Identity (already tmt-core/identity.rs)",
+            "tmt-core/identity_copy.rs: duplicate owner Marker (already tmt-core/identity.rs)",
+            "tmt-core/identity_copy.rs: duplicate owner Name (already tmt-core/identity.rs)",
+            "tmt-core/identity_copy.rs: duplicate owner State (already tmt-core/identity.rs)",
+            "tmt-core/identity_copy.rs: duplicate owner Storage (already tmt-core/identity.rs)",
+            "tmt-core/identity_copy.rs: duplicate owner identity_name (already tmt-core/identity.rs)",
+        ],
+    );
+}
+
+#[test]
+fn owner_policy_rejects_nested_and_foreign_declarations() {
+    assert_exact(
+        &[
+            syntax("tmt-core", "identity.rs", "pub struct Identity;\n"),
+            syntax(
+                "tmt-core",
+                "other.rs",
+                "mod nested { pub struct Identity; }\n",
+            ),
+        ],
+        &["tmt-core/other.rs: Identity is owned by tmt-core/identity.rs"],
+    );
+    assert_exact(
+        &[
+            syntax("tmt-core", "identity.rs", "pub struct Identity;\n"),
+            syntax("tmt-adapters", "dto.rs", "pub type Identity = String;\n"),
+        ],
+        &["tmt-adapters/dto.rs: Identity is owned by tmt-core/identity.rs"],
+    );
+}
+
+#[test]
+fn broad_string_failure_conversion_is_rejected() {
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "config.rs",
+            r#"
+                pub struct Failure;
+                impl From<String> for Failure {
+                    fn from(_value: String) -> Self { Failure }
+                }
+            "#,
+        )],
+        &[
+            "tmt-core/config.rs: map String errors explicitly; do not implement From<String> for shared Failure",
+        ],
+    );
+}
+
+#[test]
+fn typed_local_error_mapping_is_allowed() {
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "config.rs",
+            r#"
+                pub struct Failure;
+                pub struct ConfigError;
+                impl From<ConfigError> for Failure {
+                    fn from(_error: ConfigError) -> Self { Failure }
+                }
+                fn invalid_setting(_message: String) -> Failure { Failure }
+            "#,
+        )],
+        &[],
+    );
+}
+
+#[test]
+fn comments_text_and_test_only_items_do_not_trigger_policy() {
+    assert_exact(
+        &[syntax(
+            "tmt-core",
+            "test_helpers.rs",
+            r#"
+                // std::fs::File and println! are comments, not references.
+                #[cfg(test)]
+                fn test_io() { let _ = std::fs::read_to_string("state"); println!("x"); }
+                #[cfg(all(test, unix))]
+                fn unix_test_io() { let _ = std::fs::read_to_string("state"); }
+                pub fn pure() { let _ = std::collections::BTreeMap::<String, String>::new(); }
+                const TEXT: &str = "std::fs::read_to_string";
+            "#,
+        )],
+        &[],
+    );
+}
+
+fn dependency(name: &str, kind: &str, target: Option<&str>, rename: Option<&str>) -> Value {
+    json!({
+        "name": name,
+        "kind": kind,
+        "target": target,
+        "rename": rename,
+    })
+}
+
+fn package(name: &str, dependencies: Vec<Value>) -> Value {
+    json!({ "name": name, "dependencies": dependencies })
+}
+
+#[test]
+fn dependency_policy_handles_normal_build_target_renamed_and_dev_entries() {
+    assert_eq!(
+        policy::dependency_violations(&package(
+            "tmt-core",
+            vec![
+                dependency("uuid", "normal", None, None),
+                dependency("serde_json", "dev", None, None)
+            ],
+        )),
+        Vec::<String>::new(),
+    );
+    assert_eq!(
+        policy::dependency_violations(&package(
+            "tmt-core",
+            vec![dependency("serde_json", "build", None, None)],
+        )),
+        vec![
+            "tmt-core: unreviewed production dependency serde_json (kind=\"build\", target=null, rename=null)"
+        ],
+    );
+    assert_eq!(
+        policy::dependency_violations(&package(
+            "tmt-core",
+            vec![dependency("serde_json", "normal", Some("cfg(unix)"), None)],
+        )),
+        vec![
+            "tmt-core: unreviewed production dependency serde_json (kind=\"normal\", target=\"cfg(unix)\", rename=null)"
+        ],
+    );
+    assert_eq!(
+        policy::dependency_violations(&package(
+            "tmt-core",
+            vec![dependency("serde_json", "normal", None, Some("json"))],
+        )),
+        vec![
+            "tmt-core: unreviewed production dependency serde_json (kind=\"normal\", target=null, rename=\"json\")"
+        ],
+    );
+    assert_eq!(
+        policy::dependency_violations(&package(
+            "tmt-core",
+            vec![dependency("uuid", "normal", None, Some("ids"))],
+        )),
+        vec![
+            "tmt-core: unreviewed production dependency uuid (kind=\"normal\", target=null, rename=\"ids\")"
+        ],
+    );
+}
+
+#[test]
+fn dependency_policy_rejects_unknown_workspace_packages() {
+    assert_eq!(
+        policy::dependency_violations(&package("unknownpackage", Vec::new())),
+        vec!["unreviewed workspace package unknownpackage"],
+    );
+}
+
+struct FixtureDirectory {
+    path: PathBuf,
+}
+
+impl FixtureDirectory {
+    fn new() -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "tmt-native-architecture-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed),
+        ));
+        fs::create_dir(&path).expect("create unique architecture fixture directory");
+        Self { path }
+    }
+
+    fn write(&self, relative: &str, text: &str) {
+        let path = self.path.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create architecture fixture parent");
+        }
+        fs::write(path, text).expect("write architecture fixture source");
+    }
+
+    fn root(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for FixtureDirectory {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_dir_all(&self.path) {
+            if std::thread::panicking() {
+                eprintln!(
+                    "Could not remove architecture fixture {}: {error}",
+                    self.path.display()
+                );
+            } else {
+                panic!(
+                    "Could not remove architecture fixture {}: {error}",
+                    self.path.display()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn collector_reaches_inline_nested_and_external_modules() {
+    let fixture = FixtureDirectory::new();
+    fixture.write(
+        "lib.rs",
+        "pub mod inline { pub mod nested { pub fn leaf() {} } }\nmod outer;\n",
+    );
+    fixture.write("outer.rs", "pub mod inner;\n");
+    fixture.write("outer/inner/mod.rs", "pub fn external_leaf() {}\n");
+
+    let sources = source::collect("fixture", &fixture.root().join("lib.rs"))
+        .expect("collect fixture modules");
+    let files = sources
+        .iter()
+        .map(|source| source.file.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(files, vec!["lib.rs", "outer.rs", "outer/inner/mod.rs"]);
+    assert!(sources.iter().all(|source| source.package == "fixture"));
+}
+
+#[test]
+fn collector_skips_provably_test_only_all_branch_but_inspects_unknown_cfg_branches() {
+    let fixture = FixtureDirectory::new();
+    fixture.write(
+        "lib.rs",
+        "#[cfg(all(test, unix))] mod skipped;\n#[cfg(any(test, unix))] mod inspected;\n#[cfg(not(test))] mod production;\n",
+    );
+    fixture.write("inspected.rs", "pub fn inspected() {}\n");
+    fixture.write("production.rs", "pub fn production() {}\n");
+
+    let sources = source::collect("fixture", &fixture.root().join("lib.rs"))
+        .expect("collect cfg fixture modules");
+    let files = sources
+        .iter()
+        .map(|source| source.file.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(files, vec!["inspected.rs", "lib.rs", "production.rs"]);
+
+    let any_missing = FixtureDirectory::new();
+    any_missing.write("lib.rs", "#[cfg(any(test, unix))] mod inspected;\n");
+    let error = source::collect("fixture", &any_missing.root().join("lib.rs"))
+        .err()
+        .expect("unknown any(test, unix) branch must be inspected");
+    assert!(
+        error.contains("module inspected needs exactly one source file"),
+        "{error}"
+    );
+
+    let not_missing = FixtureDirectory::new();
+    not_missing.write("lib.rs", "#[cfg(not(test))] mod production;\n");
+    let error = source::collect("fixture", &not_missing.root().join("lib.rs"))
+        .err()
+        .expect("not(test) branch must be inspected");
+    assert!(
+        error.contains("module production needs exactly one source file"),
+        "{error}"
+    );
+}
+
+#[test]
+fn collector_fails_closed_for_missing_ambiguous_invalid_and_remapped_modules() {
+    let missing = FixtureDirectory::new();
+    missing.write("lib.rs", "mod missing;\n");
+    let error = source::collect("fixture", &missing.root().join("lib.rs"))
+        .err()
+        .expect("missing module must fail closed");
+    assert!(
+        error.contains("module missing needs exactly one source file"),
+        "{error}"
+    );
+
+    let ambiguous = FixtureDirectory::new();
+    ambiguous.write("lib.rs", "mod ambiguous;\n");
+    ambiguous.write("ambiguous.rs", "pub fn one() {}\n");
+    ambiguous.write("ambiguous/mod.rs", "pub fn two() {}\n");
+    let error = source::collect("fixture", &ambiguous.root().join("lib.rs"))
+        .err()
+        .expect("ambiguous module must fail closed");
+    assert!(
+        error.contains("module ambiguous needs exactly one source file"),
+        "{error}"
+    );
+
+    let invalid = FixtureDirectory::new();
+    invalid.write("lib.rs", "pub fn malformed( {\n");
+    let error = source::collect("fixture", &invalid.root().join("lib.rs"))
+        .err()
+        .expect("invalid source must fail closed");
+    assert!(error.starts_with("lib.rs:"), "{error}");
+
+    let remapped = FixtureDirectory::new();
+    remapped.write("lib.rs", "#[path = \"renamed.rs\"] mod original;\n");
+    remapped.write("renamed.rs", "pub fn original() {}\n");
+    let error = source::collect("fixture", &remapped.root().join("lib.rs"))
+        .err()
+        .expect("path-remapped module must fail closed");
+    assert_eq!(error, "lib.rs: unsupported module remapping on original");
+
+    let included = FixtureDirectory::new();
+    included.write("lib.rs", "include!(\"generated.rs\");\n");
+    let error = source::collect("fixture", &included.root().join("lib.rs"))
+        .err()
+        .expect("include! must fail closed");
+    assert_eq!(
+        error,
+        "lib.rs: source include! requires explicit collector support"
+    );
+
+    let verbatim = FixtureDirectory::new();
+    verbatim.write("lib.rs", "pub fn declaration_only();\n");
+    let error = source::collect("fixture", &verbatim.root().join("lib.rs"))
+        .err()
+        .expect("verbatim items must fail closed");
+    assert_eq!(error, "lib.rs: unsupported verbatim Rust item");
+}

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -1,6 +1,6 @@
 //! Review policy, separate from syntax collection and adverse examples.
 
-use super::source::{Source, production};
+use super::source::{Source, production, production_impl, production_trait};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use syn::{
@@ -98,6 +98,18 @@ fn type_named(value: &syn::Type, name: &str) -> bool {
 }
 
 impl<'ast> Visit<'ast> for Facts {
+    fn visit_impl_item(&mut self, item: &'ast syn::ImplItem) {
+        if production_impl(item) {
+            visit::visit_impl_item(self, item);
+        }
+    }
+
+    fn visit_trait_item(&mut self, item: &'ast syn::TraitItem) {
+        if production_trait(item) {
+            visit::visit_trait_item(self, item);
+        }
+    }
+
     fn visit_item(&mut self, item: &'ast Item) {
         if !production(item) {
             return;
@@ -178,7 +190,7 @@ pub fn source_violations(sources: &[Source]) -> Vec<String> {
         for d in &facts.declarations {
             // Public free functions in core are policy entrypoints. Methods and
             // command-local execute/run helpers do not become reserved names.
-            if !d.public || d.nested || (d.function && source.package != "tmt-core") {
+            if !d.public || (d.function && source.package != "tmt-core") {
                 continue;
             }
             let owner = format!("{}/{}", source.package, source.file);
@@ -199,11 +211,10 @@ pub fn source_violations(sources: &[Source]) -> Vec<String> {
     for (source, facts) in sources.iter().zip(&facts) {
         let location = format!("{}/{}", source.package, source.file);
         for d in &facts.declarations {
-            // Top-level public owners were checked above. Keep one actionable
+            // Public owners (including inline modules) were checked above. Keep one actionable
             // diagnostic per competing owner instead of reporting both ways.
             if owns_declarations(source)
                 && d.public
-                && !d.nested
                 && (!d.function || source.package == "tmt-core")
             {
                 continue;

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -1,0 +1,286 @@
+//! Review policy, separate from syntax collection and adverse examples.
+
+use super::source::{Source, production};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use syn::{
+    Item, UseTree,
+    visit::{self, Visit},
+};
+
+// These are reviewed layer permissions, not a second version/dependency graph.
+// Cargo metadata is the inventory, including renamed and target/build entries.
+pub fn dependency_violations(package: &Value) -> Vec<String> {
+    let name = package["name"].as_str().expect("Cargo package name");
+    let allowed: &[&str] = match name {
+        "tmt-core" => &["uuid", "icu_casemap", "icu_normalizer", "icu_locale_core"],
+        "tmt-adapters" => &[
+            "tmt-core",
+            "rusqlite",
+            "serde_json",
+            "uuid",
+            "subprocess",
+            "nix",
+        ],
+        "tmt-cli" => &[
+            "tmt-core",
+            "tmt-adapters",
+            "clap",
+            "clap_complete",
+            "serde_json",
+        ],
+        _ => return vec![format!("unreviewed workspace package {name}")],
+    };
+    package["dependencies"]
+        .as_array()
+        .expect("Cargo dependencies")
+        .iter()
+        .filter(|d| d["kind"] != "dev")
+        .filter_map(|d| {
+            let dependency = d["name"].as_str().expect("Cargo dependency name");
+            // Source paths use canonical crate names. Renaming even an allowed
+            // package requires an explicit policy review instead of bypassing
+            // the source-layer checks through a new external crate alias.
+            let unreviewed = !allowed.contains(&dependency) || !d["rename"].is_null();
+            unreviewed.then(|| {
+                format!(
+                    "{name}: unreviewed production dependency {dependency} (kind={}, target={}, rename={})",
+                    d["kind"], d["target"], d["rename"]
+                )
+            })
+        })
+        .collect()
+}
+
+struct Declaration {
+    name: String,
+    public: bool,
+    function: bool,
+    nested: bool,
+}
+#[derive(Default)]
+struct Facts {
+    references: Vec<Vec<String>>,
+    declarations: Vec<Declaration>,
+    broad_failure: bool,
+    depth: usize,
+}
+
+fn use_paths(tree: &UseTree, mut prefix: Vec<String>, paths: &mut Vec<Vec<String>>) {
+    match tree {
+        UseTree::Path(path) => {
+            prefix.push(path.ident.to_string());
+            use_paths(&path.tree, prefix, paths);
+        }
+        UseTree::Name(name) => {
+            prefix.push(name.ident.to_string());
+            paths.push(prefix);
+        }
+        UseTree::Rename(name) => {
+            prefix.push(name.ident.to_string());
+            paths.push(prefix);
+        }
+        UseTree::Glob(_) => {
+            prefix.push("*".into());
+            paths.push(prefix);
+        }
+        UseTree::Group(group) => {
+            for tree in &group.items {
+                use_paths(tree, prefix.clone(), paths);
+            }
+        }
+    }
+}
+
+fn type_named(value: &syn::Type, name: &str) -> bool {
+    matches!(value, syn::Type::Path(path)
+        if path.path.segments.last().is_some_and(|segment| segment.ident == name))
+}
+
+impl<'ast> Visit<'ast> for Facts {
+    fn visit_item(&mut self, item: &'ast Item) {
+        if !production(item) {
+            return;
+        }
+        let declaration = match item {
+            Item::Struct(i) => Some((&i.ident, &i.vis, false)),
+            Item::Enum(i) => Some((&i.ident, &i.vis, false)),
+            Item::Type(i) => Some((&i.ident, &i.vis, false)),
+            Item::Trait(i) => Some((&i.ident, &i.vis, false)),
+            Item::TraitAlias(i) => Some((&i.ident, &i.vis, false)),
+            Item::Union(i) => Some((&i.ident, &i.vis, false)),
+            Item::Fn(i) => Some((&i.sig.ident, &i.vis, true)),
+            _ => None,
+        };
+        if let Some((ident, visibility, function)) = declaration {
+            self.declarations.push(Declaration {
+                name: ident.to_string(),
+                public: matches!(visibility, syn::Visibility::Public(_)),
+                function,
+                nested: self.depth != 0,
+            });
+        }
+        self.depth += 1;
+        visit::visit_item(self, item);
+        self.depth -= 1;
+    }
+
+    fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+        use_paths(&item.tree, Vec::new(), &mut self.references);
+    }
+
+    fn visit_item_extern_crate(&mut self, item: &'ast syn::ItemExternCrate) {
+        self.references.push(vec![item.ident.to_string()]);
+    }
+
+    fn visit_path(&mut self, path: &'ast syn::Path) {
+        self.references
+            .push(path.segments.iter().map(|p| p.ident.to_string()).collect());
+        visit::visit_path(self, path);
+    }
+
+    fn visit_item_impl(&mut self, item: &'ast syn::ItemImpl) {
+        if let Some((_, path, _)) = &item.trait_
+            && let Some(segment) = path.segments.last()
+            && segment.ident == "From"
+            && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        {
+            let string = args.args.iter().any(|arg| {
+                matches!(arg, syn::GenericArgument::Type(value) if type_named(value, "String"))
+            });
+            self.broad_failure |= string && type_named(&item.self_ty, "Failure");
+        }
+        visit::visit_item_impl(self, item);
+    }
+}
+
+fn owns_declarations(source: &Source) -> bool {
+    source.package == "tmt-core"
+        || (source.package == "tmt-cli"
+            && matches!(source.file.as_str(), "invocation.rs" | "output.rs"))
+}
+
+pub fn source_violations(sources: &[Source]) -> Vec<String> {
+    let facts: Vec<_> = sources
+        .iter()
+        .map(|source| {
+            let mut facts = Facts::default();
+            facts.visit_file(&source.syntax);
+            facts
+        })
+        .collect();
+    let mut owners = BTreeMap::new();
+    let mut violations = Vec::new();
+    for (source, facts) in sources.iter().zip(&facts) {
+        if !owns_declarations(source) {
+            continue;
+        }
+        for d in &facts.declarations {
+            // Public free functions in core are policy entrypoints. Methods and
+            // command-local execute/run helpers do not become reserved names.
+            if !d.public || d.nested || (d.function && source.package != "tmt-core") {
+                continue;
+            }
+            let owner = format!("{}/{}", source.package, source.file);
+            match owners.entry((d.name.clone(), d.function)) {
+                std::collections::btree_map::Entry::Occupied(previous) => {
+                    violations.push(format!(
+                        "{owner}: duplicate owner {} (already {})",
+                        d.name,
+                        previous.get()
+                    ));
+                }
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(owner);
+                }
+            }
+        }
+    }
+    for (source, facts) in sources.iter().zip(&facts) {
+        let location = format!("{}/{}", source.package, source.file);
+        for d in &facts.declarations {
+            // Top-level public owners were checked above. Keep one actionable
+            // diagnostic per competing owner instead of reporting both ways.
+            if owns_declarations(source)
+                && d.public
+                && !d.nested
+                && (!d.function || source.package == "tmt-core")
+            {
+                continue;
+            }
+            if let Some(owner) = owners.get(&(d.name.clone(), d.function))
+                && (owner != &location || d.nested)
+            {
+                violations.push(format!("{location}: {} is owned by {owner}", d.name));
+            }
+        }
+        for path in &facts.references {
+            let root = path.first().map(String::as_str).unwrap_or_default();
+            let module = path.get(1).map(String::as_str).unwrap_or_default();
+            if source.package == "tmt-core" {
+                let pure_std = [
+                    "borrow",
+                    "boxed",
+                    "char",
+                    "clone",
+                    "cmp",
+                    "collections",
+                    "convert",
+                    "default",
+                    "error",
+                    "fmt",
+                    "hash",
+                    "iter",
+                    "marker",
+                    "mem",
+                    "num",
+                    "ops",
+                    "option",
+                    "result",
+                    "slice",
+                    "str",
+                    "string",
+                    "vec",
+                ];
+                if (root == "std" && !pure_std.contains(&module))
+                    || ["print", "println", "eprint", "eprintln", "dbg"].contains(&root)
+                {
+                    violations.push(format!(
+                        "{location}: non-pure core reference {}",
+                        path.join("::")
+                    ));
+                }
+            }
+            if source.package == "tmt-cli" {
+                let parsing = ["grammar.rs", "parser.rs", "diagnostics.rs", "invocation.rs"]
+                    .contains(&source.file.as_str());
+                if parsing
+                    && (root == "tmt_adapters"
+                        || (["crate", "super"].contains(&root)
+                            && !["grammar", "parser", "diagnostics", "invocation"]
+                                .contains(&module)))
+                {
+                    violations.push(format!(
+                        "{location}: parsing depends on effects via {}",
+                        path.join("::")
+                    ));
+                }
+                if ["clap", "clap_complete"].contains(&root)
+                    && (!["main.rs", "grammar.rs", "parser.rs", "diagnostics.rs"]
+                        .contains(&source.file.as_str()))
+                {
+                    violations.push(format!(
+                        "{location}: CLI parsing belongs to grammar/parser, not {}",
+                        path.join("::")
+                    ));
+                }
+            }
+        }
+        if facts.broad_failure {
+            violations.push(format!("{location}: map String errors explicitly; do not implement From<String> for shared Failure"));
+        }
+    }
+    violations.sort();
+    violations.dedup();
+    violations
+}

--- a/rust/crates/tmt-cli/tests/architecture/source.rs
+++ b/rust/crates/tmt-cli/tests/architecture/source.rs
@@ -77,9 +77,33 @@ fn cfg_value(meta: &Meta) -> Option<bool> {
 }
 
 pub fn production(item: &Item) -> bool {
-    !attributes(item).iter().any(|attr| {
+    production_attributes(attributes(item))
+}
+
+fn production_attributes(attributes: &[Attribute]) -> bool {
+    !attributes.iter().any(|attr| {
         attr.path().is_ident("cfg")
             && attr.parse_args::<Meta>().ok().and_then(|m| cfg_value(&m)) == Some(false)
+    })
+}
+
+pub fn production_impl(item: &syn::ImplItem) -> bool {
+    production_attributes(match item {
+        syn::ImplItem::Const(i) => &i.attrs,
+        syn::ImplItem::Fn(i) => &i.attrs,
+        syn::ImplItem::Type(i) => &i.attrs,
+        syn::ImplItem::Macro(i) => &i.attrs,
+        _ => &[],
+    })
+}
+
+pub fn production_trait(item: &syn::TraitItem) -> bool {
+    production_attributes(match item {
+        syn::TraitItem::Const(i) => &i.attrs,
+        syn::TraitItem::Fn(i) => &i.attrs,
+        syn::TraitItem::Type(i) => &i.attrs,
+        syn::TraitItem::Macro(i) => &i.attrs,
+        _ => &[],
     })
 }
 
@@ -90,6 +114,18 @@ struct Modules {
 }
 
 impl<'ast> Visit<'ast> for Modules {
+    fn visit_impl_item(&mut self, item: &'ast syn::ImplItem) {
+        if production_impl(item) {
+            visit::visit_impl_item(self, item);
+        }
+    }
+
+    fn visit_trait_item(&mut self, item: &'ast syn::TraitItem) {
+        if production_trait(item) {
+            visit::visit_trait_item(self, item);
+        }
+    }
+
     fn visit_item(&mut self, item: &'ast Item) {
         if production(item) {
             if matches!(item, Item::Verbatim(_)) {

--- a/rust/crates/tmt-cli/tests/architecture/source.rs
+++ b/rust/crates/tmt-cli/tests/architecture/source.rs
@@ -1,0 +1,201 @@
+//! Test-only Rust syntax collection. No source-text pattern matching or macro
+//! expansion: unsupported module remapping fails rather than hiding files.
+
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+use syn::{
+    Attribute, Item, Meta, Token,
+    parse::Parser,
+    punctuated::Punctuated,
+    visit::{self, Visit},
+};
+
+pub struct Source {
+    pub package: String,
+    pub file: String,
+    pub syntax: syn::File,
+}
+
+pub fn attributes(item: &Item) -> &[Attribute] {
+    match item {
+        Item::Const(i) => &i.attrs,
+        Item::Enum(i) => &i.attrs,
+        Item::ExternCrate(i) => &i.attrs,
+        Item::Fn(i) => &i.attrs,
+        Item::ForeignMod(i) => &i.attrs,
+        Item::Impl(i) => &i.attrs,
+        Item::Macro(i) => &i.attrs,
+        Item::Mod(i) => &i.attrs,
+        Item::Static(i) => &i.attrs,
+        Item::Struct(i) => &i.attrs,
+        Item::Trait(i) => &i.attrs,
+        Item::TraitAlias(i) => &i.attrs,
+        Item::Type(i) => &i.attrs,
+        Item::Union(i) => &i.attrs,
+        Item::Use(i) => &i.attrs,
+        _ => &[],
+    }
+}
+
+// Unknown platform/feature flags stay unknown. Only a provably false branch
+// with test=false may be skipped; cfg(any(test, unix)) is still production.
+fn cfg_value(meta: &Meta) -> Option<bool> {
+    match meta {
+        Meta::Path(path) if path.is_ident("test") => Some(false),
+        Meta::List(list) => {
+            let args = Punctuated::<Meta, Token![,]>::parse_terminated
+                .parse2(list.tokens.clone())
+                .ok()?;
+            let values: Vec<_> = args.iter().map(cfg_value).collect();
+            if list.path.is_ident("all") {
+                if values.contains(&Some(false)) {
+                    Some(false)
+                } else if values.iter().all(|v| *v == Some(true)) {
+                    Some(true)
+                } else {
+                    None
+                }
+            } else if list.path.is_ident("any") {
+                if values.contains(&Some(true)) {
+                    Some(true)
+                } else if values.iter().all(|v| *v == Some(false)) {
+                    Some(false)
+                } else {
+                    None
+                }
+            } else if list.path.is_ident("not") && values.len() == 1 {
+                values[0].map(|v| !v)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+pub fn production(item: &Item) -> bool {
+    !attributes(item).iter().any(|attr| {
+        attr.path().is_ident("cfg")
+            && attr.parse_args::<Meta>().ok().and_then(|m| cfg_value(&m)) == Some(false)
+    })
+}
+
+struct Modules {
+    directory: PathBuf,
+    children: Vec<PathBuf>,
+    errors: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for Modules {
+    fn visit_item(&mut self, item: &'ast Item) {
+        if production(item) {
+            if matches!(item, Item::Verbatim(_)) {
+                self.errors.push("unsupported verbatim Rust item".into());
+                return;
+            }
+            visit::visit_item(self, item);
+        }
+    }
+
+    fn visit_macro(&mut self, node: &'ast syn::Macro) {
+        if node.path.is_ident("include") {
+            self.errors
+                .push("source include! requires explicit collector support".into());
+        }
+        visit::visit_macro(self, node);
+    }
+
+    fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
+        if item
+            .attrs
+            .iter()
+            .any(|a| a.path().is_ident("path") || a.path().is_ident("cfg_attr"))
+        {
+            self.errors
+                .push(format!("unsupported module remapping on {}", item.ident));
+            return;
+        }
+        let name = item.ident.to_string();
+        if let Some((_, items)) = &item.content {
+            let previous = self.directory.clone();
+            self.directory.push(&name);
+            for item in items {
+                self.visit_item(item);
+            }
+            self.directory = previous;
+        } else {
+            let candidates = [
+                self.directory.join(format!("{name}.rs")),
+                self.directory.join(&name).join("mod.rs"),
+            ];
+            let found: Vec<_> = candidates
+                .into_iter()
+                .filter(|path| path.is_file())
+                .collect();
+            if found.len() == 1 {
+                self.children.push(found[0].clone());
+            } else {
+                self.errors.push(format!(
+                    "module {name} needs exactly one source file under {}",
+                    self.directory.display()
+                ));
+            }
+        }
+    }
+}
+
+pub fn collect(package: &str, root: &Path) -> Result<Vec<Source>, String> {
+    let directory = root
+        .parent()
+        .ok_or("source root has no directory")?
+        .canonicalize()
+        .map_err(|e| e.to_string())?;
+    let mut sources = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    let mut seen = BTreeSet::new();
+    while let Some(path) = pending.pop() {
+        let path = path
+            .canonicalize()
+            .map_err(|e| format!("{}: {e}", path.display()))?;
+        if !path.starts_with(&directory) || !seen.insert(path.clone()) {
+            return Err(format!("duplicate or escaped module: {}", path.display()));
+        }
+        let file = path
+            .strip_prefix(&directory)
+            .map_err(|e| e.to_string())?
+            .to_string_lossy()
+            .replace('\\', "/");
+        let text = fs::read_to_string(&path).map_err(|e| format!("{file}: {e}"))?;
+        let syntax = syn::parse_file(&text).map_err(|e| format!("{file}: {e}"))?;
+        let mut module_dir = path
+            .parent()
+            .ok_or("module has no directory")?
+            .to_path_buf();
+        if !matches!(
+            path.file_name().and_then(|v| v.to_str()),
+            Some("lib.rs" | "main.rs" | "mod.rs")
+        ) {
+            module_dir.push(path.file_stem().ok_or("module has no stem")?);
+        }
+        let mut modules = Modules {
+            directory: module_dir,
+            children: Vec::new(),
+            errors: Vec::new(),
+        };
+        modules.visit_file(&syntax);
+        if !modules.errors.is_empty() {
+            return Err(format!("{file}: {}", modules.errors.join("; ")));
+        }
+        pending.extend(modules.children);
+        sources.push(Source {
+            package: package.into(),
+            file,
+            syntax,
+        });
+    }
+    sources.sort_by(|a, b| a.file.cmp(&b.file));
+    Ok(sources)
+}


### PR DESCRIPTION
## Scope

Closes #115. Architecture/SSOT prerequisite for #109 under Rust rewrite #93.

- Add an ordinary Cargo integration test with separate module collector, policy and adversarial cases. Reuse offline Cargo metadata, the existing bounded process adapter and already locked syn 2.0.119 (dev-only).
- Guard production dependency edges/aliases, core IO, parser-to-handler/adapters coupling, handler Clap use, owner-derived declarations and broad Failure string conversion.
- Replace config's crate-wide `From<String> for Failure` with explicit local mapping. Public code `ERROR`, message, status 1 and publication behavior are unchanged.
- Update architecture, conventions, development commands and rewrite transition/dependency rationale. No workflow, installed skill, runtime dependency, tmux behavior or release change.

## Architecture and review

- Primary reviewer: Codex. Personally reviewed all 11 changed files, production module roots, core declarations, typed invocation, parser/grammar/diagnostics, shared Failure, config callers and existing process/config tests. Luna contributed only adverse/positive cases; primary corrected fixture issues and reviewed final assertions.
- Reviewed commit: `7e4f6a3a70df45624081a029b10e4646f955bcfe`.
- Findings addressed: generic String conversion had crate-wide authority; Cargo aliases could bypass canonical source references; competing owner insertion produced misleading reverse diagnostics. Config now maps explicitly, package aliases require review, and duplicate ownership retains the first owner with one actionable diagnostic.
- Existing ownership reused: CLI owns grammar/invocation/presentation; core owns pure policy/types; adapters own effects. The guard creates no production registry, parser, subprocess runner or architecture crate. Cargo supplies dependencies/source roots; declarations supply reserved names. Policy permissions are explicit review gates, not a second version graph.
- Source discovery fails closed for missing/ambiguous/malformed/escaped modules, remapping, include! and unsupported verbatim items. Unknown cfg branches remain inspected. Diagnostics name the package/source and offender.
- Final review refinement: impl/trait items now use the same cfg evaluator in collection and policy; public inline module declarations seed ownership. The alleged method-name collision did not reproduce because methods are not Item::Fn; an explicit positive fixture now protects that distinction. Luna re-reviewed the bounded fix with no remaining concrete finding. All revised Rust/check/cwd tests pass; production code and TypeScript behavior are unchanged from the first local verification.
- Limits: syntactic checks do not perform full name resolution, macro expansion or semantic-equivalence detection of differently named implementations. Manual architecture review remains mandatory. No #109 metadata evaluator or binding behavior is added here.
- Dependency evidence: existing syn 2.0.119 gains only a dev edge with full/parsing/visit; no newly locked package. Published MSRV 1.71, MIT/Apache-2.0; RustSec revision `faedffd5118c1835e13cca3babb6059afb1eb8d0` has no syn advisory. Actual 1.88 and 1.97 verification follows.

## Verification

- [x] Primary reviewed every changed file and relevant callers/tests.
- [x] Exact commands/results recorded below.
- [x] CI verified on the reviewed head before authorized merge.

Local checks, using isolated fixture state:

| Commands | Result |
| --- | --- |
| `cargo fmt --all --check`; `cargo clippy --offline --locked --all-targets -- -D warnings` | Pass |
| `cargo test --offline --locked`; `cargo +1.88.0 test --offline --locked` | 123 tests each: 62 adapters, 26 core, 17 CLI, 18 architecture |
| `cargo build --offline --locked --bins --examples`; same with `+1.88.0` | Pass on both toolchains |
| From `/private/tmp`: `cargo +1.97.0 test --offline --locked --manifest-path /absolute/checkout/rust/Cargo.toml --test architecture`; same with `+1.88.0` | 18 pass each; no cwd assumption or network |
| `pnpm check` | Pass |
| `pnpm test:run` | 1,102 tests / 70 files; 95.66% statements/lines, 89.47% branches, 97.55% functions; coverage gate passes |
| Explicit native CLI/storage probe selectors + `pnpm test:native` | 56 pass |
| Same CLI selector + `pnpm exec vitest run src/config-cli-contract.test.ts -t 'accepts omitted\|accepts safe\|keeps unknown\|rejects decimal\|repairs a targeted\|allows zero'` | 6 pass; 4 intentionally unsupported cases skipped |
| Same CLI selector + `pnpm exec vitest run src/cli-contract.test.ts -t 'reports JSON parse errors\|rejects ignored options\|validates invalid options\|keeps JSON leaf\|does not treat\|keeps a literal\|does not reinterpret\|rejects JSON mode for text-only'` | 8 pass; 14 other contracts excluded, not claimed as parity |

Real workspace mutation experiments (not only string fixtures):

1. Original `From<String> for Failure`: actual guard failed with the explicit-map diagnostic before production cleanup.
2. Temporary core `std::fs::metadata` call and adapter `pub struct Identity`: compiled, then guard failed with the precise IO and core-ownership diagnostics.
3. Temporary core build dependency on Clap: refreshed lock offline, then guard failed with `unreviewed production dependency clap (kind="build", ...)`, not a stale-lock error.
4. Restored source files, manifest and post-dev-edge lock to identical SHA-256 hashes; full guard then passed.

This tooling/config-mapping slice has no Docker lifecycle change, so #115 explicitly does not require two new full local Docker runs. The existing required CI Docker E2E and package matrix remain unchanged; The first CI candidate was canceled while Docker was still running after review identified test-only associated-item traversal and incomplete inline owner discovery. Those guards and regression fixtures are corrected, locally verified and independently re-reviewed; the second candidate must pass every check. No matrix bypass or blind rerun.

## Project lifecycle

- Dedicated branch/worktree: `test/115-native-architecture`, `/Users/benhsieh/dev/tmt-115-native-architecture`.
- Docs updated in this PR; installed guidance remains unchanged because user behavior is unchanged.
- #109 still owns identity binding/lifetime workflows and marker/name-policy convergence. No release, user database, global install or host tmux was touched.
- Delivered as `c0a583f972a3ba243a8f59da73bd7d2f42436e21` on main. All 11 checks in run 34144168510 (attempt 1 for final head `7e4f6a3a70df45624081a029b10e4646f955bcfe`) passed; merge state was CLEAN before matching-head squash merge. CI logs confirm 18 architecture tests and Docker's 115 passing cases plus one optional skipped resource benchmark, with 62 Linux adapter tests. Existing Node-action deprecation notices are unrelated to this change; no warnings were suppressed or workflows weakened.
- Issue #115 is closed. The clean, fully pushed worktree and local branch were removed after merge; the task-owned node_modules symlink was removed without touching shared dependencies. Parent #93 and prerequisite #109 are synchronized; user data and global installs remain unchanged.
