### PR TITLE
feat(native): implement global identity binding lifecycle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -892,7 +892,7 @@ failure semantics; merely introducing an interface is not an architectural fix.
 
 `rust/` contains a development-only native CLI under #96; installed entry points
 remain TypeScript. `tmt-core` owns numeric and settings policy, while `tmt-cli`
-owns one Clap grammar, typed requests, presentation, configuration and storage-only identity composition
+owns one Clap grammar, typed requests, presentation, configuration and identity command composition
 and explicit no-effects rejection for unimplemented commands. `tmt-adapters`
 owns the SQLite lifecycle under #97 and native schema 9 under #108, configuration files under #103,
 and bounded Unix tmux evidence under #105;
@@ -908,15 +908,15 @@ an exit status through `main` and does not terminate from a domain operation.
 Native syntax includes the approved #100 amendment (`rm`/`remove`, temporary
 binding defaults and `-s`/`--save`). Names remain globally unique across temporary
 and saved identities in one database; no project/workspace name isolation or
-directory-based discovery filter is planned. Native `ls` is planned to list all
+directory-based discovery filter is planned. Native `ls` lists all
 non-retired identities, including saved offline entries, and show lifetime
 separately from active/offline/unknown presence. Unverified evidence cannot retire
 a temporary identity or release a saved name. Visibility does not extend routing.
 The storage-only identity record foundation under #111 supplies shared creation,
 promotion and non-retired selection; #113 wires storage-only create/show/list.
-Binding command wiring, retirement and these
-presence-listing changes are not yet implemented. The durable-global invariants elsewhere in
-this map still describe the shipped TypeScript runtime, not the amended future
+Binding command wiring, retirement and presence listing are implemented under
+#109. The durable-global invariants elsewhere in
+this map still describe the shipped TypeScript runtime, not the amended
 native lifecycle. See [RUST-REWRITE.md](RUST-REWRITE.md) for transition boundaries.
 
 `test/native/` uses the existing CLI sandbox/executable selector for explicit
@@ -991,8 +991,46 @@ creation owner before its separate publication transaction, not fork the policy.
 Non-retired selection uses schema 9's index and deterministic BINARY ordering.
 Tombstones are excluded and replacement names receive fresh UUIDs; no profile,
 binding, request, cadence or attention row is changed by creation/promotion.
-Retirement authorization and live presence remain in #109, not in this
-storage-only foundation.
+Retirement authorization and live presence belong to `core::binding` (#109),
+not this storage-only foundation.
+
+`core::binding` owns one evidence evaluator and the binding use cases over
+narrow transaction/endpoint ports. Active agreement requires identity, binding,
+server/socket/PID/start, pane PID and normalized marker agreement. A changed
+server ID alone or inaccessible evidence is unknown, never proof of death.
+Conclusive endpoint loss retires temporary rows; saved rows detach and remain
+offline. Marker mismatch detaches only the binding, retaining even temporary
+identity records. Never-published temporary rows remain offline for retry.
+
+Binding reconciles only the selected old name before invoking the shared
+create/promote owner. Creation/promotion commits separately from publication,
+so occupied panes or failed metadata writes retain the new UUID/save decision.
+Publication acquires a fresh immediate transaction, re-reads ownership and
+observations, checks conflicts, writes metadata and verifies before commit.
+Concurrent retirement must never resurrect a tombstone. Explicit unbind retires
+temporary rows and detaches saved rows without erasing profiles. `rm` retires
+either lifetime and deletes only its role/preamble; saved removal requires
+`--force`. Exchanges, UUID provenance, attention and cadence survive both.
+Unknown evidence fails closed even for forced removal. Matching active markers
+are cleared on their recorded socket, never an ambient foreign fallback.
+
+`storage::bindings` extends the existing connection, shared identity decoder and
+immediate transaction helper. Global listing starts with one joined ordered
+query, groups scopes by full server evidence and probes the selected socket
+first, then deterministic socket/server order. No subprocess is spawned per
+identity. `tmux::BindingSession` owns a three-second monotonic budget reset after
+lock acquisition; SQLite's five-second contention wait is separate. Exhausted
+global observations preserve remaining rows as unknown. Scoped lookup never
+reconciles unrelated rows; reads never backfill orphan metadata. Native public
+presence output omits internal binding/process evidence and stale pane details.
+
+`binding_command` performs caller/target preflight before config/storage,
+validates binding settings before identity changes, composes the core use cases,
+and publishes one buffered report only after close. Shared `output` owns the
+identity projection as well as error publication. Optional pane badge updates
+are post-success, recheck the recorded endpoint and alter only the pane-local
+option. They never rewrite titles or border themes; failed child cleanup still
+propagates instead of claiming clean success.
 
 Native `identity_command` composes the existing typed request, ConfigPaths and
 one invocation-owned Storage handle. It never loads configuration contents or
@@ -1018,7 +1056,7 @@ nullable `retired_at_ms` to that same identity table. A partial unique index
 reserves canonical names only for non-retired rows; old UUID/name metadata can
 survive name reuse. It does not retire rows, remove bindings or profiles, or
 acknowledge exchanges. Actual retirement and cleanup authorization belong to
-the pending identity service, not SQL triggers or a second registry.
+the binding service, not SQL triggers or a second registry.
 Lifetime and retirement are independent: explicit confirmed removal may also
 retire a saved identity; ordinary pane death must not do so.
 
@@ -1090,20 +1128,27 @@ small query, while ancestry and its pane query share a one-second deadline.
 Scoped reads never expand an empty scope, and linked/grouped rows are validated
 before deduplication. Only reliable recorded-PID absence establishes death.
 Known-socket probes never initialize or overwrite foreign server metadata.
+Validated observation scopes are bounded to 1,024 panes and a conservatively
+estimated 32 KiB filter argument before construction. Larger probes are unknown,
+not dead; explicit snapshots fail closed. Filters append a balanced disjunction
+into one buffer, bounding tmux evaluation depth rather than nesting once per
+identity. A copied server UUID on another socket cannot pass full evidence
+agreement; binding fails closed rather than adding a second endpoint registry.
 
 Expected unavailable caller/target evidence and uncertain probes retain their
 optional/unknown results, but failed subprocess cleanup propagates as an error.
 It cannot trigger fallback server initialization or be hidden by best-effort
 observation. Metadata reads remain fatal before writes; unknown siblings survive
-marker replacement/clear. There is no native binding transaction, retirement,
-badge or message transport in this adapter slice.
+marker replacement/clear. Binding coordination uses the application port above;
+there is still no native message transport.
 
 The non-installed `tmux-probe` example exposes only narrow adapter operations
 and counts runner calls. The existing Docker fixture selects it through the
 shared executable descriptor. The same pinned Debian image builds native
 artifacts, runs adapter unit tests under `--init`, and executes real private-tmux
 scenarios with mock agents and no network. These are adapter integration tests,
-not evidence that unported native identity/talk commands work.
+not evidence that unported native talk commands work. The same image separately
+builds the native CLI and selects it for the identity lifecycle suite under #109.
 
 The [Rust rewrite decision](RUST-REWRITE.md) records the proposed native package
 boundaries, compatibility/test matrix, data coexistence gates and dependency

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,12 +33,12 @@ pnpm dev -- --help
 
 The `rust/` workspace is not the installed runtime yet. It implements only
 help/version/completion, typed grammar, the existing `config` command and
-storage-only `identity create/show/list` under #113.
+storage-only `identity create/show/list` under #113, and pane identity
+`name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` under #109.
 Other effectful commands still explicitly fail.
 The separate storage adapter upgrades historical schemas 0–8 to native schema 9,
 tested through a development-only probe rather than an installed command.
 Use isolated test databases only: installed TypeScript cannot reopen schema 9.
-Native pane binding, presence listing and retirement are still unimplemented.
 The #111 internal record service supports temporary/saved creation, same-UUID
 promotion and non-retired selection, tested against real isolated SQLite. It
 supplies the public storage-only commands but does not establish live presence.
@@ -135,13 +135,14 @@ before creation. Their evidence is storage policy, not public CLI/tmux parity.
 
 `test/native/identity.test.ts` separately exercises the public native
 create/show/list commands across bounded processes and working directories.
-Use independent SQL only to seed temporary/retired states that the public native
-binding commands cannot produce yet, and to inspect preserved records. Do not
+Use independent SQL to arrange storage-only fixtures without requiring tmux,
+and to inspect preserved records. Test actual binding lifecycle through its
+public native commands in Docker. Do not
 initialize schema 9 through the TypeScript Storage owner. Test exact public
 lifetime projections, missing-name status 3, invalid-name status 1, malformed
 unrelated configuration isolation, and calibrated no-tmux guards. CLI cleanup
 precedence is tested in `output.rs`; real SQLite close/rollback/contention tests
-remain adapter evidence. Native reads omit retired records and never reconcile
+remain adapter evidence. Storage-only identity reads omit retired records and never reconcile
 bindings; these tests are not proof of tmux presence or retirement authorization.
 
 The Docker image builds Linux adapter test artifacts in a pinned Rust/Debian
@@ -159,6 +160,20 @@ public native CLI parity. The probe requires fixture socket environment as an
 accidental-host-use guard, not an authorization boundary. Never run its tmux
 operations against a host server. Process fixtures use finite children even
 on failure and never signal a recycled PID after observed reaping.
+
+`test/native/binding.test.ts` checks isolated public preflight, offline removal,
+and lifetime/presence output. `test/e2e/native-identity.e2e.test.ts` selects the
+Docker-built `TMT_TEST_NATIVE_CLI` through the same fixture descriptor; it does
+not change the selected runtime for unported TS transport scenarios. Exercise
+real descendant caller resolution, temporary/save/unbind/rm lifecycle, global
+cross-directory/server discovery, grouped/linked presentation, publication
+failure/retry and theme-preserving badge behavior. The read-only SQL oracle
+also verifies copied-server-ID collision safety and conclusive foreign death.
+Adapter bounds tests cover pane-count/filter-byte limits and balanced depth;
+the real tmux probe checks multi-pane balanced-filter results. The SQL oracle
+observes committed state independently of reconciliation. Metadata barriers
+recognize explicit-socket invocations as well as ambient calls. Run the whole
+Docker suite twice for lifecycle changes; counts alone do not prove cleanup.
 
 For runtime-rewrite work, read [RUST-REWRITE.md](RUST-REWRITE.md) for the proposed
 boundaries and parity gates. The optional [performance baseline](PERFORMANCE-BASELINE.md)

--- a/README.md
+++ b/README.md
@@ -134,8 +134,10 @@ an older command or plugin installed.
 ## Native rewrite development
 
 The Rust executable is an isolated development preview, not the installer above.
-It currently supports configuration and storage-only `identity create/show/list`;
-pane binding and messaging still require the TypeScript runtime. Do not point
+It supports configuration, `identity create/show/list`, and pane identity
+`name`/`this`/`add`/`whoami`/`unbind`/`rm`/`ls`. Native bindings are temporary
+unless saved with `-s`; `ls` shows lifetime and active/offline/unknown presence.
+Messaging still requires the TypeScript runtime. Do not point
 the native preview at existing user data: its schema upgrade is forward-only.
 See [development and verification](DEVELOPMENT.md#native-development-preview).
 

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -2,7 +2,7 @@
 
 Status: native grammar (#96), storage lifecycle (#97) with native identity schema 9 (#108), configuration (#103)
 and bounded tmux evidence (#105), shared identity records (#111), and
-storage-only identity commands (#113)
+storage-only identity commands (#113), and pane identity lifecycle (#109)
 are implemented in the development preview, not a shipped Rust runtime.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
@@ -61,23 +61,23 @@ tmux evidence under #105). The npm entry points still execute TypeScript. No com
 delegates from native to Node.
 
 The preview implements help, version, Bash/Zsh completion and the existing
-`config` command plus storage-only `identity create/show/list` (#113).
+`config` command plus storage-only `identity create/show/list` (#113) and pane
+identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109).
 Other recognized effectful commands return
 `NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
 storage, tmux or input acquisition. Text-only commands reject JSON. Native
-`name`/`this`/`add` parse temporary defaults and save flags; `rm`/`remove` parse
-explicit force. This is not evidence that native lifecycle operations work.
+`name`/`this`/`add` create temporary bindings unless `-s`/`--save` promotes or
+creates a saved identity. `rm`/`remove` require explicit force for saved rows.
 
-The planned #100 listing includes all non-retired temporary and saved identities,
+The implemented #100/#109 listing includes all non-retired temporary and saved identities,
 including saved offline identities. It exposes lifetime separately from verified
 presence: `temporary`/`saved` and `active`/`offline`/`unknown`. Unavailable evidence
 is not proof of death; retired temporary identities are omitted, while offline
 saved identities continue to reserve their names. Visibility does not silently
 expand current-server routing or justify unbounded per-identity tmux queries.
-The implementing issue must define exact JSON and failure precedence and test
-cross-directory name collisions, promotion, retirement/reuse, preserved exchanges
-and truthful unknown presence. These are planned native changes, not installed
-TypeScript behavior or a second identity registry.
+The exact JSON and failure precedence are recorded in #109, with real SQLite
+service tests and public CLI/private-tmux lifecycle tests. These are native
+preview changes, not installed TypeScript behavior or a second identity registry.
 
 #103 makes settings an invocation-owned shared boundary rather than a rule set
 inside each CLI handler. Core owns typed defaults, scalar bounds, setting scope
@@ -175,8 +175,11 @@ settings. JSON excludes internal timestamps, retirement and binding evidence.
 Missing show names return NAME_NOT_FOUND/3; semantic invalid names return
 INVALID_NAME/1. Storage acquisition precedes semantic validation, while grammar
 errors still precede effects. Cleanup failure replaces only success with an
-effects warning; primary errors survive. #109 retains binding, removal, presence
-and their real-tmux gates. Installed npm still uses TypeScript/schema 8.
+effects warning; primary errors survive. #109 composes binding, removal and
+presence through one core evidence evaluator and shared SQLite/tmux adapters.
+Creation/promotion and verified publication remain separate commits; unknown
+evidence cannot retire a name. Global reads batch recorded servers under a
+shared observation budget. Installed npm still uses TypeScript/schema 8.
 
 Name normalization uses pinned `icu_normalizer`, `icu_casemap` and
 `icu_locale_core` 2.3.0, with defaults disabled and compiled data only for the

--- a/rust/crates/tmt-adapters/src/storage/bindings.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings.rs
@@ -1,0 +1,213 @@
+//! SQLite-backed identity bindings.
+
+use rusqlite::{Connection, OptionalExtension, Row, params};
+use tmt_core::{
+    binding::{Binding, BindingEntry, BindingRecords, BindingRepository},
+    endpoint::{PaneObservation, ServerEvidence},
+    identity::{Identity, IdentityReader},
+};
+
+use super::{
+    Storage, StorageError,
+    errors::classify,
+    identities::{identity_row_at, with_immediate_transaction},
+};
+
+const IDENTITY_COLUMNS: &str =
+    "i.id, i.name, i.canonical_name, i.lifetime, i.created_at, i.updated_at";
+const BINDING_COLUMNS: &str = "b.id, b.identity_id, b.pane_id, b.server_id, b.socket_path, \
+    b.server_pid, b.server_start_time, b.pane_pid";
+
+struct BindingRows<'a>(&'a Connection);
+
+fn binding_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<Binding> {
+    Ok(Binding {
+        id: row.get(offset)?,
+        identity_id: row.get(offset + 1)?,
+        server: ServerEvidence {
+            server_id: row.get(offset + 3)?,
+            socket_path: row.get(offset + 4)?,
+            server_pid: row.get::<_, i64>(offset + 5)? as u64,
+            server_start_time: row.get(offset + 6)?,
+        },
+        pane_id: row.get(offset + 2)?,
+        pane_pid: row.get::<_, i64>(offset + 7)? as u64,
+    })
+}
+
+fn entry_row(row: &Row<'_>) -> rusqlite::Result<BindingEntry> {
+    let identity = identity_row_at(row, 0)?;
+    let binding = if row.get_ref(6)?.data_type() == rusqlite::types::Type::Null {
+        None
+    } else {
+        Some(binding_row(row, 6)?)
+    };
+    Ok(BindingEntry { identity, binding })
+}
+
+impl IdentityReader for BindingRows<'_> {
+    type Error = StorageError;
+
+    fn find_identity(&self, canonical_name: &str) -> Result<Option<Identity>, Self::Error> {
+        super::identities::IdentityRecords(self.0).find_identity(canonical_name)
+    }
+
+    fn list_identities(&self) -> Result<Vec<Identity>, Self::Error> {
+        super::identities::IdentityRecords(self.0).list_identities()
+    }
+}
+
+impl BindingRecords for BindingRows<'_> {
+    fn entry_by_id(&self, id: &str) -> Result<Option<BindingEntry>, Self::Error> {
+        self.0
+            .query_row(
+                &format!(
+                    "SELECT {IDENTITY_COLUMNS}, {BINDING_COLUMNS} \
+                     FROM identities AS i LEFT JOIN bindings AS b \
+                       ON b.identity_id = i.id AND b.transport = 'tmux' \
+                     WHERE i.id = ? AND i.retired_at_ms IS NULL"
+                ),
+                [id],
+                entry_row,
+            )
+            .optional()
+            .map_err(|error| classify(error, "Find binding"))
+    }
+
+    fn entry_by_pane(&self, pane: &str, server: &str) -> Result<Option<BindingEntry>, Self::Error> {
+        self.0
+            .query_row(
+                &format!(
+                    "SELECT {IDENTITY_COLUMNS}, {BINDING_COLUMNS} \
+                     FROM bindings AS b JOIN identities AS i ON i.id = b.identity_id \
+                     WHERE b.transport = 'tmux' AND b.pane_id = ? AND b.server_id = ? \
+                       AND i.retired_at_ms IS NULL"
+                ),
+                [pane, server],
+                entry_row,
+            )
+            .optional()
+            .map_err(|error| classify(error, "Find binding by pane"))
+    }
+
+    fn binding_entries(&self) -> Result<Vec<BindingEntry>, Self::Error> {
+        let mut statement = self
+            .0
+            .prepare(&format!(
+                "SELECT {IDENTITY_COLUMNS}, {BINDING_COLUMNS} \
+                 FROM identities AS i LEFT JOIN bindings AS b \
+                   ON b.identity_id = i.id AND b.transport = 'tmux' \
+                 WHERE i.retired_at_ms IS NULL \
+                 ORDER BY i.canonical_name COLLATE BINARY"
+            ))
+            .map_err(|error| classify(error, "Prepare binding list"))?;
+        statement
+            .query_map([], entry_row)
+            .and_then(|rows| rows.collect())
+            .map_err(|error| classify(error, "List bindings"))
+    }
+
+    fn insert_binding(
+        &mut self,
+        identity: &Identity,
+        server: &ServerEvidence,
+        pane: &PaneObservation,
+    ) -> Result<Binding, Self::Error> {
+        let id = uuid::Uuid::new_v4().to_string();
+        self.0
+            .query_row(
+                "INSERT INTO bindings (
+                    id, identity_id, transport, pane_id, server_id, socket_path,
+                    server_pid, server_start_time, pane_pid, bound_at, last_verified_at
+                 ) VALUES (?, ?, 'tmux', ?, ?, ?, ?, ?, ?,
+                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+                 RETURNING id, identity_id, pane_id, server_id, socket_path,
+                    server_pid, server_start_time, pane_pid",
+                params![
+                    id,
+                    identity.id,
+                    pane.id,
+                    server.server_id,
+                    server.socket_path,
+                    server.server_pid as i64,
+                    server.server_start_time,
+                    pane.pane_pid as i64,
+                ],
+                |row| binding_row(row, 0),
+            )
+            .map_err(|error| classify(error, "Create binding"))
+    }
+
+    fn touch_binding(&mut self, id: &str) -> Result<(), Self::Error> {
+        self.0
+            .execute(
+                "UPDATE bindings SET last_verified_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                 WHERE id = ?",
+                [id],
+            )
+            .map_err(|error| classify(error, "Touch binding"))?;
+        Ok(())
+    }
+
+    fn detach_binding(&mut self, id: &str) -> Result<(), Self::Error> {
+        self.0
+            .execute("DELETE FROM bindings WHERE id = ?", [id])
+            .map_err(|error| classify(error, "Detach binding"))?;
+        Ok(())
+    }
+
+    fn retire_identity(
+        &mut self,
+        identity: &Identity,
+        remove_content: bool,
+    ) -> Result<(), Self::Error> {
+        self.0
+            .execute("DELETE FROM bindings WHERE identity_id = ?", [&identity.id])
+            .map_err(|error| classify(error, "Detach identity binding"))?;
+        if remove_content {
+            self.0
+                .execute(
+                    "DELETE FROM role_profiles WHERE identity_id = ?",
+                    [&identity.id],
+                )
+                .map_err(|error| classify(error, "Remove identity role"))?;
+            self.0
+                .execute(
+                    "DELETE FROM identity_preambles WHERE identity_id = ?",
+                    [&identity.id],
+                )
+                .map_err(|error| classify(error, "Remove identity preamble"))?;
+        }
+        self.0
+            .execute(
+                "UPDATE identities
+                 SET retired_at_ms = CAST(strftime('%s','now') AS INTEGER) * 1000
+                    + CAST(substr(strftime('%f','now'), 4, 3) AS INTEGER)
+                 WHERE id = ? AND retired_at_ms IS NULL",
+                [&identity.id],
+            )
+            .map_err(|error| classify(error, "Retire identity"))?;
+        Ok(())
+    }
+}
+
+impl BindingRepository for Storage {
+    fn with_binding_transaction<T, E: From<Self::Error>>(
+        &mut self,
+        operation: impl FnOnce(&mut dyn BindingRecords<Error = Self::Error>) -> Result<T, E>,
+    ) -> Result<T, E> {
+        with_immediate_transaction(self, "binding", |transaction| {
+            operation(&mut BindingRows(transaction))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+mod service_tests;
+
+#[cfg(test)]
+mod test_support;

--- a/rust/crates/tmt-adapters/src/storage/bindings/service_tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings/service_tests.rs
@@ -1,0 +1,4 @@
+mod endpoint;
+mod presence;
+mod publication;
+mod removal;

--- a/rust/crates/tmt-adapters/src/storage/bindings/service_tests/endpoint.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings/service_tests/endpoint.rs
@@ -1,0 +1,172 @@
+use std::fmt;
+
+use tmt_core::{
+    binding::{Binding, BindingEndpoint},
+    endpoint::{EndpointProbe, EndpointSnapshot, PaneObservation, ServerEvidence},
+    identity::Identity,
+};
+
+use super::super::test_support::pane;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProbeMode {
+    Live,
+    Dead,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct EndpointFailure(pub(super) &'static str);
+
+impl fmt::Display for EndpointFailure {
+    fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+        output.write_str(self.0)
+    }
+}
+
+impl std::error::Error for EndpointFailure {}
+
+pub(super) struct FakeEndpoint {
+    pub(super) server: ServerEvidence,
+    panes: Vec<PaneObservation>,
+    pub(super) probe_mode: ProbeMode,
+    budget: bool,
+    pub(super) expire_after_probe: Option<usize>,
+    pub(super) expire_after_publish: bool,
+    pub(super) hide_panes_after_current: Option<usize>,
+    pub(super) publish_failure: bool,
+    pub(super) verification_failure: bool,
+    pub(super) clear_result: bool,
+    pub(super) clear_failure: bool,
+    pub(super) begin_calls: usize,
+    pub(super) current_calls: usize,
+    pub(super) publish_calls: usize,
+    pub(super) clear_calls: usize,
+    pub(super) probe_calls: Vec<(String, Vec<String>)>,
+}
+
+impl FakeEndpoint {
+    pub(super) fn new(pane_ids: &[&str]) -> Self {
+        Self {
+            server: server("server-a", "/tmp/tmux-a.sock", 41, "start-a"),
+            panes: pane_ids.iter().map(|id| pane(id, 100)).collect(),
+            probe_mode: ProbeMode::Live,
+            budget: true,
+            expire_after_probe: None,
+            expire_after_publish: false,
+            hide_panes_after_current: None,
+            publish_failure: false,
+            verification_failure: false,
+            clear_result: true,
+            clear_failure: false,
+            begin_calls: 0,
+            current_calls: 0,
+            publish_calls: 0,
+            clear_calls: 0,
+            probe_calls: Vec::new(),
+        }
+    }
+
+    pub(super) fn pane_mut(&mut self, id: &str) -> &mut PaneObservation {
+        self.panes
+            .iter_mut()
+            .find(|pane| pane.id == id)
+            .expect("fixture pane exists")
+    }
+
+    fn snapshot(&self, server: &ServerEvidence, pane_ids: &[String]) -> EndpointSnapshot {
+        let mut panes = self
+            .panes
+            .iter()
+            .filter(|pane| pane_ids.iter().any(|id| id == &pane.id))
+            .cloned()
+            .collect::<Vec<_>>();
+        if self.verification_failure && self.publish_calls > 0 {
+            for pane in &mut panes {
+                pane.marker = None;
+            }
+        }
+        EndpointSnapshot {
+            server: server.clone(),
+            panes,
+        }
+    }
+}
+
+impl BindingEndpoint for FakeEndpoint {
+    type Error = EndpointFailure;
+
+    fn begin_coordination(&mut self) {
+        self.begin_calls += 1;
+    }
+
+    fn budget_available(&self) -> bool {
+        self.budget
+            && !(self.expire_after_publish && self.publish_calls > 0)
+            && self
+                .expire_after_probe
+                .is_none_or(|limit| self.probe_calls.len() < limit)
+    }
+
+    fn current_snapshot(&mut self, panes: &[String]) -> Result<EndpointSnapshot, Self::Error> {
+        self.current_calls += 1;
+        let mut snapshot = self.snapshot(&self.server, panes);
+        if self
+            .hide_panes_after_current
+            .is_some_and(|call| self.current_calls >= call)
+        {
+            snapshot.panes.clear();
+        }
+        Ok(snapshot)
+    }
+
+    fn probe_binding(
+        &mut self,
+        server: &ServerEvidence,
+        panes: &[String],
+    ) -> Result<EndpointProbe, Self::Error> {
+        self.probe_calls
+            .push((server.server_id.clone(), panes.to_vec()));
+        Ok(match self.probe_mode {
+            ProbeMode::Live => EndpointProbe::Live(self.snapshot(server, panes)),
+            ProbeMode::Dead => EndpointProbe::Dead,
+            ProbeMode::Unknown => EndpointProbe::Unknown,
+        })
+    }
+
+    fn publish(&mut self, binding: &Binding, identity: &Identity) -> Result<(), Self::Error> {
+        if self.publish_failure {
+            return Err(EndpointFailure("publish failed"));
+        }
+        self.publish_calls += 1;
+        self.pane_mut(&binding.pane_id).marker = Some(binding.marker(identity));
+        Ok(())
+    }
+
+    fn clear(&mut self, binding: &Binding) -> Result<bool, Self::Error> {
+        self.clear_calls += 1;
+        if self.clear_failure {
+            return Err(EndpointFailure("clear failed"));
+        }
+        if self.clear_result {
+            let pane = self.pane_mut(&binding.pane_id);
+            if pane
+                .marker
+                .as_ref()
+                .is_some_and(|marker| marker.binding_id == binding.id)
+            {
+                pane.marker = None;
+            }
+        }
+        Ok(self.clear_result)
+    }
+}
+
+pub(super) fn server(id: &str, socket: &str, pid: u64, start: &str) -> ServerEvidence {
+    ServerEvidence {
+        server_id: id.into(),
+        socket_path: socket.into(),
+        server_pid: pid,
+        server_start_time: start.into(),
+    }
+}

--- a/rust/crates/tmt-adapters/src/storage/bindings/service_tests/presence.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings/service_tests/presence.rs
@@ -1,0 +1,247 @@
+use rusqlite::Connection;
+use tmt_core::{
+    binding::{
+        BindingError, BindingRepository, Presence, bind_identity, list_presence, name_presence,
+    },
+    identity::{IdentityReader, Lifetime, create_or_resolve},
+};
+
+use super::super::super::StorageError;
+use super::super::test_support::{Fixture, pane};
+use super::endpoint::{FakeEndpoint, ProbeMode, server};
+
+#[test]
+fn marker_mismatch_detaches_binding_but_keeps_temporary_identity_offline() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let identity = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", false)
+        .unwrap()
+        .identity;
+    endpoint.pane_mut("%1").marker = None;
+
+    let presence = name_presence(&mut storage, &mut endpoint, "Alice").unwrap();
+    assert_eq!(presence.presence, Presence::Offline);
+    assert!(presence.binding.is_none());
+    assert_eq!(
+        storage.find_identity("alice").unwrap().unwrap().id,
+        identity.id
+    );
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&identity.id))
+        .unwrap()
+        .unwrap();
+    assert!(entry.binding.is_none());
+    storage.close().unwrap();
+}
+
+#[test]
+fn temporary_name_presence_death_commits_retirement_before_name_not_found() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let identity = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", false)
+        .unwrap()
+        .identity;
+    endpoint.probe_mode = ProbeMode::Dead;
+
+    let error = name_presence(&mut storage, &mut endpoint, "Alice").unwrap_err();
+    assert!(matches!(error, BindingError::NameNotFound(name) if name == "Alice"));
+    assert!(storage.find_identity("alice").unwrap().is_none());
+    let connection = Connection::open(&fixture.database).unwrap();
+    assert!(
+        connection
+            .query_row(
+                "SELECT retired_at_ms FROM identities WHERE id = ?",
+                [&identity.id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .unwrap()
+            .is_some()
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn saved_dead_binding_keeps_uuid_and_never_bound_temporary_stays_offline() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let saved = bind_identity(&mut storage, &mut endpoint, "%1", "Saved", true)
+        .unwrap()
+        .identity;
+    endpoint.probe_mode = ProbeMode::Dead;
+
+    let presence = name_presence(&mut storage, &mut endpoint, "Saved").unwrap();
+    assert_eq!(presence.presence, Presence::Offline);
+    assert!(presence.binding.is_none());
+    assert_eq!(presence.identity.id, saved.id);
+    assert_eq!(
+        storage.find_identity("saved").unwrap().unwrap().id,
+        saved.id
+    );
+
+    let temporary = create_or_resolve(&mut storage, "NeverBound", Lifetime::Temporary)
+        .unwrap()
+        .identity;
+    let presence = name_presence(&mut storage, &mut endpoint, "NeverBound").unwrap();
+    assert_eq!(presence.presence, Presence::Offline);
+    assert!(presence.binding.is_none());
+    assert_eq!(presence.identity.id, temporary.id);
+    assert_eq!(
+        storage.find_identity("neverbound").unwrap().unwrap().id,
+        temporary.id
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn unknown_probe_preserves_binding_state() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true).unwrap();
+    endpoint.probe_mode = ProbeMode::Unknown;
+
+    let presence = name_presence(&mut storage, &mut endpoint, "Alice").unwrap();
+    assert_eq!(presence.presence, Presence::Unknown);
+    let entry = storage
+        .with_binding_transaction(|records| {
+            records.find_identity("alice").and_then(|identity| {
+                identity.map_or(Ok(None), |identity| records.entry_by_id(&identity.id))
+            })
+        })
+        .unwrap()
+        .unwrap();
+    assert!(entry.binding.is_some());
+    storage.close().unwrap();
+}
+
+#[test]
+fn dead_temporary_binding_retires_before_fresh_name_creation() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1", "%2"]);
+    let old = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", false)
+        .unwrap()
+        .identity;
+    endpoint.probe_mode = ProbeMode::Dead;
+
+    let fresh = bind_identity(&mut storage, &mut endpoint, "%2", "Alice", false)
+        .unwrap()
+        .identity;
+    assert_ne!(old.id, fresh.id);
+    assert!(
+        storage
+            .find_identity("alice")
+            .unwrap()
+            .is_some_and(|identity| identity.id == fresh.id)
+    );
+    let connection = Connection::open(&fixture.database).unwrap();
+    assert!(
+        connection
+            .query_row(
+                "SELECT retired_at_ms FROM identities WHERE id = ?",
+                [&old.id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .unwrap()
+            .is_some()
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn list_groups_servers_orders_identities_and_preserves_rows_when_budget_is_exhausted() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let server_a = server("server-a", "/tmp/tmux-a.sock", 41, "start-a");
+    let server_b = server("server-b", "/tmp/tmux-b.sock", 42, "start-b");
+    let alpha = create_or_resolve(&mut storage, "Alpha", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let bravo = create_or_resolve(&mut storage, "Bravo", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let charlie = create_or_resolve(&mut storage, "Charlie", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let bindings = storage
+        .with_binding_transaction(|records| {
+            Ok::<_, StorageError>(vec![
+                records.insert_binding(&charlie, &server_a, &pane("%1", 101))?,
+                records.insert_binding(&alpha, &server_a, &pane("%2", 102))?,
+                records.insert_binding(&bravo, &server_b, &pane("%3", 103))?,
+            ])
+        })
+        .unwrap();
+    let mut endpoint = FakeEndpoint::new(&["%1", "%2", "%3"]);
+    endpoint.server = server_a.clone();
+    endpoint.pane_mut("%1").pane_pid = 101;
+    endpoint.pane_mut("%2").pane_pid = 102;
+    endpoint.pane_mut("%3").pane_pid = 103;
+    for (identity, binding) in [
+        (&charlie, &bindings[0]),
+        (&alpha, &bindings[1]),
+        (&bravo, &bindings[2]),
+    ] {
+        endpoint.pane_mut(&binding.pane_id).marker = Some(binding.marker(identity));
+    }
+
+    let result = list_presence(
+        &mut storage,
+        &mut endpoint,
+        Some(server_b.socket_path.as_str()),
+    )
+    .unwrap();
+    assert_eq!(
+        result
+            .iter()
+            .map(|presence| presence.identity.canonical_name.as_str())
+            .collect::<Vec<_>>(),
+        ["alpha", "bravo", "charlie"]
+    );
+    assert!(
+        result
+            .iter()
+            .all(|presence| presence.presence == Presence::Active)
+    );
+    assert_eq!(endpoint.probe_calls.len(), 2);
+    assert_eq!(
+        endpoint.probe_calls,
+        vec![
+            ("server-b".into(), vec!["%3".into()]),
+            ("server-a".into(), vec!["%2".into(), "%1".into()]),
+        ]
+    );
+
+    endpoint.expire_after_probe = Some(endpoint.probe_calls.len() + 1);
+    let probe_count = endpoint.probe_calls.len();
+    let result = list_presence(
+        &mut storage,
+        &mut endpoint,
+        Some(server_b.socket_path.as_str()),
+    )
+    .unwrap();
+    assert_eq!(endpoint.probe_calls.len(), probe_count + 1);
+    assert_eq!(
+        result
+            .iter()
+            .find(|presence| presence.identity.canonical_name == "bravo")
+            .unwrap()
+            .presence,
+        Presence::Active
+    );
+    assert_eq!(
+        result
+            .iter()
+            .filter(|presence| presence.presence == Presence::Unknown)
+            .count(),
+        2
+    );
+    let entries = storage
+        .with_binding_transaction(|records| records.binding_entries())
+        .unwrap();
+    assert!(entries.iter().all(|entry| entry.binding.is_some()));
+    storage.close().unwrap();
+}

--- a/rust/crates/tmt-adapters/src/storage/bindings/service_tests/publication.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings/service_tests/publication.rs
@@ -1,0 +1,170 @@
+use tmt_core::{
+    binding::{BindingError, BindingRepository, bind_identity},
+    identity::{IdentityReader, Lifetime, create_or_resolve},
+};
+
+use super::super::test_support::Fixture;
+use super::endpoint::{EndpointFailure, FakeEndpoint};
+
+#[test]
+fn temporary_binding_save_reuses_uuid_and_never_downgrades() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+
+    let first = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", false).unwrap();
+    let second = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true).unwrap();
+    let third = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", false).unwrap();
+
+    assert_eq!(first.identity.id, second.identity.id);
+    assert_eq!(second.identity, third.identity);
+    assert_eq!(second.identity.lifetime, Lifetime::Saved);
+    assert_eq!(
+        first.binding.as_ref().unwrap().id,
+        second.binding.as_ref().unwrap().id
+    );
+    assert_eq!(endpoint.publish_calls, 1);
+    storage.close().unwrap();
+}
+
+#[test]
+fn occupied_pane_leaves_new_identity_committed_without_binding() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let alice = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true)
+        .unwrap()
+        .identity;
+
+    let error = bind_identity(&mut storage, &mut endpoint, "%1", "Bob", false).unwrap_err();
+    assert!(matches!(error, BindingError::PaneAlreadyBound));
+    let bob = storage.find_identity("bob").unwrap().unwrap();
+    assert_ne!(alice.id, bob.id);
+    let bob_entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&bob.id))
+        .unwrap()
+        .unwrap();
+    assert!(bob_entry.binding.is_none());
+    let alice_entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&alice.id))
+        .unwrap()
+        .unwrap();
+    assert!(alice_entry.binding.is_some());
+    storage.close().unwrap();
+}
+
+#[test]
+fn publish_and_verification_failures_rollback_binding_but_keep_identity() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1", "%2"]);
+    endpoint.publish_failure = true;
+    let error = bind_identity(&mut storage, &mut endpoint, "%1", "PublishFail", false).unwrap_err();
+    assert!(matches!(
+        error,
+        BindingError::Endpoint(EndpointFailure("publish failed"))
+    ));
+    let identity = storage.find_identity("publishfail").unwrap().unwrap();
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&identity.id))
+        .unwrap()
+        .unwrap();
+    assert!(entry.binding.is_none());
+
+    endpoint.publish_failure = false;
+    endpoint.verification_failure = true;
+    let error = bind_identity(&mut storage, &mut endpoint, "%2", "VerifyFail", false).unwrap_err();
+    assert!(matches!(error, BindingError::Unverified));
+    let identity = storage.find_identity("verifyfail").unwrap().unwrap();
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&identity.id))
+        .unwrap()
+        .unwrap();
+    assert!(entry.binding.is_none());
+    storage.close().unwrap();
+}
+
+#[test]
+fn preflight_missing_or_invalid_name_does_not_create_identity_or_publish() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut missing = FakeEndpoint::new(&[]);
+    let error = bind_identity(&mut storage, &mut missing, "%9", "Missing", false).unwrap_err();
+    assert!(matches!(error, BindingError::PaneNotFound(pane) if pane == "%9"));
+    assert!(storage.find_identity("missing").unwrap().is_none());
+    assert_eq!(missing.publish_calls, 0);
+
+    let mut invalid = FakeEndpoint::new(&["%1"]);
+    let error = bind_identity(&mut storage, &mut invalid, "%1", "   ", false).unwrap_err();
+    assert!(matches!(error, BindingError::InvalidName(_)));
+    assert!(storage.find_identity("").unwrap().is_none());
+    assert_eq!(invalid.publish_calls, 0);
+    storage.close().unwrap();
+}
+
+#[test]
+fn failed_saved_publication_keeps_separately_committed_promotion() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let original = create_or_resolve(&mut storage, "Promote", Lifetime::Temporary)
+        .unwrap()
+        .identity;
+    endpoint.publish_failure = true;
+
+    let error = bind_identity(&mut storage, &mut endpoint, "%1", "Promote", true).unwrap_err();
+    assert!(matches!(
+        error,
+        BindingError::Endpoint(EndpointFailure("publish failed"))
+    ));
+    let promoted = storage.find_identity("promote").unwrap().unwrap();
+    assert_eq!(promoted.id, original.id);
+    assert_eq!(promoted.lifetime, Lifetime::Saved);
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&promoted.id))
+        .unwrap()
+        .unwrap();
+    assert!(entry.binding.is_none());
+    assert_eq!(endpoint.publish_calls, 0);
+    storage.close().unwrap();
+}
+
+#[test]
+fn dead_pane_after_creation_cannot_be_revived_between_creation_and_publication() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    endpoint.hide_panes_after_current = Some(2);
+
+    let error = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", false).unwrap_err();
+    assert!(matches!(error, BindingError::PaneNotFound(pane) if pane == "%1"));
+    let identity = storage.find_identity("alice").unwrap().unwrap();
+    assert_eq!(identity.lifetime, Lifetime::Temporary);
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&identity.id))
+        .unwrap()
+        .unwrap();
+    assert!(entry.binding.is_none());
+    assert_eq!(endpoint.publish_calls, 0);
+    storage.close().unwrap();
+}
+
+#[test]
+fn expiry_after_publication_rolls_back_binding_without_losing_identity() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    endpoint.expire_after_publish = true;
+
+    let error = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", false).unwrap_err();
+    assert!(matches!(error, BindingError::Deadline));
+    assert_eq!(endpoint.publish_calls, 1);
+    let identity = storage.find_identity("alice").unwrap().unwrap();
+    assert_eq!(identity.lifetime, Lifetime::Temporary);
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&identity.id))
+        .unwrap()
+        .unwrap();
+    assert!(entry.binding.is_none());
+    storage.close().unwrap();
+}

--- a/rust/crates/tmt-adapters/src/storage/bindings/service_tests/removal.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings/service_tests/removal.rs
@@ -1,0 +1,244 @@
+use rusqlite::{Connection, params, types::Value};
+use tmt_core::{
+    binding::{BindingError, remove_identity, unbind_identity},
+    identity::{IdentityReader, Lifetime, create_or_resolve},
+};
+
+use super::super::test_support::Fixture;
+use super::endpoint::{EndpointFailure, FakeEndpoint, ProbeMode};
+
+fn state_counts(connection: &Connection, identity_id: &str) -> (i64, i64, i64, i64, i64, i64) {
+    connection
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM role_profiles WHERE identity_id = ?),
+                (SELECT COUNT(*) FROM identity_preambles WHERE identity_id = ?),
+                (SELECT COUNT(*) FROM preamble_counters WHERE identity_id = ?),
+                (SELECT COUNT(*) FROM request_attempts WHERE identity_id = ?),
+                (SELECT COUNT(*) FROM request_responses WHERE request_id = ?),
+                (SELECT COUNT(*) FROM request_attention_identities WHERE identity_id = ?)",
+            params![
+                identity_id,
+                identity_id,
+                identity_id,
+                identity_id,
+                format!("request-{identity_id}"),
+                identity_id,
+            ],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            },
+        )
+        .unwrap()
+}
+
+fn binding_rows(connection: &Connection, identity_id: &str) -> Vec<Vec<Value>> {
+    let mut statement = connection
+        .prepare("SELECT * FROM bindings WHERE identity_id = ? ORDER BY id")
+        .unwrap();
+    statement
+        .query_map([identity_id], |row| {
+            (0..row.as_ref().column_count())
+                .map(|index| row.get(index))
+                .collect::<rusqlite::Result<Vec<Value>>>()
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+}
+
+fn seed_state(connection: &Connection, identity_id: &str) {
+    let attempt_id = format!("attempt-{identity_id}");
+    let request_id = format!("request-{identity_id}");
+    connection
+        .execute(
+            "INSERT INTO role_profiles VALUES (?, 'role body', 'role-time')",
+            [identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO identity_preambles VALUES (?, 'preamble body', 'preamble-time')",
+            [identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO preamble_counters VALUES (?, 12, 123456789)",
+            [identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO request_attention_identities VALUES (?, 7, 5)",
+            [identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO request_attempts (
+                attempt_id, request_id, identity_id, server_id, socket_path, server_pid,
+                server_start_time, pane_id, pane_pid, wait_active, status, inject_preamble,
+                cadence_reserved, prepared_at_ms, expires_at_ms, retention_days,
+                retention_expires_at_ms
+             ) VALUES (?, ?, ?, 'server', '/tmp/socket', 41, 'server-start', '%1', 99,
+                0, 'sent', 0, 1, 100, 200, 7, 300)",
+            params![attempt_id, request_id, identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO request_responses (
+                request_id, attempt_id, server_id, socket_path, server_pid,
+                server_start_time, pane_id, pane_pid, body, body_bytes, submitted_at_ms,
+                response_expires_at_ms
+             ) VALUES (?, ?, 'server', '/tmp/socket', 41, 'server-start', '%1', 99,
+                'response body', 13, 150, 500)",
+            params![request_id, attempt_id],
+        )
+        .unwrap();
+}
+
+#[test]
+fn remove_unknown_or_unclearable_binding_fails_closed_without_mutating_state() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let identity =
+        tmt_core::binding::bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true)
+            .unwrap()
+            .identity;
+    seed_state(storage.connection().unwrap(), &identity.id);
+    let rows = binding_rows(storage.connection().unwrap(), &identity.id);
+    let counts = state_counts(storage.connection().unwrap(), &identity.id);
+
+    endpoint.probe_mode = ProbeMode::Unknown;
+    let error = remove_identity(&mut storage, &mut endpoint, "Alice", true).unwrap_err();
+    assert!(matches!(error, BindingError::Unverified));
+    assert_eq!(endpoint.clear_calls, 0);
+    assert_eq!(
+        binding_rows(storage.connection().unwrap(), &identity.id),
+        rows
+    );
+    assert_eq!(
+        state_counts(storage.connection().unwrap(), &identity.id),
+        counts
+    );
+
+    endpoint.probe_mode = ProbeMode::Live;
+    endpoint.clear_result = false;
+    let error = remove_identity(&mut storage, &mut endpoint, "Alice", true).unwrap_err();
+    assert!(matches!(error, BindingError::Unverified));
+    assert_eq!(
+        binding_rows(storage.connection().unwrap(), &identity.id),
+        rows
+    );
+    assert_eq!(
+        state_counts(storage.connection().unwrap(), &identity.id),
+        counts
+    );
+
+    endpoint.clear_result = true;
+    endpoint.clear_failure = true;
+    let error = remove_identity(&mut storage, &mut endpoint, "Alice", true).unwrap_err();
+    assert!(matches!(
+        error,
+        BindingError::Endpoint(EndpointFailure("clear failed"))
+    ));
+    assert_eq!(
+        binding_rows(storage.connection().unwrap(), &identity.id),
+        rows
+    );
+    assert_eq!(
+        state_counts(storage.connection().unwrap(), &identity.id),
+        counts
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn unbind_retires_temporary_but_saved_offline_only_detaches() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1", "%2"]);
+    let temporary =
+        tmt_core::binding::bind_identity(&mut storage, &mut endpoint, "%1", "Temporary", false)
+            .unwrap()
+            .identity;
+    let unbound = unbind_identity(&mut storage, &mut endpoint, "%1")
+        .unwrap()
+        .unwrap();
+    assert!(unbound.retired);
+    assert!(unbound.binding.is_some());
+    assert!(storage.find_identity("temporary").unwrap().is_none());
+    assert_eq!(unbound.identity.id, temporary.id);
+
+    let saved = tmt_core::binding::bind_identity(&mut storage, &mut endpoint, "%2", "Saved", true)
+        .unwrap()
+        .identity;
+    endpoint.pane_mut("%2").marker = None;
+    let unbound = unbind_identity(&mut storage, &mut endpoint, "%2")
+        .unwrap()
+        .unwrap();
+    assert!(!unbound.retired);
+    assert!(unbound.binding.is_none());
+    assert_eq!(unbound.identity.id, saved.id);
+    assert!(storage.find_identity("saved").unwrap().is_some());
+    assert_eq!(endpoint.clear_calls, 1);
+    storage.close().unwrap();
+}
+
+#[test]
+fn saved_remove_requires_confirmation_without_endpoint_io_and_force_removes_only_content() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&[]);
+    let identity = create_or_resolve(&mut storage, "Saved", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    seed_state(storage.connection().unwrap(), &identity.id);
+    let calls = (
+        endpoint.begin_calls,
+        endpoint.current_calls,
+        endpoint.probe_calls.len(),
+        endpoint.clear_calls,
+    );
+
+    let error = remove_identity(&mut storage, &mut endpoint, "Saved", false).unwrap_err();
+    assert!(matches!(error, BindingError::ConfirmationRequired));
+    assert_eq!(
+        calls,
+        (
+            endpoint.begin_calls,
+            endpoint.current_calls,
+            endpoint.probe_calls.len(),
+            endpoint.clear_calls
+        )
+    );
+    let removed = remove_identity(&mut storage, &mut endpoint, "Saved", true).unwrap();
+    assert_eq!(removed.identity.id, identity.id);
+    assert!(removed.binding.is_none());
+    assert_eq!(
+        state_counts(storage.connection().unwrap(), &identity.id),
+        (0, 0, 1, 1, 1, 1)
+    );
+    assert!(storage.find_identity("saved").unwrap().is_none());
+    let tombstone: Option<i64> = storage
+        .connection()
+        .unwrap()
+        .query_row(
+            "SELECT retired_at_ms FROM identities WHERE id = ?",
+            [&identity.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(tombstone.is_some());
+    storage.close().unwrap();
+}

--- a/rust/crates/tmt-adapters/src/storage/bindings/test_support.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings/test_support.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+
+use crate::test_support::TestDirectory;
+use tmt_core::endpoint::PaneObservation;
+
+use super::super::Storage;
+
+pub(super) struct Fixture {
+    _directory: TestDirectory,
+    pub(super) database: PathBuf,
+}
+
+impl Fixture {
+    pub(super) fn new() -> Self {
+        let directory = TestDirectory::new();
+        Self {
+            database: directory.path.join("state").join("tmux-team.db"),
+            _directory: directory,
+        }
+    }
+
+    pub(super) fn open(&self) -> Storage {
+        Storage::open(&self.database).unwrap()
+    }
+}
+
+pub(super) fn pane(id: &str, pid: u64) -> PaneObservation {
+    PaneObservation {
+        id: id.into(),
+        target: None,
+        cwd: None,
+        command: "agent".into(),
+        pane_pid: pid,
+        suggested_name: None,
+        marker: None,
+    }
+}

--- a/rust/crates/tmt-adapters/src/storage/bindings/tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings/tests.rs
@@ -1,0 +1,344 @@
+use std::time::Duration;
+
+use rusqlite::Connection;
+use tmt_core::{
+    binding::BindingRepository,
+    endpoint::ServerEvidence,
+    identity::{Lifetime, create_or_resolve},
+};
+
+use super::super::*;
+
+use super::test_support::{Fixture, pane};
+
+fn server() -> ServerEvidence {
+    ServerEvidence {
+        server_id: "123e4567-e89b-42d3-a456-426614174000".into(),
+        socket_path: "/tmp/tmux-test.sock".into(),
+        server_pid: 41,
+        server_start_time: "server-start".into(),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ApplicationFailure;
+
+impl From<StorageError> for ApplicationFailure {
+    fn from(_: StorageError) -> Self {
+        Self
+    }
+}
+
+#[test]
+fn joined_entries_are_binary_ordered_and_exclude_retired_identities() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let beta = create_or_resolve(&mut storage, "Beta", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let alpha = create_or_resolve(&mut storage, "alpha", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let binding = storage
+        .with_binding_transaction(|records| {
+            records.insert_binding(&alpha, &server(), &pane("%3", 99))
+        })
+        .unwrap();
+
+    let entries = storage
+        .with_binding_transaction(|records| Ok::<_, StorageError>(records.binding_entries()))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry.identity.canonical_name.as_str())
+            .collect::<Vec<_>>(),
+        ["alpha", "beta"]
+    );
+    assert_eq!(entries[0].binding.as_ref(), Some(&binding));
+    assert!(entries[1].binding.is_none());
+    let selected = storage
+        .with_binding_transaction(|records| records.entry_by_id(&alpha.id))
+        .unwrap()
+        .unwrap();
+    assert_eq!(selected.binding, Some(binding.clone()));
+
+    storage
+        .with_binding_transaction(|records| records.retire_identity(&alpha, false))
+        .unwrap();
+    let remaining = storage
+        .with_binding_transaction(|records| Ok::<_, StorageError>(records.binding_entries()))
+        .unwrap()
+        .unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].identity.id, beta.id);
+    assert!(remaining[0].binding.is_none());
+
+    let connection = Connection::open(&fixture.database).unwrap();
+    let retired: (Option<i64>, i64) = connection
+        .query_row(
+            "SELECT retired_at_ms, (SELECT COUNT(*) FROM bindings WHERE identity_id = ?) FROM identities WHERE id = ?",
+            [&alpha.id, &alpha.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert!(retired.0.is_some_and(|value| value > 0));
+    assert_eq!(retired.1, 0);
+    storage.close().unwrap();
+}
+
+#[test]
+fn binding_mutations_are_exact_and_content_removal_is_opt_in() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let identity = create_or_resolve(&mut storage, "Alice", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let other = create_or_resolve(&mut storage, "Other", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let binding = storage
+        .with_binding_transaction(|records| {
+            records.insert_binding(&identity, &server(), &pane("%3", 99))
+        })
+        .unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE bindings SET last_verified_at = 'old' WHERE id = ?",
+            [&binding.id],
+        )
+        .unwrap();
+
+    storage
+        .with_binding_transaction(|records| records.touch_binding(&other.id))
+        .unwrap();
+    assert_eq!(
+        storage
+            .connection()
+            .unwrap()
+            .query_row(
+                "SELECT last_verified_at FROM bindings WHERE id = ?",
+                [&binding.id],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+        "old"
+    );
+    storage
+        .with_binding_transaction(|records| records.touch_binding(&binding.id))
+        .unwrap();
+    assert_ne!(
+        storage
+            .connection()
+            .unwrap()
+            .query_row(
+                "SELECT last_verified_at FROM bindings WHERE id = ?",
+                [&binding.id],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+        "old"
+    );
+
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "INSERT INTO role_profiles VALUES (?, 'role', 'role-time')",
+            [&identity.id],
+        )
+        .unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "INSERT INTO identity_preambles VALUES (?, 'preamble', 'preamble-time')",
+            [&identity.id],
+        )
+        .unwrap();
+    storage
+        .with_binding_transaction(|records| records.retire_identity(&identity, false))
+        .unwrap();
+    let retained_content: (i64, i64) = storage
+        .connection()
+        .unwrap()
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM role_profiles WHERE identity_id = ?),
+                (SELECT COUNT(*) FROM identity_preambles WHERE identity_id = ?)",
+            [&identity.id, &identity.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(retained_content, (1, 1));
+
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "INSERT INTO role_profiles VALUES (?, 'role', 'role-time')",
+            [&other.id],
+        )
+        .unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "INSERT INTO identity_preambles VALUES (?, 'preamble', 'preamble-time')",
+            [&other.id],
+        )
+        .unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "INSERT INTO preamble_counters VALUES (?, 4, 100)",
+            [&other.id],
+        )
+        .unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "INSERT INTO request_attention_identities VALUES (?, 2, 1)",
+            [&other.id],
+        )
+        .unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "INSERT INTO request_attempts (
+                attempt_id, request_id, identity_id, server_id, socket_path, server_pid,
+                server_start_time, pane_id, pane_pid, wait_active, status, inject_preamble,
+                cadence_reserved, prepared_at_ms, expires_at_ms, retention_days,
+                retention_expires_at_ms
+             ) VALUES ('attempt-other', 'request-other', ?, 'server', '/tmp/socket', 41,
+                'server-start', '%3', 99, 0, 'sent', 0, 1, 100, 200, 7, 300)",
+            [&other.id],
+        )
+        .unwrap();
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "INSERT INTO request_responses (
+                request_id, attempt_id, server_id, socket_path, server_pid,
+                server_start_time, pane_id, pane_pid, body, body_bytes, submitted_at_ms,
+                response_expires_at_ms
+             ) VALUES ('request-other', 'attempt-other', 'server', '/tmp/socket', 41,
+                'server-start', '%3', 99, 'response', 8, 150, 500)",
+            [],
+        )
+        .unwrap();
+    storage
+        .with_binding_transaction(|records| records.retire_identity(&other, true))
+        .unwrap();
+    let retained_state: (i64, i64, i64, i64, i64, i64) = storage
+        .connection()
+        .unwrap()
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM role_profiles WHERE identity_id = ?),
+                (SELECT COUNT(*) FROM identity_preambles WHERE identity_id = ?),
+                (SELECT COUNT(*) FROM preamble_counters WHERE identity_id = ?),
+                (SELECT COUNT(*) FROM request_attempts WHERE identity_id = ?),
+                (SELECT COUNT(*) FROM request_responses WHERE request_id = 'request-other'),
+                (SELECT COUNT(*) FROM request_attention_identities WHERE identity_id = ?)",
+            [&other.id, &other.id, &other.id, &other.id, &other.id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(retained_state, (0, 0, 1, 1, 1, 1));
+
+    // A stale exact ID cannot detach another identity's binding.
+    let survivor = create_or_resolve(&mut storage, "Survivor", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let survivor_binding = storage
+        .with_binding_transaction(|records| {
+            records.insert_binding(&survivor, &server(), &pane("%4", 100))
+        })
+        .unwrap();
+    storage
+        .with_binding_transaction(|records| records.detach_binding("stale-binding-id"))
+        .unwrap();
+    assert_eq!(
+        storage
+            .connection()
+            .unwrap()
+            .query_row(
+                "SELECT id FROM bindings WHERE identity_id = ?",
+                [&survivor.id],
+                |row| row.get::<_, String>(0)
+            )
+            .unwrap(),
+        survivor_binding.id
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn application_failure_rolls_back_binding_writes_and_releases_lock() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let identity = create_or_resolve(&mut storage, "Rollback", Lifetime::Temporary)
+        .unwrap()
+        .identity;
+    let result: Result<(), ApplicationFailure> = storage.with_binding_transaction(|records| {
+        records.insert_binding(&identity, &server(), &pane("%8", 100))?;
+        Err(ApplicationFailure)
+    });
+    assert_eq!(result, Err(ApplicationFailure));
+
+    let verification = Connection::open(&fixture.database).unwrap();
+    assert_eq!(
+        verification
+            .query_row("SELECT COUNT(*) FROM bindings", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    verification
+        .execute_batch("BEGIN IMMEDIATE; COMMIT;")
+        .unwrap();
+    storage.close().unwrap();
+}
+
+#[test]
+fn closed_storage_and_immediate_lock_contention_are_reported() {
+    let fixture = Fixture::new();
+    let mut closed = fixture.open();
+    closed.close().unwrap();
+    let error: Result<(), StorageError> = closed.with_binding_transaction(|_| Ok(()));
+    assert_eq!(error.unwrap_err().code, StorageErrorCode::Closed);
+
+    let mut storage = fixture.open();
+    storage
+        .connection()
+        .unwrap()
+        .busy_timeout(Duration::from_millis(25))
+        .unwrap();
+    let blocker = Connection::open(&fixture.database).unwrap();
+    blocker.busy_timeout(Duration::from_millis(25)).unwrap();
+    blocker.execute_batch("BEGIN IMMEDIATE;").unwrap();
+    let error: Result<(), StorageError> = storage.with_binding_transaction(|_| Ok(()));
+    let error = error.unwrap_err();
+    assert_eq!(error.code, StorageErrorCode::Busy);
+    assert!(error.retryable);
+    assert!(storage.connection().unwrap().is_autocommit());
+    blocker.execute_batch("ROLLBACK;").unwrap();
+    storage.close().unwrap();
+}

--- a/rust/crates/tmt-adapters/src/storage/identities.rs
+++ b/rust/crates/tmt-adapters/src/storage/identities.rs
@@ -1,6 +1,6 @@
 //! Identity SQL shares the invocation-owned connection and schema history.
 
-use rusqlite::{Connection, OptionalExtension, Row, TransactionBehavior, params};
+use rusqlite::{Connection, OptionalExtension, Row, Transaction, TransactionBehavior, params};
 use tmt_core::{
     identity::{Identity, IdentityReader, IdentityRepository, IdentityWriter, Lifetime},
     names::ValidatedName,
@@ -10,22 +10,26 @@ use super::{Storage, StorageError, StorageErrorCode, errors::classify};
 
 const COLUMNS: &str = "id, name, canonical_name, lifetime, created_at, updated_at";
 
-struct IdentityRecords<'a>(&'a Connection);
+pub(super) struct IdentityRecords<'a>(pub(super) &'a Connection);
 
-fn identity_row(row: &Row<'_>) -> rusqlite::Result<Identity> {
-    let lifetime = match row.get::<_, String>(3)?.as_str() {
+pub(super) fn identity_row_at(row: &Row<'_>, offset: usize) -> rusqlite::Result<Identity> {
+    let lifetime = match row.get::<_, String>(offset + 3)?.as_str() {
         "temporary" => Lifetime::Temporary,
         "saved" => Lifetime::Saved,
         _ => return Err(rusqlite::Error::InvalidQuery),
     };
     Ok(Identity {
-        id: row.get(0)?,
-        name: row.get(1)?,
-        canonical_name: row.get(2)?,
+        id: row.get(offset)?,
+        name: row.get(offset + 1)?,
+        canonical_name: row.get(offset + 2)?,
         lifetime,
-        created_at: row.get(4)?,
-        updated_at: row.get(5)?,
+        created_at: row.get(offset + 4)?,
+        updated_at: row.get(offset + 5)?,
     })
+}
+
+fn identity_row(row: &Row<'_>) -> rusqlite::Result<Identity> {
+    identity_row_at(row, 0)
 }
 
 impl IdentityReader for IdentityRecords<'_> {
@@ -93,18 +97,42 @@ impl IdentityRepository for Storage {
         &mut self,
         operation: impl FnOnce(&mut dyn IdentityWriter<Error = Self::Error>) -> Result<T, Self::Error>,
     ) -> Result<T, Self::Error> {
-        let connection = self.connection.as_mut().ok_or_else(|| {
-            StorageError::new(StorageErrorCode::Closed, "Storage is already closed")
-        })?;
-        let transaction = connection
-            .transaction_with_behavior(TransactionBehavior::Immediate)
-            .map_err(|error| classify(error, "Begin identity transaction"))?;
-        let result = operation(&mut IdentityRecords(&transaction))?;
-        transaction
-            .commit()
-            .map_err(|error| classify(error, "Commit identity transaction"))?;
-        Ok(result)
+        with_immediate_transaction(self, "identity", |transaction| {
+            operation(&mut IdentityRecords(transaction))
+        })
     }
+}
+
+pub(super) fn with_immediate_transaction<T, E>(
+    storage: &mut Storage,
+    operation_name: &str,
+    operation: impl FnOnce(&Transaction<'_>) -> Result<T, E>,
+) -> Result<T, E>
+where
+    E: From<StorageError>,
+{
+    let connection = storage.connection.as_mut().ok_or_else(|| {
+        E::from(StorageError::new(
+            StorageErrorCode::Closed,
+            "Storage is already closed",
+        ))
+    })?;
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| {
+            E::from(classify(
+                error,
+                &format!("Begin {operation_name} transaction"),
+            ))
+        })?;
+    let result = operation(&transaction)?;
+    transaction.commit().map_err(|error| {
+        E::from(classify(
+            error,
+            &format!("Commit {operation_name} transaction"),
+        ))
+    })?;
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/rust/crates/tmt-adapters/src/storage/mod.rs
+++ b/rust/crates/tmt-adapters/src/storage/mod.rs
@@ -1,3 +1,4 @@
+mod bindings;
 mod errors;
 mod identities;
 mod migrations;

--- a/rust/crates/tmt-adapters/src/tmux/binding.rs
+++ b/rust/crates/tmt-adapters/src/tmux/binding.rs
@@ -1,0 +1,177 @@
+//! Application-port composition over the existing tmux runner and wire parser.
+
+use super::{CommandRunner, OperationOptions, Tmux, TmuxError, TmuxFailure, socket_args};
+use std::time::{Duration, Instant};
+use tmt_core::{
+    binding::{Binding, BindingEndpoint},
+    endpoint::{EndpointProbe, EndpointSnapshot, ServerEvidence},
+    identity::Identity,
+};
+
+pub struct BindingSession<'a, R> {
+    tmux: &'a Tmux<R>,
+    deadline: Instant,
+}
+
+impl<'a, R: CommandRunner> BindingSession<'a, R> {
+    pub fn new(tmux: &'a Tmux<R>) -> Self {
+        Self {
+            tmux,
+            deadline: Instant::now(),
+        }
+    }
+
+    fn options<'b>(&self, panes: Option<&'b [String]>) -> OperationOptions<'b> {
+        OperationOptions {
+            deadline: Some(self.deadline),
+            pane_ids: panes,
+        }
+    }
+}
+
+impl<R: CommandRunner> BindingEndpoint for BindingSession<'_, R> {
+    type Error = TmuxError;
+
+    fn begin_coordination(&mut self) {
+        self.deadline = Instant::now() + Duration::from_secs(3);
+    }
+    fn budget_available(&self) -> bool {
+        Instant::now() < self.deadline
+    }
+
+    fn current_snapshot(&mut self, panes: &[String]) -> Result<EndpointSnapshot, Self::Error> {
+        self.tmux.snapshot(self.options(Some(panes)))
+    }
+
+    fn probe_binding(
+        &mut self,
+        server: &ServerEvidence,
+        panes: &[String],
+    ) -> Result<EndpointProbe, Self::Error> {
+        if !self.budget_available() {
+            return Ok(EndpointProbe::Unknown);
+        }
+        let probe = self.tmux.probe(
+            &server.socket_path,
+            server.server_pid,
+            self.options(Some(panes)),
+        )?;
+        // A spent coordination budget does not authorize loss/retirement.
+        Ok(if self.budget_available() {
+            probe
+        } else {
+            EndpointProbe::Unknown
+        })
+    }
+
+    fn publish(&mut self, binding: &Binding, identity: &Identity) -> Result<(), Self::Error> {
+        self.tmux.set_marker_on(
+            Some(&binding.server.socket_path),
+            &binding.pane_id,
+            &binding.marker(identity),
+            self.options(None),
+        )
+    }
+
+    fn clear(&mut self, binding: &Binding) -> Result<bool, Self::Error> {
+        self.tmux.clear_marker_on(
+            Some(&binding.server.socket_path),
+            &binding.pane_id,
+            Some(&binding.id),
+            self.options(None),
+        )
+    }
+}
+
+impl<R: CommandRunner> Tmux<R> {
+    /// Cosmetic work is bounded and post-commit. Recheck the recorded endpoint
+    /// and marker before touching the pane-local option; never change a title,
+    /// window theme or another binding. Only failed child cleanup propagates.
+    pub fn update_binding_badge(
+        &self,
+        binding: &Binding,
+        name: Option<&str>,
+    ) -> Result<(), TmuxError> {
+        let result = (|| {
+            let panes = [binding.pane_id.clone()];
+            let options = OperationOptions {
+                deadline: Some(Instant::now() + Duration::from_secs(1)),
+                pane_ids: Some(&panes),
+            };
+            let EndpointProbe::Live(snapshot) = self.probe(
+                &binding.server.socket_path,
+                binding.server.server_pid,
+                options,
+            )?
+            else {
+                return Ok(());
+            };
+            if snapshot.server != binding.server {
+                return Ok(());
+            }
+            let Some(pane) = snapshot
+                .panes
+                .iter()
+                .find(|p| p.id == binding.pane_id && p.pane_pid == binding.pane_pid)
+            else {
+                return Ok(());
+            };
+            if pane
+                .marker
+                .as_ref()
+                .is_some_and(|marker| marker.binding_id != binding.id)
+            {
+                return Ok(());
+            }
+            if name.is_some()
+                && pane
+                    .marker
+                    .as_ref()
+                    .is_none_or(|marker| marker.binding_id != binding.id)
+            {
+                return Ok(());
+            }
+            let mut args = socket_args(Some(&binding.server.socket_path));
+            args.extend(["set-option".into(), "-p".into()]);
+            if name.is_none() {
+                args.push("-u".into());
+            }
+            args.extend([
+                "-t".into(),
+                binding.pane_id.clone(),
+                "@tmux-team.badge".into(),
+            ]);
+            if let Some(name) = name {
+                args.push(badge_label(name));
+            }
+            self.execute(args, options, TmuxFailure::Command)
+                .map(|_| ())
+        })();
+        match result {
+            Err(error) if error.cleanup_failed() => Err(error),
+            _ => Ok(()),
+        }
+    }
+}
+
+fn badge_label(name: &str) -> String {
+    let mut characters = name.chars();
+    let mut label: String = characters
+        .by_ref()
+        .take(48)
+        .map(|c| {
+            if c == '#' {
+                '＃'
+            } else if c.is_control() {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect();
+    if characters.next().is_some() {
+        label.push('…');
+    }
+    label.push_str(" (tmt)");
+    label
+}

--- a/rust/crates/tmt-adapters/src/tmux/caller.rs
+++ b/rust/crates/tmt-adapters/src/tmux/caller.rs
@@ -20,6 +20,11 @@ pub struct CallerEnvironment {
 }
 
 impl CallerEnvironment {
+    /// A scheduling preference only, not verified caller or routing authority.
+    pub fn selected_socket(&self) -> Option<&str> {
+        context(self.tmux.as_ref()?.to_str()?).map(|context| context.socket)
+    }
+
     pub fn current() -> Self {
         Self {
             tmux: std::env::var_os("TMUX"),

--- a/rust/crates/tmt-adapters/src/tmux/evidence.rs
+++ b/rust/crates/tmt-adapters/src/tmux/evidence.rs
@@ -7,6 +7,10 @@ use tmt_core::endpoint::{
 use super::{TmuxError, metadata};
 
 pub(super) const SEPARATOR: &str = "__TMT_FIELD_4f1c__";
+// Bound work before constructing argv, not only after a subprocess starts.
+// Oversized probes stay Unknown; explicit scoped mutations fail closed.
+const MAX_SCOPE_PANES: usize = 1024;
+const MAX_FILTER_BYTES: usize = 32 * 1024;
 
 pub(super) fn server_format() -> String {
     [
@@ -155,15 +159,33 @@ fn suggested_name(command: &str) -> Option<String> {
 
 pub(super) fn scoped_ids(ids: Option<&[String]>) -> Result<Option<Vec<&str>>, TmuxError> {
     ids.map(|ids| {
+        if ids.len() > MAX_SCOPE_PANES {
+            return Err(TmuxError::evidence(
+                "tmux pane scope exceeds observation limits",
+            ));
+        }
         let mut scoped = Vec::new();
         let mut seen = HashSet::new();
+        let mut filter_bytes = 0usize;
         for id in ids {
+            if id.len() > MAX_FILTER_BYTES {
+                return Err(TmuxError::evidence(
+                    "tmux pane scope exceeds observation limits",
+                ));
+            }
             if !valid_pane_id(id) {
                 return Err(TmuxError::evidence(
                     "tmux pane scope contains an invalid pane ID",
                 ));
             }
             if seen.insert(id.as_str()) {
+                // One leaf and (conservatively) one disjunction per pane.
+                filter_bytes += id.len() + "#{==:#{pane_id},}".len() + "#{||:,}".len();
+                if filter_bytes > MAX_FILTER_BYTES {
+                    return Err(TmuxError::evidence(
+                        "tmux pane scope exceeds observation limits",
+                    ));
+                }
                 scoped.push(id.as_str());
             }
         }
@@ -173,7 +195,24 @@ pub(super) fn scoped_ids(ids: Option<&[String]>) -> Result<Option<Vec<&str>>, Tm
 }
 
 pub(super) fn pane_filter(ids: &[&str]) -> String {
-    let mut expressions = ids.iter().map(|id| format!("#{{==:#{{pane_id}},{id}}}"));
-    let first = expressions.next().expect("nonempty validated pane scope");
-    expressions.fold(first, |combined, next| format!("#{{||:{combined},{next}}}"))
+    // A balanced expression bounds tmux's own recursion depth. Append into one
+    // buffer instead of repeatedly copying an ever-growing nested expression.
+    fn append(output: &mut String, ids: &[&str]) {
+        if let [id] = ids {
+            output.push_str("#{==:#{pane_id},");
+            output.push_str(id);
+            output.push('}');
+        } else {
+            let (left, right) = ids.split_at(ids.len() / 2);
+            output.push_str("#{||:");
+            append(output, left);
+            output.push(',');
+            append(output, right);
+            output.push('}');
+        }
+    }
+    assert!(!ids.is_empty(), "nonempty validated pane scope");
+    let mut output = String::new();
+    append(&mut output, ids);
+    output
 }

--- a/rust/crates/tmt-adapters/src/tmux/evidence_tests.rs
+++ b/rust/crates/tmt-adapters/src/tmux/evidence_tests.rs
@@ -224,6 +224,40 @@ fn deduplicates_scoped_ids_and_builds_nested_tmux_filter() {
 }
 
 #[test]
+fn scope_bounds_cover_argv_bytes_and_expression_depth_before_io() {
+    let too_many = (0..1025)
+        .map(|index| format!("%{index}"))
+        .collect::<Vec<_>>();
+    assert!(evidence::scoped_ids(Some(&too_many)).is_err());
+    let oversized = vec![format!("%{}", "1".repeat(32 * 1024))];
+    assert!(evidence::scoped_ids(Some(&oversized)).is_err());
+    let aggregate = (0..1024)
+        .map(|index| format!("%00000000000000000000{index}"))
+        .collect::<Vec<_>>();
+    assert!(evidence::scoped_ids(Some(&aggregate)).is_err());
+    let ids = (0..1024)
+        .map(|index| format!("%{index}"))
+        .collect::<Vec<_>>();
+    let scoped = evidence::scoped_ids(Some(&ids)).unwrap().unwrap();
+    let filter = evidence::pane_filter(&scoped);
+    assert!(filter.len() < 32 * 1024);
+    assert_eq!(filter.matches("#{==:").count(), ids.len());
+    let mut depth = 0;
+    let mut maximum = 0;
+    for character in filter.chars() {
+        if character == '{' {
+            depth += 1;
+            maximum = maximum.max(depth);
+        }
+        if character == '}' {
+            depth -= 1;
+        }
+    }
+    assert_eq!(depth, 0);
+    assert_eq!(maximum, 12); // Ten disjunction levels, equality and pane_id.
+}
+
+#[test]
 fn prefers_attached_presentation_for_grouped_pane_rows() {
     let detached = endpoint_row(
         SERVER_ID,
@@ -420,6 +454,10 @@ fn extracts_marker_only_when_all_identity_strings_are_nonempty() {
     assert_eq!(metadata::marker(&document), Some(marker()));
 
     document["globalIdentity"]["name"] = Value::String("  ".into());
+    // Wire decoding retains nonempty strings verbatim; core binding evidence
+    // owns name validity (including the distinct BOM and NEL trim semantics).
+    assert_eq!(metadata::marker(&document).unwrap().name, "  ");
+    document["globalIdentity"]["name"] = Value::String(String::new());
     assert_eq!(metadata::marker(&document), None);
 }
 

--- a/rust/crates/tmt-adapters/src/tmux/io_tests.rs
+++ b/rust/crates/tmt-adapters/src/tmux/io_tests.rs
@@ -299,6 +299,90 @@ fn nonmatching_clear_preserves_metadata_without_a_write() {
 }
 
 #[test]
+fn explicit_socket_metadata_updates_preserve_opaque_data_and_never_fall_back() {
+    let tmux = Tmux::new(ScriptedRunner::new([
+        Ok(r#"{"version":1,"opaque":{"keep":true}}"#),
+        Ok(""),
+    ]));
+    let marker = BindingMarker {
+        name: "Alice".into(),
+        canonical_name: "alice".into(),
+        identity_id: "identity".into(),
+        binding_id: "binding".into(),
+        server_id: SERVER_ID.into(),
+        pane_pid: 654,
+    };
+    tmux.set_marker_on(
+        Some("/foreign/socket"),
+        "%9",
+        &marker,
+        OperationOptions::default(),
+    )
+    .unwrap();
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 2);
+    for call in calls.iter() {
+        assert_eq!(&call.args[..2], ["-S", "/foreign/socket"]);
+    }
+    let written: serde_json::Value = serde_json::from_str(calls[1].args.last().unwrap()).unwrap();
+    assert_eq!(written["opaque"], serde_json::json!({"keep": true}));
+    assert_eq!(written["globalIdentity"]["bindingId"], "binding");
+
+    let tmux = Tmux::new(ScriptedRunner::new([Err(failure(false))]));
+    assert!(
+        tmux.clear_marker_on(
+            Some("/foreign/socket"),
+            "%9",
+            Some("binding"),
+            OperationOptions::default()
+        )
+        .is_err()
+    );
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(&calls[0].args[..2], ["-S", "/foreign/socket"]);
+}
+
+#[test]
+fn binding_session_requires_a_budget_and_preserves_failed_probe_cleanup() {
+    use tmt_core::binding::BindingEndpoint;
+    let server = ServerEvidence {
+        server_id: SERVER_ID.into(),
+        socket_path: "/foreign/socket".into(),
+        server_pid: 321,
+        server_start_time: "start".into(),
+    };
+    let tmux = Tmux::new(ScriptedRunner::default());
+    let mut session = BindingSession::new(&tmux);
+    assert!(!session.budget_available());
+    assert_eq!(
+        session.probe_binding(&server, &["%9".into()]).unwrap(),
+        EndpointProbe::Unknown
+    );
+    assert!(tmux.runner.calls.borrow().is_empty());
+    session.begin_coordination();
+    let oversize = (0..1025)
+        .map(|index| format!("%{index}"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        session.probe_binding(&server, &oversize).unwrap(),
+        EndpointProbe::Unknown
+    );
+    assert!(tmux.runner.calls.borrow().is_empty());
+
+    let tmux = Tmux::new(ScriptedRunner::new([Err(failure(true))]));
+    let mut session = BindingSession::new(&tmux);
+    session.begin_coordination();
+    assert!(
+        session
+            .probe_binding(&server, &["%9".into()])
+            .unwrap_err()
+            .cleanup_failed()
+    );
+    assert_eq!(tmux.runner.calls.borrow().len(), 1);
+}
+
+#[test]
 fn empty_scope_reads_server_only_and_never_enumerates_panes() {
     let tmux = Tmux::new(ScriptedRunner::new([
         Ok(SERVER_ID),

--- a/rust/crates/tmt-adapters/src/tmux/metadata.rs
+++ b/rust/crates/tmt-adapters/src/tmux/metadata.rs
@@ -16,7 +16,9 @@ pub(super) fn marker(document: &Value) -> Option<BindingMarker> {
         value
             .get(name)?
             .as_str()
-            .filter(|text| !text.trim().is_empty())
+            // Decode shape only. The shared core name validator owns Unicode
+            // whitespace/normalization when evaluating a binding marker.
+            .filter(|text| !text.is_empty())
             .map(str::to_owned)
     };
     let pane_pid = value

--- a/rust/crates/tmt-adapters/src/tmux/mod.rs
+++ b/rust/crates/tmt-adapters/src/tmux/mod.rs
@@ -1,9 +1,11 @@
 //! Concrete tmux evidence/metadata IO. Identity transactions, reconciliation and
 //! retirement remain application policy; uncertain observations are not death.
 
+mod binding;
 mod caller;
 mod evidence;
 mod metadata;
+pub use binding::BindingSession;
 
 #[cfg(test)]
 mod evidence_tests;
@@ -352,32 +354,33 @@ impl<R: CommandRunner> Tmux<R> {
 
     fn read_metadata(
         &self,
+        socket: Option<&str>,
         pane: &str,
         options: OperationOptions<'_>,
     ) -> Result<serde_json::Value, TmuxError> {
-        let output = self.execute(
-            vec![
-                "show-options".into(),
-                "-q".into(),
-                "-p".into(),
-                "-t".into(),
-                pane.into(),
-                "-v".into(),
-                AGENT_METADATA_OPTION.into(),
-            ],
-            options,
-            TmuxFailure::MetadataRead,
-        )?;
+        let mut args = socket_args(socket);
+        args.extend([
+            "show-options".into(),
+            "-q".into(),
+            "-p".into(),
+            "-t".into(),
+            pane.into(),
+            "-v".into(),
+            AGENT_METADATA_OPTION.into(),
+        ]);
+        let output = self.execute(args, options, TmuxFailure::MetadataRead)?;
         Ok(metadata::decode(&output))
     }
 
     fn write_metadata(
         &self,
+        socket: Option<&str>,
         pane: &str,
         document: &serde_json::Value,
         options: OperationOptions<'_>,
     ) -> Result<(), TmuxError> {
-        let mut args = vec!["set-option".into(), "-p".into()];
+        let mut args = socket_args(socket);
+        args.extend(["set-option".into(), "-p".into()]);
         if !metadata::has_fields(document) {
             args.push("-u".into());
         }
@@ -395,9 +398,19 @@ impl<R: CommandRunner> Tmux<R> {
         marker: &BindingMarker,
         options: OperationOptions<'_>,
     ) -> Result<(), TmuxError> {
-        let mut document = self.read_metadata(pane, options)?;
+        self.set_marker_on(None, pane, marker, options)
+    }
+
+    fn set_marker_on(
+        &self,
+        socket: Option<&str>,
+        pane: &str,
+        marker: &BindingMarker,
+        options: OperationOptions<'_>,
+    ) -> Result<(), TmuxError> {
+        let mut document = self.read_metadata(socket, pane, options)?;
         metadata::replace(&mut document, marker);
-        self.write_metadata(pane, &document, options)
+        self.write_metadata(socket, pane, &document, options)
     }
 
     pub fn clear_marker(
@@ -406,11 +419,21 @@ impl<R: CommandRunner> Tmux<R> {
         binding_id: Option<&str>,
         options: OperationOptions<'_>,
     ) -> Result<bool, TmuxError> {
-        let mut document = self.read_metadata(pane, options)?;
+        self.clear_marker_on(None, pane, binding_id, options)
+    }
+
+    fn clear_marker_on(
+        &self,
+        socket: Option<&str>,
+        pane: &str,
+        binding_id: Option<&str>,
+        options: OperationOptions<'_>,
+    ) -> Result<bool, TmuxError> {
+        let mut document = self.read_metadata(socket, pane, options)?;
         if !metadata::clear(&mut document, binding_id) {
             return Ok(false);
         }
-        self.write_metadata(pane, &document, options)?;
+        self.write_metadata(socket, pane, &document, options)?;
         Ok(true)
     }
 }

--- a/rust/crates/tmt-cli/src/binding_command.rs
+++ b/rust/crates/tmt-cli/src/binding_command.rs
@@ -1,0 +1,240 @@
+//! Thin composition of typed commands, one storage handle and binding policy.
+//! Preflight caller/target checks precede configuration and database effects.
+
+mod presentation;
+
+use crate::{
+    invocation::{Invocation, OutputMode},
+    output::{Failure, after_cleanup},
+};
+use std::io::{self, Write};
+use tmt_adapters::{
+    config::{ConfigFiles, ConfigPaths},
+    storage::{Storage, StorageError},
+    tmux::{BindingSession, CallerEnvironment, OperationOptions, Tmux, TmuxError},
+};
+use tmt_core::{
+    binding::{self, BindingEntry, BindingError, IdentityPresence, UnboundIdentity},
+    endpoint::PaneObservation,
+    identity::Identity,
+    names::is_pane_target,
+    settings::PaneBadge,
+};
+
+enum Report {
+    Bound(IdentityPresence),
+    Caller {
+        pane: String,
+        identity: Option<Identity>,
+    },
+    Unbound {
+        pane: String,
+        result: UnboundIdentity,
+    },
+    Removed(BindingEntry),
+    Listed(Vec<IdentityPresence>),
+    Named {
+        target: String,
+        row: IdentityPresence,
+    },
+    Pane {
+        target: String,
+        pane: PaneObservation,
+        identity: Option<Identity>,
+    },
+}
+
+fn endpoint_failure(error: TmuxError) -> Failure {
+    Failure::new("RECONCILIATION_FAILED", error.to_string(), 1).caused_by(error)
+}
+
+fn binding_failure(error: BindingError<StorageError, TmuxError>) -> Failure {
+    let (code, status) = match &error {
+        BindingError::InvalidName(_) => ("INVALID_NAME", 1),
+        BindingError::NameNotFound(_) => ("NAME_NOT_FOUND", 3),
+        BindingError::PaneNotFound(_) => ("PANE_NOT_FOUND", 3),
+        BindingError::NameAlreadyActive => ("NAME_ALREADY_ACTIVE", 5),
+        BindingError::PaneAlreadyBound => ("PANE_ALREADY_BOUND", 5),
+        BindingError::ConfirmationRequired => ("CONFIRMATION_REQUIRED", 5),
+        _ => ("RECONCILIATION_FAILED", 1),
+    };
+    Failure::new(code, error.to_string(), status).caused_by(error)
+}
+
+fn preflight(
+    request: &Invocation,
+    tmux: &Tmux,
+    environment: &CallerEnvironment,
+) -> Result<Option<String>, Failure> {
+    let target = match request {
+        Invocation::Bind {
+            pane: Some(pane),
+            name,
+            ..
+        } => {
+            if !is_pane_target(pane) && is_pane_target(name) {
+                return Err(Failure::new(
+                    "LEGACY_ADD_ORDER",
+                    "The v4 add argument order is no longer supported.",
+                    1,
+                )
+                .suggestion(format!("Use: tmt add {name} {pane}")));
+            }
+            Some(pane.as_str())
+        }
+        Invocation::List {
+            target: Some(target),
+        } if is_pane_target(target) => Some(target.as_str()),
+        Invocation::Bind { pane: None, .. } | Invocation::Whoami | Invocation::Unbind => {
+            return tmux
+                .caller_pane(environment)
+                .map_err(endpoint_failure)?
+                .map(Some)
+                .ok_or_else(|| {
+                    Failure::new(
+                        "PANE_NOT_FOUND",
+                        "Not running inside a resolvable tmux pane.",
+                        3,
+                    )
+                });
+        }
+        _ => None,
+    };
+    target
+        .map(|target| {
+            tmux.resolve_target(target, OperationOptions::default())
+                .map_err(endpoint_failure)?
+                .ok_or_else(|| {
+                    Failure::new(
+                        "PANE_NOT_FOUND",
+                        format!("Pane target '{target}' was not found."),
+                        3,
+                    )
+                })
+        })
+        .transpose()
+}
+
+fn run(request: Invocation) -> Result<Report, Failure> {
+    let tmux = Tmux::default();
+    let environment = CallerEnvironment::current();
+    let pane = preflight(&request, &tmux, &environment)?;
+    let paths = ConfigPaths::discover().map_err(Failure::from)?;
+    let badge = if matches!(request, Invocation::Bind { .. }) {
+        ConfigFiles {
+            paths: paths.clone(),
+        }
+        .load()
+        .map_err(Failure::from)?
+        .settings
+        .pane_badge
+    } else {
+        PaneBadge::Off
+    };
+    let mut storage = Storage::open(paths.database).map_err(|error| {
+        Failure::new("IDENTITY_ERROR", "Could not open identity storage.", 1).caused_by(error)
+    })?;
+    let mut endpoint = BindingSession::new(&tmux);
+    let pending = operation(&mut storage, &mut endpoint, request, pane, environment.selected_socket())
+        .and_then(|report| {
+            // Presentation follows successful durable effects, never decides
+            // them. The adapter preserves user themes and changed endpoints.
+            let update = match &report {
+                Report::Bound(row) => row.binding.as_ref().map(|binding|
+                    (binding, (badge == PaneBadge::On).then_some(row.identity.name.as_str()))),
+                Report::Unbound { result, .. } => result.binding.as_ref().map(|binding| (binding, None)),
+                Report::Removed(entry) => entry.binding.as_ref().map(|binding| (binding, None)),
+                _ => None,
+            };
+            if let Some((binding, name)) = update {
+                tmux.update_binding_badge(binding, name).map_err(|error|
+                    Failure::new("CLEANUP_ERROR", "Could not clean up cosmetic operation resources. Effects may already have occurred.", 1).caused_by(error))?;
+            }
+            Ok(report)
+        });
+    after_cleanup(pending, || storage.close())
+}
+
+fn operation(
+    storage: &mut Storage,
+    endpoint: &mut BindingSession<'_, tmt_adapters::process::UnixCommandRunner>,
+    request: Invocation,
+    pane: Option<String>,
+    current_socket: Option<&str>,
+) -> Result<Report, Failure> {
+    match request {
+        Invocation::Bind { name, save, .. } => binding::bind_identity(
+            storage,
+            endpoint,
+            pane.as_deref().expect("binding preflight"),
+            &name,
+            save,
+        )
+        .map(Report::Bound)
+        .map_err(binding_failure),
+        Invocation::Whoami => {
+            let pane = pane.expect("caller preflight");
+            let observed =
+                binding::pane_presence(storage, endpoint, &pane).map_err(binding_failure)?;
+            Ok(Report::Caller {
+                pane,
+                identity: observed.identity,
+            })
+        }
+        Invocation::Unbind => {
+            let pane = pane.expect("caller preflight");
+            let result = binding::unbind_identity(storage, endpoint, &pane)
+                .map_err(binding_failure)?
+                .ok_or_else(|| {
+                    Failure::new("UNBOUND_PANE", "Pane has no active global name.", 1)
+                })?;
+            Ok(Report::Unbound { pane, result })
+        }
+        Invocation::Remove { name, force } => {
+            binding::remove_identity(storage, endpoint, &name, force)
+                .map(Report::Removed)
+                .map_err(binding_failure)
+        }
+        Invocation::List { target: None } => {
+            binding::list_presence(storage, endpoint, current_socket)
+                .map(Report::Listed)
+                .map_err(binding_failure)
+        }
+        Invocation::List {
+            target: Some(target),
+        } => {
+            if let Some(pane) = pane {
+                let observed =
+                    binding::pane_presence(storage, endpoint, &pane).map_err(binding_failure)?;
+                Ok(Report::Pane {
+                    target,
+                    pane: observed.pane,
+                    identity: observed.identity,
+                })
+            } else {
+                let row =
+                    binding::name_presence(storage, endpoint, &target).map_err(binding_failure)?;
+                Ok(Report::Named { target, row })
+            }
+        }
+        _ => Err(Failure::new(
+            "INTERNAL_ERROR",
+            "Unexpected binding command.",
+            1,
+        )),
+    }
+}
+
+pub fn execute(request: Invocation, mode: OutputMode) -> io::Result<u8> {
+    let report = match run(request) {
+        Ok(report) => report,
+        Err(error) => return error.publish(mode),
+    };
+    let mut stdout = io::stdout().lock();
+    if mode.json {
+        writeln!(stdout, "{}", presentation::document(&report))?;
+    } else {
+        presentation::text(&mut stdout, &report)?;
+    }
+    Ok(0)
+}

--- a/rust/crates/tmt-cli/src/binding_command/presentation.rs
+++ b/rust/crates/tmt-cli/src/binding_command/presentation.rs
@@ -1,0 +1,170 @@
+//! Public projections deliberately omit binding markers and process evidence.
+
+use super::Report;
+use crate::output::identity_document;
+use serde_json::{Value, json};
+use std::io::{self, Write};
+use tmt_core::{binding::IdentityPresence, endpoint::PaneObservation, identity::Identity};
+
+fn pane_document(pane: &PaneObservation) -> Value {
+    let mut value = json!({"id": pane.id, "command": pane.command});
+    if let Some(target) = &pane.target {
+        value["target"] = target.clone().into();
+    }
+    if let Some(cwd) = &pane.cwd {
+        value["cwd"] = cwd.clone().into();
+    }
+    value
+}
+
+fn bound_document(identity: &Identity, pane: &str) -> Value {
+    json!({"bound": true, "id": identity.id, "name": identity.name,
+        "pane": pane, "lifetime": identity.lifetime.as_str()})
+}
+
+fn presence_document(row: &IdentityPresence) -> Value {
+    let mut value = identity_document(&row.identity);
+    value["presence"] = row.presence.as_str().into();
+    value["pane"] = row.pane.as_ref().map(|pane| pane.id.clone()).into();
+    value["command"] = row
+        .pane
+        .as_ref()
+        .map_or("", |pane| pane.command.as_str())
+        .into();
+    if let Some(pane) = &row.pane {
+        let details = pane_document(pane);
+        for key in ["target", "cwd"] {
+            if let Some(detail) = details.get(key) {
+                value[key] = detail.clone();
+            }
+        }
+    }
+    value
+}
+
+pub(super) fn document(report: &Report) -> Value {
+    match report {
+        Report::Bound(row) => bound_document(
+            &row.identity,
+            &row.pane.as_ref().expect("verified binding").id,
+        ),
+        Report::Caller { pane, identity } => identity.as_ref().map_or_else(
+            || json!({"bound": false, "pane": pane}),
+            |identity| bound_document(identity, pane),
+        ),
+        Report::Unbound { pane, result } => json!({"unbound": true, "id": result.identity.id,
+            "name": result.identity.name, "pane": pane, "lifetime": result.identity.lifetime.as_str(), "retired": result.retired}),
+        Report::Removed(entry) => {
+            json!({"removed": true, "identity": identity_document(&entry.identity)})
+        }
+        Report::Listed(rows) => {
+            json!({"identities": rows.iter().map(presence_document).collect::<Vec<_>>()})
+        }
+        Report::Named { target, row } => {
+            json!({"target": target, "identity": identity_document(&row.identity),
+            "presence": row.presence.as_str(), "pane": row.pane.as_ref().map(pane_document)})
+        }
+        Report::Pane {
+            target,
+            pane,
+            identity,
+        } => json!({"target": target,
+            "identity": identity.as_ref().map(identity_document), "pane": pane_document(pane)}),
+    }
+}
+
+fn identity_row(
+    output: &mut impl Write,
+    identity: &Identity,
+    status: &str,
+    pane: Option<&PaneObservation>,
+) -> io::Result<()> {
+    writeln!(
+        output,
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+        identity.name,
+        identity.lifetime.as_str(),
+        status,
+        pane.map_or("-", |pane| pane.id.as_str()),
+        pane.and_then(|pane| pane.target.as_deref()).unwrap_or("-"),
+        pane.and_then(|pane| pane.cwd.as_deref()).unwrap_or("-"),
+        pane.map_or("", |pane| pane.command.as_str())
+    )
+}
+
+pub(super) fn text(output: &mut impl Write, report: &Report) -> io::Result<()> {
+    match report {
+        Report::Bound(row) => writeln!(
+            output,
+            "Bound {} identity '{}' on pane {}.",
+            row.identity.lifetime.as_str(),
+            row.identity.name,
+            row.pane.as_ref().expect("verified binding").id
+        ),
+        Report::Caller {
+            pane,
+            identity: Some(identity),
+        } => writeln!(
+            output,
+            "Bound {} identity '{}' on pane {pane}.",
+            identity.lifetime.as_str(),
+            identity.name
+        ),
+        Report::Caller {
+            pane,
+            identity: None,
+        } => writeln!(output, "Pane {pane} is unbound."),
+        Report::Unbound { pane, result } => writeln!(
+            output,
+            "Unbound '{}' from pane {pane}; identity {}.",
+            result.identity.name,
+            if result.retired {
+                "retired"
+            } else {
+                "saved offline"
+            }
+        ),
+        Report::Removed(entry) => writeln!(
+            output,
+            "Removed identity '{}'. Exchanges are retained.",
+            entry.identity.name
+        ),
+        Report::Listed(rows) if rows.is_empty() => writeln!(output, "No identities found."),
+        Report::Listed(rows) => {
+            writeln!(output, "NAME\tLIFETIME\tSTATUS\tPANE\tTARGET\tCWD\tCOMMAND")?;
+            for row in rows {
+                identity_row(
+                    output,
+                    &row.identity,
+                    row.presence.as_str(),
+                    row.pane.as_ref(),
+                )?;
+            }
+            Ok(())
+        }
+        Report::Named { row, .. } => {
+            writeln!(output, "NAME\tLIFETIME\tSTATUS\tPANE\tTARGET\tCWD\tCOMMAND")?;
+            identity_row(
+                output,
+                &row.identity,
+                row.presence.as_str(),
+                row.pane.as_ref(),
+            )
+        }
+        Report::Pane { pane, identity, .. } => {
+            writeln!(
+                output,
+                "Pane: {}\nCWD:  {}\nCMD:  {}",
+                pane.id,
+                pane.cwd.as_deref().unwrap_or("-"),
+                pane.command
+            )?;
+            if let Some(identity) = identity {
+                writeln!(output, "NAME\tLIFETIME\tSTATUS\tPANE\tTARGET\tCWD\tCOMMAND")?;
+                identity_row(output, identity, "active", Some(pane))
+            } else {
+                writeln!(output, "Pane has no active global identity.")
+            }
+        }
+    }
+}

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -35,7 +35,7 @@ pub fn grammar() -> Command {
         )
         .subcommand(general("init", "Create workspace settings"))
         .subcommand(
-            general("list", "List active identities in the current workspace")
+            general("list", "List global identities, lifetime and live presence")
                 .visible_alias("ls")
                 .arg(operand("target", false)),
         )
@@ -57,7 +57,7 @@ pub fn grammar() -> Command {
         )
         .subcommand(
             with_options(
-                general("rm", "Retire an identity without killing its pane"),
+                general("rm", "Retire identity and remove role/preamble; keep pane/exchanges (--force for saved)"),
                 &["force"],
             )
             .visible_alias("remove")

--- a/rust/crates/tmt-cli/src/identity_command.rs
+++ b/rust/crates/tmt-cli/src/identity_command.rs
@@ -3,9 +3,9 @@
 
 use crate::{
     invocation::{IdentityRequest, OutputMode},
-    output::{Failure, after_cleanup},
+    output::{Failure, after_cleanup, identity_document},
 };
-use serde_json::{Value, json};
+use serde_json::json;
 use std::{
     error::Error,
     io::{self, Write},
@@ -82,11 +82,11 @@ pub fn execute(request: IdentityRequest, mode: OutputMode) -> io::Result<u8> {
     if mode.json {
         let document = match report {
             Report::Created(result) => {
-                json!({"identity": public_identity(&result.identity), "created": result.created})
+                json!({"identity": identity_document(&result.identity), "created": result.created})
             }
-            Report::Shown(identity) => json!({"identity": public_identity(&identity)}),
+            Report::Shown(identity) => json!({"identity": identity_document(&identity)}),
             Report::Listed(identities) => {
-                json!({"identities": identities.iter().map(public_identity).collect::<Vec<_>>()})
+                json!({"identities": identities.iter().map(identity_document).collect::<Vec<_>>()})
             }
         };
         writeln!(stdout, "{document}")?;
@@ -133,8 +133,4 @@ pub fn execute(request: IdentityRequest, mode: OutputMode) -> io::Result<u8> {
         }
     }
     Ok(0)
-}
-
-fn public_identity(identity: &Identity) -> Value {
-    json!({"id": identity.id, "name": identity.name, "canonicalName": identity.canonical_name, "lifetime": identity.lifetime.as_str()})
 }

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod binding_command;
 mod config_command;
 mod diagnostics;
 mod grammar;
@@ -33,7 +34,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration and storage-only identity create/show/list are available; pane binding and transport commands are not implemented yet. Use isolated test state only.\n"
+                "Native development preview: configuration, storage-only identity create/show/list, and pane identity name/this/add/whoami/unbind/rm/list are available. Transport commands are not implemented yet. Use isolated test state only.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -66,6 +67,14 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Identity(request) => {
             drop(stdout);
             return identity_command::execute(request, parsed.mode);
+        }
+        request @ (Invocation::Bind { .. }
+        | Invocation::Whoami
+        | Invocation::Unbind
+        | Invocation::Remove { .. }
+        | Invocation::List { .. }) => {
+            drop(stdout);
+            return binding_command::execute(request, parsed.mode);
         }
         _ => {
             drop(stdout);

--- a/rust/crates/tmt-cli/src/output.rs
+++ b/rust/crates/tmt-cli/src/output.rs
@@ -13,6 +13,7 @@ pub struct Failure {
     pub message: String,
     pub status: u8,
     cause: Option<Box<dyn Error>>,
+    suggestion: Option<String>,
 }
 
 impl Failure {
@@ -22,6 +23,7 @@ impl Failure {
             message: message.into(),
             status,
             cause: None,
+            suggestion: None,
         }
     }
 
@@ -30,16 +32,32 @@ impl Failure {
         self
     }
 
+    pub fn suggestion(mut self, suggestion: String) -> Self {
+        self.suggestion = Some(suggestion);
+        self
+    }
+
     pub fn publish(&self, mode: OutputMode) -> io::Result<u8> {
         if mode.json {
-            let document =
+            let mut document =
                 serde_json::json!({"error": {"code": self.code, "message": self.message}});
+            if let Some(suggestion) = &self.suggestion {
+                document["error"]["suggestion"] = suggestion.clone().into();
+            }
             writeln!(io::stdout().lock(), "{document}")?;
         } else {
             writeln!(io::stderr().lock(), "{}", self.message)?;
+            if let Some(suggestion) = &self.suggestion {
+                writeln!(io::stderr().lock(), "{suggestion}")?;
+            }
         }
         Ok(self.status)
     }
+}
+
+pub fn identity_document(identity: &tmt_core::identity::Identity) -> serde_json::Value {
+    serde_json::json!({"id": identity.id, "name": identity.name,
+        "canonicalName": identity.canonical_name, "lifetime": identity.lifetime.as_str()})
 }
 
 impl fmt::Display for Failure {

--- a/rust/crates/tmt-core/src/binding.rs
+++ b/rust/crates/tmt-core/src/binding.rs
@@ -1,0 +1,183 @@
+//! Identity binding policy. SQLite, tmux and monotonic clocks remain adapters.
+
+mod observation;
+mod operations;
+
+#[cfg(test)]
+mod evidence_tests;
+
+pub use observation::{evaluate_binding, list_presence, name_presence, pane_presence};
+pub use operations::{bind_identity, remove_identity, unbind_identity};
+
+use crate::{
+    endpoint::{BindingMarker, EndpointProbe, EndpointSnapshot, PaneObservation, ServerEvidence},
+    identity::{Identity, IdentityReader, IdentityRepository},
+    names::NameError,
+};
+use std::{error::Error, fmt};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Binding {
+    pub id: String,
+    pub identity_id: String,
+    pub server: ServerEvidence,
+    pub pane_id: String,
+    pub pane_pid: u64,
+}
+
+impl Binding {
+    pub fn marker(&self, identity: &Identity) -> BindingMarker {
+        BindingMarker {
+            name: identity.name.clone(),
+            canonical_name: identity.canonical_name.clone(),
+            identity_id: identity.id.clone(),
+            binding_id: self.id.clone(),
+            server_id: self.server.server_id.clone(),
+            pane_pid: self.pane_pid,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindingEntry {
+    pub identity: Identity,
+    pub binding: Option<Binding>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindingEvidence {
+    Active(Box<PaneObservation>),
+    EndpointLost,
+    MarkerMismatch,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Presence {
+    Active,
+    Offline,
+    Unknown,
+}
+
+impl Presence {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Offline => "offline",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentityPresence {
+    pub identity: Identity,
+    pub presence: Presence,
+    pub pane: Option<PaneObservation>,
+    pub binding: Option<Binding>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaneIdentity {
+    pub pane: PaneObservation,
+    pub identity: Option<Identity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnboundIdentity {
+    pub identity: Identity,
+    pub retired: bool,
+    pub binding: Option<Binding>,
+}
+
+pub trait BindingRecords: IdentityReader {
+    fn entry_by_id(&self, id: &str) -> Result<Option<BindingEntry>, Self::Error>;
+    fn entry_by_pane(&self, pane: &str, server: &str) -> Result<Option<BindingEntry>, Self::Error>;
+    fn binding_entries(&self) -> Result<Vec<BindingEntry>, Self::Error>;
+    fn insert_binding(
+        &mut self,
+        identity: &Identity,
+        server: &ServerEvidence,
+        pane: &PaneObservation,
+    ) -> Result<Binding, Self::Error>;
+    fn touch_binding(&mut self, id: &str) -> Result<(), Self::Error>;
+    fn detach_binding(&mut self, id: &str) -> Result<(), Self::Error>;
+    /// Application policy chooses retirement and whether explicit removal also
+    /// erases profile/preamble. Retained exchanges/cadence must never be erased.
+    fn retire_identity(
+        &mut self,
+        identity: &Identity,
+        remove_content: bool,
+    ) -> Result<(), Self::Error>;
+}
+
+pub trait BindingRepository: IdentityRepository {
+    fn with_binding_transaction<T, E: From<Self::Error>>(
+        &mut self,
+        operation: impl FnOnce(&mut dyn BindingRecords<Error = Self::Error>) -> Result<T, E>,
+    ) -> Result<T, E>;
+}
+
+/// One invocation-owned adapter, reset only after the repository acquires its
+/// immediate lock. It owns the shared three-second budget, not core wall time.
+pub trait BindingEndpoint {
+    type Error;
+    fn begin_coordination(&mut self);
+    fn budget_available(&self) -> bool;
+    fn current_snapshot(&mut self, panes: &[String]) -> Result<EndpointSnapshot, Self::Error>;
+    fn probe_binding(
+        &mut self,
+        server: &ServerEvidence,
+        panes: &[String],
+    ) -> Result<EndpointProbe, Self::Error>;
+    fn publish(&mut self, binding: &Binding, identity: &Identity) -> Result<(), Self::Error>;
+    fn clear(&mut self, binding: &Binding) -> Result<bool, Self::Error>;
+}
+
+#[derive(Debug)]
+pub enum BindingError<R, O> {
+    InvalidName(NameError),
+    NameNotFound(String),
+    PaneNotFound(String),
+    PaneAlreadyBound,
+    NameAlreadyActive,
+    ConfirmationRequired,
+    Unverified,
+    Deadline,
+    Repository(R),
+    Endpoint(O),
+}
+
+impl<R, O> From<R> for BindingError<R, O> {
+    fn from(error: R) -> Self {
+        Self::Repository(error)
+    }
+}
+
+impl<R, O: fmt::Display> fmt::Display for BindingError<R, O> {
+    fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidName(error) => error.fmt(output),
+            Self::NameNotFound(name) => write!(output, "Identity '{name}' was not found."),
+            Self::PaneNotFound(pane) => write!(output, "Pane '{pane}' was not found."),
+            Self::PaneAlreadyBound => output.write_str("Pane is already bound to another name."),
+            Self::NameAlreadyActive => output.write_str("Name is already active on another pane."),
+            Self::ConfirmationRequired => output.write_str("Saved identity removal requires --force. Its role and preamble will be removed; exchanges are retained."),
+            Self::Unverified => output.write_str("Could not verify the identity binding. No successful binding change is claimed."),
+            Self::Deadline => output.write_str("Identity coordination deadline exceeded."),
+            Self::Repository(_) => output.write_str("Could not update identity state."),
+            Self::Endpoint(error) => error.fmt(output),
+        }
+    }
+}
+
+impl<R: Error + 'static, O: Error + 'static> Error for BindingError<R, O> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidName(error) => Some(error),
+            Self::Repository(error) => Some(error),
+            Self::Endpoint(error) => Some(error),
+            _ => None,
+        }
+    }
+}

--- a/rust/crates/tmt-core/src/binding/evidence_tests.rs
+++ b/rust/crates/tmt-core/src/binding/evidence_tests.rs
@@ -1,0 +1,285 @@
+use super::*;
+use crate::{
+    endpoint::{BindingMarker, EndpointSnapshot, PaneObservation, ServerEvidence},
+    identity::Lifetime,
+    names::validate_name,
+};
+
+fn fixture(name: &str) -> (Identity, Binding, EndpointSnapshot) {
+    let validated = validate_name(name).expect("fixture identity name must be valid");
+    let identity = Identity {
+        id: "identity-1".into(),
+        name: validated.display_name().into(),
+        canonical_name: validated.canonical_name().into(),
+        lifetime: Lifetime::Temporary,
+        created_at: "created".into(),
+        updated_at: "updated".into(),
+    };
+    let server = ServerEvidence {
+        server_id: "123e4567-e89b-42d3-a456-426614174000".into(),
+        socket_path: "/tmp/tmt.sock".into(),
+        server_pid: 321,
+        server_start_time: "1700000000".into(),
+    };
+    let binding = Binding {
+        id: "binding-1".into(),
+        identity_id: identity.id.clone(),
+        server: server.clone(),
+        pane_id: "%9".into(),
+        pane_pid: 654,
+    };
+    let pane = PaneObservation {
+        id: binding.pane_id.clone(),
+        target: Some("main:1.0".into()),
+        cwd: Some("/repo".into()),
+        command: "codex".into(),
+        pane_pid: binding.pane_pid,
+        suggested_name: Some("codex".into()),
+        marker: Some(binding.marker(&identity)),
+    };
+    (
+        identity,
+        binding,
+        EndpointSnapshot {
+            server,
+            panes: vec![pane],
+        },
+    )
+}
+
+fn entry(identity: &Identity, binding: &Binding) -> BindingEntry {
+    BindingEntry {
+        identity: identity.clone(),
+        binding: Some(binding.clone()),
+    }
+}
+
+fn live(snapshot: EndpointSnapshot) -> EndpointProbe {
+    EndpointProbe::Live(snapshot)
+}
+
+#[test]
+fn active_requires_agreement_between_server_pane_and_marker() {
+    let (identity, binding, snapshot) = fixture("Alice");
+    let expected = snapshot.panes[0].clone();
+
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &live(snapshot)),
+        BindingEvidence::Active(Box::new(expected))
+    );
+}
+
+#[test]
+fn presentation_fields_do_not_change_active_identity_evidence() {
+    let (identity, binding, mut snapshot) = fixture("Alice");
+    let pane = snapshot.panes.first_mut().expect("fixture pane");
+    pane.target = Some("attached:7.3".into());
+    pane.cwd = Some("/different/worktree".into());
+    pane.command = "shell".into();
+    pane.suggested_name = None;
+
+    let expected = pane.clone();
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &live(snapshot)),
+        BindingEvidence::Active(Box::new(expected))
+    );
+}
+
+#[test]
+fn server_endpoint_changes_are_classified_without_guessing_death() {
+    let (identity, binding, snapshot) = fixture("Alice");
+
+    let mut socket_changed = snapshot.clone();
+    socket_changed.server.socket_path = "/tmp/other.sock".into();
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &live(socket_changed)),
+        BindingEvidence::Unknown
+    );
+
+    let mut pid_changed = snapshot.clone();
+    pid_changed.server.server_pid += 1;
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &live(pid_changed)),
+        BindingEvidence::EndpointLost
+    );
+
+    let mut start_changed = snapshot.clone();
+    start_changed.server.server_start_time = "1700000001".into();
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &live(start_changed)),
+        BindingEvidence::EndpointLost
+    );
+
+    let mut id_changed = snapshot;
+    id_changed.server.server_id = "123e4567-e89b-42d3-a456-426614174001".into();
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &live(id_changed)),
+        BindingEvidence::Unknown
+    );
+}
+
+#[test]
+fn pane_loss_and_replacement_are_endpoint_loss() {
+    let (identity, binding, snapshot) = fixture("Alice");
+
+    let mut missing = snapshot.clone();
+    missing.panes.clear();
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &live(missing)),
+        BindingEvidence::EndpointLost
+    );
+
+    let mut replaced = snapshot;
+    replaced.panes[0].pane_pid += 1;
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &live(replaced)),
+        BindingEvidence::EndpointLost
+    );
+
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &EndpointProbe::Dead),
+        BindingEvidence::EndpointLost
+    );
+}
+
+#[test]
+fn unavailable_observation_and_absent_binding_remain_unknown() {
+    let (identity, binding, snapshot) = fixture("Alice");
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &EndpointProbe::Unknown),
+        BindingEvidence::Unknown
+    );
+    assert_eq!(
+        evaluate_binding(
+            &BindingEntry {
+                identity,
+                binding: None,
+            },
+            &live(snapshot),
+        ),
+        BindingEvidence::Unknown
+    );
+}
+
+#[test]
+fn marker_mismatches_never_become_endpoint_loss() {
+    let (identity, binding, snapshot) = fixture("Alice");
+    let cases = [
+        ("missing marker", None),
+        (
+            "identity ID",
+            Some(BindingMarker {
+                identity_id: "other-identity".into(),
+                ..binding.marker(&identity)
+            }),
+        ),
+        (
+            "binding ID",
+            Some(BindingMarker {
+                binding_id: "other-binding".into(),
+                ..binding.marker(&identity)
+            }),
+        ),
+        (
+            "server ID",
+            Some(BindingMarker {
+                server_id: "123e4567-e89b-42d3-a456-426614174001".into(),
+                ..binding.marker(&identity)
+            }),
+        ),
+        (
+            "pane PID",
+            Some(BindingMarker {
+                pane_pid: binding.pane_pid + 1,
+                ..binding.marker(&identity)
+            }),
+        ),
+    ];
+
+    for (label, marker) in cases {
+        let mut observed = snapshot.clone();
+        observed.panes[0].marker = marker;
+        assert_eq!(
+            evaluate_binding(&entry(&identity, &binding), &live(observed)),
+            BindingEvidence::MarkerMismatch,
+            "{label}"
+        );
+    }
+
+    let mut binding_identity_mismatch = binding.clone();
+    binding_identity_mismatch.identity_id = "other-identity".into();
+    assert_eq!(
+        evaluate_binding(
+            &entry(&identity, &binding_identity_mismatch),
+            &live(snapshot.clone())
+        ),
+        BindingEvidence::MarkerMismatch
+    );
+
+    let mut identity_id_mismatch = identity.clone();
+    identity_id_mismatch.id = "other-identity".into();
+    assert_eq!(
+        evaluate_binding(
+            &entry(&identity_id_mismatch, &binding),
+            &live(snapshot.clone())
+        ),
+        BindingEvidence::MarkerMismatch
+    );
+
+    let mut binding_id_mismatch = binding;
+    binding_id_mismatch.id = "other-binding".into();
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding_id_mismatch), &live(snapshot)),
+        BindingEvidence::MarkerMismatch
+    );
+}
+
+#[test]
+fn marker_names_use_core_name_normalization_and_reject_malformed_values() {
+    let (identity, binding, snapshot) = fixture("Alice");
+    for name in [" ＡＬＩＣＥ ", "\u{feff}Ａlice\u{feff}"] {
+        let mut observed = snapshot.clone();
+        observed.panes[0].marker = Some(BindingMarker {
+            name: name.into(),
+            ..binding.marker(&identity)
+        });
+        let expected = observed.panes[0].clone();
+        assert_eq!(
+            evaluate_binding(&entry(&identity, &binding), &live(observed)),
+            BindingEvidence::Active(Box::new(expected)),
+            "{name:?}"
+        );
+    }
+
+    let (nel_identity, nel_binding, nel_snapshot) = fixture("\u{85}Alice\u{85}");
+    assert_eq!(
+        evaluate_binding(
+            &entry(&nel_identity, &nel_binding),
+            &live(nel_snapshot.clone())
+        ),
+        BindingEvidence::Active(Box::new(nel_snapshot.panes[0].clone()))
+    );
+
+    for name in ["", "  ", "\u{feff}", "bad\u{1}name", "%1"] {
+        let mut observed = snapshot.clone();
+        observed.panes[0].marker = Some(BindingMarker {
+            name: name.into(),
+            ..binding.marker(&identity)
+        });
+        assert_eq!(
+            evaluate_binding(&entry(&identity, &binding), &live(observed)),
+            BindingEvidence::MarkerMismatch,
+            "{name:?}"
+        );
+    }
+
+    let mut canonical_mismatch = snapshot;
+    canonical_mismatch.panes[0].marker = Some(BindingMarker {
+        canonical_name: "other".into(),
+        ..binding.marker(&identity)
+    });
+    assert_eq!(
+        evaluate_binding(&entry(&identity, &binding), &live(canonical_mismatch)),
+        BindingEvidence::MarkerMismatch
+    );
+}

--- a/rust/crates/tmt-core/src/binding/observation.rs
+++ b/rust/crates/tmt-core/src/binding/observation.rs
@@ -1,0 +1,230 @@
+use super::*;
+use crate::{
+    identity::{self, IdentityError, Lifetime},
+    names::validate_name,
+};
+use std::collections::BTreeMap;
+
+// Presentation priority followed by complete endpoint evidence. Keep grouping
+// and lookup keyed identically without allocating a second server registry.
+fn server_key(
+    server: &ServerEvidence,
+    current_socket: Option<&str>,
+) -> (bool, String, String, u64, String) {
+    (
+        current_socket != Some(server.socket_path.as_str()),
+        server.socket_path.clone(),
+        server.server_id.clone(),
+        server.server_pid,
+        server.server_start_time.clone(),
+    )
+}
+
+/// A malformed marker is not proof that a process died. A changed server ID
+/// alone likewise cannot prove that the recorded server process was replaced.
+pub fn evaluate_binding(entry: &BindingEntry, probe: &EndpointProbe) -> BindingEvidence {
+    let Some(binding) = &entry.binding else {
+        return BindingEvidence::Unknown;
+    };
+    let snapshot = match probe {
+        EndpointProbe::Dead => return BindingEvidence::EndpointLost,
+        EndpointProbe::Unknown => return BindingEvidence::Unknown,
+        EndpointProbe::Live(snapshot) => snapshot,
+    };
+    if snapshot.server.socket_path != binding.server.socket_path {
+        return BindingEvidence::Unknown;
+    }
+    if snapshot.server.server_pid != binding.server.server_pid
+        || snapshot.server.server_start_time != binding.server.server_start_time
+    {
+        return BindingEvidence::EndpointLost;
+    }
+    if snapshot.server.server_id != binding.server.server_id {
+        return BindingEvidence::Unknown;
+    }
+    let Some(pane) = snapshot
+        .panes
+        .iter()
+        .find(|pane| pane.id == binding.pane_id)
+    else {
+        return BindingEvidence::EndpointLost;
+    };
+    if pane.pane_pid != binding.pane_pid {
+        return BindingEvidence::EndpointLost;
+    }
+    let Some(marker) = &pane.marker else {
+        return BindingEvidence::MarkerMismatch;
+    };
+    let valid = validate_name(&marker.name).is_ok_and(|name| {
+        name.canonical_name() == marker.canonical_name
+            && marker.canonical_name == entry.identity.canonical_name
+    });
+    if !valid
+        || binding.identity_id != entry.identity.id
+        || marker.identity_id != entry.identity.id
+        || marker.binding_id != binding.id
+        || marker.server_id != binding.server.server_id
+        || marker.pane_pid != binding.pane_pid
+    {
+        return BindingEvidence::MarkerMismatch;
+    }
+    BindingEvidence::Active(Box::new(pane.clone()))
+}
+
+pub(super) fn named_entry<R, O>(
+    records: &dyn BindingRecords<Error = R>,
+    name: &str,
+) -> Result<Option<BindingEntry>, BindingError<R, O>> {
+    let identity = identity::find_by_name(records, name).map_err(|error| match error {
+        IdentityError::InvalidName(error) => BindingError::InvalidName(error),
+        IdentityError::Repository(error) => BindingError::Repository(error),
+    })?;
+    identity
+        .map(|identity| records.entry_by_id(&identity.id))
+        .transpose()
+        .map(Option::flatten)
+        .map_err(BindingError::Repository)
+}
+
+pub(super) fn reconcile<R, O>(
+    records: &mut dyn BindingRecords<Error = R>,
+    entry: BindingEntry,
+    probe: &EndpointProbe,
+) -> Result<Option<IdentityPresence>, BindingError<R, O>> {
+    let Some(binding) = &entry.binding else {
+        return Ok(Some(IdentityPresence {
+            identity: entry.identity,
+            presence: Presence::Offline,
+            pane: None,
+            binding: None,
+        }));
+    };
+    let (presence, pane) = match evaluate_binding(&entry, probe) {
+        BindingEvidence::Active(pane) => {
+            records.touch_binding(&binding.id)?;
+            (Presence::Active, Some(*pane))
+        }
+        BindingEvidence::EndpointLost if entry.identity.lifetime == Lifetime::Temporary => {
+            records.retire_identity(&entry.identity, false)?;
+            return Ok(None);
+        }
+        BindingEvidence::EndpointLost | BindingEvidence::MarkerMismatch => {
+            records.detach_binding(&binding.id)?;
+            (Presence::Offline, None)
+        }
+        BindingEvidence::Unknown => (Presence::Unknown, None),
+    };
+    let binding = (presence == Presence::Active).then_some(binding.clone());
+    Ok(Some(IdentityPresence {
+        identity: entry.identity,
+        presence,
+        pane,
+        binding,
+    }))
+}
+
+pub(super) fn observe<O: BindingEndpoint>(
+    endpoint: &mut O,
+    entry: &BindingEntry,
+) -> Result<EndpointProbe, O::Error> {
+    match &entry.binding {
+        Some(binding) if endpoint.budget_available() => {
+            endpoint.probe_binding(&binding.server, std::slice::from_ref(&binding.pane_id))
+        }
+        _ => Ok(EndpointProbe::Unknown),
+    }
+}
+
+pub fn name_presence<R: BindingRepository, O: BindingEndpoint>(
+    repository: &mut R,
+    endpoint: &mut O,
+    name: &str,
+) -> Result<IdentityPresence, BindingError<R::Error, O::Error>> {
+    repository
+        .with_binding_transaction(|records| {
+            endpoint.begin_coordination();
+            let entry = named_entry(records, name)?
+                .ok_or_else(|| BindingError::NameNotFound(name.into()))?;
+            let probe = observe(endpoint, &entry).map_err(BindingError::Endpoint)?;
+            // Commit conclusive retirement even when this read no longer finds a
+            // live-name record. Convert absence to the public error after commit.
+            reconcile(records, entry, &probe)
+        })?
+        .ok_or_else(|| BindingError::NameNotFound(name.into()))
+}
+
+pub fn pane_presence<R: BindingRepository, O: BindingEndpoint>(
+    repository: &mut R,
+    endpoint: &mut O,
+    pane_id: &str,
+) -> Result<PaneIdentity, BindingError<R::Error, O::Error>> {
+    repository.with_binding_transaction(|records| {
+        endpoint.begin_coordination();
+        let snapshot = endpoint
+            .current_snapshot(&[pane_id.into()])
+            .map_err(BindingError::Endpoint)?;
+        let pane = snapshot
+            .panes
+            .iter()
+            .find(|pane| pane.id == pane_id)
+            .cloned()
+            .ok_or_else(|| BindingError::PaneNotFound(pane_id.into()))?;
+        let entry = records.entry_by_pane(pane_id, &snapshot.server.server_id)?;
+        let identity = match entry {
+            Some(entry) => reconcile(records, entry, &EndpointProbe::Live(snapshot))?
+                .filter(|row| row.presence == Presence::Active)
+                .map(|row| row.identity),
+            None => None,
+        };
+        Ok(PaneIdentity { pane, identity })
+    })
+}
+
+/// One joined repository read and one bounded observation per recorded server,
+/// never one process per identity. Unknown or exhausted observations preserve
+/// their rows; output ordering stays the repository's canonical BINARY order.
+pub fn list_presence<R: BindingRepository, O: BindingEndpoint>(
+    repository: &mut R,
+    endpoint: &mut O,
+    current_socket: Option<&str>,
+) -> Result<Vec<IdentityPresence>, BindingError<R::Error, O::Error>> {
+    repository.with_binding_transaction(|records| {
+        endpoint.begin_coordination();
+        let entries = records.binding_entries()?;
+        let mut groups = BTreeMap::<_, (ServerEvidence, Vec<String>)>::new();
+        for entry in &entries {
+            if let Some(binding) = &entry.binding {
+                let server = &binding.server;
+                let key = server_key(server, current_socket);
+                groups
+                    .entry(key)
+                    .or_insert_with(|| (server.clone(), Vec::new()))
+                    .1
+                    .push(binding.pane_id.clone());
+            }
+        }
+        let mut probes = BTreeMap::new();
+        for (key, (server, panes)) in groups {
+            let probe = if endpoint.budget_available() {
+                endpoint
+                    .probe_binding(&server, &panes)
+                    .map_err(BindingError::Endpoint)?
+            } else {
+                EndpointProbe::Unknown
+            };
+            probes.insert(key, probe);
+        }
+        let mut result = Vec::new();
+        for entry in entries {
+            let probe = entry
+                .binding
+                .as_ref()
+                .and_then(|binding| probes.get(&server_key(&binding.server, current_socket)))
+                .unwrap_or(&EndpointProbe::Unknown);
+            if let Some(row) = reconcile(records, entry, probe)? {
+                result.push(row);
+            }
+        }
+        Ok(result)
+    })
+}

--- a/rust/crates/tmt-core/src/binding/operations.rs
+++ b/rust/crates/tmt-core/src/binding/operations.rs
@@ -1,0 +1,239 @@
+use super::observation::{named_entry, observe, reconcile};
+use super::*;
+use crate::identity::{self, IdentityError, Lifetime};
+
+fn deadline<R, O: BindingEndpoint>(endpoint: &O) -> Result<(), BindingError<R, O::Error>> {
+    if endpoint.budget_available() {
+        Ok(())
+    } else {
+        Err(BindingError::Deadline)
+    }
+}
+
+pub fn bind_identity<R: BindingRepository, O: BindingEndpoint>(
+    repository: &mut R,
+    endpoint: &mut O,
+    pane_id: &str,
+    name: &str,
+    save: bool,
+) -> Result<IdentityPresence, BindingError<R::Error, O::Error>> {
+    endpoint.begin_coordination();
+    let preflight = endpoint
+        .current_snapshot(&[pane_id.into()])
+        .map_err(BindingError::Endpoint)?;
+    if !preflight.panes.iter().any(|pane| pane.id == pane_id) {
+        return Err(BindingError::PaneNotFound(pane_id.into()));
+    }
+    // Reconcile only the requested old name before creation. Conclusively lost
+    // temporary identities release their name; create_or_resolve then allocates
+    // a new UUID instead of resurrecting that old identity's history.
+    repository.with_binding_transaction(|records| {
+        endpoint.begin_coordination();
+        if let Some(entry) = named_entry(records, name)? {
+            let probe = observe(endpoint, &entry).map_err(BindingError::Endpoint)?;
+            if entry.binding.is_some()
+                && evaluate_binding(&entry, &probe) == BindingEvidence::Unknown
+            {
+                return Err(BindingError::Unverified);
+            }
+            reconcile(records, entry, &probe)?;
+        }
+        deadline(endpoint)
+    })?;
+    let created = identity::create_or_resolve(
+        repository,
+        name,
+        if save {
+            Lifetime::Saved
+        } else {
+            Lifetime::Temporary
+        },
+    )
+    .map_err(|error| match error {
+        IdentityError::InvalidName(error) => BindingError::InvalidName(error),
+        IdentityError::Repository(error) => BindingError::Repository(error),
+    })?;
+    // Everything below may fail without undoing the separately committed
+    // creation/promotion. Re-read ownership after acquiring this second lock.
+    repository.with_binding_transaction(|records| {
+        endpoint.begin_coordination();
+        let selected = records
+            .entry_by_id(&created.identity.id)?
+            .ok_or(BindingError::Unverified)?;
+        let mut scope = vec![pane_id.into()];
+        if let Some(binding) = &selected.binding
+            && binding.pane_id != pane_id
+        {
+            scope.push(binding.pane_id.clone());
+        }
+        let snapshot = endpoint
+            .current_snapshot(&scope)
+            .map_err(BindingError::Endpoint)?;
+        let pane = snapshot
+            .panes
+            .iter()
+            .find(|pane| pane.id == pane_id)
+            .ok_or_else(|| BindingError::PaneNotFound(pane_id.into()))?;
+        let mut current = None;
+        if let Some(occupied) = records.entry_by_pane(pane_id, &snapshot.server.server_id)? {
+            match evaluate_binding(&occupied, &EndpointProbe::Live(snapshot.clone())) {
+                BindingEvidence::Active(_) if occupied.identity.id != selected.identity.id => {
+                    return Err(BindingError::PaneAlreadyBound);
+                }
+                BindingEvidence::Active(_) => current = occupied.binding,
+                BindingEvidence::Unknown => return Err(BindingError::Unverified),
+                BindingEvidence::EndpointLost
+                    if occupied.identity.id == selected.identity.id
+                        && occupied.identity.lifetime == Lifetime::Temporary =>
+                {
+                    return Err(BindingError::Unverified);
+                }
+                _ => {
+                    reconcile(records, occupied, &EndpointProbe::Live(snapshot.clone()))?;
+                }
+            }
+        }
+        if let Some(old) = &selected.binding
+            && current.as_ref().is_none_or(|current| current.id != old.id)
+        {
+            let probe = if old.server.socket_path == snapshot.server.socket_path {
+                EndpointProbe::Live(snapshot.clone())
+            } else {
+                observe(endpoint, &selected).map_err(BindingError::Endpoint)?
+            };
+            match evaluate_binding(&selected, &probe) {
+                BindingEvidence::Active(_) => return Err(BindingError::NameAlreadyActive),
+                BindingEvidence::Unknown => return Err(BindingError::Unverified),
+                BindingEvidence::EndpointLost
+                    if selected.identity.lifetime == Lifetime::Temporary =>
+                {
+                    return Err(BindingError::Unverified);
+                }
+                _ => {
+                    records.detach_binding(&old.id)?;
+                }
+            }
+        }
+        let publish = current.is_none();
+        let binding = match current {
+            Some(binding) => binding,
+            None => records.insert_binding(&selected.identity, &snapshot.server, pane)?,
+        };
+        if publish {
+            endpoint
+                .publish(&binding, &selected.identity)
+                .map_err(BindingError::Endpoint)?;
+        }
+        let verified = endpoint
+            .current_snapshot(&[pane_id.into()])
+            .map_err(BindingError::Endpoint)?;
+        let persisted = records
+            .entry_by_pane(pane_id, &binding.server.server_id)?
+            .ok_or(BindingError::Unverified)?;
+        if persisted.identity.id != selected.identity.id
+            || persisted.binding.as_ref() != Some(&binding)
+        {
+            return Err(BindingError::Unverified);
+        }
+        let BindingEvidence::Active(pane) =
+            evaluate_binding(&persisted, &EndpointProbe::Live(verified))
+        else {
+            return Err(BindingError::Unverified);
+        };
+        records.touch_binding(&binding.id)?;
+        deadline(endpoint)?;
+        Ok(IdentityPresence {
+            identity: selected.identity,
+            presence: Presence::Active,
+            pane: Some(*pane),
+            binding: Some(binding),
+        })
+    })
+}
+
+pub fn unbind_identity<R: BindingRepository, O: BindingEndpoint>(
+    repository: &mut R,
+    endpoint: &mut O,
+    pane_id: &str,
+) -> Result<Option<UnboundIdentity>, BindingError<R::Error, O::Error>> {
+    repository.with_binding_transaction(|records| {
+        endpoint.begin_coordination();
+        let snapshot = endpoint
+            .current_snapshot(&[pane_id.into()])
+            .map_err(BindingError::Endpoint)?;
+        if !snapshot.panes.iter().any(|pane| pane.id == pane_id) {
+            return Err(BindingError::PaneNotFound(pane_id.into()));
+        }
+        let Some(entry) = records.entry_by_pane(pane_id, &snapshot.server.server_id)? else {
+            return Ok(None);
+        };
+        let evidence = evaluate_binding(&entry, &EndpointProbe::Live(snapshot));
+        clear_observed(endpoint, &entry, &evidence)?;
+        let retired = entry.identity.lifetime == Lifetime::Temporary;
+        if retired {
+            records.retire_identity(&entry.identity, false)?;
+        } else if let Some(binding) = &entry.binding {
+            records.detach_binding(&binding.id)?;
+        }
+        deadline(endpoint)?;
+        let binding = matches!(evidence, BindingEvidence::Active(_))
+            .then_some(entry.binding)
+            .flatten();
+        Ok(Some(UnboundIdentity {
+            identity: entry.identity,
+            retired,
+            binding,
+        }))
+    })
+}
+
+fn clear_observed<R, O: BindingEndpoint>(
+    endpoint: &mut O,
+    entry: &BindingEntry,
+    evidence: &BindingEvidence,
+) -> Result<(), BindingError<R, O::Error>> {
+    match (evidence, &entry.binding) {
+        (BindingEvidence::Unknown, Some(_)) => Err(BindingError::Unverified),
+        (BindingEvidence::Active(_), Some(binding)) => {
+            if endpoint.clear(binding).map_err(BindingError::Endpoint)? {
+                Ok(())
+            } else {
+                Err(BindingError::Unverified)
+            }
+        }
+        // A mismatched marker belongs to neither this binding nor its removal.
+        // Explicit retirement may detach the obsolete row but never erase it.
+        _ => Ok(()),
+    }
+}
+
+pub fn remove_identity<R: BindingRepository, O: BindingEndpoint>(
+    repository: &mut R,
+    endpoint: &mut O,
+    name: &str,
+    force: bool,
+) -> Result<BindingEntry, BindingError<R::Error, O::Error>> {
+    repository.with_binding_transaction(|records| {
+        let entry =
+            named_entry(records, name)?.ok_or_else(|| BindingError::NameNotFound(name.into()))?;
+        if entry.identity.lifetime == Lifetime::Saved && !force {
+            return Err(BindingError::ConfirmationRequired);
+        }
+        endpoint.begin_coordination();
+        let mut cleared_binding = None;
+        if entry.binding.is_some() {
+            let probe = observe(endpoint, &entry).map_err(BindingError::Endpoint)?;
+            let evidence = evaluate_binding(&entry, &probe);
+            clear_observed(endpoint, &entry, &evidence)?;
+            if matches!(evidence, BindingEvidence::Active(_)) {
+                cleared_binding = entry.binding.clone();
+            }
+        }
+        records.retire_identity(&entry.identity, true)?;
+        deadline(endpoint)?;
+        Ok(BindingEntry {
+            identity: entry.identity,
+            binding: cleared_binding,
+        })
+    })
+}

--- a/rust/crates/tmt-core/src/identity.rs
+++ b/rust/crates/tmt-core/src/identity.rs
@@ -115,7 +115,7 @@ pub fn create_or_resolve<R: IdentityRepository>(
         .map_err(IdentityError::Repository)
 }
 
-pub fn find_by_name<R: IdentityReader>(
+pub fn find_by_name<R: IdentityReader + ?Sized>(
     repository: &R,
     name: &str,
 ) -> Result<Option<Identity>, IdentityError<R::Error>> {

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared native-domain contracts for tmux-team.
 
+pub mod binding;
 pub mod endpoint;
 pub mod identity;
 pub mod limits;

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -10,6 +10,32 @@ Use `tmt` (the short alias for `tmux-team`) when the user asks you to communicat
 SQLite owns durable identities and profiles independently of the working
 directory. Active presence also requires matching live tmux binding metadata.
 
+## Runtime boundary
+
+The instructions below describe the installed TypeScript runtime. The separate
+Rust executable is a development preview: use isolated test state only, never an
+existing user database (schema 9 is forward-only and TypeScript cannot reopen it).
+Its help explicitly identifies the native preview. It implements configuration
+and identity commands, not messaging, role/preamble, X, skill installation or
+upgrade; do not fall back to TypeScript on the same upgraded database.
+
+For an explicitly selected native preview, `name`, retained alias `this`, and
+`add <pane-target> <name>` default to temporary identities; `-s`/`--save` saves
+the same UUID without downgrading existing saved identities. Names remain
+globally unique, not folder-scoped. `identity create` creates or promotes saved
+records. `ls` includes all non-retired identities with `lifetime` and independent
+`presence` (`active`, `offline`, `unknown`); offline/unknown entries are not
+verified destinations. Unknown evidence never authorizes retirement.
+Conclusive pane loss or explicit unbind retires temporary identities; saved
+identities remain offline. Native `rm <name>` retires a temporary identity;
+saved removal needs `--force`. Removal never kills a pane and removes only its
+role/preamble, retaining exchanges and historical ownership. Reusing a retired
+name gets a fresh UUID. A failed publication can leave a never-bound temporary
+identity offline for retry; do not mistake missing binding for pane death.
+These native-only lifetime/removal rules do not apply to the installed runtime
+described below. Check the selected executable's help instead of inferring
+capabilities from the shared alpha version number.
+
 ## Delivery safety
 
 Normal delivery pastes a tmux buffer, waits for the configured paste-to-Enter

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -2,9 +2,11 @@ FROM rust:1.97.0-bookworm@sha256:8fa55b2f3ddf97471ab6a767bfa3f37e6bad0986ba823e7
 WORKDIR /native
 COPY rust/ ./
 RUN cargo build --locked --example tmux-probe \
+  && cargo build --locked -p tmt-cli \
   && cargo test --locked --no-run -p tmt-adapters \
   && mkdir /native-artifacts \
   && cp target/debug/examples/tmux-probe /native-artifacts/tmux-probe \
+  && cp target/debug/tmt /native-artifacts/tmt \
   && find target/debug/deps -maxdepth 1 -type f -name 'tmt_adapters-*' -executable \
     -exec cp {} /native-artifacts/adapter-tests \;
 
@@ -24,6 +26,7 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 COPY --from=native-tests /native-artifacts/ /opt/tmt-tests/
 ENV TMT_TEST_TMUX_PROBE='{"executable":"/opt/tmt-tests/tmux-probe","args":[]}'
+ENV TMT_TEST_NATIVE_CLI='{"executable":"/opt/tmt-tests/tmt","args":[]}'
 
 # Run process lifecycle tests under the wrapper's --init, not a build-stage
 # shell that may retain orphan zombies. Both suites share network isolation.

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -194,7 +194,19 @@ if [ -n "${'$'}{TMT_E2E_PROGRESS_FILE:-}" ]; then
 fi
 metadata_write=0
 metadata_clear=0
-if [ "${'$'}1" = "set-option" ]; then
+# Keep explicit-socket native calls visible to the same publication barrier.
+# Inspect the command without changing argv passed to the real tmux binary.
+tmux_command=""
+skip_option_value=0
+for arg in "${'$'}@"; do
+  if [ "${'$'}skip_option_value" = "1" ]; then skip_option_value=0; continue; fi
+  case "${'$'}arg" in
+    -S|-L|-f) skip_option_value=1 ;;
+    -*) ;;
+    *) tmux_command="${'$'}arg"; break ;;
+  esac
+done
+if [ "${'$'}tmux_command" = "set-option" ]; then
   unset_metadata=0
   pane_metadata=0
   for arg in "${'$'}@"; do

--- a/test/e2e/native-identity.e2e.test.ts
+++ b/test/e2e/native-identity.e2e.test.ts
@@ -1,0 +1,507 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type CliResult, type E2EFixtureOptions } from './harness.js';
+import { durableState } from './identity-state-oracle.js';
+import { readRealTmuxCli, releaseRealTmuxCli, spawnRealTmuxCli } from './real-tmux-caller.js';
+import { installTmuxTrace } from './tmux-trace.js';
+import { processTreeHasOpenFile } from './process-file-oracle.js';
+
+interface Identity {
+  id: string;
+  name: string;
+  canonicalName: string;
+  lifetime: 'temporary' | 'saved';
+}
+interface Bound extends Omit<Identity, 'canonicalName'> {
+  bound: true;
+  pane: string;
+}
+interface Listed extends Identity {
+  presence: 'active' | 'offline' | 'unknown';
+  pane: string | null;
+  command: string;
+  target?: string;
+  cwd?: string;
+}
+interface Listing {
+  identities: Listed[];
+}
+
+function options(extra: E2EFixtureOptions = {}): E2EFixtureOptions {
+  const native = process.env.TMT_TEST_NATIVE_CLI;
+  if (!native) throw new Error('Native identity E2E requires the Docker-built CLI.');
+  return { mode: 'input-log', executableEnv: { TMT_TEST_CLI: native }, ...extra };
+}
+
+function success<T>(result: CliResult<T>): T {
+  expect(result.code, result.stderr || result.stdout).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.json, result.stdout).toBeDefined();
+  return result.json as T;
+}
+
+describe.sequential('native identity CLI lifecycle', () => {
+  it('coordinates a concurrent global observer with uncommitted publication and rechecks after lock acquisition', async () => {
+    await withE2EFixture(async (fixture) => {
+      fixture.enableMetadataBarrier({ phase: 'after' });
+      const binder = fixture.runCliProcess<Bound>(['--json', 'name', 'Concurrent']);
+      await fixture.waitForMetadataBarrier('applied');
+      expect(durableState(fixture).bindings).toEqual([]);
+      expect(JSON.parse(fixture.paneMetadata()).globalIdentity.name).toBe('Concurrent');
+      const trace = installTmuxTrace(fixture);
+      // Outside context avoids the harness's own pane-session lookup entering
+      // this CLI-only trace; global observation itself needs no caller pane.
+      const observer = fixture.runCliProcess<Listing>(['--json', 'ls'], { outsideTmux: true });
+      let settled = false;
+      void observer.result.then(() => {
+        settled = true;
+      });
+      await fixture.waitFor(
+        () =>
+          !settled &&
+          processTreeHasOpenFile(observer.pid, path.join(fixture.globalDir, 'tmux-team.db')),
+        900,
+        'native observer to open the locked database'
+      );
+      expect(settled).toBe(false);
+      expect(trace.invocations()).toEqual([]);
+      expect(durableState(fixture).bindings).toEqual([]);
+      fixture.releaseMetadataBarrier();
+      const bound = success(await binder.result);
+      expect(success(await observer.result).identities).toEqual([
+        expect.objectContaining({ id: bound.id, presence: 'active', pane: fixture.pane }),
+      ]);
+      expect(durableState(fixture).bindings).toEqual([
+        expect.objectContaining({ identity_id: bound.id }),
+      ]);
+    }, options());
+  });
+
+  it('fails closed on a copied server UUID instead of confusing equal pane IDs across sockets', async () => {
+    await withE2EFixture(async (first) => {
+      const alice = success(await first.runJsonCli<Bound>(['name', 'Alice']));
+      const metadata = first.paneMetadata();
+      const serverId = JSON.parse(metadata).globalIdentity.serverId;
+      await withE2EFixture(
+        async (second) => {
+          second.tmux(['set-option', '-s', '@tmux-team.server-id', serverId]);
+          expect(second.pane).toBe(first.pane);
+          const result = await second.runJsonCli<{ error: { code: string } }>(['name', 'Bob']);
+          expect(result.code).toBe(1);
+          expect(result.json?.error.code).toBe('RECONCILIATION_FAILED');
+          expect(first.paneMetadata()).toBe(metadata);
+          expect(second.paneMetadata()).toBe('');
+          expect(durableState(first).bindings).toEqual([
+            expect.objectContaining({ identity_id: alice.id, socket_path: first.socketPath }),
+          ]);
+          const list = success(await second.runJsonCli<Listing>(['ls'])).identities;
+          expect(list.map((row) => [row.name, row.presence])).toEqual([
+            ['Alice', 'active'],
+            ['Bob', 'offline'],
+          ]);
+        },
+        options({ globalDir: first.globalDir })
+      );
+    }, options());
+  });
+
+  it('preserves unknown evidence even under force and only detaches marker-mismatched temporary rows', async () => {
+    await withE2EFixture(async (fixture) => {
+      const initial = success(await fixture.runJsonCli<Bound>(['name', 'Uncertain']));
+      const original = fixture.paneMetadata();
+      const serverId = JSON.parse(original).globalIdentity.serverId;
+      const before = durableState(fixture);
+      fixture.tmux([
+        'set-option',
+        '-s',
+        '@tmux-team.server-id',
+        '123e4567-e89b-42d3-a456-426614174111',
+      ]);
+      const rows = success(await fixture.runJsonCli<Listing>(['ls'])).identities;
+      expect(rows).toEqual([
+        {
+          id: initial.id,
+          name: 'Uncertain',
+          canonicalName: 'uncertain',
+          lifetime: 'temporary',
+          presence: 'unknown',
+          pane: null,
+          command: '',
+        },
+      ]);
+      const removed = await fixture.runJsonCli<{ error: { code: string } }>([
+        'rm',
+        'Uncertain',
+        '--force',
+      ]);
+      expect(removed.code).toBe(1);
+      expect(removed.json?.error.code).toBe('RECONCILIATION_FAILED');
+      expect(durableState(fixture)).toEqual(before);
+      expect(fixture.paneMetadata()).toBe(original);
+      fixture.tmux(['set-option', '-s', '@tmux-team.server-id', serverId]);
+      const mismatched = JSON.parse(original);
+      mismatched.globalIdentity.bindingId = 'different-binding';
+      fixture.tmux([
+        'set-option',
+        '-p',
+        '-t',
+        fixture.pane,
+        '@tmux-team.agent',
+        JSON.stringify(mismatched),
+      ]);
+      const scoped = success(
+        await fixture.runJsonCli<{ presence: string; pane: null }>(['ls', 'Uncertain'])
+      );
+      expect(scoped).toMatchObject({ presence: 'offline', pane: null });
+      expect(durableState(fixture).identities).toEqual(before.identities);
+      expect(durableState(fixture).bindings).toEqual([]);
+      expect(JSON.parse(fixture.paneMetadata())).toEqual(mismatched);
+    }, options());
+  });
+
+  it('keeps scoped reads constant and batches global discovery in a mostly unbound server', async () => {
+    await withE2EFixture(async (fixture) => {
+      const owner = success(await fixture.runJsonCli<Bound>(['name', 'Owner']));
+      const trace = installTmuxTrace(fixture);
+      success(await fixture.runJsonCli(['whoami']));
+      const small = trace.invocations().length;
+      for (let index = 0; index < 40; index++) {
+        fixture.tmux(['new-window', '-d', '-t', 'e2e:', '-n', `idle-${index}`, 'sleep', '300']);
+      }
+      const peer = await fixture.createMockPane('peer');
+      const second = success(await fixture.runJsonCli<Bound>(['add', peer.pane, 'Second']));
+      trace.clear();
+      expect(success(await fixture.runJsonCli<Bound>(['whoami']))).toEqual(owner);
+      expect(trace.invocations()).toHaveLength(small);
+      expect(
+        trace
+          .invocations()
+          .filter((line) => line.includes('list-panes'))
+          .every((line) => line.includes(' -f ') && line.includes(fixture.pane))
+      ).toBe(true);
+      trace.clear();
+      const all = success(await fixture.runJsonCli<Listing>(['ls'])).identities;
+      expect(all.map((row) => row.id)).toEqual([owner.id, second.id]);
+      const queries = trace.invocations().filter((line) => line.includes('list-panes'));
+      expect(queries).toHaveLength(1);
+      expect(queries[0]).toContain(' -f ');
+      expect(queries[0]).toContain(fixture.pane);
+      expect(queries[0]).toContain(peer.pane);
+      expect(durableState(fixture).identities).toHaveLength(2);
+    }, options());
+  });
+
+  it('uses global names, promotes the same UUID, and keeps saved identities offline', async () => {
+    await withE2EFixture(async (fixture) => {
+      const initial = success(await fixture.runJsonCli<Bound>(['name', 'Alice']));
+      expect(initial).toEqual({
+        bound: true,
+        id: expect.any(String),
+        name: 'Alice',
+        pane: fixture.pane,
+        lifetime: 'temporary',
+      });
+      expect(JSON.parse(fixture.paneMetadata()).globalIdentity.identityId).toBe(initial.id);
+      const otherFolder = fixture.createWorkspace('other-folder');
+      const saved = success(
+        await fixture.runJsonCli<Bound>(['this', 'ALICE', '-s'], { cwd: otherFolder })
+      );
+      expect(saved).toEqual({ ...initial, lifetime: 'saved' });
+      expect(success(await fixture.runJsonCli<Bound>(['name', 'alice']))).toEqual(saved);
+      expect(success(await fixture.runJsonCli<Bound>(['whoami']))).toEqual(saved);
+      const live = success(
+        await fixture.runJsonCli<Listing>(['ls'], { cwd: otherFolder })
+      ).identities;
+      expect(live).toEqual([
+        {
+          id: initial.id,
+          name: 'Alice',
+          canonicalName: 'alice',
+          lifetime: 'saved',
+          presence: 'active',
+          pane: fixture.pane,
+          command: expect.any(String),
+          target: fixture.paneTarget(fixture.pane),
+          cwd: fixture.workspace,
+        },
+      ]);
+
+      expect(success(await fixture.runJsonCli(['unbind']))).toEqual({
+        unbound: true,
+        id: initial.id,
+        name: 'Alice',
+        pane: fixture.pane,
+        lifetime: 'saved',
+        retired: false,
+      });
+      expect(fixture.paneMetadata()).toBe('');
+      expect(
+        success(await fixture.runJsonCli<Listing>(['ls'], { withoutTmux: true })).identities
+      ).toEqual([
+        {
+          id: initial.id,
+          name: 'Alice',
+          canonicalName: 'alice',
+          lifetime: 'saved',
+          presence: 'offline',
+          pane: null,
+          command: '',
+        },
+      ]);
+      const denied = await fixture.runJsonCli<{ error: { code: string } }>(['rm', 'Alice'], {
+        withoutTmux: true,
+      });
+      expect(denied.code).toBe(5);
+      expect(denied.json?.error.code).toBe('CONFIRMATION_REQUIRED');
+      expect(
+        success(await fixture.runJsonCli(['remove', 'Alice', '--force'], { withoutTmux: true }))
+      ).toEqual({
+        removed: true,
+        identity: { id: initial.id, name: 'Alice', canonicalName: 'alice', lifetime: 'saved' },
+      });
+      expect(
+        success(await fixture.runJsonCli<Listing>(['ls'], { withoutTmux: true })).identities
+      ).toEqual([]);
+      expect(durableState(fixture).identities).toEqual([
+        expect.objectContaining({ id: initial.id, retired_at_ms: expect.any(Number) }),
+      ]);
+      expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+    }, options());
+  });
+
+  it('resolves pane selectors, preserves movement, retires dead temporary names, and never kills on rm', async () => {
+    await withE2EFixture(async (fixture) => {
+      const peer = await fixture.createMockPane('peer');
+      const named = success(
+        await fixture.runJsonCli<Bound>(['add', fixture.paneTarget(peer.pane), 'Worker'])
+      );
+      fixture.tmux([
+        'move-window',
+        '-s',
+        fixture.paneTarget(peer.pane).split('.')[0]!,
+        '-t',
+        'e2e:8',
+      ]);
+      const moved = success(await fixture.runJsonCli<Listing>(['ls'])).identities[0];
+      expect(moved).toMatchObject({
+        id: named.id,
+        pane: peer.pane,
+        target: fixture.paneTarget(peer.pane),
+        lifetime: 'temporary',
+        presence: 'active',
+      });
+      fixture.tmux(['kill-pane', '-t', peer.pane]);
+      expect(success(await fixture.runJsonCli<Listing>(['ls'])).identities).toEqual([]);
+      const fresh = success(await fixture.runJsonCli<Bound>(['add', fixture.pane, 'worker']));
+      expect(fresh.id).not.toBe(named.id);
+      const removed = success(await fixture.runJsonCli<{ removed: boolean }>(['rm', 'worker']));
+      expect(removed.removed).toBe(true);
+      expect(fixture.mockProcessIsRunning()).toBe(true);
+      expect(fixture.paneMetadata()).toBe('');
+      expect(success(await fixture.runJsonCli(['whoami']))).toEqual({
+        bound: false,
+        pane: fixture.pane,
+      });
+      expect(durableState(fixture).identities).toHaveLength(2);
+      expect(
+        durableState(fixture).identities.every((row) => typeof row.retired_at_ms === 'number')
+      ).toBe(true);
+    }, options());
+  });
+
+  it('retains separately committed creation on an occupied pane and permits an explicit retry', async () => {
+    await withE2EFixture(async (fixture) => {
+      const owner = success(await fixture.runJsonCli<Bound>(['name', 'Owner']));
+      const failed = await fixture.runJsonCli<{ error: { code: string } }>(['name', 'Retry']);
+      expect(failed.code).toBe(5);
+      expect(failed.json?.error.code).toBe('PANE_ALREADY_BOUND');
+      const state = durableState(fixture);
+      const retry = state.identities.find((row) => row.canonical_name === 'retry')!;
+      expect(retry).toMatchObject({
+        id: expect.any(String),
+        lifetime: 'temporary',
+        retired_at_ms: null,
+      });
+      expect(state.bindings).toEqual([expect.objectContaining({ identity_id: owner.id })]);
+      const listing = success(await fixture.runJsonCli<Listing>(['ls']));
+      expect(listing.identities[1]).toMatchObject({
+        id: retry.id,
+        presence: 'offline',
+        pane: null,
+        command: '',
+      });
+      const peer = await fixture.createMockPane('retry');
+      expect(success(await fixture.runJsonCli<Bound>(['add', peer.pane, 'retry'])).id).toBe(
+        retry.id
+      );
+    }, options());
+  });
+
+  it.each([
+    { name: 'complete', stripTmux: false, stripPane: false },
+    { name: 'no-pane', stripTmux: false, stripPane: true },
+    { name: 'no-tmux', stripTmux: true, stripPane: false },
+    { name: 'neither', stripTmux: true, stripPane: true },
+  ])(
+    'binds a real descendant with $name context without guessing the selected pane',
+    async (context) => {
+      await withE2EFixture(async (fixture) => {
+        const real = await spawnRealTmuxCli(fixture, ['name', 'Descendant'], context);
+        fixture.tmux(['select-pane', '-t', fixture.pane]);
+        await releaseRealTmuxCli(fixture, real);
+        const result = readRealTmuxCli<Bound>(real);
+        expect(result.code, result.stderr).toBe(0);
+        expect(result.stdout).toMatchObject({
+          bound: true,
+          name: 'Descendant',
+          pane: real.pane,
+          lifetime: 'temporary',
+        });
+        expect(JSON.parse(fixture.paneMetadata(real.pane)).globalIdentity.identityId).toBe(
+          result.stdout.id
+        );
+        expect(fixture.paneMetadata()).toBe('');
+        expect(
+          success(await fixture.runJsonCli<Listing>(['ls'])).identities.map((row) => row.pane)
+        ).toEqual([real.pane]);
+      }, options());
+    },
+    20_000
+  );
+
+  it.each(['grouped', 'linked'] as const)(
+    'keeps one identity and the attached presentation for %s windows',
+    async (mode) => {
+      await withE2EFixture(async (fixture) => {
+        const identity = success(await fixture.runJsonCli<Bound>(['name', 'Grouped']));
+        if (mode === 'grouped') fixture.tmux(['new-session', '-d', '-t', 'e2e', '-s', 'attached']);
+        else {
+          fixture.tmux(['new-session', '-d', '-s', 'attached', 'sleep', '300']);
+          fixture.tmux(['link-window', '-s', 'e2e:0', '-t', 'attached:']);
+        }
+        await fixture.attachSessionClient('attached');
+        const live = success(await fixture.runJsonCli<Listing>(['ls'])).identities;
+        expect(live).toHaveLength(1);
+        expect(live[0]).toMatchObject({
+          id: identity.id,
+          pane: fixture.pane,
+          presence: 'active',
+          target: expect.stringMatching(/^attached:/),
+        });
+        const scoped = success(
+          await fixture.runJsonCli<{ pane: { id: string; target: string } }>(['ls', fixture.pane])
+        );
+        expect(scoped.pane).toMatchObject({ id: fixture.pane, target: live[0]!.target });
+        expect(durableState(fixture).bindings).toHaveLength(1);
+      }, options());
+    }
+  );
+
+  it('rolls back a failed post-publication verification and recovers an orphan marker on retry', async () => {
+    await withE2EFixture(async (fixture) => {
+      fixture.enableMetadataBarrier({ phase: 'after' });
+      const process = fixture.runCliProcess(['--json', 'name', 'Retry']);
+      await fixture.waitForMetadataBarrier('applied');
+      const orphan = JSON.parse(fixture.paneMetadata()).globalIdentity;
+      const pending = durableState(fixture);
+      expect(pending.bindings).toEqual([]);
+      expect(pending.identities).toEqual([
+        expect.objectContaining({ id: orphan.identityId, retired_at_ms: null }),
+      ]);
+      // Kill only this fixture-owned CLI group while its published metadata is
+      // visible but the transaction is uncommitted.
+      process.kill('SIGKILL');
+      expect((await process.result).code).not.toBe(0);
+      fixture.releaseMetadataBarrier();
+      expect(durableState(fixture).bindings).toEqual([]);
+      const offline = success(await fixture.runJsonCli<Listing>(['ls'])).identities;
+      expect(offline).toEqual([
+        expect.objectContaining({ id: orphan.identityId, presence: 'offline', pane: null }),
+      ]);
+      expect(JSON.parse(fixture.paneMetadata()).globalIdentity).toEqual(orphan);
+      const retry = success(await fixture.runJsonCli<Bound>(['name', 'Retry']));
+      expect(retry.id).toBe(orphan.identityId);
+      const marker = JSON.parse(fixture.paneMetadata()).globalIdentity;
+      expect(marker.bindingId).not.toBe(orphan.bindingId);
+      expect(durableState(fixture).bindings).toEqual([
+        expect.objectContaining({ id: marker.bindingId, identity_id: retry.id }),
+      ]);
+    }, options());
+  });
+
+  it('does not publish success when the pane disappears during publication', async () => {
+    await withE2EFixture(async (fixture) => {
+      const peer = await fixture.createMockPane('vanishing');
+      fixture.enableMetadataBarrier({ phase: 'before' });
+      const process = fixture.runCliProcess(['--json', 'add', peer.pane, 'Vanished']);
+      await fixture.waitForMetadataBarrier();
+      fixture.tmux(['kill-pane', '-t', peer.pane]);
+      fixture.releaseMetadataBarrier();
+      const result = await process.result;
+      expect(result.code).toBe(1);
+      expect(result.json).toMatchObject({ error: { code: 'RECONCILIATION_FAILED' } });
+      expect(result.stdout).not.toContain('"bound":true');
+      expect(durableState(fixture).bindings).toEqual([]);
+      expect(durableState(fixture).identities).toEqual([
+        expect.objectContaining({ canonical_name: 'vanished', retired_at_ms: null }),
+      ]);
+      expect(fixture.paneMetadata()).toBe('');
+    }, options());
+  });
+
+  it('leaves user border formats untouched and only opts into the pane-local badge value', async () => {
+    await withE2EFixture(async (fixture) => {
+      const theme = '#{pane_index}---#{pane_current_path}';
+      fixture.tmux(['set-option', '-w', '-t', fixture.pane, 'pane-border-format', theme]);
+      success(await fixture.runJsonCli(['name', 'Alice']));
+      const badge = () =>
+        fixture.tmux(['show-options', '-p', '-qv', '-t', fixture.pane, '@tmux-team.badge']).trim();
+      expect(badge()).toBe('');
+      success(await fixture.runJsonCli(['config', 'set', 'ui.paneBadge', 'on', '--global']));
+      success(await fixture.runJsonCli(['name', 'Alice']));
+      expect(badge()).toBe('Alice (tmt)');
+      expect(
+        fixture.tmux(['show-options', '-w', '-v', '-t', fixture.pane, 'pane-border-format']).trim()
+      ).toBe(theme);
+      success(await fixture.runJsonCli(['unbind']));
+      expect(badge()).toBe('');
+      expect(
+        fixture.tmux(['show-options', '-w', '-v', '-t', fixture.pane, 'pane-border-format']).trim()
+      ).toBe(theme);
+    }, options());
+  });
+
+  it('routes foreign removal by its recorded socket without touching an equal local pane ID', async () => {
+    await withE2EFixture(async (first) => {
+      const alice = success(await first.runJsonCli<Bound>(['name', 'Alice', '-s']));
+      await withE2EFixture(
+        async (second) => {
+          const bob = success(await second.runJsonCli<Bound>(['name', 'Bob']));
+          expect(second.pane).toBe(first.pane);
+          expect(
+            success(await second.runJsonCli<Listing>(['ls'])).identities.map((row) => [
+              row.id,
+              row.presence,
+            ])
+          ).toEqual([
+            [alice.id, 'active'],
+            [bob.id, 'active'],
+          ]);
+          success(await second.runJsonCli(['rm', 'Alice', '--force']));
+          expect(first.paneMetadata()).toBe('');
+          expect(JSON.parse(second.paneMetadata()).globalIdentity.identityId).toBe(bob.id);
+          expect(first.mockProcessIsRunning()).toBe(true);
+          expect(second.mockProcessIsRunning()).toBe(true);
+        },
+        options({ globalDir: first.globalDir })
+      );
+      // Native global visibility reconciles conclusive foreign death too;
+      // the installed TS current-server-only rule is not this contract.
+      expect(success(await first.runJsonCli<Listing>(['ls'])).identities).toEqual([]);
+      expect(
+        durableState(first).identities.every((row) => typeof row.retired_at_ms === 'number')
+      ).toBe(true);
+    }, options());
+  });
+});

--- a/test/e2e/native-tmux.e2e.test.ts
+++ b/test/e2e/native-tmux.e2e.test.ts
@@ -109,6 +109,14 @@ describe.sequential('native tmux adapter integration (not identity CLI parity)',
       expect(initial.panes.every((pane) => pane.marker === null)).toBe(true);
       const full = successful(await fixture.runJsonCli<Snapshot & Counted>(['snapshot']));
       expect(full.commandCount).toBe(2);
+      const batched = successful(
+        await fixture.runJsonCli<Snapshot & Counted>([
+          'snapshot',
+          ...full.panes.map((pane) => pane.id),
+        ])
+      );
+      expect(batched.panes).toEqual(full.panes);
+      expect(batched.commandCount).toBe(2);
       const scoped = successful(
         await fixture.runJsonCli<Snapshot & Counted>(['snapshot', fixture.pane])
       );

--- a/test/e2e/process-file-oracle.ts
+++ b/test/e2e/process-file-oracle.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function isEnoent(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+/**
+ * The Docker E2E image is Linux. A direct native CLI or wrapper may own the
+ * returned PID while the actual process opens SQLite, so walk its /proc child
+ * tree and inspect open descriptors instead of relying on a tmux-first hook.
+ */
+export function processTreeHasOpenFile(rootPid: number, file: string): boolean {
+  const target = path.resolve(file);
+  const pending = [rootPid];
+  const visited = new Set<number>();
+
+  while (pending.length > 0) {
+    const pid = pending.pop();
+    if (pid === undefined || visited.has(pid)) continue;
+    visited.add(pid);
+
+    let children: string;
+    try {
+      children = fs.readFileSync(`/proc/${pid}/task/${pid}/children`, 'utf8');
+    } catch (error) {
+      if (isEnoent(error)) continue;
+      throw error;
+    }
+    for (const value of children.trim().split(/\s+/)) {
+      if (value) pending.push(Number(value));
+    }
+
+    let descriptors: string[];
+    try {
+      descriptors = fs.readdirSync(`/proc/${pid}/fd`);
+    } catch (error) {
+      if (isEnoent(error)) continue;
+      throw error;
+    }
+    for (const descriptor of descriptors) {
+      let opened: string;
+      try {
+        opened = fs.readlinkSync(`/proc/${pid}/fd/${descriptor}`);
+      } catch (error) {
+        if (isEnoent(error)) continue;
+        throw error;
+      }
+      if (opened === target) return true;
+    }
+  }
+  return false;
+}

--- a/test/e2e/publication-race.e2e.test.ts
+++ b/test/e2e/publication-race.e2e.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { E2EFixture, withE2EFixture, type CliProcess, type CliResult } from './harness.js';
+import { processTreeHasOpenFile } from './process-file-oracle.js';
 
 interface IdentityListItem {
   name: string;
@@ -89,57 +90,6 @@ function writerIsLocked(fixture: E2EFixture): boolean {
   } finally {
     database.close();
   }
-}
-
-function isEnoent(error: unknown): boolean {
-  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
-}
-
-/**
- * The Docker E2E image is Linux. A CLI wrapper owns the returned PID and
- * spawns the actual Node process, so walk its /proc child tree and inspect
- * open descriptors instead of relying on a tmux-first progress hook.
- */
-function processTreeHasOpenFile(rootPid: number, file: string): boolean {
-  const target = path.resolve(file);
-  const pending = [rootPid];
-  const visited = new Set<number>();
-
-  while (pending.length > 0) {
-    const pid = pending.pop();
-    if (pid === undefined || visited.has(pid)) continue;
-    visited.add(pid);
-
-    let children: string;
-    try {
-      children = fs.readFileSync(`/proc/${pid}/task/${pid}/children`, 'utf8');
-    } catch (error) {
-      if (isEnoent(error)) continue;
-      throw error;
-    }
-    for (const value of children.trim().split(/\s+/)) {
-      if (value) pending.push(Number(value));
-    }
-
-    let descriptors: string[];
-    try {
-      descriptors = fs.readdirSync(`/proc/${pid}/fd`);
-    } catch (error) {
-      if (isEnoent(error)) continue;
-      throw error;
-    }
-    for (const descriptor of descriptors) {
-      let opened: string;
-      try {
-        opened = fs.readlinkSync(`/proc/${pid}/fd/${descriptor}`);
-      } catch (error) {
-        if (isEnoent(error)) continue;
-        throw error;
-      }
-      if (opened === target) return true;
-    }
-  }
-  return false;
 }
 
 function json<T>(result: CliResult<T>): T {

--- a/test/native/binding.test.ts
+++ b/test/native/binding.test.ts
@@ -1,0 +1,302 @@
+import Database from 'better-sqlite3';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  parseWholeStdout,
+  runCli,
+  type Sandbox,
+  withSandbox,
+} from '../../src/test-support/cli-process.js';
+
+if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
+
+type Identity = {
+  readonly id: string;
+  readonly name: string;
+  readonly canonicalName: string;
+  readonly lifetime: 'temporary' | 'saved';
+};
+
+function documentIdentity(result: Awaited<ReturnType<typeof runCli>>): Identity {
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe('');
+  const document = parseWholeStdout(result) as { identity?: unknown };
+  expect(document.identity).toMatchObject({
+    id: expect.any(String),
+    name: expect.any(String),
+    canonicalName: expect.any(String),
+    lifetime: expect.stringMatching(/^(temporary|saved)$/),
+  });
+  expect(Object.keys(document.identity as object).sort()).toEqual([
+    'canonicalName',
+    'id',
+    'lifetime',
+    'name',
+  ]);
+  return document.identity as Identity;
+}
+
+function withDatabase<T>(file: string, callback: (database: Database.Database) => T): T {
+  const database = new Database(file);
+  try {
+    database.pragma('foreign_keys = ON');
+    return callback(database);
+  } finally {
+    database.close();
+  }
+}
+
+function installTmuxTripwire(sandbox: Sandbox): string {
+  const directory = path.join(sandbox.root, 'task-owned-tripwire');
+  const logPath = path.join(sandbox.root, 'tmux-invocations.log');
+  mkdirSync(directory);
+  const executable = path.join(directory, 'tmux');
+  writeFileSync(executable, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TMT_BINDING_TMUX_LOG"\nexit 97\n');
+  chmodSync(executable, 0o755);
+  sandbox.env.PATH = `${directory}${path.delimiter}${process.env.PATH ?? ''}`;
+  sandbox.env.TMT_BINDING_TMUX_LOG = logPath;
+  return logPath;
+}
+
+async function calibrateTmuxTripwire(sandbox: Sandbox): Promise<string> {
+  const logPath = installTmuxTripwire(sandbox);
+  const tripwire = await runCli(
+    {
+      ...sandbox,
+      cli: { executable: '/usr/bin/env', args: ['tmux'] },
+    },
+    [],
+    { deadlineMs: 2_000 }
+  );
+  expect(tripwire.status).toBe(97);
+  expect(tripwire.stdout).toBe('');
+  expect(tripwire.stderr).toBe('');
+  expect(readFileSync(logPath, 'utf8')).toBe('\n');
+  return logPath;
+}
+
+function seedExchange(database: Database.Database, identityId: string): void {
+  database
+    .prepare(
+      `
+    INSERT INTO request_attempts (
+      attempt_id, request_id, identity_id, server_id, socket_path, server_pid,
+      server_start_time, pane_id, pane_pid, wait_active, status,
+      inject_preamble, cadence_reserved, prepared_at_ms, expires_at_ms,
+      originator_kind, originator_identity_id, attention_revision
+    ) VALUES (
+      'attempt-retained', 'request-retained', ?, 'server-retained',
+      '/tmp/retained.sock', 101, 'start-retained', '%12', 202, 0, 'sent',
+      0, 0, 1700000000000, 1700000010000, 'explicit', ?, 1
+    )
+  `
+    )
+    .run(identityId, identityId);
+  database
+    .prepare(
+      `
+      INSERT INTO request_responses (
+      request_id, attempt_id, server_id, socket_path, server_pid,
+      server_start_time, pane_id, pane_pid, body, body_bytes, submitted_at_ms
+      ) VALUES (
+      'request-retained', 'attempt-retained', 'server-retained', '/tmp/retained.sock',
+      101, 'start-retained', '%12', 202, 'retained exchange', 17, 1700000000200
+      )
+    `
+    )
+    .run();
+}
+
+describe('native identity binding process contract', () => {
+  it('runs pane preflight before malformed config or invalid names and leaves no effects', async () => {
+    await withSandbox(async (sandbox) => {
+      mkdirSync(sandbox.globalDir, { recursive: true });
+      const globalConfig = '{ malformed global config';
+      const localConfig = '{ malformed local config';
+      writeFileSync(sandbox.globalConfig, globalConfig);
+      writeFileSync(sandbox.localConfig, localConfig);
+      const logPath = await calibrateTmuxTripwire(sandbox);
+      const calibratedLog = readFileSync(logPath, 'utf8');
+
+      for (const args of [
+        ['name', 'bad\u007f', '--json'],
+        ['this', 'bad\u007f', '--json'],
+        ['add', '%99', 'bad\u007f', '--json'],
+        ['whoami', '--json'],
+        ['unbind', '--json'],
+      ]) {
+        const result = await runCli(sandbox, args);
+        expect(result.status, args.join(' ')).toBe(3);
+        expectError(result, 'PANE_NOT_FOUND');
+        expect(result.stderr).toBe('');
+        expect(existsSync(sandbox.database)).toBe(false);
+        expect(readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalConfig);
+        expect(readFileSync(sandbox.localConfig, 'utf8')).toBe(localConfig);
+      }
+      expect(readFileSync(logPath, 'utf8')).not.toBe(calibratedLog);
+    });
+  });
+
+  it('reports the legacy add order before probing or opening storage', async () => {
+    await withSandbox(async (sandbox) => {
+      const logPath = await calibrateTmuxTripwire(sandbox);
+      const before = readFileSync(logPath, 'utf8');
+      const result = await runCli(sandbox, ['add', 'worker', '%99', '--json']);
+      expect(result.status).toBe(1);
+      expectError(result, 'LEGACY_ADD_ORDER');
+      expect(parseWholeStdout(result)).toEqual({
+        error: {
+          code: 'LEGACY_ADD_ORDER',
+          message: 'The v4 add argument order is no longer supported.',
+          suggestion: 'Use: tmt add %99 worker',
+        },
+      });
+      expect(result.stderr).toBe('');
+      expect(readFileSync(logPath, 'utf8')).toBe(before);
+      expect(existsSync(sandbox.database)).toBe(false);
+    });
+  });
+
+  it('lists an offline identity globally and by name without exposing binding evidence', async () => {
+    await withSandbox(async (sandbox) => {
+      const logPath = await calibrateTmuxTripwire(sandbox);
+      const calibratedLog = readFileSync(logPath, 'utf8');
+      const identity = documentIdentity(
+        await runCli(sandbox, ['identity', 'create', 'Offline Agent', '--json'])
+      );
+
+      const global = await runCli(sandbox, ['ls', '--json']);
+      expect(global.status).toBe(0);
+      expect(global.stderr).toBe('');
+      expect(parseWholeStdout(global)).toEqual({
+        identities: [
+          {
+            ...identity,
+            presence: 'offline',
+            pane: null,
+            command: '',
+          },
+        ],
+      });
+      const globalRow = (parseWholeStdout(global) as { identities: Array<Record<string, unknown>> })
+        .identities[0];
+      expect(Object.keys(globalRow).sort()).toEqual([
+        'canonicalName',
+        'command',
+        'id',
+        'lifetime',
+        'name',
+        'pane',
+        'presence',
+      ]);
+
+      const named = await runCli(sandbox, ['list', 'offline agent', '--json']);
+      expect(named.status).toBe(0);
+      expect(named.stderr).toBe('');
+      expect(parseWholeStdout(named)).toEqual({
+        target: 'offline agent',
+        identity,
+        presence: 'offline',
+        pane: null,
+      });
+      expect(Object.keys(parseWholeStdout(named)).sort()).toEqual([
+        'identity',
+        'pane',
+        'presence',
+        'target',
+      ]);
+
+      const missing = await runCli(sandbox, ['list', 'missing', '--json']);
+      expect(missing.status).toBe(3);
+      expectError(missing, 'NAME_NOT_FOUND');
+      expect(readFileSync(logPath, 'utf8')).toBe(calibratedLog);
+
+      const human = await runCli(sandbox, ['ls']);
+      expect(human.status).toBe(0);
+      expect(human.stderr).toBe('');
+      expect(human.stdout).toBe(
+        'NAME\tLIFETIME\tSTATUS\tPANE\tTARGET\tCWD\tCOMMAND\n' +
+          'Offline Agent\tsaved\toffline\t-\t-\t-\t\n'
+      );
+    });
+  });
+
+  it('requires rm confirmation and force-retirement preserves exchange rows', async () => {
+    await withSandbox(async (sandbox) => {
+      const identity = documentIdentity(
+        await runCli(sandbox, ['identity', 'create', 'Retained Exchange', '--json'])
+      );
+      withDatabase(sandbox.database, (database) => seedExchange(database, identity.id));
+
+      const before = withDatabase(sandbox.database, (database) => ({
+        identity: database
+          .prepare('SELECT id, retired_at_ms FROM identities WHERE id = ?')
+          .get(identity.id),
+        attempt: database
+          .prepare(
+            'SELECT identity_id, originator_identity_id, status FROM request_attempts WHERE attempt_id = ?'
+          )
+          .get('attempt-retained'),
+        response: database
+          .prepare('SELECT body, body_bytes FROM request_responses WHERE request_id = ?')
+          .get('request-retained'),
+      }));
+
+      const confirmation = await runCli(sandbox, ['rm', 'retained exchange', '--json']);
+      expect(confirmation.status).toBe(5);
+      expectError(
+        confirmation,
+        'CONFIRMATION_REQUIRED',
+        'Saved identity removal requires --force. Its role and preamble will be removed; exchanges are retained.'
+      );
+      expect(
+        withDatabase(sandbox.database, (database) => ({
+          identity: database
+            .prepare('SELECT id, retired_at_ms FROM identities WHERE id = ?')
+            .get(identity.id),
+          attempt: database
+            .prepare(
+              'SELECT identity_id, originator_identity_id, status FROM request_attempts WHERE attempt_id = ?'
+            )
+            .get('attempt-retained'),
+          response: database
+            .prepare('SELECT body, body_bytes FROM request_responses WHERE request_id = ?')
+            .get('request-retained'),
+        }))
+      ).toEqual(before);
+
+      const removed = await runCli(sandbox, ['remove', 'retained exchange', '--force', '--json']);
+      expect(removed.status).toBe(0);
+      expect(removed.stderr).toBe('');
+      expect(parseWholeStdout(removed)).toEqual({
+        removed: true,
+        identity,
+      });
+      const missing = await runCli(sandbox, ['identity', 'show', 'retained exchange', '--json']);
+      expect(missing.status).toBe(3);
+      expectError(missing, 'NAME_NOT_FOUND');
+
+      expect(
+        withDatabase(sandbox.database, (database) => ({
+          identity: database
+            .prepare('SELECT id, retired_at_ms FROM identities WHERE id = ?')
+            .get(identity.id),
+          attempt: database
+            .prepare(
+              'SELECT identity_id, originator_identity_id, status FROM request_attempts WHERE attempt_id = ?'
+            )
+            .get('attempt-retained'),
+          response: database
+            .prepare('SELECT body, body_bytes FROM request_responses WHERE request_id = ?')
+            .get('request-retained'),
+        }))
+      ).toEqual({
+        identity: { id: identity.id, retired_at_ms: expect.any(Number) },
+        attempt: { identity_id: identity.id, originator_identity_id: identity.id, status: 'sent' },
+        response: { body: 'retained exchange', body_bytes: 17 },
+      });
+    });
+  });
+});

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -61,10 +61,15 @@ describe('native grammar preview process contract', () => {
       expect(help.status).toBe(0);
       expect(help.stderr).toBe('');
       expect(help.stdout).toContain('Native development preview');
-      expect(help.stdout).toContain('storage-only identity create/show/list are available');
+      expect(help.stdout).toContain(
+        'configuration, storage-only identity create/show/list, and pane identity name/this/add/whoami/unbind/rm/list are available'
+      );
+      expect(help.stdout).toContain('Transport commands are not implemented yet.');
       expect(help.stdout).toContain('Manage identity records without probing tmux');
       expect(help.stdout).toContain('temporary unless saved');
       expect(help.stdout).toContain('rm');
+      expect(help.stdout).toContain('remove role/preamble');
+      expect(help.stdout).toContain('keep pane/exchanges');
       expect(help.stdout).not.toContain('--wait');
       expect(fileSnapshot(sandbox.root)).toEqual(before);
     });
@@ -74,14 +79,6 @@ describe('native grammar preview process contract', () => {
     await withSandbox(async (sandbox) => {
       const before = fileSnapshot(sandbox.root);
       for (const args of [
-        ['name', 'worker'],
-        ['this', 'worker', '-s'],
-        ['add', '%14', 'worker', '--save'],
-        ['rm', 'worker'],
-        ['remove', 'saved', '--force'],
-        ['whoami'],
-        ['unbind'],
-        ['list'],
         ['talk', 'worker', 'hello'],
         ['check', '%14'],
         ['init'],


### PR DESCRIPTION
## Scope

- Closes #109; identity workflow slice of #100 / #93, building on #105, #108, #111, #113 and #115.
- Implements native `name`/`this`/`add`, `whoami`, `unbind`, `rm`/`remove`, and global/scoped `ls`/`list`. Temporary defaults, same-UUID `-s`/`--save`, saved-removal confirmation and retained historical ownership are deliberate native-only amendments.
- No TypeScript runtime cutover, schema migration, new dependency, message transport, MCP, release or global installation.

## Architecture and review

- `core::identity` remains the create/promote/name owner. `core::binding` owns one evidence evaluator and coordinated use cases over narrow ports. Existing Storage, identity decoding, immediate transaction helper, tmux runner and shared output publication are reused.
- Creation/promotion commits separately from verified publication. Unknown evidence preserves bindings/names; conclusive loss retires temporary identities, while marker mismatch only detaches. Saved rows remain offline. Explicit removal deletes only selected role/preamble content and preserves exchanges, cadence and attention.
- Global presence uses a joined ordered query and server-grouped observation, not per-identity subprocesses. Each coordinated phase starts its three-second observation budget after lock acquisition; the SQLite contention wait is separate. Foreign metadata changes use the recorded socket and full endpoint agreement.
- `ls` reports `lifetime` independently from `presence`; offline/unknown projections omit stale endpoint details. Existing storage-only identity projections remain shared. All output is buffered until cleanup.
- Primary reviewer: Codex. Personally reviewed all changed production/test/docs diffs and the existing identity, SQL, tmux, CLI, selector, fixture and cleanup callers. Luna supplied bounded implementation/test work and a supplementary review; findings were checked against the amended issue, not accepted automatically.
- Review findings resolved: fixed a false-positive stale-binding test, shared repeated fixtures/oracles, separated publication/presence/removal scenarios, strengthened partial-budget/current-server ordering assertions, corrected marker whitespace policy ownership, and bounded/balanced tmux scope construction (1,024 panes / conservative 32 KiB filter). Oversized probes are unknown, not dead.
- Additional review dispositions: global foreign reconciliation is intentional under #109, unlike installed TS current-server discovery; copied server UUIDs fail closed through full socket/evidence agreement (real regression test added); per-phase deadlines match the recorded separate-commit design. Real Docker crash-after-publication/retry and concurrent-observer cases cover orphan markers, not only fake endpoints.
- Reviewed commit: `eff74085b8dfbd02acbda44584d72ed49d282588`. The final follow-up also makes role/preamble deletion and exchange/pane preservation explicit in grammar-backed removal help; its help/process and Rust checks were rerun.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge.

CI run [34149701340](https://github.com/wkh237/tmux-team/actions/runs/34149701340), attempt 1: all 11 jobs passed on reviewed head `eff74085b8dfbd02acbda44584d72ed49d282588`, including all branch-protection requirements. GitHub reported `CLEAN` immediately before merge. No CI rerun or protection bypass was used.

Commands and results (local):

- `cargo fmt --all --check`; `cargo clippy --workspace --all-targets --locked -- -D warnings`: passed.
- `cargo test --workspace --locked` and `cargo +1.88.0 test --workspace --locked`: 153 each passed (85 adapters, 33 core, 17 CLI, 18 architecture).
- `cargo build --workspace --locked --bins --examples`: passed; Rust 1.97.0, MSRV 1.88.0 also tested.
- `pnpm check`: passed. `pnpm test:run`: 1,102 tests / 70 files passed, existing coverage gate passed.
- `pnpm test:native` with native CLI and storage-probe descriptors: 60 / 5 files passed.
- Existing shared parser/config contract selectors from CI: 8 + 6 passed; unported cases remain explicitly excluded, not claimed as parity.
- `pnpm test:e2e` through the existing `--init --network none` wrapper: repeated full local runs; implementation run A passed 85 adapters + 131 E2E, and final expanded run C passed 85 adapters + 132 E2E including all 17 native identity scenarios. Each deliberately skips one optional performance benchmark. Cleanup completed on passing and failed runs. The only later product change is the removal-help clarification, separately reverified above.
- The added concurrent-observer test initially included a fixture-owned session lookup in its CLI trace. It now uses caller-independent global observation, preserving the no-tmux-before-lock assertion; focused isolated Docker verification passed. No product assertion or CI gate was lowered.
- Canonical skill validator passed using task-local PyYAML; installed guidance/viewer/link behavior remains covered by the existing TS tests and required packed-install matrix.

## Project lifecycle

- Updated README, canonical installed skill, grammar help/completion source, ARCHITECTURE, DEVELOPMENT and RUST-REWRITE. Clearly distinguish the installed TypeScript runtime from native-only lifetime/removal behavior and forward-only schema 9.
- GitHub #109 contains the implementation plan, design refinements and local review/evidence. This PR does not claim request/reply or distribution readiness.
- Delivery complete: merged as `b63664e10b62077738eda5437e8ab8c72e57659f`. Issue #109 is closed; #100 and #93 are synchronized, with actual native late-reply/result integration explicitly remaining open. The clean, pushed issue worktree and local/remote branch were removed after merge, preserving shared dependencies. Main is clean and synchronized. No host tmux, real agents or user state touched.
