### PR TITLE
feat(native): add transactional request and final-response foundation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1051,6 +1051,46 @@ storage/path failures use bounded IDENTITY_ERROR/1. RAII remains the fallback,
 not the ordinary close path. No general service container, second error writer
 or new resource framework is introduced by this slice.
 
+#### Native transactional requests
+
+Under #118, `core::request::RequestService` owns preparation, delivery-state
+transitions, waiter release, exact final submission, context/result reads and
+bounded housekeeping. `RequestRecords` is available only inside the existing
+Storage immediate transaction. The clock is sampled after acquiring that lock;
+the concrete caller supplies attempt IDs and frozen settings before entry.
+There is no service-owned connection, tmux lookup, file input or configuration
+loader. This foundation does not enable public native talk/reply/result yet.
+
+`core::retention` is the shared settings/runtime owner for day limits and checked
+JavaScript-safe deadlines. Historical migration arithmetic remains frozen.
+`core::exact_text` validates UTF-8 bytes without normalization; request and final
+bodies share the 1 MiB bound but retain feature-specific errors. Rust strings
+already exclude lone surrogates; byte-oriented input must reject malformed UTF-8.
+
+Preparation reserves cadence and known-originator attention with its original
+prompt and immutable endpoint. Begin-send and settlement remain separate commits.
+Expired prepared attempts commit waiter release/refund before reporting failure;
+expired sending attempts become uncertain without refund. Same terminal settlement
+and waiter release are idempotent. No request transaction spans transport or polling.
+
+Final submission checks an existing retained final first, allowing exact retries
+after attempt metadata removal. Otherwise it validates the request/attempt/full
+recorded endpoint, eligibility and completion marker before writing a final,
+marker, horizon and attention revision atomically. It never consults current
+identity/pane presence; retirement/name reuse does not redirect historical replies.
+Rejected submissions perform no housekeeping or other mutation. Reads can perform
+bounded cleanup but never acknowledge attention. Prompt, body and metadata expiry
+remain independent; only first submission/explicit settlement can extend metadata.
+
+`storage::requests` composes the private connection and shared transaction helper;
+record decoding and SQL stay in the adapter. Ordered bounded cleanup retains the
+existing horizon-index protection and settlement floor. Attention counter writes
+preserve acknowledgment watermarks; revision arithmetic belongs to core. No schema,
+receipt table or alternate persistence owner is introduced. #106 retains short-token
+encoding and old-v1 receipt execution, and #93 retains public transport integration.
+
+#### Native storage and runtime adapters
+
 Native migration 9 adds `lifetime` (default `saved` for existing identities) and
 nullable `retired_at_ms` to that same identity table. A partial unique index
 reserves canonical names only for non-retired rows; old UUID/name metadata can

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,6 +36,14 @@ help/version/completion, typed grammar, the existing `config` command and
 storage-only `identity create/show/list` under #113, and pane identity
 `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` under #109.
 Other effectful commands still explicitly fail.
+The #118 request/final service is an internal transactional foundation only;
+it does not make public native talk/reply/result available. Its real SQLite
+tests run in ordinary adapter Cargo tests and therefore in the existing Docker
+adapter-test stage. They must verify committed rows independently of service
+reads, since those reads can perform housekeeping. Inject clocks for deadline
+equality/rollback and use bounded barriers between real connections for races.
+Retained final retries, attention rollback, cadence refunds and late replies
+after identity retirement are service evidence, not CLI/receipt/transport parity.
 The separate storage adapter upgrades historical schemas 0–8 to native schema 9,
 tested through a development-only probe rather than an installed command.
 Use isolated test databases only: installed TypeScript cannot reopen schema 9.

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -4,6 +4,8 @@ Status: native grammar (#96), storage lifecycle (#97) with native identity schem
 and bounded tmux evidence (#105), shared identity records (#111), and
 storage-only identity commands (#113), and pane identity lifecycle (#109)
 are implemented in the development preview, not a shipped Rust runtime.
+#118 adds the internal transactional request/final foundation; public native
+talk/reply/result and the #106 short-receipt transition remain unimplemented.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
 The compatibility reference is TypeScript main `cb53533f3a9f19a1a2ab95af59dda20df419200b`
@@ -205,6 +207,25 @@ zerovec-derive's RUSTSEC-2024-0346 are patched before the selected 0.11.8/0.11.6
 The other added package names had no entries in that dated snapshot. Baked
 data manifests record ICU release-78.1rc/CLDR 48.2.1; no data download occurs
 at CLI startup. Repeat the graph/advisory review on dependency updates.
+
+### Native request foundation
+
+#118 ports request preparation, begin-send/settlement, waiter release, final
+submission and retained context/result reads into one `core::request` service.
+Its narrow transaction-scoped records port composes the existing private SQLite
+connection and immediate transaction helper. No new migration or dependency is
+needed. Retention moves out of settings into a shared pure owner consumed by
+both settings and request policy, avoiding two independently evolving defaults.
+Historical migration saturation is not replaced by runtime checked arithmetic.
+
+The foundation preserves exact bodies, full endpoint fences, independently
+frozen horizons, bounded cleanup, cadence refunds and attention revisions.
+Final insertion/marker/revision are one transaction; retries can use a retained
+final without attempt metadata. No current identity lookup authorizes a reply.
+Real SQLite tests cover retirement/name reuse and late submission, but this is
+not old receipt execution or public CLI transport acceptance. #106 consumes this
+same owner for compact correlation; it must not add a token-specific final store.
+Native command adapters and transport remain explicit follow-on slices under #93.
 
 ### Execution and resource ownership
 

--- a/rust/crates/tmt-adapters/src/storage/mod.rs
+++ b/rust/crates/tmt-adapters/src/storage/mod.rs
@@ -2,6 +2,7 @@ mod bindings;
 mod errors;
 mod identities;
 mod migrations;
+mod requests;
 
 #[cfg(test)]
 mod tests;

--- a/rust/crates/tmt-adapters/src/storage/requests.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests.rs
@@ -1,0 +1,581 @@
+//! SQLite-backed durable request state.
+//!
+//! Request policy stays in `tmt-core`; this module only decodes rows and applies
+//! the bounded SQL mutations while the invocation-owned immediate transaction is
+//! held.
+
+mod rows;
+
+use rusqlite::{Connection, OptionalExtension, params};
+use tmt_core::request::{
+    AttemptStatus, FinalResponse, RawRequestContext, RequestAttempt, RequestEndpoint,
+    RequestRecords, RequestRepository, StoredPrompt,
+};
+
+use super::{
+    Storage, StorageError, StorageErrorCode, errors::classify,
+    identities::with_immediate_transaction,
+};
+
+struct RequestRows<'a>(&'a Connection);
+
+const DELETE_RETAINED_SQL: &str = "DELETE FROM request_attempts
+             WHERE attempt_id IN (
+                 SELECT attempt_id
+                 FROM request_attempts INDEXED BY request_attempts_retention_horizon
+                 WHERE wait_active = 0
+                   AND status IN ('sent', 'uncertain', 'definitely_failed')
+                   AND settled_at_ms IS NOT NULL
+                   AND settled_at_ms <= ?
+                   AND retention_expires_at_ms <= ?
+                   AND NOT EXISTS (
+                       SELECT 1 FROM request_responses
+                       WHERE request_responses.attempt_id = request_attempts.attempt_id
+                         AND request_responses.response_expires_at_ms > ?
+                   )
+                 ORDER BY retention_expires_at_ms, attempt_id
+                 LIMIT ?
+             )";
+
+fn endpoint_args(endpoint: &RequestEndpoint) -> Result<[rusqlite::types::Value; 6], StorageError> {
+    Ok([
+        endpoint.server.server_id.clone().into(),
+        endpoint.server.socket_path.clone().into(),
+        checked_i64(endpoint.server.server_pid, "Server PID")?.into(),
+        endpoint.server.server_start_time.clone().into(),
+        endpoint.pane_id.clone().into(),
+        checked_i64(endpoint.pane_pid, "Pane PID")?.into(),
+    ])
+}
+
+fn checked_i64(value: u64, label: &str) -> Result<i64, StorageError> {
+    i64::try_from(value).map_err(|_| {
+        StorageError::new(
+            StorageErrorCode::Unknown,
+            format!("{label} is outside the supported range"),
+        )
+    })
+}
+
+fn checked_limit(value: u64) -> Result<i64, StorageError> {
+    checked_i64(value, "Cleanup batch limit").and_then(|value| {
+        if value > 0 {
+            Ok(value)
+        } else {
+            Err(StorageError::new(
+                StorageErrorCode::Unknown,
+                "Cleanup batch limit must be positive",
+            ))
+        }
+    })
+}
+
+fn checked_now(value: u64, label: &str) -> Result<i64, StorageError> {
+    checked_i64(value, label).and_then(|value| {
+        if value > 0 {
+            Ok(value)
+        } else {
+            Err(StorageError::new(
+                StorageErrorCode::Unknown,
+                format!("{label} is outside the supported range"),
+            ))
+        }
+    })
+}
+
+impl RequestRecords for RequestRows<'_> {
+    type Error = StorageError;
+
+    fn find_attempt(&self, attempt_id: &str) -> Result<Option<RequestAttempt>, Self::Error> {
+        self.0
+            .query_row(
+                &format!(
+                    "SELECT {} FROM request_attempts WHERE attempt_id = ?",
+                    rows::ATTEMPT_COLUMNS
+                ),
+                [attempt_id],
+                rows::attempt_row,
+            )
+            .optional()
+            .map_err(|error| classify(error, "Find request attempt"))
+    }
+
+    fn find_request(&self, request_id: &str) -> Result<Option<RequestAttempt>, Self::Error> {
+        self.0
+            .query_row(
+                &format!(
+                    "SELECT {} FROM request_attempts WHERE request_id = ?",
+                    rows::ATTEMPT_COLUMNS
+                ),
+                [request_id],
+                rows::attempt_row,
+            )
+            .optional()
+            .map_err(|error| classify(error, "Find request"))
+    }
+
+    fn find_context(&self, request_id: &str) -> Result<Option<RawRequestContext>, Self::Error> {
+        self.0
+            .query_row(
+                &format!(
+                    "SELECT {}, message_text, message_bytes, message_expires_at_ms
+                     FROM request_attempts WHERE request_id = ?",
+                    rows::ATTEMPT_COLUMNS
+                ),
+                [request_id],
+                rows::context_row,
+            )
+            .optional()
+            .map_err(|error| classify(error, "Find request context"))
+    }
+
+    fn find_response(&self, request_id: &str) -> Result<Option<FinalResponse>, Self::Error> {
+        self.0
+            .query_row(
+                &format!(
+                    "SELECT {} FROM request_responses WHERE request_id = ?",
+                    rows::RESPONSE_COLUMNS
+                ),
+                [request_id],
+                rows::response_row,
+            )
+            .optional()
+            .map_err(|error| classify(error, "Find request response"))
+    }
+
+    fn find_active_request(
+        &self,
+        endpoint: &RequestEndpoint,
+    ) -> Result<Option<String>, Self::Error> {
+        let args = endpoint_args(endpoint)?;
+        self.0
+            .query_row(
+                "SELECT request_id FROM request_attempts
+             WHERE server_id = ? AND socket_path = ? AND server_pid = ?
+               AND server_start_time = ? AND pane_id = ? AND pane_pid = ?
+               AND wait_active = 1
+             ORDER BY prepared_at_ms, attempt_id LIMIT 1",
+                rusqlite::params_from_iter(args),
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|error| classify(error, "Find active request"))
+    }
+
+    fn create_attempt(
+        &mut self,
+        attempt: &RequestAttempt,
+        prompt: &StoredPrompt,
+        revision: u64,
+    ) -> Result<(), Self::Error> {
+        let server_pid = checked_i64(attempt.endpoint.server.server_pid, "Server PID")?;
+        let pane_pid = checked_i64(attempt.endpoint.pane_pid, "Pane PID")?;
+        let preamble_every = attempt
+            .preamble_every
+            .map(|value| checked_i64(value, "Preamble cadence"))
+            .transpose()?;
+        let sending_at_ms = attempt
+            .sending_at_ms
+            .map(|value| checked_i64(value, "Sending timestamp"))
+            .transpose()?;
+        let settled_at_ms = attempt
+            .settled_at_ms
+            .map(|value| checked_i64(value, "Settlement timestamp"))
+            .transpose()?;
+        let wait_released_at_ms = attempt
+            .wait_released_at_ms
+            .map(|value| checked_i64(value, "Wait release timestamp"))
+            .transpose()?;
+        let response_submitted_at_ms = attempt
+            .response_submitted_at_ms
+            .map(|value| checked_i64(value, "Response timestamp"))
+            .transpose()?;
+        let prepared_at_ms = checked_i64(attempt.prepared_at_ms, "Preparation timestamp")?;
+        let expires_at_ms = checked_i64(attempt.expires_at_ms, "Expiry timestamp")?;
+        let retention_days = checked_i64(attempt.retention_days, "Retention days")?;
+        let retention_expires_at_ms = checked_i64(
+            attempt.retention_expires_at_ms,
+            "Retention expiry timestamp",
+        )?;
+        let revision = checked_i64(revision, "Attention revision")?;
+        let prompt_bytes = checked_i64(prompt.message_bytes, "Prompt bytes")?;
+        let prompt_expires_at_ms = checked_i64(prompt.expires_at_ms, "Prompt expiry timestamp")?;
+        self.0
+            .execute(
+                "INSERT INTO request_attempts (
+                attempt_id, request_id, originator_kind, originator_identity_id,
+                recipient_identity_id, nonce, identity_id, server_id, socket_path,
+                server_pid, server_start_time, pane_id, pane_pid, wait_active, status,
+                preamble_every, inject_preamble, cadence_reserved, prepared_at_ms,
+                sending_at_ms, settled_at_ms, wait_released_at_ms,
+                response_submitted_at_ms, expires_at_ms, retention_days,
+                retention_expires_at_ms, attention_revision,
+                attention_acknowledged_revision, message_text, message_bytes,
+                message_expires_at_ms
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?
+            )",
+                params![
+                    attempt.attempt_id,
+                    attempt.request_id,
+                    attempt.originator.as_str(),
+                    attempt.originator.identity_id(),
+                    attempt.recipient_identity_id,
+                    attempt.nonce,
+                    attempt.identity_id,
+                    attempt.endpoint.server.server_id,
+                    attempt.endpoint.server.socket_path,
+                    server_pid,
+                    attempt.endpoint.server.server_start_time,
+                    attempt.endpoint.pane_id,
+                    pane_pid,
+                    if attempt.wait_active { 1 } else { 0 },
+                    attempt.status.as_str(),
+                    preamble_every,
+                    if attempt.inject_preamble { 1 } else { 0 },
+                    if attempt.cadence_reserved { 1 } else { 0 },
+                    prepared_at_ms,
+                    sending_at_ms,
+                    settled_at_ms,
+                    wait_released_at_ms,
+                    response_submitted_at_ms,
+                    expires_at_ms,
+                    retention_days,
+                    retention_expires_at_ms,
+                    revision,
+                    0_i64,
+                    prompt.message,
+                    prompt_bytes,
+                    prompt_expires_at_ms,
+                ],
+            )
+            .map_err(|error| classify(error, "Create request attempt"))?;
+        Ok(())
+    }
+
+    fn create_response(&mut self, response: &FinalResponse) -> Result<(), Self::Error> {
+        let server_pid = checked_i64(response.endpoint.server.server_pid, "Server PID")?;
+        let pane_pid = checked_i64(response.endpoint.pane_pid, "Pane PID")?;
+        let body_bytes = checked_i64(response.body_bytes, "Response bytes")?;
+        let submitted_at_ms = checked_i64(response.submitted_at_ms, "Submission timestamp")?;
+        let response_expires_at_ms =
+            checked_i64(response.response_expires_at_ms, "Response expiry timestamp")?;
+        self.0
+            .execute(
+                "INSERT INTO request_responses (
+                request_id, attempt_id, server_id, socket_path, server_pid,
+                server_start_time, pane_id, pane_pid, body, body_bytes,
+                submitted_at_ms, response_expires_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    response.request_id,
+                    response.attempt_id,
+                    response.endpoint.server.server_id,
+                    response.endpoint.server.socket_path,
+                    server_pid,
+                    response.endpoint.server.server_start_time,
+                    response.endpoint.pane_id,
+                    pane_pid,
+                    response.body,
+                    body_bytes,
+                    submitted_at_ms,
+                    response_expires_at_ms,
+                ],
+            )
+            .map_err(|error| classify(error, "Create request response"))?;
+        let changed = self
+            .0
+            .execute(
+                "UPDATE request_attempts
+             SET response_submitted_at_ms = ?,
+                 retention_expires_at_ms = MAX(retention_expires_at_ms, ?)
+             WHERE attempt_id = ? AND request_id = ?
+               AND response_submitted_at_ms IS NULL",
+                params![
+                    submitted_at_ms,
+                    response_expires_at_ms,
+                    response.attempt_id,
+                    response.request_id,
+                ],
+            )
+            .map_err(|error| classify(error, "Record request response completion"))?;
+        if changed != 1 {
+            return Err(StorageError::new(
+                StorageErrorCode::Unknown,
+                format!(
+                    "Request attempt '{}' could not record response completion",
+                    response.attempt_id
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn update_state(
+        &mut self,
+        attempt: &RequestAttempt,
+        status: AttemptStatus,
+        reserved: bool,
+        now_ms: u64,
+        horizon: Option<u64>,
+    ) -> Result<bool, Self::Error> {
+        let now = checked_i64(now_ms, "Request state timestamp")?;
+        let horizon = horizon
+            .map(|value| checked_i64(value, "Request retention horizon"))
+            .transpose()?;
+        let changed = self
+            .0
+            .execute(
+                "UPDATE request_attempts
+             SET status = ?,
+                 cadence_reserved = ?,
+                 sending_at_ms = CASE
+                     WHEN ? = 'sending' THEN ? ELSE sending_at_ms
+                 END,
+                 settled_at_ms = CASE
+                     WHEN ? IN ('sent', 'uncertain', 'definitely_failed')
+                         THEN ? ELSE settled_at_ms
+                 END,
+                 retention_expires_at_ms = MAX(
+                     retention_expires_at_ms,
+                     COALESCE(?, retention_expires_at_ms)
+                 )
+             WHERE attempt_id = ? AND status = ?",
+                params![
+                    status.as_str(),
+                    if reserved { 1 } else { 0 },
+                    status.as_str(),
+                    now,
+                    status.as_str(),
+                    now,
+                    horizon,
+                    attempt.attempt_id,
+                    attempt.status.as_str(),
+                ],
+            )
+            .map_err(|error| classify(error, "Update request state"))?;
+        Ok(changed == 1)
+    }
+
+    fn release_wait(&mut self, attempt_id: &str, now_ms: u64) -> Result<bool, Self::Error> {
+        let changed = self
+            .0
+            .execute(
+                "UPDATE request_attempts SET wait_active = 0, wait_released_at_ms = ?
+             WHERE attempt_id = ? AND wait_active = 1",
+                params![checked_i64(now_ms, "Wait release timestamp")?, attempt_id],
+            )
+            .map_err(|error| classify(error, "Release request wait"))?;
+        Ok(changed == 1)
+    }
+
+    fn preamble_count(&self, identity_id: &str) -> Result<u64, Self::Error> {
+        self.0
+            .query_row(
+                "SELECT reserved_count FROM preamble_counters WHERE identity_id = ?",
+                [identity_id],
+                |row| rows::u64_at(row, 0),
+            )
+            .optional()
+            .map_err(|error| classify(error, "Read preamble counter"))
+            .map(|value| value.unwrap_or(0))
+    }
+
+    fn set_preamble_count(
+        &mut self,
+        identity_id: &str,
+        count: u64,
+        now_ms: u64,
+    ) -> Result<(), Self::Error> {
+        self.0
+            .execute(
+                "INSERT INTO preamble_counters (identity_id, reserved_count, updated_at_ms)
+             VALUES (?, ?, ?) ON CONFLICT(identity_id) DO UPDATE SET
+               reserved_count = excluded.reserved_count,
+               updated_at_ms = excluded.updated_at_ms",
+                params![
+                    identity_id,
+                    checked_i64(count, "Preamble counter")?,
+                    checked_i64(now_ms, "Preamble counter timestamp")?
+                ],
+            )
+            .map_err(|error| classify(error, "Set preamble counter"))?;
+        Ok(())
+    }
+
+    fn attention_counter(&self, identity_id: &str) -> Result<Option<u64>, Self::Error> {
+        self.0
+            .query_row(
+                "SELECT latest_revision FROM request_attention_identities WHERE identity_id = ?",
+                [identity_id],
+                |row| rows::u64_at(row, 0),
+            )
+            .optional()
+            .map_err(|error| classify(error, "Read attention counter"))
+    }
+
+    fn set_attention_counter(
+        &mut self,
+        identity_id: &str,
+        expected: Option<u64>,
+        next: u64,
+    ) -> Result<(), Self::Error> {
+        let next = checked_i64(next, "Attention revision")?;
+        let changed = match expected {
+            None => self
+                .0
+                .execute(
+                    "INSERT INTO request_attention_identities
+                 (identity_id, latest_revision, acknowledged_through) VALUES (?, ?, 0)",
+                    params![identity_id, next],
+                )
+                .map_err(|error| classify(error, "Create attention counter"))?,
+            Some(expected) => self
+                .0
+                .execute(
+                    "UPDATE request_attention_identities SET latest_revision = ?
+                 WHERE identity_id = ? AND latest_revision = ?",
+                    params![
+                        next,
+                        identity_id,
+                        checked_i64(expected, "Expected attention revision")?
+                    ],
+                )
+                .map_err(|error| classify(error, "Advance attention counter"))?,
+        };
+        if expected.is_some() && changed != 1 {
+            return Err(StorageError::new(
+                StorageErrorCode::Unknown,
+                format!("Attention counter for identity '{identity_id}' changed unexpectedly"),
+            ));
+        }
+        Ok(())
+    }
+
+    fn set_attention_revision(
+        &mut self,
+        request_id: &str,
+        revision: u64,
+    ) -> Result<(), Self::Error> {
+        let changed = self
+            .0
+            .execute(
+                "UPDATE request_attempts SET attention_revision = ? WHERE request_id = ?",
+                params![checked_i64(revision, "Attention revision")?, request_id],
+            )
+            .map_err(|error| classify(error, "Set request attention revision"))?;
+        if changed != 1 {
+            return Err(StorageError::new(
+                StorageErrorCode::Unknown,
+                format!("Request '{request_id}' was not found"),
+            ));
+        }
+        Ok(())
+    }
+
+    fn expired_attempts(
+        &self,
+        now_ms: u64,
+        limit: u64,
+    ) -> Result<Vec<RequestAttempt>, Self::Error> {
+        let query = format!(
+            "SELECT {} FROM request_attempts
+             WHERE expires_at_ms <= ? AND (wait_active = 1 OR status IN ('prepared', 'sending'))
+             ORDER BY expires_at_ms, attempt_id LIMIT ?",
+            rows::ATTEMPT_COLUMNS
+        );
+        let mut statement = self
+            .0
+            .prepare(&query)
+            .map_err(|error| classify(error, "Prepare expired request query"))?;
+        let rows = statement
+            .query_map(
+                params![
+                    checked_now(now_ms, "Request expiry cutoff")?,
+                    checked_limit(limit)?
+                ],
+                rows::attempt_row,
+            )
+            .map_err(|error| classify(error, "List expired requests"))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|error| classify(error, "Decode expired requests"))
+    }
+
+    fn clear_expired_prompts(&mut self, now_ms: u64, limit: u64) -> Result<(), Self::Error> {
+        self.0
+            .execute(
+                "UPDATE request_attempts
+             SET message_text = NULL, message_bytes = NULL
+             WHERE attempt_id IN (
+                 SELECT attempt_id FROM request_attempts
+                 WHERE message_text IS NOT NULL
+                   AND message_expires_at_ms <= ?
+                 ORDER BY message_expires_at_ms, attempt_id
+                 LIMIT ?
+             )",
+                params![
+                    checked_now(now_ms, "Prompt retention cutoff")?,
+                    checked_limit(limit)?
+                ],
+            )
+            .map_err(|error| classify(error, "Clear expired request prompts"))?;
+        Ok(())
+    }
+
+    fn delete_expired_responses(&mut self, now_ms: u64, limit: u64) -> Result<(), Self::Error> {
+        self.0
+            .execute(
+                "DELETE FROM request_responses
+             WHERE request_id IN (
+                 SELECT request_id FROM request_responses
+                 WHERE response_expires_at_ms <= ?
+                 ORDER BY response_expires_at_ms, request_id
+                 LIMIT ?
+             )",
+                params![
+                    checked_now(now_ms, "Response retention cutoff")?,
+                    checked_limit(limit)?
+                ],
+            )
+            .map_err(|error| classify(error, "Delete expired request responses"))?;
+        Ok(())
+    }
+
+    fn delete_retained(
+        &mut self,
+        now_ms: u64,
+        settled_cutoff_ms: u64,
+        limit: u64,
+    ) -> Result<(), Self::Error> {
+        let now = checked_now(now_ms, "Request retention cutoff")?;
+        let settled_cutoff = checked_i64(settled_cutoff_ms, "Settlement retention cutoff")?;
+        self.0
+            .execute(
+                DELETE_RETAINED_SQL,
+                params![settled_cutoff, now, now, checked_limit(limit)?],
+            )
+            .map_err(|error| classify(error, "Delete retained requests"))?;
+        Ok(())
+    }
+}
+
+impl RequestRepository for Storage {
+    type Error = StorageError;
+
+    fn with_request_transaction<T, E: From<Self::Error>>(
+        &mut self,
+        operation: impl FnOnce(&mut dyn RequestRecords<Error = Self::Error>) -> Result<T, E>,
+    ) -> Result<T, E> {
+        with_immediate_transaction(self, "request", |transaction| {
+            operation(&mut RequestRows(transaction))
+        })
+    }
+}
+
+#[cfg(test)]
+mod service_tests;
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-adapters/src/storage/requests/rows.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/rows.rs
@@ -1,0 +1,168 @@
+//! Strict SQLite row decoding for request state.
+
+use rusqlite::Row;
+use tmt_core::{
+    endpoint::ServerEvidence,
+    limits::is_valid_js_safe_integer,
+    request::{
+        AttemptStatus, FinalResponse, Originator, RawRequestContext, RequestAttempt,
+        RequestEndpoint,
+    },
+};
+
+pub(super) const ATTEMPT_COLUMNS: &str = "
+    attempt_id, request_id, originator_kind, originator_identity_id,
+    recipient_identity_id, nonce, identity_id, server_id, socket_path,
+    server_pid, server_start_time, pane_id, pane_pid, wait_active, status,
+    preamble_every, inject_preamble, cadence_reserved, prepared_at_ms,
+    sending_at_ms, settled_at_ms, wait_released_at_ms, response_submitted_at_ms,
+    expires_at_ms, retention_days, retention_expires_at_ms,
+    attention_revision, attention_acknowledged_revision";
+pub(super) const RESPONSE_COLUMNS: &str = "
+    request_id, attempt_id, server_id, socket_path, server_pid, server_start_time,
+    pane_id, pane_pid, body, body_bytes, submitted_at_ms, response_expires_at_ms";
+
+fn invalid_row() -> rusqlite::Error {
+    rusqlite::Error::InvalidQuery
+}
+
+fn checked_u64(value: i64) -> rusqlite::Result<u64> {
+    let value = u64::try_from(value).map_err(|_| invalid_row())?;
+    if !is_valid_js_safe_integer(value) {
+        Err(invalid_row())
+    } else {
+        Ok(value)
+    }
+}
+
+pub(super) fn u64_at(row: &Row<'_>, offset: usize) -> rusqlite::Result<u64> {
+    checked_u64(row.get(offset)?)
+}
+
+fn optional_u64_at(row: &Row<'_>, offset: usize) -> rusqlite::Result<Option<u64>> {
+    row.get::<_, Option<i64>>(offset)?
+        .map(checked_u64)
+        .transpose()
+}
+
+fn bool_at(row: &Row<'_>, offset: usize) -> rusqlite::Result<bool> {
+    match row.get::<_, i64>(offset)? {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(invalid_row()),
+    }
+}
+
+fn status_at(row: &Row<'_>, offset: usize) -> rusqlite::Result<AttemptStatus> {
+    match row.get::<_, String>(offset)?.as_str() {
+        "prepared" => Ok(AttemptStatus::Prepared),
+        "sending" => Ok(AttemptStatus::Sending),
+        "sent" => Ok(AttemptStatus::Sent),
+        "uncertain" => Ok(AttemptStatus::Uncertain),
+        "definitely_failed" => Ok(AttemptStatus::DefinitelyFailed),
+        _ => Err(invalid_row()),
+    }
+}
+
+pub(super) fn attempt_row(row: &Row<'_>) -> rusqlite::Result<RequestAttempt> {
+    let originator_kind = row.get::<_, String>(2)?;
+    let originator_identity_id = row.get::<_, Option<String>>(3)?;
+    let originator = match originator_kind.as_str() {
+        "unknown" if originator_identity_id.is_none() => Originator::Unknown,
+        "explicit" => Originator::Explicit(originator_identity_id.ok_or_else(invalid_row)?),
+        "verified" => Originator::Verified(originator_identity_id.ok_or_else(invalid_row)?),
+        _ => return Err(invalid_row()),
+    };
+    let server_pid = u64_at(row, 9)?;
+    let pane_pid = u64_at(row, 12)?;
+    if server_pid == 0 || pane_pid == 0 {
+        return Err(invalid_row());
+    }
+    let attention_revision = u64_at(row, 26)?;
+    let attention_acknowledged_revision = u64_at(row, 27)?;
+    if attention_acknowledged_revision > attention_revision {
+        return Err(invalid_row());
+    }
+    let preamble_every = optional_u64_at(row, 15)?;
+    if preamble_every == Some(0) {
+        return Err(invalid_row());
+    }
+    Ok(RequestAttempt {
+        attempt_id: row.get(0)?,
+        request_id: row.get(1)?,
+        originator,
+        recipient_identity_id: row.get(4)?,
+        nonce: row.get(5)?,
+        identity_id: row.get(6)?,
+        endpoint: RequestEndpoint {
+            server: ServerEvidence {
+                server_id: row.get(7)?,
+                socket_path: row.get(8)?,
+                server_pid,
+                server_start_time: row.get(10)?,
+            },
+            pane_id: row.get(11)?,
+            pane_pid,
+        },
+        wait_active: bool_at(row, 13)?,
+        status: status_at(row, 14)?,
+        preamble_every,
+        inject_preamble: bool_at(row, 16)?,
+        cadence_reserved: bool_at(row, 17)?,
+        prepared_at_ms: u64_at(row, 18)?,
+        sending_at_ms: optional_u64_at(row, 19)?,
+        settled_at_ms: optional_u64_at(row, 20)?,
+        wait_released_at_ms: optional_u64_at(row, 21)?,
+        response_submitted_at_ms: optional_u64_at(row, 22)?,
+        expires_at_ms: u64_at(row, 23)?,
+        retention_days: u64_at(row, 24)?,
+        retention_expires_at_ms: u64_at(row, 25)?,
+    })
+}
+
+pub(super) fn response_row(row: &Row<'_>) -> rusqlite::Result<FinalResponse> {
+    let server_pid = u64_at(row, 4)?;
+    let pane_pid = u64_at(row, 7)?;
+    if server_pid == 0 || pane_pid == 0 {
+        return Err(invalid_row());
+    }
+    Ok(FinalResponse {
+        request_id: row.get(0)?,
+        attempt_id: row.get(1)?,
+        endpoint: RequestEndpoint {
+            server: ServerEvidence {
+                server_id: row.get(2)?,
+                socket_path: row.get(3)?,
+                server_pid,
+                server_start_time: row.get(5)?,
+            },
+            pane_id: row.get(6)?,
+            pane_pid,
+        },
+        body: row.get(8)?,
+        body_bytes: u64_at(row, 9)?,
+        submitted_at_ms: u64_at(row, 10)?,
+        response_expires_at_ms: u64_at(row, 11)?,
+    })
+}
+
+pub(super) fn context_row(row: &Row<'_>) -> rusqlite::Result<RawRequestContext> {
+    let attempt = attempt_row(row)?;
+    let message: Option<String> = row.get(28)?;
+    let message_bytes = optional_u64_at(row, 29)?;
+    let expires_at_ms = optional_u64_at(row, 30)?;
+    // Prompt scrubbing removes text and byte count but intentionally retains
+    // the expiry marker, allowing reads to distinguish expired from historical
+    // content that was never stored.
+    if message.is_some() != message_bytes.is_some()
+        || (message.is_some() && expires_at_ms.is_none())
+    {
+        return Err(invalid_row());
+    }
+    Ok(RawRequestContext {
+        attempt,
+        message,
+        message_bytes,
+        expires_at_ms,
+    })
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests.rs
@@ -1,0 +1,7 @@
+mod acceptance;
+mod concurrency;
+mod lifecycle;
+mod response;
+mod retention;
+mod retirement;
+mod support;

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/acceptance.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/acceptance.rs
@@ -1,0 +1,293 @@
+//! Cross-operation retention and ownership assertions use independent SQL.
+
+use super::support::{
+    DAY_MS, Fixture, NOW_MS, count_rows, endpoint, preamble_count, prepare_input, service,
+};
+use crate::storage::Storage;
+use tmt_core::request::{
+    Originator, RequestError, RequestPrompt, RequestService, ResponseRejection, Settlement,
+    SubmitResponse,
+};
+
+#[test]
+fn retained_final_survives_restart_and_missing_attempt_without_renewing_retry_deadline() {
+    let mut fixture = Fixture::new();
+    let target = endpoint("%70", 170);
+    let input = prepare_input(
+        &fixture,
+        "orphan",
+        target.clone(),
+        false,
+        NOW_MS + 1,
+        Originator::Unknown,
+        false,
+    );
+    let prepared = service(&mut fixture)
+        .prepare(input, "orphan-attempt".into(), 1)
+        .unwrap();
+    service(&mut fixture)
+        .begin_send(&prepared.attempt_id)
+        .unwrap();
+    let submission = || SubmitResponse {
+        request_id: prepared.request_id.clone(),
+        attempt_id: prepared.attempt_id.clone(),
+        endpoint: target.clone(),
+        body: "\u{feff}\0 exact\r\n".into(),
+    };
+    let first = service(&mut fixture).submit_response(submission()).unwrap();
+    fixture.storage.close().unwrap();
+    let oracle = rusqlite::Connection::open(&fixture.database).unwrap();
+    assert_eq!(
+        oracle
+            .execute(
+                "DELETE FROM request_attempts WHERE request_id = 'orphan'",
+                []
+            )
+            .unwrap(),
+        1
+    );
+    drop(oracle);
+    fixture.storage = Storage::open(&fixture.database).unwrap();
+    fixture.set_now(NOW_MS + 42_000);
+    assert_eq!(
+        service(&mut fixture).submit_response(submission()).unwrap(),
+        first
+    );
+    assert_eq!(
+        service(&mut fixture).get_response("orphan").unwrap(),
+        Some(first.clone())
+    );
+    assert_eq!(count_rows(&fixture.database, "request_attempts"), 0);
+    let oracle = rusqlite::Connection::open_with_flags(
+        &fixture.database,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .unwrap();
+    let stored: (String, i64, i64) = oracle.query_row(
+        "SELECT body, submitted_at_ms, response_expires_at_ms FROM request_responses WHERE request_id = 'orphan'",
+        [], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    ).unwrap();
+    assert_eq!(
+        stored,
+        (first.body, NOW_MS as i64, (NOW_MS + DAY_MS) as i64)
+    );
+    drop(oracle);
+    fixture.set_now(NOW_MS + DAY_MS);
+    assert!(matches!(
+        service(&mut fixture).submit_response(submission()),
+        Err(RequestError::Response(ResponseRejection::Expired))
+    ));
+    assert_eq!(
+        count_rows(&fixture.database, "request_responses"),
+        1,
+        "rejection does not run housekeeping"
+    );
+    assert!(
+        service(&mut fixture)
+            .get_response("orphan")
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+    assert!(matches!(
+        service(&mut fixture).submit_response(submission()),
+        Err(RequestError::Response(ResponseRejection::RequestNotFound))
+    ));
+}
+
+#[test]
+fn pruned_body_completion_marker_prevents_recreation_and_false_refund() {
+    let mut fixture = Fixture::new();
+    let target = endpoint("%71", 171);
+    let input = prepare_input(
+        &fixture,
+        "marker",
+        target.clone(),
+        false,
+        NOW_MS + 14 * DAY_MS,
+        Originator::Unknown,
+        true,
+    );
+    let prepared = service(&mut fixture)
+        .prepare(input, "marker-attempt".into(), 1)
+        .unwrap();
+    service(&mut fixture)
+        .begin_send(&prepared.attempt_id)
+        .unwrap();
+    let submission = || SubmitResponse {
+        request_id: prepared.request_id.clone(),
+        attempt_id: prepared.attempt_id.clone(),
+        endpoint: target.clone(),
+        body: "final".into(),
+    };
+    service(&mut fixture).submit_response(submission()).unwrap();
+    fixture.set_now(NOW_MS + DAY_MS);
+    service(&mut fixture).cleanup().unwrap();
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+    assert!(matches!(
+        service(&mut fixture).submit_response(submission()),
+        Err(RequestError::Response(ResponseRejection::Expired))
+    ));
+    service(&mut fixture)
+        .settle(&prepared.attempt_id, Settlement::DefinitelyFailed)
+        .unwrap();
+    let attempt = service(&mut fixture)
+        .get_attempt(&prepared.attempt_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(attempt.status, tmt_core::request::AttemptStatus::Uncertain);
+    assert_eq!(attempt.response_submitted_at_ms, Some(NOW_MS));
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 1);
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+}
+
+#[test]
+fn late_final_extends_metadata_not_original_prompt_or_attention_acknowledgment() {
+    let mut fixture = Fixture::new();
+    let target = endpoint("%72", 172);
+    let originator = Originator::Verified(fixture.identity_id.clone());
+    let mut input = prepare_input(
+        &fixture,
+        "horizons",
+        target.clone(),
+        false,
+        NOW_MS + 1,
+        originator,
+        false,
+    );
+    input.message = "\0original !\r\n".into();
+    let prepared = service(&mut fixture)
+        .prepare(input, "horizons-attempt".into(), 90)
+        .unwrap();
+    service(&mut fixture)
+        .begin_send(&prepared.attempt_id)
+        .unwrap();
+    service(&mut fixture)
+        .settle(&prepared.attempt_id, Settlement::Sent)
+        .unwrap();
+    let oracle = rusqlite::Connection::open(&fixture.database).unwrap();
+    oracle
+        .execute(
+            "UPDATE request_attention_identities SET acknowledged_through = latest_revision",
+            [],
+        )
+        .unwrap();
+    drop(oracle);
+    fixture.set_now(NOW_MS + 3 * DAY_MS);
+    let final_response = service(&mut fixture)
+        .submit_response(SubmitResponse {
+            request_id: prepared.request_id.clone(),
+            attempt_id: prepared.attempt_id.clone(),
+            endpoint: target,
+            body: "late final".into(),
+        })
+        .unwrap();
+    assert_eq!(final_response.response_expires_at_ms, NOW_MS + 93 * DAY_MS);
+    let oracle = rusqlite::Connection::open_with_flags(
+        &fixture.database,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .unwrap();
+    let stored: (String, i64, i64, i64, i64) = oracle
+        .query_row(
+            "SELECT message_text, message_expires_at_ms, retention_expires_at_ms,
+                attention_revision, attention_acknowledged_revision
+         FROM request_attempts WHERE request_id = 'horizons'",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        stored,
+        (
+            "\0original !\r\n".into(),
+            (NOW_MS + 90 * DAY_MS) as i64,
+            (NOW_MS + 93 * DAY_MS) as i64,
+            2,
+            0
+        )
+    );
+    let attention: (i64, i64) = oracle.query_row(
+        "SELECT latest_revision, acknowledged_through FROM request_attention_identities WHERE identity_id = ?",
+        [&fixture.identity_id], |row| Ok((row.get(0)?, row.get(1)?)),
+    ).unwrap();
+    assert_eq!(attention, (2, 1));
+    drop(oracle);
+    fixture.set_now(NOW_MS + 90 * DAY_MS);
+    assert!(matches!(
+        service(&mut fixture)
+            .get_context("horizons")
+            .unwrap()
+            .unwrap()
+            .prompt,
+        RequestPrompt::Expired { .. }
+    ));
+    assert_eq!(
+        service(&mut fixture).get_response("horizons").unwrap(),
+        Some(final_response)
+    );
+    fixture.set_now(NOW_MS + 93 * DAY_MS);
+    assert!(
+        service(&mut fixture)
+            .get_response("horizons")
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        service(&mut fixture)
+            .get_context("horizons")
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn request_clock_is_sampled_only_while_the_real_writer_lock_is_held() {
+    let mut fixture = Fixture::new();
+    let input = prepare_input(
+        &fixture,
+        "clock",
+        endpoint("%73", 173),
+        false,
+        NOW_MS + 1,
+        Originator::Unknown,
+        false,
+    );
+    let database = fixture.database.clone();
+    let clock = || {
+        let probe = rusqlite::Connection::open(&database).unwrap();
+        probe.busy_timeout(std::time::Duration::ZERO).unwrap();
+        let error = probe
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect_err("service clock must run after its writer lock is held");
+        assert_eq!(
+            error.sqlite_error_code(),
+            Some(rusqlite::ErrorCode::DatabaseBusy)
+        );
+        NOW_MS
+    };
+    let mut requests = RequestService::new(&mut fixture.storage, clock);
+    requests.prepare(input, "clock-attempt".into(), 1).unwrap();
+    requests.begin_send("clock-attempt").unwrap();
+    requests.settle("clock-attempt", Settlement::Sent).unwrap();
+    requests.release_wait("clock-attempt").unwrap();
+    requests
+        .submit_response(SubmitResponse {
+            request_id: "clock".into(),
+            attempt_id: "clock-attempt".into(),
+            endpoint: endpoint("%73", 173),
+            body: "done".into(),
+        })
+        .unwrap();
+    requests.get_response("clock").unwrap();
+    requests.get_context("clock").unwrap();
+    requests.cleanup().unwrap();
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/concurrency.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/concurrency.rs
@@ -1,0 +1,261 @@
+use super::support::{
+    DAY_MS, Fixture, NOW_MS, count_rows, endpoint, preamble_count, prepare_input, service,
+};
+use crate::storage::{Storage, StorageError};
+use std::{path::Path, sync::mpsc, thread, time::Duration};
+use tmt_core::request::{
+    FinalResponse, Originator, PreambleReservation, PrepareRequest, PreparedRequest, RequestError,
+    RequestService, ResponseRejection, SubmitResponse,
+};
+
+type Operation<T> = Box<dyn FnOnce(&mut Storage) -> T + Send>;
+
+/// Open before racing: this targets request transactions, not cold-WAL startup.
+/// Scoped workers finish before fixture deletion; channel waits are bounded.
+fn concurrent_pair<T: Send>(database: &Path, operations: [Operation<T>; 2]) -> [T; 2] {
+    let connections = [
+        Storage::open(database).unwrap(),
+        Storage::open(database).unwrap(),
+    ];
+    thread::scope(|scope| {
+        let mut starts = Vec::new();
+        let mut results = Vec::new();
+        let mut handles = Vec::new();
+        for (mut storage, operation) in connections.into_iter().zip(operations) {
+            let (start_tx, start_rx) = mpsc::sync_channel(1);
+            let (result_tx, result_rx) = mpsc::sync_channel(1);
+            starts.push(start_tx);
+            results.push(result_rx);
+            handles.push(scope.spawn(move || {
+                start_rx
+                    .recv_timeout(Duration::from_secs(10))
+                    .expect("request worker start");
+                let result = operation(&mut storage);
+                storage.close().expect("close request worker storage");
+                assert!(
+                    result_tx.send(result).is_ok(),
+                    "request worker receiver disappeared"
+                );
+            }));
+        }
+        for start in starts {
+            start.send(()).unwrap();
+        }
+        let values: Vec<T> = results
+            .into_iter()
+            .map(|result| {
+                result
+                    .recv_timeout(Duration::from_secs(15))
+                    .expect("bounded request worker result")
+            })
+            .collect();
+        for handle in handles {
+            handle.join().expect("request worker panicked");
+        }
+        values.try_into().ok().expect("exactly two worker results")
+    })
+}
+
+#[test]
+fn concurrent_prepare_connections_serialize_cadence_and_preserve_both_attempts() {
+    let fixture = Fixture::new();
+    let operations: [Operation<Result<PreparedRequest, RequestError<StorageError>>>; 2] =
+        ["a", "b"].map(|suffix| {
+            let identity_id = fixture.identity_id.clone();
+            Box::new(move |storage: &mut Storage| {
+                let input = PrepareRequest {
+                    request_id: format!("request-{suffix}"),
+                    message: format!("prompt-{suffix}"),
+                    endpoint: endpoint("%60", 160),
+                    wait: true,
+                    expires_at_ms: NOW_MS + 3_600_001,
+                    originator: Originator::Unknown,
+                    recipient_identity_id: Some(identity_id.clone()),
+                    preamble: Some(PreambleReservation {
+                        identity_id,
+                        every: 3,
+                    }),
+                };
+                RequestService::new(storage, || NOW_MS).prepare(
+                    input,
+                    format!("attempt-{suffix}"),
+                    7,
+                )
+            }) as Operation<_>
+        });
+    let prepared = concurrent_pair(&fixture.database, operations).map(Result::unwrap);
+    assert_eq!(prepared.iter().filter(|p| p.inject_preamble).count(), 1);
+    assert_eq!(
+        prepared
+            .iter()
+            .filter(|p| p.previous_request_id.is_some())
+            .count(),
+        1
+    );
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 2);
+    let oracle = rusqlite::Connection::open_with_flags(
+        &fixture.database,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .unwrap();
+    let rows: Vec<(String, i64, i64, String)> = oracle.prepare(
+        "SELECT attempt_id, inject_preamble, cadence_reserved, status FROM request_attempts ORDER BY attempt_id",
+    ).unwrap().query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))).unwrap().collect::<rusqlite::Result<_>>().unwrap();
+    assert_eq!(
+        rows.iter().map(|r| r.0.as_str()).collect::<Vec<_>>(),
+        ["attempt-a", "attempt-b"]
+    );
+    assert_eq!(rows.iter().filter(|r| r.1 == 1).count(), 1);
+    assert!(rows.iter().all(|r| r.2 == 1 && r.3 == "prepared"));
+}
+
+#[test]
+fn identical_and_conflicting_final_writers_keep_one_body_marker_and_revision() {
+    for bodies in [["same", "same"], ["first", "second"]] {
+        let mut fixture = Fixture::new();
+        let input = prepare_input(
+            &fixture,
+            "final-race",
+            endpoint("%61", 161),
+            false,
+            NOW_MS + 1,
+            Originator::Explicit(fixture.identity_id.clone()),
+            false,
+        );
+        service(&mut fixture)
+            .prepare(input, "final-race-attempt".into(), 7)
+            .unwrap();
+        service(&mut fixture)
+            .begin_send("final-race-attempt")
+            .unwrap();
+        let operations: [Operation<Result<FinalResponse, RequestError<StorageError>>>; 2] = [0, 1]
+            .map(|index| {
+                Box::new(move |storage: &mut Storage| {
+                    RequestService::new(storage, || NOW_MS + 10 + index as u64).submit_response(
+                        SubmitResponse {
+                            request_id: "final-race".into(),
+                            attempt_id: "final-race-attempt".into(),
+                            endpoint: endpoint("%61", 161),
+                            body: bodies[index].into(),
+                        },
+                    )
+                }) as Operation<_>
+            });
+        let results = concurrent_pair(&fixture.database, operations);
+        let winners: Vec<_> = results.iter().filter_map(|r| r.as_ref().ok()).collect();
+        if bodies[0] == bodies[1] {
+            assert_eq!(winners.len(), 2);
+            assert_eq!(winners[0], winners[1]);
+        } else {
+            assert_eq!(winners.len(), 1);
+            assert_eq!(
+                results
+                    .iter()
+                    .filter(|r| matches!(
+                        r,
+                        Err(RequestError::Response(ResponseRejection::Conflict))
+                    ))
+                    .count(),
+                1
+            );
+        }
+        assert_eq!(count_rows(&fixture.database, "request_responses"), 1);
+        let oracle = rusqlite::Connection::open_with_flags(
+            &fixture.database,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .unwrap();
+        let stored: (String, i64, i64, i64, i64) = oracle
+            .query_row(
+                "SELECT r.body, r.submitted_at_ms, a.response_submitted_at_ms,
+                    a.attention_revision, s.latest_revision
+             FROM request_responses r JOIN request_attempts a USING(request_id)
+             JOIN request_attention_identities s ON s.identity_id = a.originator_identity_id",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            (
+                winners[0].body.clone(),
+                winners[0].submitted_at_ms as i64,
+                winners[0].submitted_at_ms as i64,
+                2,
+                2
+            )
+        );
+    }
+}
+
+#[test]
+fn cleanup_and_late_submission_serialize_without_refund_or_lost_final() {
+    let mut fixture = Fixture::new();
+    let input = prepare_input(
+        &fixture,
+        "cleanup-race",
+        endpoint("%62", 162),
+        true,
+        NOW_MS + 1,
+        Originator::Unknown,
+        true,
+    );
+    service(&mut fixture)
+        .prepare(input, "cleanup-race-attempt".into(), 1)
+        .unwrap();
+    service(&mut fixture)
+        .begin_send("cleanup-race-attempt")
+        .unwrap();
+    let now = NOW_MS + 6 * DAY_MS + 10;
+    let results = concurrent_pair(
+        &fixture.database,
+        [
+            Box::new(move |storage| {
+                RequestService::new(storage, || now)
+                    .cleanup()
+                    .map(|()| None)
+            }),
+            Box::new(move |storage| {
+                RequestService::new(storage, || now)
+                    .submit_response(SubmitResponse {
+                        request_id: "cleanup-race".into(),
+                        attempt_id: "cleanup-race-attempt".into(),
+                        endpoint: endpoint("%62", 162),
+                        body: "late final".into(),
+                    })
+                    .map(Some)
+            }),
+        ],
+    )
+    .map(Result::unwrap);
+    assert!(results[0].is_none());
+    let final_response = results[1].as_ref().unwrap();
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 1);
+    let oracle = rusqlite::Connection::open_with_flags(
+        &fixture.database,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .unwrap();
+    let state: (String, i64, Option<String>, i64) = oracle.query_row(
+        "SELECT status, wait_active, message_text, response_submitted_at_ms FROM request_attempts WHERE request_id = 'cleanup-race'",
+        [], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    ).unwrap();
+    assert_eq!(state, ("uncertain".into(), 0, None, now as i64));
+    drop(oracle);
+    fixture.set_now(NOW_MS + 7 * DAY_MS);
+    assert_eq!(
+        service(&mut fixture)
+            .get_response("cleanup-race")
+            .unwrap()
+            .as_ref(),
+        Some(final_response)
+    );
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/lifecycle.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/lifecycle.rs
@@ -1,0 +1,329 @@
+use super::support::{
+    Fixture, NOW_MS, count_rows, endpoint, preamble_count, prepare_input, service,
+};
+use tmt_core::request::{AttemptStatus, Originator, RequestError, Settlement};
+
+#[test]
+fn waiter_release_is_idempotent_isolated_and_does_not_cancel_delivery() {
+    let mut fixture = Fixture::new();
+    for id in ["first", "second"] {
+        let input = prepare_input(
+            &fixture,
+            id,
+            endpoint("%80", 180),
+            true,
+            NOW_MS + 3_600_001,
+            Originator::Unknown,
+            false,
+        );
+        service(&mut fixture).prepare(input, id.into(), 7).unwrap();
+        service(&mut fixture).begin_send(id).unwrap();
+    }
+    service(&mut fixture).release_wait("first").unwrap();
+    fixture.set_now(NOW_MS + 10);
+    service(&mut fixture).release_wait("first").unwrap();
+    service(&mut fixture).release_wait("absent").unwrap();
+    service(&mut fixture)
+        .settle("first", Settlement::Sent)
+        .unwrap();
+    fixture.set_now(NOW_MS + 20);
+    service(&mut fixture)
+        .settle("first", Settlement::Sent)
+        .unwrap();
+    assert!(matches!(
+        service(&mut fixture).settle("first", Settlement::Uncertain),
+        Err(RequestError::StateInvalid)
+    ));
+    let oracle = rusqlite::Connection::open_with_flags(
+        &fixture.database,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .unwrap();
+    type WaiterState = (String, String, i64, Option<i64>, Option<i64>);
+    let rows: Vec<WaiterState> = oracle
+        .prepare(
+            "SELECT attempt_id, status, wait_active, wait_released_at_ms, settled_at_ms
+         FROM request_attempts ORDER BY attempt_id",
+        )
+        .unwrap()
+        .query_map([], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<_>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        [
+            (
+                "first".into(),
+                "sent".into(),
+                0,
+                Some(NOW_MS as i64),
+                Some((NOW_MS + 10) as i64)
+            ),
+            ("second".into(), "sending".into(), 1, None, None),
+        ]
+    );
+}
+
+#[test]
+fn proven_unsent_failure_refunds_once_and_expired_send_stays_uncertain() {
+    let mut fixture = Fixture::new();
+    let first_input = prepare_input(
+        &fixture,
+        "request-proven-failure",
+        endpoint("%1", 101),
+        true,
+        NOW_MS + 1,
+        Originator::Unknown,
+        true,
+    );
+    let first = {
+        let mut requests = service(&mut fixture);
+        requests
+            .prepare(first_input, "attempt-proven-failure".into(), 7)
+            .expect("prepare proven-failure request")
+    };
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 1);
+
+    {
+        let mut requests = service(&mut fixture);
+        requests
+            .settle(&first.attempt_id, Settlement::DefinitelyFailed)
+            .expect("settle proven failure");
+        assert!(
+            requests
+                .settle(&first.attempt_id, Settlement::DefinitelyFailed)
+                .is_ok()
+        );
+        assert_eq!(
+            requests
+                .get_attempt(&first.attempt_id)
+                .expect("read failed attempt")
+                .expect("failed attempt retained")
+                .status,
+            AttemptStatus::DefinitelyFailed
+        );
+    }
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 0);
+
+    let sending_input = prepare_input(
+        &fixture,
+        "request-expired-send",
+        endpoint("%2", 102),
+        true,
+        NOW_MS + 2 * 3_600_000,
+        Originator::Unknown,
+        true,
+    );
+    let sending = {
+        let mut requests = service(&mut fixture);
+        requests
+            .prepare(sending_input, "attempt-expired-send".into(), 7)
+            .expect("prepare expired-send request")
+    };
+    {
+        let mut requests = service(&mut fixture);
+        requests
+            .begin_send(&sending.attempt_id)
+            .expect("begin sending");
+    }
+    fixture.set_now(NOW_MS + 2 * 3_600_000 + 1);
+    {
+        let mut requests = service(&mut fixture);
+        requests.cleanup().expect("cleanup expired sending");
+        let attempt = requests
+            .get_attempt(&sending.attempt_id)
+            .expect("read uncertain attempt")
+            .expect("uncertain attempt retained");
+        assert_eq!(attempt.status, AttemptStatus::Uncertain);
+        assert!(attempt.wait_released_at_ms.is_some());
+        assert!(attempt.cadence_reserved);
+        assert!(matches!(
+            requests.settle(&sending.attempt_id, Settlement::DefinitelyFailed),
+            Err(RequestError::StateInvalid)
+        ));
+    }
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 1);
+}
+
+#[test]
+fn duplicate_preparation_rolls_back_attempt_cadence_and_attention_revision() {
+    let mut fixture = Fixture::new();
+    let first_input = prepare_input(
+        &fixture,
+        "request-duplicate",
+        endpoint("%3", 103),
+        false,
+        NOW_MS + 1,
+        Originator::Explicit(fixture.identity_id.clone()),
+        true,
+    );
+    {
+        let mut requests = service(&mut fixture);
+        requests
+            .prepare(first_input, "attempt-duplicate-original".into(), 7)
+            .expect("prepare original request");
+    }
+    let before_attempts = count_rows(&fixture.database, "request_attempts");
+    let before_cadence = preamble_count(&fixture.database, &fixture.identity_id);
+    let connection = rusqlite::Connection::open(&fixture.database).expect("open SQL oracle");
+    let before_attention: i64 = connection
+        .query_row(
+            "SELECT latest_revision FROM request_attention_identities WHERE identity_id = ?",
+            [&fixture.identity_id],
+            |row| row.get(0),
+        )
+        .expect("read attention state");
+    drop(connection);
+    let duplicate_input = prepare_input(
+        &fixture,
+        "request-duplicate",
+        endpoint("%4", 104),
+        false,
+        NOW_MS + 1,
+        Originator::Explicit(fixture.identity_id.clone()),
+        true,
+    );
+    let result = {
+        let mut requests = service(&mut fixture);
+        requests.prepare(duplicate_input, "attempt-duplicate-new".into(), 7)
+    };
+    assert!(result.is_err());
+    assert_eq!(
+        count_rows(&fixture.database, "request_attempts"),
+        before_attempts
+    );
+    assert_eq!(
+        preamble_count(&fixture.database, &fixture.identity_id),
+        before_cadence
+    );
+    let connection = rusqlite::Connection::open(&fixture.database).expect("reopen SQL oracle");
+    let attention: i64 = connection
+        .query_row(
+            "SELECT latest_revision FROM request_attention_identities WHERE identity_id = ?",
+            [&fixture.identity_id],
+            |row| row.get(0),
+        )
+        .expect("read unchanged attention state");
+    assert_eq!(attention, before_attention);
+}
+
+#[test]
+fn expired_begin_send_commits_refund_and_wait_release_before_returning_error() {
+    let mut fixture = Fixture::new();
+    let input = prepare_input(
+        &fixture,
+        "request-expired-before-send",
+        endpoint("%5", 105),
+        true,
+        NOW_MS + 1,
+        Originator::Unknown,
+        true,
+    );
+    let prepared = {
+        let mut requests = service(&mut fixture);
+        requests
+            .prepare(input, "attempt-expired-before-send".into(), 7)
+            .expect("prepare expired request")
+    };
+    fixture.set_now(NOW_MS + 3_600_001);
+    let result = {
+        let mut requests = service(&mut fixture);
+        requests.begin_send(&prepared.attempt_id)
+    };
+    assert!(matches!(result, Err(RequestError::Expired)));
+    let attempt = {
+        let mut requests = service(&mut fixture);
+        requests
+            .get_attempt(&prepared.attempt_id)
+            .expect("read expired attempt")
+            .expect("expired metadata retained")
+    };
+    assert_eq!(attempt.status, AttemptStatus::DefinitelyFailed);
+    assert!(!attempt.wait_active);
+    assert!(!attempt.cadence_reserved);
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 0);
+}
+
+#[test]
+fn cleanup_transitions_expired_prepared_rows_in_bounded_batches_and_refunds() {
+    let mut fixture = Fixture::new();
+    let inputs = (0..101)
+        .map(|index| {
+            prepare_input(
+                &fixture,
+                &format!("request-expired-batch-{index:03}"),
+                endpoint(&format!("%{}", index + 50), index + 150),
+                true,
+                NOW_MS + 1,
+                Originator::Unknown,
+                true,
+            )
+        })
+        .collect::<Vec<_>>();
+    {
+        let mut requests = service(&mut fixture);
+        for (index, input) in inputs.into_iter().enumerate() {
+            requests
+                .prepare(input, format!("attempt-expired-batch-{index:03}"), 7)
+                .expect("prepare expired batch row");
+        }
+    }
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 101);
+    fixture.set_now(NOW_MS + 3_600_001);
+    {
+        let mut requests = service(&mut fixture);
+        requests.cleanup().expect("first expired transition batch");
+    }
+    let connection = rusqlite::Connection::open(&fixture.database).expect("open transition oracle");
+    let prepared: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM request_attempts WHERE status = 'prepared'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count remaining prepared rows");
+    let failed: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM request_attempts WHERE status = 'definitely_failed'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count failed rows");
+    let first_remaining: String = connection
+        .query_row(
+            "SELECT attempt_id FROM request_attempts WHERE status = 'prepared' ORDER BY expires_at_ms, attempt_id",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read first remaining prepared row");
+    assert_eq!(prepared, 1);
+    assert_eq!(failed, 100);
+    assert_eq!(first_remaining, "attempt-expired-batch-100");
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 1);
+
+    {
+        let mut requests = service(&mut fixture);
+        requests.cleanup().expect("second expired transition batch");
+    }
+    assert_eq!(count_rows(&fixture.database, "request_attempts"), 101);
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 0);
+    let connection =
+        rusqlite::Connection::open(&fixture.database).expect("reopen transition oracle");
+    let failed: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM request_attempts WHERE status = 'definitely_failed'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count all failed rows");
+    assert_eq!(failed, 101);
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/response.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/response.rs
@@ -1,0 +1,298 @@
+use super::support::{
+    Fixture, NOW_MS, count_rows, endpoint, preamble_count, prepare_input, service,
+};
+use tmt_core::limits::MAX_JS_SAFE_INTEGER;
+use tmt_core::request::{
+    AttemptStatus, Originator, PrepareRequest, RequestError, ResponseRejection, Settlement,
+    SubmitResponse,
+};
+
+fn prepare_sending(
+    fixture: &mut Fixture,
+    request_id: &str,
+) -> (String, tmt_core::request::RequestEndpoint) {
+    let target = endpoint("%10", 110);
+    let input = prepare_input(
+        fixture,
+        request_id,
+        target.clone(),
+        true,
+        NOW_MS + 3_600_001,
+        Originator::Unknown,
+        false,
+    );
+    let prepared = {
+        let mut requests = service(fixture);
+        requests
+            .prepare(input, format!("attempt-{request_id}"), 7)
+            .expect("prepare response request")
+    };
+    {
+        let mut requests = service(fixture);
+        requests
+            .begin_send(&prepared.attempt_id)
+            .expect("begin response request");
+    }
+    (prepared.attempt_id, target)
+}
+
+fn submit(
+    fixture: &mut Fixture,
+    request_id: &str,
+    attempt_id: &str,
+    target: tmt_core::request::RequestEndpoint,
+    body: &str,
+) -> Result<tmt_core::request::FinalResponse, RequestError<crate::storage::StorageError>> {
+    let mut requests = service(fixture);
+    requests.submit_response(SubmitResponse {
+        request_id: request_id.into(),
+        attempt_id: attempt_id.into(),
+        endpoint: target,
+        body: body.into(),
+    })
+}
+
+#[test]
+fn final_body_is_exact_and_identical_retry_is_immutable() {
+    let mut fixture = Fixture::new();
+    let (attempt_id, target) = prepare_sending(&mut fixture, "request-exact-final");
+    let body = "\u{feff}  first\r\n\u{0000} 日本語 🙂  ";
+    let first = submit(
+        &mut fixture,
+        "request-exact-final",
+        &attempt_id,
+        target.clone(),
+        body,
+    )
+    .expect("submit exact final");
+    assert_eq!(first.body, body);
+    assert_eq!(first.body_bytes, body.len() as u64);
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 1);
+
+    // A retry through a fresh service at a later clock value must not renew
+    // the immutable final's submission time or expiry.
+    fixture.set_now(NOW_MS + 1);
+    let retry = submit(
+        &mut fixture,
+        "request-exact-final",
+        &attempt_id,
+        target.clone(),
+        body,
+    )
+    .expect("retry identical final");
+    assert_eq!(retry, first);
+    assert!(matches!(
+        submit(
+            &mut fixture,
+            "request-exact-final",
+            &attempt_id,
+            target,
+            "different final"
+        ),
+        Err(RequestError::Response(ResponseRejection::Conflict))
+    ));
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 1);
+}
+
+#[test]
+fn every_endpoint_fence_mismatch_leaves_final_and_attempt_unchanged() {
+    let mut fixture = Fixture::new();
+    let (attempt_id, target) = prepare_sending(&mut fixture, "request-endpoint-fence");
+    let before = {
+        let mut requests = service(&mut fixture);
+        requests
+            .get_attempt(&attempt_id)
+            .expect("read attempt")
+            .expect("attempt exists")
+    };
+    let mismatches = [
+        tmt_core::request::RequestEndpoint {
+            server: tmt_core::endpoint::ServerEvidence {
+                server_id: "other-server".into(),
+                ..target.server.clone()
+            },
+            ..target.clone()
+        },
+        tmt_core::request::RequestEndpoint {
+            server: tmt_core::endpoint::ServerEvidence {
+                socket_path: "/tmp/other.sock".into(),
+                ..target.server.clone()
+            },
+            ..target.clone()
+        },
+        tmt_core::request::RequestEndpoint {
+            server: tmt_core::endpoint::ServerEvidence {
+                server_pid: target.server.server_pid + 1,
+                ..target.server.clone()
+            },
+            ..target.clone()
+        },
+        tmt_core::request::RequestEndpoint {
+            server: tmt_core::endpoint::ServerEvidence {
+                server_start_time: "other-start".into(),
+                ..target.server.clone()
+            },
+            ..target.clone()
+        },
+        tmt_core::request::RequestEndpoint {
+            pane_id: "%11".into(),
+            ..target.clone()
+        },
+        tmt_core::request::RequestEndpoint {
+            pane_pid: target.pane_pid + 1,
+            ..target.clone()
+        },
+    ];
+    assert!(matches!(
+        submit(
+            &mut fixture,
+            "other-request",
+            &attempt_id,
+            target.clone(),
+            "body"
+        ),
+        Err(RequestError::Response(ResponseRejection::RequestNotFound))
+    ));
+    assert!(matches!(
+        submit(
+            &mut fixture,
+            "request-endpoint-fence",
+            "other-attempt",
+            target.clone(),
+            "body"
+        ),
+        Err(RequestError::Response(ResponseRejection::AttemptMismatch))
+    ));
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+    for mismatched in mismatches {
+        assert!(matches!(
+            submit(
+                &mut fixture,
+                "request-endpoint-fence",
+                &attempt_id,
+                mismatched,
+                "body"
+            ),
+            Err(RequestError::Response(ResponseRejection::RecipientMismatch))
+        ));
+        assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+    }
+    let after = {
+        let mut requests = service(&mut fixture);
+        requests
+            .get_attempt(&attempt_id)
+            .expect("read unchanged attempt")
+            .expect("attempt exists")
+    };
+    assert_eq!(after, before);
+}
+
+#[test]
+fn first_final_attention_overflow_rolls_back_body_and_completion_marker() {
+    let mut fixture = Fixture::new();
+    let target = endpoint("%12", 112);
+    let input: PrepareRequest = prepare_input(
+        &fixture,
+        "request-final-attention-overflow",
+        target.clone(),
+        false,
+        NOW_MS + 3_600_001,
+        Originator::Explicit(fixture.identity_id.clone()),
+        false,
+    );
+    let prepared = {
+        let mut requests = service(&mut fixture);
+        requests
+            .prepare(input, "attempt-final-attention-overflow".into(), 7)
+            .expect("prepare attention request")
+    };
+    {
+        let mut requests = service(&mut fixture);
+        requests
+            .begin_send(&prepared.attempt_id)
+            .expect("begin attention request");
+        requests
+            .settle(&prepared.attempt_id, Settlement::Sent)
+            .expect("settle attention request");
+    }
+    let connection = rusqlite::Connection::open(&fixture.database).expect("open SQL oracle");
+    connection
+        .execute(
+            "UPDATE request_attention_identities SET latest_revision = ? WHERE identity_id = ?",
+            rusqlite::params![MAX_JS_SAFE_INTEGER as i64, fixture.identity_id],
+        )
+        .expect("exhaust attention revision");
+    drop(connection);
+
+    let result = submit(
+        &mut fixture,
+        &prepared.request_id,
+        &prepared.attempt_id,
+        target,
+        "final before overflow",
+    );
+    assert!(matches!(result, Err(RequestError::RevisionExhausted)));
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+    let connection = rusqlite::Connection::open(&fixture.database).expect("reopen SQL oracle");
+    let marker: Option<i64> = connection
+        .query_row(
+            "SELECT response_submitted_at_ms FROM request_attempts WHERE attempt_id = ?",
+            [&prepared.attempt_id],
+            |row| row.get(0),
+        )
+        .expect("read completion marker");
+    assert_eq!(marker, None);
+    let status: String = connection
+        .query_row(
+            "SELECT status FROM request_attempts WHERE attempt_id = ?",
+            [&prepared.attempt_id],
+            |row| row.get(0),
+        )
+        .expect("read attempt status");
+    assert_eq!(status, AttemptStatus::Sent.as_str());
+}
+
+#[test]
+fn response_first_settlement_does_not_refund_reserved_cadence() {
+    let mut fixture = Fixture::new();
+    let target = endpoint("%13", 113);
+    let input = prepare_input(
+        &fixture,
+        "request-response-first",
+        target.clone(),
+        false,
+        NOW_MS + 3_600_001,
+        Originator::Explicit(fixture.identity_id.clone()),
+        true,
+    );
+    let prepared = {
+        let mut requests = service(&mut fixture);
+        requests
+            .prepare(input, "attempt-response-first".into(), 7)
+            .expect("prepare response-first request")
+    };
+    {
+        let mut requests = service(&mut fixture);
+        requests
+            .begin_send(&prepared.attempt_id)
+            .expect("begin response-first request");
+        requests
+            .submit_response(SubmitResponse {
+                request_id: prepared.request_id.clone(),
+                attempt_id: prepared.attempt_id.clone(),
+                endpoint: target,
+                body: "response arrived first".into(),
+            })
+            .expect("submit response before settlement");
+        requests
+            .settle(&prepared.attempt_id, Settlement::DefinitelyFailed)
+            .expect("settle response-first attempt as uncertain");
+        let attempt = requests
+            .get_attempt(&prepared.attempt_id)
+            .expect("read response-first attempt")
+            .expect("response-first attempt remains retained");
+        assert_eq!(attempt.status, AttemptStatus::Uncertain);
+        assert!(attempt.cadence_reserved);
+    }
+    assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 1);
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/retention.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/retention.rs
@@ -1,0 +1,284 @@
+use super::support::{DAY_MS, Fixture, NOW_MS, count_rows, endpoint, prepare_input, service};
+use tmt_core::request::{Originator, RequestError, RequestPrompt, Settlement, SubmitResponse};
+
+#[test]
+fn cleanup_failure_rolls_back_earlier_prompt_scrubbing() {
+    let mut fixture = Fixture::new();
+    let target = endpoint("%70", 170);
+    let input = prepare_input(
+        &fixture,
+        "cleanup-rollback",
+        target.clone(),
+        false,
+        NOW_MS + 1,
+        Originator::Unknown,
+        false,
+    );
+    let original_message = input.message.clone();
+    {
+        let mut requests = service(&mut fixture);
+        requests
+            .prepare(input, "cleanup-rollback-attempt".into(), 1)
+            .unwrap();
+        requests.begin_send("cleanup-rollback-attempt").unwrap();
+        requests
+            .settle("cleanup-rollback-attempt", Settlement::Sent)
+            .unwrap();
+        requests
+            .submit_response(SubmitResponse {
+                request_id: "cleanup-rollback".into(),
+                attempt_id: "cleanup-rollback-attempt".into(),
+                endpoint: target,
+                body: "final".into(),
+            })
+            .unwrap();
+    }
+    // Fail the phase after prompt scrubbing, without replacing production SQL.
+    let oracle = rusqlite::Connection::open(&fixture.database).unwrap();
+    oracle
+        .execute_batch(
+            "CREATE TRIGGER reject_final_cleanup BEFORE DELETE ON request_responses
+         BEGIN SELECT RAISE(ABORT, 'injected cleanup failure'); END;",
+        )
+        .unwrap();
+    fixture.set_now(NOW_MS + DAY_MS);
+    assert!(matches!(
+        service(&mut fixture).cleanup(),
+        Err(RequestError::Repository(_))
+    ));
+    let prompt: (String, i64) = oracle.query_row(
+        "SELECT message_text, message_bytes FROM request_attempts WHERE request_id = 'cleanup-rollback'",
+        [], |row| Ok((row.get(0)?, row.get(1)?)),
+    ).unwrap();
+    assert_eq!(
+        prompt,
+        (original_message.clone(), original_message.len() as i64)
+    );
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 1);
+
+    oracle
+        .execute_batch("DROP TRIGGER reject_final_cleanup")
+        .unwrap();
+    service(&mut fixture).cleanup().unwrap();
+    let prompt: Option<String> = oracle
+        .query_row(
+            "SELECT message_text FROM request_attempts WHERE request_id = 'cleanup-rollback'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(prompt, None);
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+}
+
+#[test]
+fn cleanup_scrubs_prompt_and_final_body_at_equality_before_metadata() {
+    let mut fixture = Fixture::new();
+    let target = endpoint("%20", 120);
+    let input = prepare_input(
+        &fixture,
+        "request-retention-boundary",
+        target.clone(),
+        true,
+        NOW_MS + 3_600_001,
+        Originator::Unknown,
+        false,
+    );
+    let prepared = {
+        let mut requests = service(&mut fixture);
+        requests
+            .prepare(input, "attempt-retention-boundary".into(), 1)
+            .expect("prepare retention request")
+    };
+    {
+        let mut requests = service(&mut fixture);
+        requests
+            .begin_send(&prepared.attempt_id)
+            .expect("begin retention request");
+        requests
+            .settle(&prepared.attempt_id, Settlement::Sent)
+            .expect("settle retention request");
+        requests
+            .submit_response(SubmitResponse {
+                request_id: prepared.request_id.clone(),
+                attempt_id: prepared.attempt_id.clone(),
+                endpoint: target,
+                body: "retained final".into(),
+            })
+            .expect("submit retention final");
+        requests
+            .release_wait(&prepared.attempt_id)
+            .expect("release retention waiter");
+    }
+    let before = {
+        let connection = rusqlite::Connection::open(&fixture.database).expect("open SQL oracle");
+        connection
+            .query_row(
+                "SELECT retention_expires_at_ms, message_expires_at_ms FROM request_attempts WHERE attempt_id = ?",
+                [&prepared.attempt_id],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .expect("read retention deadlines")
+    };
+    fixture.set_now(NOW_MS + DAY_MS);
+    {
+        let mut requests = service(&mut fixture);
+        requests.cleanup().expect("cleanup expired bodies");
+        assert!(
+            requests
+                .get_response(&prepared.request_id)
+                .expect("read final")
+                .is_none()
+        );
+        let context = requests
+            .get_context(&prepared.request_id)
+            .expect("read scrubbed context")
+            .expect("metadata remains retained");
+        assert!(matches!(context.prompt, RequestPrompt::Expired { .. }));
+    }
+    // Scrubbing is durable state, not a function of the current wall clock:
+    // rolling the injected clock back must still decode the marker as Expired.
+    fixture.set_now(NOW_MS);
+    {
+        let mut requests = service(&mut fixture);
+        let context = requests
+            .get_context(&prepared.request_id)
+            .expect("read scrubbed context after clock rollback")
+            .expect("metadata remains retained after clock rollback");
+        assert!(matches!(context.prompt, RequestPrompt::Expired { .. }));
+    }
+    let connection = rusqlite::Connection::open(&fixture.database).expect("reopen SQL oracle");
+    let row: (Option<String>, Option<i64>, Option<i64>, Option<i64>) = connection
+        .query_row(
+            "SELECT message_text, message_bytes, message_expires_at_ms, response_submitted_at_ms FROM request_attempts WHERE attempt_id = ?",
+            [&prepared.attempt_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("read scrubbed markers");
+    assert_eq!(row.0, None);
+    assert_eq!(row.1, None);
+    assert_eq!(row.2, Some(before.1));
+    assert!(row.3.is_some());
+    assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+
+    fixture.set_now(before.0 as u64);
+    {
+        let mut requests = service(&mut fixture);
+        requests.cleanup().expect("cleanup expired metadata");
+    }
+    assert_eq!(count_rows(&fixture.database, "request_attempts"), 0);
+}
+
+#[test]
+fn cleanup_drains_each_phase_in_deterministic_batches_of_one_hundred() {
+    let mut fixture = Fixture::new();
+    let inputs = (0..101)
+        .map(|index| {
+            let request_id = format!("request-batch-{index:03}");
+            prepare_input(
+                &fixture,
+                &request_id,
+                endpoint(&format!("%{}", index + 30), (index + 130) as u64),
+                true,
+                NOW_MS + 3_600_001,
+                Originator::Unknown,
+                false,
+            )
+        })
+        .collect::<Vec<_>>();
+    {
+        let mut requests = service(&mut fixture);
+        for (index, input) in inputs.into_iter().enumerate() {
+            let prepared = requests
+                .prepare(input, format!("attempt-batch-{index:03}"), 1)
+                .expect("prepare batch request");
+            requests
+                .begin_send(&prepared.attempt_id)
+                .expect("begin batch request");
+            requests
+                .settle(&prepared.attempt_id, Settlement::Sent)
+                .expect("settle batch request");
+            requests
+                .submit_response(SubmitResponse {
+                    request_id: prepared.request_id,
+                    attempt_id: prepared.attempt_id,
+                    endpoint: endpoint(&format!("%{}", index + 30), (index + 130) as u64),
+                    body: format!("body-{index:03}"),
+                })
+                .expect("submit batch final");
+            requests
+                .release_wait(&format!("attempt-batch-{index:03}"))
+                .expect("release batch waiter");
+        }
+    }
+
+    fixture.set_now(NOW_MS + DAY_MS);
+    {
+        let mut requests = service(&mut fixture);
+        requests.cleanup().expect("first bounded cleanup");
+    }
+    let connection = rusqlite::Connection::open(&fixture.database).expect("open batch SQL oracle");
+    let remaining_responses: i64 = connection
+        .query_row("SELECT COUNT(*) FROM request_responses", [], |row| {
+            row.get(0)
+        })
+        .expect("count first response batch");
+    let remaining_prompts: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM request_attempts WHERE message_text IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count first prompt batch");
+    let remaining_response_request: String = connection
+        .query_row(
+            "SELECT request_id FROM request_responses ORDER BY request_id",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read first remaining response");
+    let remaining_prompt_attempt: String = connection
+        .query_row(
+            "SELECT attempt_id FROM request_attempts WHERE message_text IS NOT NULL ORDER BY attempt_id",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read first remaining prompt");
+    assert_eq!(remaining_responses, 1);
+    assert_eq!(remaining_prompts, 1);
+    assert_eq!(remaining_response_request, "request-batch-100");
+    assert_eq!(remaining_prompt_attempt, "attempt-batch-100");
+
+    {
+        let mut requests = service(&mut fixture);
+        requests.cleanup().expect("second bounded cleanup");
+    }
+    let connection = rusqlite::Connection::open(&fixture.database).expect("reopen batch oracle");
+    let remaining_responses: i64 = connection
+        .query_row("SELECT COUNT(*) FROM request_responses", [], |row| {
+            row.get(0)
+        })
+        .expect("count drained responses");
+    let remaining_prompts: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM request_attempts WHERE message_text IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count drained prompts");
+    assert_eq!(remaining_responses, 0);
+    assert_eq!(remaining_prompts, 0);
+    assert_eq!(count_rows(&fixture.database, "request_attempts"), 101);
+
+    fixture.set_now(NOW_MS + 7 * DAY_MS);
+    {
+        let mut requests = service(&mut fixture);
+        requests.cleanup().expect("first metadata batch");
+    }
+    assert_eq!(count_rows(&fixture.database, "request_attempts"), 1);
+    {
+        let mut requests = service(&mut fixture);
+        requests.cleanup().expect("second metadata batch");
+    }
+    assert_eq!(count_rows(&fixture.database, "request_attempts"), 0);
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/retirement.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/retirement.rs
@@ -1,0 +1,121 @@
+use super::support::{Fixture, NOW_MS, endpoint, prepare_input, service};
+use rusqlite::OptionalExtension;
+use tmt_core::identity::{Lifetime, create_or_resolve};
+use tmt_core::request::{Originator, SubmitResponse};
+
+#[test]
+fn late_final_uses_original_provenance_after_identity_retirement_and_name_reuse() {
+    let mut fixture = Fixture::new();
+    let original_id = fixture.identity_id.clone();
+    let target = endpoint("%40", 140);
+    let input = prepare_input(
+        &fixture,
+        "request-retired-identity-final",
+        target.clone(),
+        false,
+        NOW_MS + 3_600_001,
+        Originator::Explicit(original_id.clone()),
+        false,
+    );
+    let prepared = {
+        let mut requests = service(&mut fixture);
+        requests
+            .prepare(input, "attempt-retired-identity-final".into(), 1)
+            .expect("prepare retired-identity request")
+    };
+    {
+        let mut requests = service(&mut fixture);
+        requests
+            .begin_send(&prepared.attempt_id)
+            .expect("begin retired-identity request");
+    }
+
+    let connection = rusqlite::Connection::open(&fixture.database).expect("open identity oracle");
+    connection
+        .execute(
+            "UPDATE identities SET retired_at_ms = ? WHERE id = ?",
+            rusqlite::params![NOW_MS as i64, original_id],
+        )
+        .expect("retire original identity");
+    drop(connection);
+    let replacement = create_or_resolve(&mut fixture.storage, "Request Owner", Lifetime::Saved)
+        .expect("reuse retired identity name")
+        .identity;
+    assert_ne!(replacement.id, fixture.identity_id);
+
+    // The original attempt is accepted after its send deadline even though the
+    // active identity now resolves to a different UUID. Direct SQL retirement
+    // is setup here; binding/removal policy has its own adapter tests.
+    fixture.set_now(NOW_MS + 3_600_002);
+    {
+        let mut requests = service(&mut fixture);
+        let final_response = requests
+            .submit_response(SubmitResponse {
+                request_id: prepared.request_id.clone(),
+                attempt_id: prepared.attempt_id.clone(),
+                endpoint: target,
+                body: "late final after retirement".into(),
+            })
+            .expect("accept late final for retired identity");
+        assert_eq!(final_response.body, "late final after retirement");
+    }
+
+    let connection = rusqlite::Connection::open(&fixture.database).expect("reopen identity oracle");
+    let provenance: (Option<String>, String, Option<String>) = connection
+        .query_row(
+            "SELECT identity_id, originator_identity_id, recipient_identity_id FROM request_attempts WHERE request_id = ?",
+            [&prepared.request_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("read historical provenance");
+    assert_eq!(
+        provenance,
+        (None, original_id.clone(), Some(original_id.clone()))
+    );
+    let final_body: String = connection
+        .query_row(
+            "SELECT body FROM request_responses WHERE request_id = ?",
+            [&prepared.request_id],
+            |row| row.get(0),
+        )
+        .expect("read late final");
+    assert_eq!(final_body, "late final after retirement");
+    let identities: Vec<(String, Option<i64>)> = connection
+        .prepare("SELECT id, retired_at_ms FROM identities WHERE canonical_name = ? ORDER BY id")
+        .expect("prepare identity rows")
+        .query_map([replacement.canonical_name.as_str()], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .expect("query identity rows")
+        .collect::<rusqlite::Result<_>>()
+        .expect("decode identity rows");
+    assert_eq!(identities.len(), 2);
+    assert!(
+        identities
+            .iter()
+            .any(|(id, retired)| id == &original_id && retired.is_some())
+    );
+    assert!(
+        identities
+            .iter()
+            .any(|(id, retired)| id == &replacement.id && retired.is_none())
+    );
+    let replacement_attention: Option<i64> = connection
+        .query_row(
+            "SELECT latest_revision FROM request_attention_identities WHERE identity_id = ?",
+            [&replacement.id],
+            |row| row.get(0),
+        )
+        .optional()
+        .expect("read replacement attention state");
+    assert_eq!(replacement_attention, None);
+    drop(connection);
+    let response = {
+        let mut requests = service(&mut fixture);
+        requests
+            .get_response(&prepared.request_id)
+            .expect("read late final through a fresh service")
+            .expect("late final remains retained")
+    };
+    assert_eq!(response.body, "late final after retirement");
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/support.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/support.rs
@@ -1,0 +1,115 @@
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use crate::{storage::Storage, test_support::TestDirectory};
+use tmt_core::{
+    endpoint::ServerEvidence,
+    identity::{Lifetime, create_or_resolve},
+    request::{Originator, PreambleReservation, PrepareRequest, RequestEndpoint, RequestService},
+};
+
+pub const NOW_MS: u64 = 1_700_000_000_000;
+pub const DAY_MS: u64 = 86_400_000;
+
+pub struct Fixture {
+    pub _directory: TestDirectory,
+    pub database: PathBuf,
+    pub storage: Storage,
+    pub identity_id: String,
+    pub clock: Arc<AtomicU64>,
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        let directory = TestDirectory::new();
+        let database = directory.path.join("state").join("tmux-team.db");
+        let mut storage = Storage::open(&database).expect("open request fixture storage");
+        let identity = create_or_resolve(&mut storage, "Request Owner", Lifetime::Saved)
+            .expect("create request fixture identity")
+            .identity;
+        Self {
+            _directory: directory,
+            database,
+            storage,
+            identity_id: identity.id,
+            clock: Arc::new(AtomicU64::new(NOW_MS)),
+        }
+    }
+
+    pub fn set_now(&self, value: u64) {
+        self.clock.store(value, Ordering::SeqCst);
+    }
+}
+
+pub fn service<'a>(fixture: &'a mut Fixture) -> RequestService<'a, Storage, impl Fn() -> u64> {
+    let clock = Arc::clone(&fixture.clock);
+    RequestService::new(&mut fixture.storage, move || clock.load(Ordering::SeqCst))
+}
+
+pub fn endpoint(pane_id: &str, pane_pid: u64) -> RequestEndpoint {
+    RequestEndpoint {
+        server: ServerEvidence {
+            server_id: "server-for-request-tests".into(),
+            socket_path: "/tmp/tmt-request-tests.sock".into(),
+            server_pid: 41,
+            server_start_time: "request-test-server-start".into(),
+        },
+        pane_id: pane_id.into(),
+        pane_pid,
+    }
+}
+
+pub fn prepare_input(
+    fixture: &Fixture,
+    request_id: &str,
+    target: RequestEndpoint,
+    wait: bool,
+    expires_at_ms: u64,
+    originator: Originator,
+    preamble: bool,
+) -> PrepareRequest {
+    PrepareRequest {
+        request_id: request_id.into(),
+        message: format!("prompt for {request_id}"),
+        endpoint: target,
+        wait,
+        expires_at_ms,
+        originator,
+        recipient_identity_id: Some(fixture.identity_id.clone()),
+        preamble: preamble.then(|| PreambleReservation {
+            identity_id: fixture.identity_id.clone(),
+            every: 3,
+        }),
+    }
+}
+
+pub fn count_rows(database: &PathBuf, table: &str) -> i64 {
+    let connection =
+        rusqlite::Connection::open_with_flags(database, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .expect("open request SQL oracle");
+    connection
+        .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+            row.get(0)
+        })
+        .expect("count request rows")
+}
+
+pub fn preamble_count(database: &PathBuf, identity_id: &str) -> i64 {
+    use rusqlite::{Connection, OpenFlags, OptionalExtension};
+    let connection = Connection::open_with_flags(database, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .expect("open request SQL oracle");
+    connection
+        .query_row(
+            "SELECT COALESCE(reserved_count, 0) FROM preamble_counters WHERE identity_id = ?",
+            [identity_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .expect("read request cadence")
+        .unwrap_or(0)
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/tests.rs
@@ -1,0 +1,187 @@
+use crate::test_support::TestDirectory;
+use tmt_core::{
+    endpoint::ServerEvidence,
+    limits::MAX_JS_SAFE_INTEGER,
+    request::{Originator, PrepareRequest, RequestEndpoint, RequestRepository, RequestService},
+};
+
+use super::super::*;
+
+fn endpoint() -> RequestEndpoint {
+    RequestEndpoint {
+        server: ServerEvidence {
+            server_id: "server-id".into(),
+            socket_path: "/tmp/tmt-request-test.sock".into(),
+            server_pid: 41,
+            server_start_time: "start".into(),
+        },
+        pane_id: "%1".into(),
+        pane_pid: 42,
+    }
+}
+
+fn seed_attempt(storage: &mut Storage, request_id: &str, attempt_id: &str) {
+    let mut service = RequestService::new(storage, || 1_000);
+    service
+        .prepare(
+            PrepareRequest {
+                request_id: request_id.into(),
+                message: "original prompt".into(),
+                endpoint: endpoint(),
+                wait: false,
+                expires_at_ms: 2_000,
+                originator: Originator::Unknown,
+                recipient_identity_id: None,
+                preamble: None,
+            },
+            attempt_id.into(),
+            7,
+        )
+        .unwrap();
+}
+
+#[test]
+fn context_keeps_scrubbed_prompt_expiry_marker() {
+    let directory = TestDirectory::new();
+    let database = directory.path.join("state").join("requests.db");
+    let mut storage = Storage::open(database).unwrap();
+    seed_attempt(&mut storage, "request-1", "attempt-1");
+
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE request_attempts SET message_text = NULL, message_bytes = NULL WHERE request_id = ?",
+            ["request-1"],
+        )
+        .unwrap();
+    let context = storage
+        .with_request_transaction(|records| records.find_context("request-1"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(context.message, None);
+    assert_eq!(context.message_bytes, None);
+    assert!(context.expires_at_ms.is_some());
+    storage.close().unwrap();
+}
+
+#[test]
+fn row_decoder_accepts_safe_maximum_and_rejects_out_of_range_values() {
+    let directory = TestDirectory::new();
+    let database = directory.path.join("state").join("requests.db");
+    let mut storage = Storage::open(database).unwrap();
+    seed_attempt(&mut storage, "request-1", "attempt-1");
+
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE request_attempts SET prepared_at_ms = ? WHERE request_id = ?",
+            rusqlite::params![MAX_JS_SAFE_INTEGER as i64, "request-1"],
+        )
+        .unwrap();
+    assert_eq!(
+        storage
+            .with_request_transaction(|records| records.find_request("request-1"))
+            .unwrap()
+            .unwrap()
+            .prepared_at_ms,
+        MAX_JS_SAFE_INTEGER
+    );
+
+    for value in [MAX_JS_SAFE_INTEGER as i64 + 1, -1] {
+        storage
+            .connection()
+            .unwrap()
+            .execute(
+                "UPDATE request_attempts SET prepared_at_ms = ? WHERE request_id = ?",
+                rusqlite::params![value, "request-1"],
+            )
+            .unwrap();
+        assert!(
+            storage
+                .with_request_transaction(|records| records.find_request("request-1"))
+                .is_err()
+        );
+    }
+    storage.close().unwrap();
+}
+
+#[test]
+fn response_marker_mismatch_rolls_back_orphan_final_insert() {
+    let directory = TestDirectory::new();
+    let database = directory.path.join("state").join("requests.db");
+    let mut storage = Storage::open(database).unwrap();
+    seed_attempt(&mut storage, "request-1", "attempt-1");
+
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE request_attempts SET response_submitted_at_ms = ? WHERE request_id = ?",
+            rusqlite::params![1_i64, "request-1"],
+        )
+        .unwrap();
+    let response = tmt_core::request::FinalResponse {
+        request_id: "request-1".into(),
+        attempt_id: "attempt-1".into(),
+        endpoint: endpoint(),
+        body: "final".into(),
+        body_bytes: 5,
+        submitted_at_ms: 1_500,
+        response_expires_at_ms: 10_000,
+    };
+    let result: Result<(), StorageError> =
+        storage.with_request_transaction(|records| records.create_response(&response));
+    assert!(result.is_err());
+    let count: i64 = storage
+        .connection()
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM request_responses WHERE request_id = ?",
+            ["request-1"],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 0);
+    let marker: i64 = storage
+        .connection()
+        .unwrap()
+        .query_row(
+            "SELECT response_submitted_at_ms FROM request_attempts WHERE request_id = ?",
+            ["request-1"],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(marker, 1);
+    storage.close().unwrap();
+}
+
+#[test]
+fn retained_cleanup_plan_uses_horizon_index_without_sort() {
+    let directory = TestDirectory::new();
+    let database = directory.path.join("state").join("requests.db");
+    let mut storage = Storage::open(database).unwrap();
+    let plan_sql = format!("EXPLAIN QUERY PLAN {}", super::DELETE_RETAINED_SQL);
+    let details = {
+        let mut statement = storage.connection().unwrap().prepare(&plan_sql).unwrap();
+        statement
+            .query_map(rusqlite::params![1_i64, 2_i64, 2_i64, 100_i64], |row| {
+                row.get::<_, String>(3)
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap()
+    };
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.contains("request_attempts_retention_horizon"))
+    );
+    assert!(
+        !details
+            .iter()
+            .any(|detail| detail.contains("USE TEMP B-TREE FOR ORDER BY"))
+    );
+    storage.close().unwrap();
+}

--- a/rust/crates/tmt-core/src/exact_text.rs
+++ b/rust/crates/tmt-core/src/exact_text.rs
@@ -1,0 +1,70 @@
+//! Request and final bodies share byte measurement, never role normalization.
+
+pub const MAX_EXCHANGE_TEXT_BYTES: usize = 1_048_576;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExactTextError {
+    InvalidUtf8,
+    TooLarge,
+}
+
+/// Rust strings already exclude lone surrogates. Byte-oriented adapters use
+/// this same primitive to reject malformed UTF-8 without replacing characters.
+pub fn validate_exact_text(bytes: &[u8]) -> Result<&str, ExactTextError> {
+    let text = std::str::from_utf8(bytes).map_err(|_| ExactTextError::InvalidUtf8)?;
+    if bytes.len() > MAX_EXCHANGE_TEXT_BYTES {
+        return Err(ExactTextError::TooLarge);
+    }
+    Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_exact_empty_control_and_unicode_content() {
+        for text in [
+            "",
+            " \r\n\0\u{feff}",
+            "é e\u{301} 🦀",
+            "!\n<tmt-reply>literal</tmt-reply>",
+        ] {
+            let actual = validate_exact_text(text.as_bytes()).unwrap();
+            assert_eq!(actual.as_bytes(), text.as_bytes());
+            assert_eq!(actual.as_ptr(), text.as_ptr());
+        }
+    }
+
+    #[test]
+    fn bound_is_utf8_bytes_not_characters_and_includes_exact_limit() {
+        for text in [
+            "a".repeat(MAX_EXCHANGE_TEXT_BYTES),
+            "🦀".repeat(MAX_EXCHANGE_TEXT_BYTES / 4),
+        ] {
+            assert!(validate_exact_text(text.as_bytes()).is_ok());
+            assert_eq!(
+                validate_exact_text(format!("{text}a").as_bytes()),
+                Err(ExactTextError::TooLarge)
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_utf8_is_never_lossily_replaced_or_normalized() {
+        for bytes in [
+            &[0xed, 0xa0, 0x80][..],
+            &[0xc0, 0x80],
+            &[0xf0, 0x9f],
+            &[0xff],
+        ] {
+            assert_eq!(validate_exact_text(bytes), Err(ExactTextError::InvalidUtf8));
+        }
+        let mut invalid = vec![b'a'; MAX_EXCHANGE_TEXT_BYTES + 1];
+        invalid.push(0xff);
+        assert_eq!(
+            validate_exact_text(&invalid),
+            Err(ExactTextError::InvalidUtf8)
+        );
+    }
+}

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -2,9 +2,12 @@
 
 pub mod binding;
 pub mod endpoint;
+pub mod exact_text;
 pub mod identity;
 pub mod limits;
 pub mod names;
+pub mod request;
+pub mod retention;
 pub mod settings;
 
 #[cfg(test)]

--- a/rust/crates/tmt-core/src/request.rs
+++ b/rust/crates/tmt-core/src/request.rs
@@ -1,0 +1,306 @@
+//! Durable request policy and transaction-scoped ports. No live endpoint lookup,
+//! configuration loading or external effects belong inside this boundary.
+
+mod service;
+pub use service::RequestService;
+
+use crate::endpoint::ServerEvidence;
+use std::{error::Error, fmt};
+
+pub const CLEANUP_BATCH_SIZE: u64 = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestEndpoint {
+    pub server: ServerEvidence,
+    pub pane_id: String,
+    pub pane_pid: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttemptStatus {
+    Prepared,
+    Sending,
+    Sent,
+    Uncertain,
+    DefinitelyFailed,
+}
+
+impl AttemptStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Prepared => "prepared",
+            Self::Sending => "sending",
+            Self::Sent => "sent",
+            Self::Uncertain => "uncertain",
+            Self::DefinitelyFailed => "definitely_failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Settlement {
+    Sent,
+    Uncertain,
+    DefinitelyFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Originator {
+    Unknown,
+    Explicit(String),
+    Verified(String),
+}
+
+impl Originator {
+    pub fn identity_id(&self) -> Option<&str> {
+        match self {
+            Self::Unknown => None,
+            Self::Explicit(id) | Self::Verified(id) => Some(id),
+        }
+    }
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Explicit(_) => "explicit",
+            Self::Verified(_) => "verified",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestAttempt {
+    pub attempt_id: String,
+    pub request_id: String,
+    pub originator: Originator,
+    pub recipient_identity_id: Option<String>,
+    pub nonce: Option<String>,
+    pub identity_id: Option<String>,
+    pub endpoint: RequestEndpoint,
+    pub wait_active: bool,
+    pub status: AttemptStatus,
+    pub preamble_every: Option<u64>,
+    pub inject_preamble: bool,
+    pub cadence_reserved: bool,
+    pub prepared_at_ms: u64,
+    pub sending_at_ms: Option<u64>,
+    pub settled_at_ms: Option<u64>,
+    pub wait_released_at_ms: Option<u64>,
+    pub response_submitted_at_ms: Option<u64>,
+    pub expires_at_ms: u64,
+    pub retention_days: u64,
+    pub retention_expires_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FinalResponse {
+    pub request_id: String,
+    pub attempt_id: String,
+    pub endpoint: RequestEndpoint,
+    pub body: String,
+    pub body_bytes: u64,
+    pub submitted_at_ms: u64,
+    pub response_expires_at_ms: u64,
+}
+
+pub struct PreambleReservation {
+    pub identity_id: String,
+    pub every: u64,
+}
+
+pub struct PrepareRequest {
+    pub request_id: String,
+    pub message: String,
+    pub endpoint: RequestEndpoint,
+    pub wait: bool,
+    pub expires_at_ms: u64,
+    pub originator: Originator,
+    pub recipient_identity_id: Option<String>,
+    pub preamble: Option<PreambleReservation>,
+}
+
+#[derive(Debug)]
+pub struct PreparedRequest {
+    pub attempt_id: String,
+    pub request_id: String,
+    pub inject_preamble: bool,
+    pub previous_request_id: Option<String>,
+}
+
+pub struct SubmitResponse {
+    pub request_id: String,
+    pub attempt_id: String,
+    pub endpoint: RequestEndpoint,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredPrompt {
+    pub message: String,
+    pub message_bytes: u64,
+    pub expires_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawRequestContext {
+    pub attempt: RequestAttempt,
+    pub message: Option<String>,
+    pub message_bytes: Option<u64>,
+    pub expires_at_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestPrompt {
+    Retained(StoredPrompt),
+    Expired { expires_at_ms: u64 },
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestContext {
+    pub attempt: RequestAttempt,
+    pub prompt: RequestPrompt,
+}
+
+/// These methods are exposed only while the invocation's immediate transaction
+/// is held. Domain decisions remain in RequestService, not in SQL adapters.
+pub trait RequestRecords {
+    type Error;
+    fn find_attempt(&self, attempt_id: &str) -> Result<Option<RequestAttempt>, Self::Error>;
+    fn find_request(&self, request_id: &str) -> Result<Option<RequestAttempt>, Self::Error>;
+    fn find_context(&self, request_id: &str) -> Result<Option<RawRequestContext>, Self::Error>;
+    fn find_response(&self, request_id: &str) -> Result<Option<FinalResponse>, Self::Error>;
+    fn find_active_request(
+        &self,
+        endpoint: &RequestEndpoint,
+    ) -> Result<Option<String>, Self::Error>;
+    fn create_attempt(
+        &mut self,
+        attempt: &RequestAttempt,
+        prompt: &StoredPrompt,
+        revision: u64,
+    ) -> Result<(), Self::Error>;
+    /// Inserts final and completion marker atomically; fails if exactly one
+    /// matching previously-uncompleted attempt cannot be marked.
+    fn create_response(&mut self, response: &FinalResponse) -> Result<(), Self::Error>;
+    fn update_state(
+        &mut self,
+        attempt: &RequestAttempt,
+        status: AttemptStatus,
+        reserved: bool,
+        now_ms: u64,
+        horizon: Option<u64>,
+    ) -> Result<bool, Self::Error>;
+    fn release_wait(&mut self, attempt_id: &str, now_ms: u64) -> Result<bool, Self::Error>;
+    fn preamble_count(&self, identity_id: &str) -> Result<u64, Self::Error>;
+    fn set_preamble_count(
+        &mut self,
+        identity_id: &str,
+        count: u64,
+        now_ms: u64,
+    ) -> Result<(), Self::Error>;
+    fn attention_counter(&self, identity_id: &str) -> Result<Option<u64>, Self::Error>;
+    /// Preserves the acknowledged-through watermark; must reject a changed
+    /// expected counter rather than overwriting concurrent ownership.
+    fn set_attention_counter(
+        &mut self,
+        identity_id: &str,
+        expected: Option<u64>,
+        next: u64,
+    ) -> Result<(), Self::Error>;
+    fn set_attention_revision(
+        &mut self,
+        request_id: &str,
+        revision: u64,
+    ) -> Result<(), Self::Error>;
+    fn expired_attempts(&self, now_ms: u64, limit: u64)
+    -> Result<Vec<RequestAttempt>, Self::Error>;
+    fn clear_expired_prompts(&mut self, now_ms: u64, limit: u64) -> Result<(), Self::Error>;
+    fn delete_expired_responses(&mut self, now_ms: u64, limit: u64) -> Result<(), Self::Error>;
+    fn delete_retained(
+        &mut self,
+        now_ms: u64,
+        settled_cutoff_ms: u64,
+        limit: u64,
+    ) -> Result<(), Self::Error>;
+}
+
+pub trait RequestRepository {
+    type Error;
+    fn with_request_transaction<T, E: From<Self::Error>>(
+        &mut self,
+        operation: impl FnOnce(&mut dyn RequestRecords<Error = Self::Error>) -> Result<T, E>,
+    ) -> Result<T, E>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseRejection {
+    InputInvalid,
+    InputTooLarge,
+    RequestNotFound,
+    AttemptMismatch,
+    RecipientMismatch,
+    StateInvalid,
+    Conflict,
+    Expired,
+}
+
+impl ResponseRejection {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::InputInvalid => "RESPONSE_INPUT_INVALID",
+            Self::InputTooLarge => "RESPONSE_INPUT_TOO_LARGE",
+            Self::RequestNotFound => "RESPONSE_REQUEST_NOT_FOUND",
+            Self::AttemptMismatch => "RESPONSE_ATTEMPT_MISMATCH",
+            Self::RecipientMismatch => "RESPONSE_RECIPIENT_MISMATCH",
+            Self::StateInvalid => "RESPONSE_STATE_INVALID",
+            Self::Conflict => "RESPONSE_CONFLICT",
+            Self::Expired => "RESPONSE_EXPIRED",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum RequestError<E> {
+    Invalid(&'static str),
+    InputTooLarge,
+    Expired,
+    NotFound,
+    StateInvalid,
+    AlreadyExists,
+    CounterExhausted,
+    RevisionExhausted,
+    Response(ResponseRejection),
+    Repository(E),
+}
+
+impl<E> From<E> for RequestError<E> {
+    fn from(error: E) -> Self {
+        Self::Repository(error)
+    }
+}
+impl<E> fmt::Display for RequestError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid(message) => f.write_str(message),
+            Self::InputTooLarge => f.write_str("Original request exceeds the UTF-8 byte limit."),
+            Self::Expired => f.write_str("Request attempt has expired."),
+            Self::NotFound => f.write_str("Request attempt was not found."),
+            Self::StateInvalid => f.write_str("Request attempt cannot make this transition."),
+            Self::AlreadyExists => f.write_str("Request ID already has a retained final."),
+            Self::CounterExhausted => f.write_str("Preamble cadence counter is exhausted."),
+            Self::RevisionExhausted => {
+                f.write_str("Exchange attention revision counter is exhausted.")
+            }
+            Self::Response(reason) => f.write_str(reason.code()),
+            Self::Repository(_) => f.write_str("Could not access request state."),
+        }
+    }
+}
+impl<E: Error + 'static> Error for RequestError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Repository(e) => Some(e),
+            _ => None,
+        }
+    }
+}

--- a/rust/crates/tmt-core/src/request/service.rs
+++ b/rust/crates/tmt-core/src/request/service.rs
@@ -1,0 +1,278 @@
+//! Short transactional use cases. The clock is sampled after acquiring the
+//! write lock; callers generate IDs and freeze configuration before entry.
+
+mod lifecycle;
+mod responses;
+
+use super::*;
+use crate::{exact_text::validate_exact_text, limits::MAX_JS_SAFE_INTEGER, retention::*};
+
+pub struct RequestService<'a, R, C> {
+    repository: &'a mut R,
+    clock: C,
+}
+
+impl<'a, R: RequestRepository, C: Fn() -> u64> RequestService<'a, R, C> {
+    pub fn new(repository: &'a mut R, clock: C) -> Self {
+        Self { repository, clock }
+    }
+
+    pub fn prepare(
+        &mut self,
+        input: PrepareRequest,
+        attempt_id: String,
+        retention_days: u64,
+    ) -> Result<PreparedRequest, RequestError<R::Error>> {
+        nonempty(&input.request_id)?;
+        nonempty(&attempt_id)?;
+        validate_exact_text(input.message.as_bytes()).map_err(|_| RequestError::InputTooLarge)?;
+        endpoint_valid(&input.endpoint)?;
+        positive(input.expires_at_ms)?;
+        if !valid_retention_days(retention_days) {
+            return Err(RequestError::Invalid("Invalid retention days."));
+        }
+        if let Some(id) = input.originator.identity_id() {
+            nonempty(id)?;
+        }
+        if let Some(id) = &input.recipient_identity_id {
+            nonempty(id)?;
+        }
+        if let Some(preamble) = &input.preamble {
+            nonempty(&preamble.identity_id)?;
+            positive(preamble.every)?;
+        }
+        let clock = &self.clock;
+        self.repository.with_request_transaction(|records| {
+            let now = positive(clock())?;
+            let expires = input
+                .expires_at_ms
+                .max(deadline(now, REQUEST_MIN_EXPIRY_MS)?);
+            let prompt_expiry = retention_deadline(now, retention_days)
+                .ok_or(RequestError::Invalid("Invalid prompt deadline."))?;
+            let horizon = prompt_expiry
+                .max(deadline(now, RESPONSE_ACCEPTANCE_WINDOW_MS)?)
+                .max(deadline(expires, METADATA_SETTLEMENT_FLOOR_MS)?);
+            cleanup_records(records, now)?;
+            if records.find_response(&input.request_id)?.is_some() {
+                return Err(RequestError::AlreadyExists);
+            }
+            let revision = match input.originator.identity_id() {
+                Some(id) => reserve_revision(records, id)?,
+                None => 0,
+            };
+            let previous_request_id = records.find_active_request(&input.endpoint)?;
+            let mut inject = false;
+            if let Some(preamble) = &input.preamble {
+                let count = records.preamble_count(&preamble.identity_id)?;
+                if count >= MAX_JS_SAFE_INTEGER {
+                    return Err(RequestError::CounterExhausted);
+                }
+                inject = count % preamble.every == 0;
+                records.set_preamble_count(&preamble.identity_id, count + 1, now)?;
+            }
+            let attempt = RequestAttempt {
+                attempt_id: attempt_id.clone(),
+                request_id: input.request_id.clone(),
+                originator: input.originator,
+                recipient_identity_id: input.recipient_identity_id,
+                nonce: None,
+                identity_id: input.preamble.as_ref().map(|p| p.identity_id.clone()),
+                endpoint: input.endpoint,
+                wait_active: input.wait,
+                status: AttemptStatus::Prepared,
+                preamble_every: input.preamble.as_ref().map(|p| p.every),
+                inject_preamble: inject,
+                cadence_reserved: input.preamble.is_some(),
+                prepared_at_ms: now,
+                sending_at_ms: None,
+                settled_at_ms: None,
+                wait_released_at_ms: None,
+                response_submitted_at_ms: None,
+                expires_at_ms: expires,
+                retention_days,
+                retention_expires_at_ms: horizon,
+            };
+            let prompt = StoredPrompt {
+                message_bytes: input.message.len() as u64,
+                message: input.message,
+                expires_at_ms: prompt_expiry,
+            };
+            records.create_attempt(&attempt, &prompt, revision)?;
+            Ok(PreparedRequest {
+                attempt_id,
+                request_id: input.request_id,
+                inject_preamble: inject,
+                previous_request_id,
+            })
+        })
+    }
+
+    pub fn cleanup(&mut self) -> Result<(), RequestError<R::Error>> {
+        self.read(|_, _| Ok(()))
+    }
+
+    pub fn get_attempt(
+        &mut self,
+        attempt_id: &str,
+    ) -> Result<Option<RequestAttempt>, RequestError<R::Error>> {
+        nonempty(attempt_id)?;
+        self.read(|records, now| {
+            Ok(records
+                .find_attempt(attempt_id)?
+                .filter(|a| now < a.retention_expires_at_ms))
+        })
+    }
+
+    pub fn get_context(
+        &mut self,
+        request_id: &str,
+    ) -> Result<Option<RequestContext>, RequestError<R::Error>> {
+        nonempty(request_id)?;
+        self.read(|records, now| {
+            let Some(raw) = records.find_context(request_id)? else {
+                return Ok(None);
+            };
+            if now >= raw.attempt.retention_expires_at_ms {
+                return Ok(None);
+            }
+            let prompt = match (raw.expires_at_ms, raw.message, raw.message_bytes) {
+                (None, _, _) => RequestPrompt::Unavailable,
+                (Some(expiry), Some(message), Some(message_bytes)) if now < expiry => {
+                    RequestPrompt::Retained(StoredPrompt {
+                        message,
+                        message_bytes,
+                        expires_at_ms: expiry,
+                    })
+                }
+                (Some(expires_at_ms), _, _) => RequestPrompt::Expired { expires_at_ms },
+            };
+            Ok(Some(RequestContext {
+                attempt: raw.attempt,
+                prompt,
+            }))
+        })
+    }
+
+    fn read<T>(
+        &mut self,
+        operation: impl FnOnce(
+            &mut dyn RequestRecords<Error = R::Error>,
+            u64,
+        ) -> Result<T, RequestError<R::Error>>,
+    ) -> Result<T, RequestError<R::Error>> {
+        let clock = &self.clock;
+        self.repository.with_request_transaction(|records| {
+            let now = positive(clock())?;
+            cleanup_records(records, now)?;
+            operation(records, now)
+        })
+    }
+}
+
+fn nonempty<E>(value: &str) -> Result<(), RequestError<E>> {
+    if value.is_empty() {
+        return Err(RequestError::Invalid(
+            "Request identifiers must be non-empty.",
+        ));
+    }
+    Ok(())
+}
+
+fn positive<E>(value: u64) -> Result<u64, RequestError<E>> {
+    if value == 0 || value > MAX_JS_SAFE_INTEGER {
+        return Err(RequestError::Invalid("Expected a positive safe integer."));
+    }
+    Ok(value)
+}
+
+fn deadline<E>(anchor: u64, delta: u64) -> Result<u64, RequestError<E>> {
+    checked_deadline(anchor, delta).ok_or(RequestError::Invalid(
+        "Request deadline is outside the supported range.",
+    ))
+}
+
+fn endpoint_valid<E>(endpoint: &RequestEndpoint) -> Result<(), RequestError<E>> {
+    // Historical correlation fences are not fresh tmux observations. Preserve
+    // the service's non-empty/safe-integer contract instead of imposing today's
+    // server UUID or wire-format rules on retained requests during upgrade.
+    nonempty(&endpoint.server.server_id)?;
+    nonempty(&endpoint.server.socket_path)?;
+    nonempty(&endpoint.server.server_start_time)?;
+    nonempty(&endpoint.pane_id)?;
+    positive(endpoint.server.server_pid)?;
+    positive(endpoint.pane_pid)?;
+    Ok(())
+}
+
+fn reserve_revision<E>(
+    records: &mut dyn RequestRecords<Error = E>,
+    id: &str,
+) -> Result<u64, RequestError<E>> {
+    let current = records.attention_counter(id)?;
+    let value = current.unwrap_or(0);
+    if value >= MAX_JS_SAFE_INTEGER {
+        return Err(RequestError::RevisionExhausted);
+    }
+    records.set_attention_counter(id, current, value + 1)?;
+    Ok(value + 1)
+}
+
+fn fail_unsent<E>(
+    records: &mut dyn RequestRecords<Error = E>,
+    attempt: &RequestAttempt,
+    now: u64,
+    horizon: Option<u64>,
+) -> Result<bool, RequestError<E>> {
+    let changed = records.update_state(
+        attempt,
+        AttemptStatus::DefinitelyFailed,
+        false,
+        now,
+        horizon,
+    )?;
+    if changed
+        && attempt.cadence_reserved
+        && let Some(id) = &attempt.identity_id
+    {
+        let count = records.preamble_count(id)?;
+        if count > MAX_JS_SAFE_INTEGER {
+            return Err(RequestError::Invalid("Invalid cadence count."));
+        }
+        records.set_preamble_count(id, count.saturating_sub(1), now)?;
+    }
+    Ok(changed)
+}
+
+fn cleanup_records<E>(
+    records: &mut dyn RequestRecords<Error = E>,
+    now: u64,
+) -> Result<(), RequestError<E>> {
+    for attempt in records.expired_attempts(now, CLEANUP_BATCH_SIZE)? {
+        if attempt.wait_active {
+            records.release_wait(&attempt.attempt_id, now)?;
+        }
+        match attempt.status {
+            AttemptStatus::Prepared => {
+                fail_unsent(records, &attempt, now, None)?;
+            }
+            AttemptStatus::Sending => {
+                records.update_state(
+                    &attempt,
+                    AttemptStatus::Uncertain,
+                    attempt.cadence_reserved,
+                    now,
+                    None,
+                )?;
+            }
+            _ => {}
+        }
+    }
+    records.clear_expired_prompts(now, CLEANUP_BATCH_SIZE)?;
+    records.delete_expired_responses(now, CLEANUP_BATCH_SIZE)?;
+    records.delete_retained(
+        now,
+        now.saturating_sub(METADATA_SETTLEMENT_FLOOR_MS),
+        CLEANUP_BATCH_SIZE,
+    )?;
+    Ok(())
+}

--- a/rust/crates/tmt-core/src/request/service/lifecycle.rs
+++ b/rust/crates/tmt-core/src/request/service/lifecycle.rs
@@ -1,0 +1,118 @@
+use super::*;
+
+impl<R: RequestRepository, C: Fn() -> u64> RequestService<'_, R, C> {
+    pub fn begin_send(&mut self, attempt_id: &str) -> Result<(), RequestError<R::Error>> {
+        nonempty(attempt_id)?;
+        let clock = &self.clock;
+        let expired = self.repository.with_request_transaction(|records| {
+            let now = positive(clock())?;
+            let attempt = records
+                .find_attempt(attempt_id)?
+                .ok_or(RequestError::NotFound)?;
+            if now >= attempt.retention_expires_at_ms {
+                return Err(RequestError::Expired);
+            }
+            if attempt.status != AttemptStatus::Prepared {
+                return Err(RequestError::StateInvalid);
+            }
+            if now >= attempt.expires_at_ms {
+                if attempt.wait_active {
+                    records.release_wait(attempt_id, now)?;
+                }
+                if !fail_unsent(records, &attempt, now, None)? {
+                    return Err(RequestError::StateInvalid);
+                }
+                // Commit refund/release before reporting expiry to the caller.
+                return Ok(true);
+            }
+            if !records.update_state(
+                &attempt,
+                AttemptStatus::Sending,
+                attempt.cadence_reserved,
+                now,
+                None,
+            )? {
+                return Err(RequestError::StateInvalid);
+            }
+            Ok(false)
+        })?;
+        if expired {
+            return Err(RequestError::Expired);
+        }
+        Ok(())
+    }
+
+    pub fn settle(
+        &mut self,
+        attempt_id: &str,
+        outcome: Settlement,
+    ) -> Result<(), RequestError<R::Error>> {
+        nonempty(attempt_id)?;
+        let clock = &self.clock;
+        self.repository.with_request_transaction(|records| {
+            let now = positive(clock())?;
+            let attempt = records
+                .find_attempt(attempt_id)?
+                .ok_or(RequestError::NotFound)?;
+            if now >= attempt.retention_expires_at_ms
+                && matches!(
+                    attempt.status,
+                    AttemptStatus::Prepared | AttemptStatus::Sending
+                )
+            {
+                return Err(RequestError::Expired);
+            }
+            let cannot_prove_unsent = (attempt.status == AttemptStatus::Sending
+                && now >= attempt.expires_at_ms)
+                || (attempt.response_submitted_at_ms.is_some()
+                    && matches!(
+                        attempt.status,
+                        AttemptStatus::Sending | AttemptStatus::Uncertain
+                    ));
+            let effective = match outcome {
+                Settlement::Sent => AttemptStatus::Sent,
+                Settlement::Uncertain => AttemptStatus::Uncertain,
+                Settlement::DefinitelyFailed if cannot_prove_unsent => AttemptStatus::Uncertain,
+                Settlement::DefinitelyFailed => AttemptStatus::DefinitelyFailed,
+            };
+            if matches!(
+                attempt.status,
+                AttemptStatus::Sent | AttemptStatus::Uncertain | AttemptStatus::DefinitelyFailed
+            ) {
+                return if attempt.status == effective {
+                    Ok(())
+                } else {
+                    Err(RequestError::StateInvalid)
+                };
+            }
+            if effective != AttemptStatus::DefinitelyFailed
+                && attempt.status != AttemptStatus::Sending
+            {
+                return Err(RequestError::StateInvalid);
+            }
+            let horizon = Some(
+                attempt
+                    .retention_expires_at_ms
+                    .max(deadline(now, METADATA_SETTLEMENT_FLOOR_MS)?),
+            );
+            let changed = if effective == AttemptStatus::DefinitelyFailed {
+                fail_unsent(records, &attempt, now, horizon)?
+            } else {
+                records.update_state(&attempt, effective, attempt.cadence_reserved, now, horizon)?
+            };
+            if !changed {
+                return Err(RequestError::StateInvalid);
+            }
+            Ok(())
+        })
+    }
+
+    pub fn release_wait(&mut self, attempt_id: &str) -> Result<(), RequestError<R::Error>> {
+        nonempty(attempt_id)?;
+        let clock = &self.clock;
+        self.repository.with_request_transaction(|records| {
+            records.release_wait(attempt_id, positive(clock())?)?;
+            Ok(())
+        })
+    }
+}

--- a/rust/crates/tmt-core/src/request/service/responses.rs
+++ b/rust/crates/tmt-core/src/request/service/responses.rs
@@ -1,0 +1,92 @@
+use super::*;
+
+impl<R: RequestRepository, C: Fn() -> u64> RequestService<'_, R, C> {
+    pub fn submit_response(
+        &mut self,
+        input: SubmitResponse,
+    ) -> Result<FinalResponse, RequestError<R::Error>> {
+        if input.request_id.is_empty()
+            || input.attempt_id.is_empty()
+            || endpoint_valid::<R::Error>(&input.endpoint).is_err()
+        {
+            return Err(RequestError::Response(ResponseRejection::InputInvalid));
+        }
+        validate_exact_text(input.body.as_bytes())
+            .map_err(|_| RequestError::Response(ResponseRejection::InputTooLarge))?;
+        let clock = &self.clock;
+        self.repository.with_request_transaction(|records| {
+            let now = positive(clock())?;
+            // No housekeeping on a rejected submission: even unrelated rows
+            // must remain unchanged. Retained finals are authoritative for retries.
+            if let Some(existing) = records.find_response(&input.request_id)? {
+                validate_fence(&existing.attempt_id, &existing.endpoint, &input)?;
+                if now >= existing.response_expires_at_ms {
+                    return Err(RequestError::Response(ResponseRejection::Expired));
+                }
+                if input.body != existing.body {
+                    return Err(RequestError::Response(ResponseRejection::Conflict));
+                }
+                return Ok(existing);
+            }
+            let attempt = records
+                .find_request(&input.request_id)?
+                .ok_or(RequestError::Response(ResponseRejection::RequestNotFound))?;
+            validate_fence(&attempt.attempt_id, &attempt.endpoint, &input)?;
+            if attempt.response_submitted_at_ms.is_some()
+                || response_deadline_passed(now, attempt.prepared_at_ms, attempt.expires_at_ms)
+            {
+                return Err(RequestError::Response(ResponseRejection::Expired));
+            }
+            if !matches!(
+                attempt.status,
+                AttemptStatus::Sending | AttemptStatus::Sent | AttemptStatus::Uncertain
+            ) {
+                return Err(RequestError::Response(ResponseRejection::StateInvalid));
+            }
+            let response = FinalResponse {
+                request_id: input.request_id,
+                attempt_id: input.attempt_id,
+                endpoint: input.endpoint,
+                body_bytes: input.body.len() as u64,
+                body: input.body,
+                submitted_at_ms: now,
+                response_expires_at_ms: retention_deadline(now, attempt.retention_days)
+                    .ok_or(RequestError::Invalid("Invalid response deadline."))?,
+            };
+            records.create_response(&response)?;
+            if let Some(id) = attempt.originator.identity_id() {
+                let revision = reserve_revision(records, id)?;
+                records.set_attention_revision(&response.request_id, revision)?;
+            }
+            Ok(response)
+        })
+    }
+
+    pub fn get_response(
+        &mut self,
+        request_id: &str,
+    ) -> Result<Option<FinalResponse>, RequestError<R::Error>> {
+        if request_id.is_empty() {
+            return Err(RequestError::Response(ResponseRejection::InputInvalid));
+        }
+        self.read(|records, now| {
+            Ok(records
+                .find_response(request_id)?
+                .filter(|r| now < r.response_expires_at_ms))
+        })
+    }
+}
+
+fn validate_fence<E>(
+    attempt_id: &str,
+    endpoint: &RequestEndpoint,
+    input: &SubmitResponse,
+) -> Result<(), RequestError<E>> {
+    if attempt_id != input.attempt_id {
+        return Err(RequestError::Response(ResponseRejection::AttemptMismatch));
+    }
+    if endpoint != &input.endpoint {
+        return Err(RequestError::Response(ResponseRejection::RecipientMismatch));
+    }
+    Ok(())
+}

--- a/rust/crates/tmt-core/src/retention.rs
+++ b/rust/crates/tmt-core/src/retention.rs
@@ -1,0 +1,111 @@
+//! Frozen Exchange deadlines. Historical migration saturation is intentionally
+//! separate; new runtime arithmetic fails rather than extending an invalid date.
+
+use crate::limits::MAX_JS_SAFE_INTEGER;
+
+pub const DEFAULT_RETENTION_DAYS: u64 = 90;
+pub const MAX_RETENTION_DAYS: u64 = 3650;
+pub const RETENTION_DAY_MS: u64 = 86_400_000;
+pub const RESPONSE_ACCEPTANCE_WINDOW_MS: u64 = 7 * RETENTION_DAY_MS;
+pub const METADATA_SETTLEMENT_FLOOR_MS: u64 = RETENTION_DAY_MS;
+pub const REQUEST_MIN_EXPIRY_MS: u64 = 3_600_000;
+
+pub fn valid_retention_days(days: u64) -> bool {
+    (1..=MAX_RETENTION_DAYS).contains(&days)
+}
+
+pub fn checked_deadline(anchor_ms: u64, delta_ms: u64) -> Option<u64> {
+    if anchor_ms == 0 {
+        return None;
+    }
+    anchor_ms
+        .checked_add(delta_ms)
+        .filter(|value| *value <= MAX_JS_SAFE_INTEGER)
+}
+
+pub fn retention_deadline(anchor_ms: u64, days: u64) -> Option<u64> {
+    valid_retention_days(days)
+        .then(|| days * RETENTION_DAY_MS)
+        .and_then(|delta| checked_deadline(anchor_ms, delta))
+}
+
+/// Avoid adding to historical anchors: the comparison remains meaningful at
+/// the safe-integer ceiling and after wall-clock rollback.
+pub fn response_deadline_passed(now_ms: u64, prepared_ms: u64, expires_ms: u64) -> bool {
+    now_ms >= expires_ms
+        && now_ms
+            .checked_sub(prepared_ms)
+            .is_some_and(|elapsed| elapsed >= RESPONSE_ACCEPTANCE_WINDOW_MS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retention_has_one_settings_owner_and_closed_day_bounds() {
+        use crate::settings::{Scalar, Setting, SettingKey, Settings};
+        assert_eq!(Settings::default().retention_days, DEFAULT_RETENTION_DAYS);
+        for days in [
+            0,
+            1,
+            90,
+            MAX_RETENTION_DAYS,
+            MAX_RETENTION_DAYS + 1,
+            u64::MAX,
+        ] {
+            assert_eq!(
+                valid_retention_days(days),
+                Setting::validate(SettingKey::RetentionDays, Scalar::Number(days as f64)).is_some()
+            );
+        }
+        for value in [-1.0, 1.5, f64::NAN, f64::INFINITY] {
+            assert!(Setting::validate(SettingKey::RetentionDays, Scalar::Number(value)).is_none());
+        }
+    }
+
+    #[test]
+    fn new_deadlines_fail_at_invalid_anchor_or_safe_integer_overflow() {
+        assert_eq!(checked_deadline(1, 0), Some(1));
+        assert_eq!(
+            checked_deadline(MAX_JS_SAFE_INTEGER - 1, 1),
+            Some(MAX_JS_SAFE_INTEGER)
+        );
+        assert_eq!(checked_deadline(MAX_JS_SAFE_INTEGER, 1), None);
+        assert_eq!(checked_deadline(0, 1), None);
+        assert_eq!(checked_deadline(1, u64::MAX), None);
+        assert_eq!(retention_deadline(1, 1), Some(86_400_001));
+        assert_eq!(retention_deadline(1, 3650), Some(315_360_000_001));
+        for days in [0, 3651, u64::MAX] {
+            assert_eq!(retention_deadline(1, days), None);
+        }
+        assert_eq!(
+            retention_deadline(MAX_JS_SAFE_INTEGER - RETENTION_DAY_MS, 1),
+            Some(MAX_JS_SAFE_INTEGER)
+        );
+        assert_eq!(
+            retention_deadline(MAX_JS_SAFE_INTEGER - RETENTION_DAY_MS + 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn acceptance_uses_later_deadline_and_equality_without_overflow() {
+        let prepared = 100;
+        let ordinary = prepared + RESPONSE_ACCEPTANCE_WINDOW_MS;
+        assert!(!response_deadline_passed(ordinary - 1, prepared, 200));
+        assert!(response_deadline_passed(ordinary, prepared, 200));
+        assert!(!response_deadline_passed(ordinary, prepared, ordinary + 1));
+        assert!(response_deadline_passed(
+            ordinary + 1,
+            prepared,
+            ordinary + 1
+        ));
+        assert!(!response_deadline_passed(prepared - 1, prepared, 1));
+        assert!(!response_deadline_passed(
+            MAX_JS_SAFE_INTEGER,
+            MAX_JS_SAFE_INTEGER - 10,
+            MAX_JS_SAFE_INTEGER
+        ));
+    }
+}

--- a/rust/crates/tmt-core/src/settings.rs
+++ b/rust/crates/tmt-core/src/settings.rs
@@ -6,8 +6,7 @@ use crate::limits::{
     is_valid_timer_delay_ms,
 };
 
-pub const DEFAULT_RETENTION_DAYS: u64 = 90;
-pub const MAX_RETENTION_DAYS: u64 = 3650;
+use crate::retention::{DEFAULT_RETENTION_DAYS, MAX_RETENTION_DAYS, valid_retention_days};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Scope {
@@ -213,7 +212,8 @@ impl Setting {
                 Some(Self::PasteEnterDelayMs(value))
             }
             (SettingKey::RetentionDays, Scalar::Number(value))
-                if unsigned_integer(value, MAX_RETENTION_DAYS) && value >= 1.0 =>
+                if unsigned_integer(value, MAX_RETENTION_DAYS)
+                    && valid_retention_days(value as u64) =>
             {
                 Some(Self::RetentionDays(value as u64))
             }

--- a/rust/crates/tmt-core/src/settings_tests.rs
+++ b/rust/crates/tmt-core/src/settings_tests.rs
@@ -1,7 +1,8 @@
 use super::limits::{MAX_CAPTURE_LINES, MAX_JS_SAFE_INTEGER, MAX_TIMER_DELAY_MS};
+use super::retention::DEFAULT_RETENTION_DAYS;
 use super::settings::{
-    DEFAULT_RETENTION_DAYS, EDITABLE_KEYS, LocalClear, PaneBadge, PreambleMode, ResolvedSettings,
-    Scalar, Scope, Setting, SettingKey, Settings,
+    EDITABLE_KEYS, LocalClear, PaneBadge, PreambleMode, ResolvedSettings, Scalar, Scope, Setting,
+    SettingKey, Settings,
 };
 
 #[test]


### PR DESCRIPTION
## Scope

Closes #118. Prerequisite for #106 under native rewrite #93.

Add the internal transactional request/final foundation: preparation, begin-send, settlement, waiter release, exact final submission, context/result reads and bounded cleanup. This does **not** enable public native talk/reply/result, shorten receipts or ship a Rust release.

## Architecture and review

- Core owns lifecycle, validation, revision arithmetic and frozen deadlines. The SQL adapter implements transaction-scoped records using the existing private Storage connection and immediate transaction helper. No new schema, dependency, receipt registry, service container or alternate persistence owner.
- Reuse `ServerEvidence`, safe-integer limits, existing migrations, transaction/error helpers and isolated SQLite fixtures. Settings and request runtime consume one retention policy; historical migration arithmetic remains unchanged.
- Exact bytes and original provenance remain distinct from transport text. First final, completion marker, horizon and attention revision commit together. Rejected submissions do not run housekeeping. Retained retries work without attempt metadata; retirement/name reuse does not redirect them. Reads/retries never renew deadlines or acknowledge attention.
- Primary reviewer: Codex. Reviewed commit: `ad0b67a85cafd3060c695615f42552966c989012`. Personally reviewed every changed file and corresponding TypeScript service/repository contracts, native storage/identity callers, schema constraints and test assertions. Delegated bounded SQL/test work was reviewed and corrected before acceptance.
- Findings corrected: legal scrubbed-prompt markers were initially rejected; row integers needed JavaScript-safe bounds; a rollback test originally failed before entering a transaction; a late-reply fixture was not actually late; concurrent tests needed explicit types and separately opened connections. No findings were waived to obtain green checks.
- Tests use independent SQL for state invariants, injected clocks sampled inside the actual writer lock, real concurrent connections and a failing SQLite trigger for cleanup rollback. Restoring the old scrubbed-prompt bug made its regression test fail; restoring the fix passed.
- Supplemental read-only Luna acceptance audit on the same commit found no further material issues in test wiring, concurrency bounds, rollback/state or retirement evidence. Primary retains architecture and acceptance responsibility.

## Verification

- [x] Primary reviewed every changed file and relevant callers/tests.
- [x] `cargo fmt --all --check`; `cargo clippy --locked --all-targets -- -D warnings`.
- [x] `cargo test --locked --workspace`: 183 passed (109 adapter, 17 CLI, 18 architecture, 39 core).
- [x] `cargo +1.88.0 test --locked --workspace`: the same 183 passed.
- [x] `cargo build --locked --bins --examples`.
- [x] `pnpm check`: type checks, lint, source/test/docs formatting passed.
- [x] `pnpm test:run`: 1,102 tests across 70 files, coverage gate passed.
- [x] Native executable/storage-probe selectors with `pnpm test:native`: 60 passed.
- [x] Existing CI-selected shared parser/config contracts against native executable: 8 + 6 passed; unrelated contracts explicitly filtered, not claimed as native parity.
- [x] Two `pnpm test:e2e` Docker runs: each 132 E2E passed, one opt-in benchmark skipped; adapter suites passed 108 then 109. Both passes use the same production code; the second includes the final added waiter-isolation test. Both wrappers exited 0 and removed their containers/images.
- [x] Current-head CI verified before authorized merge: [run 34177757532](https://github.com/wkh237/tmux-team/actions/runs/34177757532), attempt 1, all 11 jobs succeeded on `ad0b67a85cafd3060c695615f42552966c989012`, including all four protected contexts. No reruns or protection bypass.

## Project lifecycle

ARCHITECTURE.md, DEVELOPMENT.md and RUST-REWRITE.md document the new ownership and explicit public-command deferrals. Installed skill/README remain unchanged because this internal-only slice adds no user-facing command. TypeScript still must not open native schema 9; all tests use isolated task-owned state.

Branch/worktree: `feat/118-native-requests` / `/Users/benhsieh/dev/tmt-118-native-requests`. Issue records scope, review and verification. Remove the worktree only after successful authorized merge and safe handoff. No publication is included.
