### PR TITLE
feat(native): wire bounded reply and result commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1059,7 +1059,8 @@ bounded housekeeping. `RequestRecords` is available only inside the existing
 Storage immediate transaction. The clock is sampled after acquiring that lock;
 the concrete caller supplies attempt IDs and frozen settings before entry.
 There is no service-owned connection, tmux lookup, file input or configuration
-loader. This foundation does not enable public native talk/reply/result yet.
+loader. #122 supplies public native reply/result composition; native talk remains
+unimplemented in this preview.
 
 `core::retention` is the shared settings/runtime owner for day limits and checked
 JavaScript-safe deadlines. Historical migration arithmetic remains frozen.
@@ -1101,8 +1102,36 @@ The reviewed pure SHA-256 dependency is permitted only in core; base64 is
 permitted only in adapters. Existing serde_json handles bounded v1 envelopes,
 not v2 digest serialization. Architecture tests enforce these dependency edges
 with positive and adverse cases. This is local correlation, not remote access
-control. #106 still owns public adapters and installed recipient instructions;
+control. #106 still owns native talk integration and installed recipient instructions;
 #93 retains native message transport integration.
+
+#122 adds `response_command` for public storage-only reply/result. It consumes
+the parser's existing typed invocation and the codec before any input acquisition.
+Inline/file/stdin input completes and validates before ConfigPaths discovery and
+the sole invocation-owned Storage open. Current settings, identity and tmux are
+not consulted. The command injects a UTC millisecond clock sampled by the service
+under its existing transaction. No service policy, SQL or extra connection moves
+into the handler. Reports remain buffered until explicit close; unavailable
+results are primary status-3 failures, so cleanup cannot replace them.
+Shared `output::Failure` carries only optional request-ID/status correlation,
+never bodies, receipts or endpoint evidence. Cleanup failure on success preserves
+the explicit request ID with an effects warning.
+
+`response_input` owns bounded complete acquisition, using the existing core
+exact-text validator. Files use nonblocking open, regular-file verification and
+cap-plus-one reads; explicit symlinks to regular files remain supported. Stdin
+requires EOF under a five-second monotonic deadline and a 1 MiB cap, rejects TTYs,
+and uses safe nix poll/read/fcntl without reader threads or another process runner.
+Inherited open-file flags are restored before returning; normal failure preserves
+its primary cause and any restoration failure. RAII supplies descriptor closure
+and fallback flag restoration, not a substitute for explicit cleanup reporting.
+The CLI owns stdin exclusively during acquisition. Nonblocking flags do not make
+arbitrary kernel/filesystem stalls cancellable; regular-file reads retain the
+existing local-file contract, not a remote-filesystem latency guarantee.
+Darwin's EOPNOTSUPP terminal probe is accepted only after fstat confirms a socket;
+other probe failures stay errors. Public messages remain bounded and exclude paths
+and OS causes. Existing nix adds only fs/poll runtime features; term is test-only
+for an isolated pseudoterminal rejection case, with no new locked packages.
 
 #### Native storage and runtime adapters
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,10 +34,11 @@ pnpm dev -- --help
 The `rust/` workspace is not the installed runtime yet. It implements only
 help/version/completion, typed grammar, the existing `config` command and
 storage-only `identity create/show/list` under #113, and pane identity
-`name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` under #109.
+`name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` under #109, plus storage-only
+`reply`/`result` under #122.
 Other effectful commands still explicitly fail.
 The #118 request/final service is an internal transactional foundation only;
-it does not make public native talk/reply/result available. Its real SQLite
+its public reply/result composition is supplied by #122, not native talk. Its real SQLite
 tests run in ordinary adapter Cargo tests and therefore in the existing Docker
 adapter-test stage. They must verify committed rows independently of service
 reads, since those reads can perform housekeeping. Inject clocks for deadline
@@ -53,6 +54,16 @@ and a TS-generated v1 literal, with independent SQL for retained timestamps,
 attention and no-mutation checks. Compact/recorded writers race through the
 existing bounded connection harness. These remain internal service tests, not
 public native talk/reply/result acceptance.
+#122 adds `test/native/response.test.ts` over the same bounded process sandbox,
+with independent request SQL fixtures and Node-derived receipt proofs. It checks
+real public reply/result outputs, input preflight before storage creation,
+no-tmux/config isolation, retry after attempt removal and a stopped schema-8
+fixture migrated by public native reply. Do not reopen that fixture with TS.
+Adapter tests include exact-byte files, FIFO rejection, socket/pipe EOF, inherited
+flag restoration and an isolated test-only pseudoterminal. The Darwin socket
+case must reproduce the unsupported terminal probe, not weaken the public stdin
+assertion. Keep the real five-second CLI timeout separately from short injected
+adapter deadlines. This is public storage-only acceptance, not native talk.
 The separate storage adapter upgrades historical schemas 0–8 to native schema 9,
 tested through a development-only probe rather than an installed command.
 Use isolated test databases only: installed TypeScript cannot reopen schema 9.
@@ -130,7 +141,7 @@ TMT_TEST_CLI='{"executable":"/absolute/checkout/rust/target/debug/tmt","args":[]
 ```
 
 The selected config cases exercise the original public CLI contract unchanged.
-Other cases in that file still require native list/reply/result implementations;
+Other cases in that file require separately reviewed native behavior/fixtures;
 their exclusion is not parity evidence. The native suite separately exercises
 configuration validation through `config show`, path discovery, scoped edits,
 no-op clear and file preservation, without starting SQLite or tmux.

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -180,10 +180,15 @@ execute original TS-generated v1 receipts against migrated frozen schema-8
 fixtures, including in-flight and orphan finals. This proves service handoff,
 not simultaneous TS/schema-8 access to native/schema-9 state.
 
-Installed TypeScript still emits v1. This slice does not enable public native
-talk/reply/result or change installed skill/help/README instructions. Parent #106
-still owns the public adapters, generated instruction measurements, canonical
-installed guidance and full private-tmux/mock-agent acceptance before cutover.
+Installed TypeScript still emits v1. #122 enables public native preview
+`reply`/`result`, using this codec and the existing service with complete bounded
+input before storage. Both v1 and v2 receipts work without tmux or current config.
+The same submitted/completed/unavailable output and exit contracts apply; a
+stopped schema-8 fixture can migrate through native reply while retaining its v1
+instruction. This is not permission to mix writers after schema-9 migration.
+Native talk is still absent. Parent #106 owns generated instruction measurements,
+canonical installed guidance and full private-tmux/mock-agent acceptance before
+cutover; installed skill/README instructions remain unchanged for now.
 
 ### TMT-39 live durable completion
 

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -5,8 +5,9 @@ and bounded tmux evidence (#105), shared identity records (#111), and
 storage-only identity commands (#113), and pane identity lifecycle (#109)
 are implemented in the development preview, not a shipped Rust runtime.
 #118 adds the internal transactional request/final foundation; #120 adds compact
-receipt encoding and old-v1 decoding through that same service. Public native
-talk/reply/result and the full #106 short-receipt transition remain unimplemented.
+receipt encoding and old-v1 decoding through that same service. #122 adds public
+native reply/result with bounded input. Native talk and the full #106
+short-receipt transition remain unimplemented.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
 The compatibility reference is TypeScript main `cb53533f3a9f19a1a2ab95af59dda20df419200b`
@@ -65,7 +66,8 @@ delegates from native to Node.
 
 The preview implements help, version, Bash/Zsh completion and the existing
 `config` command plus storage-only `identity create/show/list` (#113) and pane
-identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109).
+identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109), plus storage-only
+`reply`/`result` (#122).
 Other recognized effectful commands return
 `NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
 storage, tmux or input acquisition. Text-only commands reject JSON. Native
@@ -250,6 +252,17 @@ RUSTSEC-2017-0004 (patched >=0.5.2); selected versions are patched. This dated
 review is not a permanent security guarantee; repeat when dependencies change.
 
 ### Execution and resource ownership
+
+#122 wires storage-only reply/result after bounded exact-text acquisition. It
+adds fs/poll features to the already locked nix 0.31.3 for safe nonblocking file
+open, descriptor inspection/flag restoration and EOF/deadline polling. These
+features add no packages to Cargo.lock; its published manifest declares MIT and
+Rust 1.69. The term feature is dev-only for a private pseudoterminal test and is
+not required by normal runtime builds. No authored unsafe bindings, reader
+thread, alternate subprocess runner or async framework is added. Existing core
+exact-text validation owns body semantics. Public errors retain internal IO
+causes without printing paths or payloads. See ARCHITECTURE for input ownership
+and Darwin socket-backed stdin handling. Installed TypeScript is unchanged.
 
 #105 implements one Unix runner using `subprocess` 1.2.1 for simultaneous pipe
 communication, `nix` 0.31.3 with only signal/process features for typed OS

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ clap_complete = { version = "=4.6.9", default-features = false }
 serde_json = { version = "=1.0.151", features = ["arbitrary_precision", "preserve_order"] }
 rusqlite = { version = "=0.40.2", default-features = false, features = ["bundled"] }
 subprocess = "=1.2.1"
-nix = { version = "=0.31.3", default-features = false, features = ["signal", "process"] }
+nix = { version = "=0.31.3", default-features = false, features = ["signal", "process", "fs", "poll"] }
 uuid = { version = "=1.26.0", default-features = false, features = ["std"] }
 icu_normalizer = { version = "=2.3.0", default-features = false, features = ["compiled_data"] }
 icu_casemap = { version = "=2.3.0", default-features = false, features = ["compiled_data"] }

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -17,5 +17,8 @@ uuid = { workspace = true, features = ["v4"] }
 subprocess.workspace = true
 nix.workspace = true
 
+[target.'cfg(unix)'.dev-dependencies]
+nix = { workspace = true, features = ["term"] }
+
 [lints]
 workspace = true

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -5,6 +5,8 @@ mod json_document;
 #[cfg(unix)]
 pub mod process;
 pub mod reply_receipt;
+#[cfg(unix)]
+pub mod response_input;
 pub mod storage;
 #[cfg(unix)]
 pub mod tmux;

--- a/rust/crates/tmt-adapters/src/response_input.rs
+++ b/rust/crates/tmt-adapters/src/response_input.rs
@@ -1,0 +1,264 @@
+//! Complete exact-text acquisition before request storage is opened.
+//! Explicit file input is not a filesystem confinement boundary.
+
+use nix::{
+    errno::Errno,
+    fcntl::{FcntlArg, OFlag, fcntl},
+    poll::{PollFd, PollFlags, PollTimeout, poll},
+    sys::stat::{SFlag, fstat},
+    unistd::{isatty, read},
+};
+use std::{
+    error::Error,
+    fmt,
+    fs::OpenOptions,
+    io::{self, Read},
+    os::{fd::AsFd, unix::fs::OpenOptionsExt},
+    path::Path,
+    time::{Duration, Instant},
+};
+use tmt_core::exact_text::{ExactTextError, MAX_EXCHANGE_TEXT_BYTES, validate_exact_text};
+
+const STDIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseInputFailure {
+    Invalid,
+    TooLarge,
+    Timeout,
+    File,
+    Restore,
+}
+
+impl ResponseInputFailure {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::Invalid | Self::Restore => "RESPONSE_INPUT_INVALID",
+            Self::TooLarge => "RESPONSE_INPUT_TOO_LARGE",
+            Self::Timeout => "RESPONSE_INPUT_TIMEOUT",
+            Self::File => "RESPONSE_FILE_ERROR",
+        }
+    }
+}
+
+impl fmt::Display for ResponseInputFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Invalid => "Response input must be complete valid UTF-8 and cannot be a TTY.",
+            Self::TooLarge => "Response body must not exceed 1048576 UTF-8 bytes.",
+            Self::Timeout => "Timed out while reading response input.",
+            Self::File => "Could not read response input file.",
+            Self::Restore => "Could not restore response input descriptor flags.",
+        })
+    }
+}
+#[derive(Debug)]
+pub struct ResponseInputError {
+    pub kind: ResponseInputFailure,
+    pub cleanup_error: Option<io::Error>,
+    cause: Option<io::Error>,
+}
+
+impl ResponseInputError {
+    fn io(kind: ResponseInputFailure, cause: impl Into<io::Error>) -> Self {
+        Self {
+            kind,
+            cause: Some(cause.into()),
+            cleanup_error: None,
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.kind.code()
+    }
+}
+
+impl From<ResponseInputFailure> for ResponseInputError {
+    fn from(kind: ResponseInputFailure) -> Self {
+        Self {
+            kind,
+            cause: None,
+            cleanup_error: None,
+        }
+    }
+}
+
+impl fmt::Display for ResponseInputError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.kind.fmt(f)?;
+        if self.cleanup_error.is_some() {
+            f.write_str(" Input cleanup also failed.")?;
+        }
+        Ok(())
+    }
+}
+
+impl Error for ResponseInputError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause.as_ref().map(|cause| cause as &dyn Error)
+    }
+}
+
+fn decode(bytes: &[u8]) -> Result<String, ResponseInputError> {
+    // Acquisition rejects overflow before decoding, including invalid trailing
+    // bytes. The shared core validator owns exact UTF-8 and body semantics.
+    if bytes.len() > MAX_EXCHANGE_TEXT_BYTES {
+        return Err(ResponseInputFailure::TooLarge.into());
+    }
+    validate_exact_text(bytes)
+        .map(str::to_owned)
+        .map_err(|error| match error {
+            ExactTextError::InvalidUtf8 => ResponseInputFailure::Invalid.into(),
+            ExactTextError::TooLarge => ResponseInputFailure::TooLarge.into(),
+        })
+}
+
+pub fn read_file(path: &Path) -> Result<String, ResponseInputError> {
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(OFlag::O_NONBLOCK.bits())
+        .open(path)
+        .map_err(|cause| ResponseInputError::io(ResponseInputFailure::File, cause))?;
+    if !file
+        .metadata()
+        .map_err(|cause| ResponseInputError::io(ResponseInputFailure::File, cause))?
+        .is_file()
+    {
+        return Err(ResponseInputFailure::File.into());
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_EXCHANGE_TEXT_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|cause| ResponseInputError::io(ResponseInputFailure::File, cause))?;
+    decode(&bytes)
+}
+
+pub fn read_stdin() -> Result<String, ResponseInputError> {
+    read_stream(&io::stdin(), STDIN_TIMEOUT)
+}
+
+// fcntl operates on the inherited open-file description. Restore its exact
+// previous flags before reporting success or failure; never leave a shell pipe
+// nonblocking. The caller must not concurrently read this invocation's stdin.
+struct StreamFlags<'a, F: AsFd> {
+    stream: &'a F,
+    previous: OFlag,
+    restored: bool,
+}
+
+impl<'a, F: AsFd> StreamFlags<'a, F> {
+    fn acquire(stream: &'a F) -> Result<Self, ResponseInputError> {
+        let previous = OFlag::from_bits_retain(
+            fcntl(stream, FcntlArg::F_GETFL)
+                .map_err(|cause| ResponseInputError::io(ResponseInputFailure::Invalid, cause))?,
+        );
+        fcntl(stream, FcntlArg::F_SETFL(previous | OFlag::O_NONBLOCK))
+            .map_err(|cause| ResponseInputError::io(ResponseInputFailure::Invalid, cause))?;
+        Ok(Self {
+            stream,
+            previous,
+            restored: false,
+        })
+    }
+
+    fn restore(&mut self) -> Result<(), ResponseInputError> {
+        fcntl(self.stream, FcntlArg::F_SETFL(self.previous))
+            .map_err(|cause| ResponseInputError::io(ResponseInputFailure::Restore, cause))?;
+        self.restored = true;
+        Ok(())
+    }
+}
+
+impl<F: AsFd> Drop for StreamFlags<'_, F> {
+    fn drop(&mut self) {
+        if !self.restored {
+            let _ = self.restore();
+        }
+    }
+}
+
+fn read_stream(stream: &impl AsFd, timeout: Duration) -> Result<String, ResponseInputError> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(ResponseInputFailure::Invalid)?;
+    let terminal = match isatty(stream) {
+        Ok(terminal) => terminal,
+        // Darwin returns EOPNOTSUPP for a socket-backed child stdin (including
+        // Node's pipe launcher). Confirm the descriptor kind instead of treating
+        // arbitrary terminal-probe failures as usable input.
+        Err(Errno::EOPNOTSUPP) => {
+            let metadata = fstat(stream)
+                .map_err(|cause| ResponseInputError::io(ResponseInputFailure::Invalid, cause))?;
+            if SFlag::from_bits_truncate(metadata.st_mode) & SFlag::S_IFMT != SFlag::S_IFSOCK {
+                return Err(ResponseInputFailure::Invalid.into());
+            }
+            false
+        }
+        Err(cause) => return Err(ResponseInputError::io(ResponseInputFailure::Invalid, cause)),
+    };
+    if timeout.is_zero() || terminal {
+        return Err(ResponseInputFailure::Invalid.into());
+    }
+    let mut flags = StreamFlags::acquire(stream)?;
+    let pending = read_until_eof(stream, deadline);
+    let restored = flags.restore();
+    match pending {
+        Err(mut primary) => {
+            primary.cleanup_error = restored.err().and_then(|error| error.cause);
+            Err(primary)
+        }
+        Ok(body) => restored.map(|()| body),
+    }
+}
+
+fn read_until_eof(stream: &impl AsFd, deadline: Instant) -> Result<String, ResponseInputError> {
+    let mut bytes = Vec::new();
+    let mut chunk = [0; 8192];
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|time| !time.is_zero())
+            .ok_or(ResponseInputFailure::Timeout)?;
+        // Round up to the next millisecond to avoid busy-polling the final
+        // fraction. The monotonic check after every poll/read decides expiry.
+        let timeout =
+            PollTimeout::try_from(remaining.as_millis().saturating_add(1)).map_err(|cause| {
+                ResponseInputError::io(ResponseInputFailure::Invalid, io::Error::other(cause))
+            })?;
+        let mut events = [PollFd::new(stream.as_fd(), PollFlags::POLLIN)];
+        match poll(&mut events, timeout) {
+            Err(Errno::EINTR) => continue,
+            Err(cause) => return Err(ResponseInputError::io(ResponseInputFailure::Invalid, cause)),
+            Ok(_) => {}
+        }
+        if Instant::now() >= deadline {
+            return Err(ResponseInputFailure::Timeout.into());
+        }
+        let ready = events[0].revents().ok_or(ResponseInputFailure::Invalid)?;
+        if ready.intersects(PollFlags::POLLERR | PollFlags::POLLNVAL) {
+            return Err(ResponseInputFailure::Invalid.into());
+        }
+        if !ready.intersects(PollFlags::POLLIN | PollFlags::POLLHUP) {
+            continue;
+        }
+        let capacity = chunk.len().min(MAX_EXCHANGE_TEXT_BYTES + 1 - bytes.len());
+        let count = match read(stream, &mut chunk[..capacity]) {
+            Ok(count) => count,
+            Err(Errno::EINTR | Errno::EAGAIN) => continue,
+            Err(cause) => return Err(ResponseInputError::io(ResponseInputFailure::Invalid, cause)),
+        };
+        if Instant::now() >= deadline {
+            return Err(ResponseInputFailure::Timeout.into());
+        }
+        if count == 0 {
+            return decode(&bytes);
+        }
+        bytes.extend_from_slice(&chunk[..count]);
+        if bytes.len() > MAX_EXCHANGE_TEXT_BYTES {
+            return Err(ResponseInputFailure::TooLarge.into());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-adapters/src/response_input/tests.rs
+++ b/rust/crates/tmt-adapters/src/response_input/tests.rs
@@ -1,0 +1,159 @@
+use super::*;
+use crate::test_support::TestDirectory;
+use nix::{
+    sys::stat::Mode,
+    unistd::{mkfifo, pipe, write},
+};
+use std::{
+    fs::{self, File},
+    os::unix::fs::symlink,
+};
+
+#[test]
+fn regular_files_preserve_exact_text_and_follow_explicit_symlinks() {
+    let directory = TestDirectory::new();
+    let file = directory.path.join("body");
+    let link = directory.path.join("link");
+    symlink(&file, &link).unwrap();
+    for text in ["", "\u{feff}résumé\0\r\n尾\n", "   "] {
+        fs::write(&file, text).unwrap();
+        assert_eq!(file_result(&file).unwrap(), text);
+        assert_eq!(file_result(&link).unwrap(), text);
+    }
+}
+
+#[test]
+fn file_failures_reject_nonregular_input_without_waiting_for_a_fifo_writer() {
+    let directory = TestDirectory::new();
+    let fifo = directory.path.join("fifo");
+    mkfifo(&fifo, Mode::S_IRUSR | Mode::S_IWUSR).unwrap();
+    for file in [directory.path.clone(), directory.path.join("absent"), fifo] {
+        assert_eq!(file_result(&file), Err(ResponseInputFailure::File));
+    }
+}
+
+#[test]
+fn file_and_stdin_share_the_byte_cap_and_strict_decoding() {
+    let directory = TestDirectory::new();
+    let file = directory.path.join("body");
+    for (bytes, expected) in [
+        (vec![b'x'; MAX_EXCHANGE_TEXT_BYTES], None),
+        (
+            vec![b'x'; MAX_EXCHANGE_TEXT_BYTES + 1],
+            Some(ResponseInputFailure::TooLarge),
+        ),
+        (vec![0xef, 0xbb], Some(ResponseInputFailure::Invalid)),
+        (vec![0xed, 0xa0, 0x80], Some(ResponseInputFailure::Invalid)),
+    ] {
+        fs::write(&file, &bytes).unwrap();
+        let stream = File::open(&file).unwrap();
+        let flags = fcntl(&stream, FcntlArg::F_GETFL).unwrap();
+        for result in [
+            file_result(&file),
+            stream_result(&stream, Duration::from_secs(2)),
+        ] {
+            match expected {
+                Some(error) => assert_eq!(result, Err(error)),
+                None => assert_eq!(result.unwrap().as_bytes(), bytes),
+            }
+        }
+        assert_eq!(fcntl(&stream, FcntlArg::F_GETFL).unwrap(), flags);
+    }
+}
+
+#[test]
+fn pipe_requires_eof_and_restores_flags_after_success_and_invalid_utf8() {
+    for (bytes, expected) in [
+        (b"".as_slice(), Ok("")),
+        (
+            b"\xef\xbb\xbfbody\0\r\n".as_slice(),
+            Ok("\u{feff}body\0\r\n"),
+        ),
+        (b"\xff".as_slice(), Err(ResponseInputFailure::Invalid)),
+    ] {
+        let (reader, writer) = pipe().unwrap();
+        let flags = fcntl(&reader, FcntlArg::F_GETFL).unwrap();
+        for byte in bytes {
+            assert_eq!(write(&writer, &[*byte]).unwrap(), 1);
+        }
+        drop(writer);
+        assert_eq!(
+            stream_result(&reader, Duration::from_secs(1))
+                .as_deref()
+                .map_err(|error| *error),
+            expected
+        );
+        assert_eq!(fcntl(&reader, FcntlArg::F_GETFL).unwrap(), flags);
+    }
+}
+
+#[test]
+fn missing_eof_discards_partial_input_and_restores_both_initial_flag_modes() {
+    for nonblocking in [false, true] {
+        let (reader, writer) = pipe().unwrap();
+        if nonblocking {
+            let flags = OFlag::from_bits_retain(fcntl(&reader, FcntlArg::F_GETFL).unwrap());
+            fcntl(&reader, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK)).unwrap();
+        }
+        let flags = fcntl(&reader, FcntlArg::F_GETFL).unwrap();
+        write(&writer, b"partial").unwrap();
+        let before = Instant::now();
+        assert_eq!(
+            stream_result(&reader, Duration::from_millis(20)),
+            Err(ResponseInputFailure::Timeout)
+        );
+        assert!(before.elapsed() < Duration::from_secs(1));
+        assert_eq!(fcntl(&reader, FcntlArg::F_GETFL).unwrap(), flags);
+        // Still-open writer proves timeout was not an accidental EOF success.
+        write(&writer, b"still open").unwrap();
+    }
+}
+
+#[test]
+fn invalid_deadline_does_not_modify_the_descriptor() {
+    let (reader, _writer) = pipe().unwrap();
+    let flags = fcntl(&reader, FcntlArg::F_GETFL).unwrap();
+    assert_eq!(
+        stream_result(&reader, Duration::ZERO),
+        Err(ResponseInputFailure::Invalid)
+    );
+    assert_eq!(fcntl(&reader, FcntlArg::F_GETFL).unwrap(), flags);
+}
+
+#[test]
+fn socket_backed_stdin_accepts_eof_from_a_process_launcher() {
+    use std::{io::Write, net::Shutdown, os::unix::net::UnixStream};
+    let (reader, mut writer) = UnixStream::pair().unwrap();
+    writer.write_all(b"socket body").unwrap();
+    writer.shutdown(Shutdown::Write).unwrap();
+    assert_eq!(
+        stream_result(&reader, Duration::from_secs(1)).unwrap(),
+        "socket body"
+    );
+}
+
+fn file_result(path: &Path) -> Result<String, ResponseInputFailure> {
+    super::read_file(path).map_err(|error| error.kind)
+}
+fn stream_result(stream: &impl AsFd, timeout: Duration) -> Result<String, ResponseInputFailure> {
+    super::read_stream(stream, timeout).map_err(|error| error.kind)
+}
+#[test]
+fn file_failure_preserves_the_os_cause_without_exposing_the_path() {
+    let directory = TestDirectory::new();
+    let error = super::read_file(&directory.path.join("private-missing-body")).unwrap_err();
+    assert_eq!(error.kind, ResponseInputFailure::File);
+    assert!(error.source().is_some());
+    assert!(!error.to_string().contains("private-missing-body"));
+}
+
+#[test]
+fn terminal_input_is_rejected_before_flags_change() {
+    let terminal = nix::pty::openpty(None, None).unwrap();
+    let before = fcntl(&terminal.slave, FcntlArg::F_GETFL).unwrap();
+    assert_eq!(
+        stream_result(&terminal.slave, Duration::from_secs(1)),
+        Err(ResponseInputFailure::Invalid)
+    );
+    assert_eq!(fcntl(&terminal.slave, FcntlArg::F_GETFL).unwrap(), before);
+}

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -6,6 +6,7 @@ mod identity_command;
 mod invocation;
 mod output;
 mod parser;
+mod response_command;
 
 use std::io::{self, Write};
 use std::process::ExitCode;
@@ -34,7 +35,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration, storage-only identity create/show/list, and pane identity name/this/add/whoami/unbind/rm/list are available. Transport commands are not implemented yet. Use isolated test state only.\n"
+                "Native development preview: configuration, storage-only identity create/show/list and reply/result, and pane identity name/this/add/whoami/unbind/rm/list are available. Transport commands are not implemented yet. Use isolated test state only.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -67,6 +68,10 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Identity(request) => {
             drop(stdout);
             return identity_command::execute(request, parsed.mode);
+        }
+        request @ (Invocation::Reply { .. } | Invocation::Result { .. }) => {
+            drop(stdout);
+            return response_command::execute(request, parsed.mode);
         }
         request @ (Invocation::Bind { .. }
         | Invocation::Whoami

--- a/rust/crates/tmt-cli/src/output.rs
+++ b/rust/crates/tmt-cli/src/output.rs
@@ -14,6 +14,7 @@ pub struct Failure {
     pub status: u8,
     cause: Option<Box<dyn Error>>,
     suggestion: Option<String>,
+    request: Option<Box<(String, Option<&'static str>)>>,
 }
 
 impl Failure {
@@ -24,6 +25,7 @@ impl Failure {
             status,
             cause: None,
             suggestion: None,
+            request: None,
         }
     }
 
@@ -37,12 +39,26 @@ impl Failure {
         self
     }
 
+    /// Only explicit public correlation is carried into an error document;
+    /// bodies, receipt proofs and endpoint evidence are never included.
+    pub fn with_request(mut self, request_id: String, status: Option<&'static str>) -> Self {
+        self.request = Some(Box::new((request_id, status)));
+        self
+    }
+
     pub fn publish(&self, mode: OutputMode) -> io::Result<u8> {
         if mode.json {
             let mut document =
                 serde_json::json!({"error": {"code": self.code, "message": self.message}});
             if let Some(suggestion) = &self.suggestion {
                 document["error"]["suggestion"] = suggestion.clone().into();
+            }
+            if let Some(request) = &self.request {
+                let (request_id, status) = request.as_ref();
+                document["requestId"] = request_id.clone().into();
+                if let Some(status) = status {
+                    document["status"] = (*status).into();
+                }
             }
             writeln!(io::stdout().lock(), "{document}")?;
         } else {

--- a/rust/crates/tmt-cli/src/response_command.rs
+++ b/rust/crates/tmt-cli/src/response_command.rs
@@ -1,0 +1,188 @@
+//! Storage-only public response composition. Wire/input acquisition completes
+//! before storage; all final-response decisions remain in RequestService.
+
+use crate::{
+    invocation::{ContentInput, Invocation, OutputMode},
+    output::{Failure, after_cleanup},
+};
+use serde_json::json;
+use std::{
+    error::Error,
+    io::{self, Write},
+    path::Path,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tmt_adapters::{
+    config::ConfigPaths,
+    reply_receipt::decode_reply_receipt,
+    response_input::{ResponseInputError, ResponseInputFailure, read_file, read_stdin},
+    storage::{Storage, StorageError},
+};
+use tmt_core::{
+    exact_text::{MAX_EXCHANGE_TEXT_BYTES, validate_exact_text},
+    request::{FinalResponse, RequestError, RequestService, ResponseRejection, SubmitResponse},
+};
+
+enum Report {
+    Submitted(FinalResponse),
+    Completed(FinalResponse),
+}
+
+fn unavailable(error: impl Error + 'static) -> Failure {
+    Failure::new(
+        "RESPONSE_ERROR",
+        "Could not complete the response operation.",
+        1,
+    )
+    .caused_by(error)
+}
+
+fn input_failure(error: ResponseInputError) -> Failure {
+    let status = if error.kind == ResponseInputFailure::Timeout {
+        4
+    } else {
+        1
+    };
+    Failure::new(error.code(), error.to_string(), status).caused_by(error)
+}
+
+fn response_failure(error: RequestError<StorageError>) -> Failure {
+    let RequestError::Response(reason) = &error else {
+        return unavailable(error);
+    };
+    let (status, message) = match reason {
+        ResponseRejection::InputInvalid => (1, "Response input is invalid."),
+        ResponseRejection::InputTooLarge => (1, "Response body exceeds the UTF-8 byte limit."),
+        ResponseRejection::RequestNotFound => (3, "Request was not found."),
+        ResponseRejection::AttemptMismatch => (1, "Response attempt does not match the request."),
+        ResponseRejection::RecipientMismatch => {
+            (1, "Response does not match the original recipient.")
+        }
+        ResponseRejection::ReceiptMismatch => (1, "Response receipt does not match the request."),
+        ResponseRejection::StateInvalid => (
+            1,
+            "Final response cannot be accepted in the current request state.",
+        ),
+        ResponseRejection::Conflict => (5, "Request already has a different final response."),
+        ResponseRejection::Expired => (
+            1,
+            "Final response can no longer be accepted or is no longer retained.",
+        ),
+    };
+    Failure::new(reason.code(), message, status).caused_by(error)
+}
+
+fn body(input: ContentInput) -> Result<String, Failure> {
+    match input {
+        ContentInput::Inline(text) => {
+            validate_exact_text(text.as_bytes()).map_err(|_| {
+                Failure::new(
+                    "RESPONSE_INPUT_TOO_LARGE",
+                    format!("Response body must not exceed {MAX_EXCHANGE_TEXT_BYTES} UTF-8 bytes."),
+                    1,
+                )
+            })?;
+            Ok(text)
+        }
+        ContentInput::File(path) => read_file(Path::new(&path)).map_err(input_failure),
+        ContentInput::Stdin => read_stdin().map_err(input_failure),
+    }
+}
+
+fn run(request: Invocation) -> Result<Report, Failure> {
+    // A prepared input is not a parallel service request: use the core owner.
+    let (request_id, submission) = match request {
+        Invocation::Reply {
+            request_id,
+            receipt,
+            input,
+        } => {
+            let proof = decode_reply_receipt(&receipt, &request_id).map_err(|error| {
+                Failure::new(error.code(), error.to_string(), 1).caused_by(error)
+            })?;
+            let body = body(input)?;
+            let input = SubmitResponse {
+                request_id: request_id.clone(),
+                proof,
+                body,
+            };
+            (request_id, Some(input))
+        }
+        Invocation::Result { request_id } => (request_id, None),
+        _ => unreachable!("response dispatch only accepts reply/result"),
+    };
+    let paths = ConfigPaths::discover().map_err(unavailable)?;
+    let mut storage = Storage::open(paths.database).map_err(unavailable)?;
+    // Invalid clocks fail closed through the service's safe-integer validation.
+    // Sample inside its transaction, not once before acquiring the writer lock.
+    let mut service = RequestService::new(&mut storage, || {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .and_then(|time| u64::try_from(time.as_millis()).ok())
+            .unwrap_or(0)
+    });
+    let pending = match submission {
+        Some(input) => service
+            .submit_response(input)
+            .map(Report::Submitted)
+            .map_err(response_failure),
+        None => service
+            .get_response(&request_id)
+            .map_err(response_failure)
+            .and_then(|record| {
+                record.map(Report::Completed).ok_or_else(|| {
+                    Failure::new(
+                        "RESPONSE_NOT_AVAILABLE",
+                        format!("Response for request '{request_id}' is not available."),
+                        3,
+                    )
+                    .with_request(request_id.clone(), Some("unavailable"))
+                })
+            }),
+    };
+    after_cleanup(pending, || storage.close()).map_err(|error| {
+        if error.code == "CLEANUP_ERROR" {
+            error.with_request(request_id, None)
+        } else {
+            error
+        }
+    })
+}
+
+pub fn execute(request: Invocation, mode: OutputMode) -> io::Result<u8> {
+    let report = match run(request) {
+        Ok(report) => report,
+        Err(error) => return error.publish(mode),
+    };
+    let mut stdout = io::stdout().lock();
+    match report {
+        Report::Submitted(record) if mode.json => writeln!(
+            stdout,
+            "{}",
+            json!({
+                "status": "submitted", "requestId": record.request_id,
+                "bodyBytes": record.body_bytes, "submittedAtMs": record.submitted_at_ms
+            })
+        )?,
+        Report::Completed(record) if mode.json => writeln!(
+            stdout,
+            "{}",
+            json!({
+                "status": "completed", "requestId": record.request_id, "response": record.body,
+                "bodyBytes": record.body_bytes, "submittedAtMs": record.submitted_at_ms
+            })
+        )?,
+        Report::Submitted(record) => writeln!(
+            stdout,
+            "Submitted response for request '{}' ({} bytes).",
+            record.request_id, record.body_bytes
+        )?,
+        Report::Completed(record) => writeln!(
+            stdout,
+            "Response for request '{}':\n{}",
+            record.request_id, record.body
+        )?,
+    }
+    Ok(0)
+}

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -62,7 +62,7 @@ describe('native grammar preview process contract', () => {
       expect(help.stderr).toBe('');
       expect(help.stdout).toContain('Native development preview');
       expect(help.stdout).toContain(
-        'configuration, storage-only identity create/show/list, and pane identity name/this/add/whoami/unbind/rm/list are available'
+        'configuration, storage-only identity create/show/list and reply/result, and pane identity name/this/add/whoami/unbind/rm/list are available'
       );
       expect(help.stdout).toContain('Transport commands are not implemented yet.');
       expect(help.stdout).toContain('Manage identity records without probing tmux');
@@ -85,8 +85,6 @@ describe('native grammar preview process contract', () => {
         ['role', 'show'],
         ['preamble'],
         ['x', 'ackall'],
-        ['reply', 'request', '--receipt', 'literal', '--message', 'done'],
-        ['result', 'request'],
         ['install', '--dir', sandbox.cwd],
       ]) {
         const result = await runCli(sandbox, [...args, '--json']);

--- a/test/native/response-fixture.ts
+++ b/test/native/response-fixture.ts
@@ -1,0 +1,202 @@
+import crypto from 'node:crypto';
+import Database from 'better-sqlite3';
+
+export const MAX_RESPONSE_BYTES = 1_048_576;
+export const RESPONSE_SERVER = {
+  serverId: 'native-response-server',
+  socketPath: '/tmp/native-response.sock',
+  serverPid: 1234,
+  serverStartTime: 'native-response-start',
+  paneId: '%1',
+  panePid: 5678,
+} as const;
+
+const DAY_MS = 86_400_000;
+
+export interface SeededResponse {
+  readonly requestId: string;
+  readonly attemptId: string;
+  readonly preparedAtMs: number;
+  readonly v1Receipt: string;
+  readonly compactReceipt: string;
+}
+
+export interface SeedResponseOptions {
+  readonly nowMs?: number;
+  readonly status?: 'prepared' | 'sent';
+  readonly expired?: boolean;
+}
+
+function appendString(parts: Buffer[], value: string): void {
+  const bytes = Buffer.from(value, 'utf8');
+  const length = Buffer.alloc(8);
+  length.writeBigUInt64BE(BigInt(bytes.byteLength));
+  parts.push(length, bytes);
+}
+
+/** Independently derive the native compact receipt protocol. */
+export function compactReceipt(
+  requestId: string,
+  attemptId: string,
+  endpoint: typeof RESPONSE_SERVER = RESPONSE_SERVER
+): string {
+  const parts = [Buffer.from('tmux-team/reply-receipt/v2\0', 'utf8')];
+  appendString(parts, requestId);
+  appendString(parts, attemptId);
+  appendString(parts, endpoint.serverId);
+  appendString(parts, endpoint.socketPath);
+  const serverPid = Buffer.alloc(8);
+  serverPid.writeBigUInt64BE(BigInt(endpoint.serverPid));
+  parts.push(serverPid);
+  appendString(parts, endpoint.serverStartTime);
+  appendString(parts, endpoint.paneId);
+  const panePid = Buffer.alloc(8);
+  panePid.writeBigUInt64BE(BigInt(endpoint.panePid));
+  parts.push(panePid);
+  return `v2_${crypto.createHash('sha256').update(Buffer.concat(parts)).digest().subarray(0, 16).toString('base64url')}`;
+}
+
+/** Produce the installed TypeScript receipt envelope without importing its codec. */
+export function v1Receipt(
+  requestId: string,
+  attemptId: string,
+  endpoint: typeof RESPONSE_SERVER = RESPONSE_SERVER
+): string {
+  return Buffer.from(
+    JSON.stringify({
+      version: 1,
+      requestId,
+      attemptId,
+      endpoint,
+    }),
+    'utf8'
+  ).toString('base64url');
+}
+
+function withDatabase<T>(
+  file: string,
+  callback: (database: Database.Database) => T,
+  readonly = false
+): T {
+  const database = new Database(file, { readonly });
+  try {
+    database.pragma('foreign_keys = ON');
+    return callback(database);
+  } finally {
+    database.close();
+  }
+}
+
+export function seedResponse(
+  file: string,
+  requestId: string,
+  options: SeedResponseOptions = {}
+): SeededResponse {
+  const nowMs = options.nowMs ?? Date.now();
+  // The native service only rejects an expired attempt after the frozen
+  // seven-day acceptance window has elapsed. Keep the row retained while
+  // moving its prepared/deadline timestamps far enough into the past.
+  const preparedAtMs = options.expired ? nowMs - 8 * DAY_MS : nowMs;
+  const attemptId = `attempt-${requestId}`;
+  const expiresAtMs = options.expired ? preparedAtMs - 1 : preparedAtMs + 60 * 60 * 1000;
+  const retentionExpiresAtMs = nowMs + 7 * DAY_MS;
+  const status = options.status ?? 'sent';
+  withDatabase(file, (database) => {
+    database
+      .prepare(
+        `INSERT INTO request_attempts (
+           attempt_id, request_id, nonce, identity_id, server_id, socket_path,
+           server_pid, server_start_time, pane_id, pane_pid, wait_active, status,
+           preamble_every, inject_preamble, cadence_reserved, prepared_at_ms,
+           sending_at_ms, settled_at_ms, wait_released_at_ms, response_submitted_at_ms,
+           expires_at_ms, retention_days, retention_expires_at_ms, originator_kind,
+           originator_identity_id, recipient_identity_id, message_text, message_bytes,
+           message_expires_at_ms, attention_revision, attention_acknowledged_revision
+         ) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 0, 0, ?, ?, ?, NULL, NULL,
+                   ?, 7, ?, 'unknown', NULL, NULL, ?, ?, ?, 0, 0)`
+      )
+      .run(
+        attemptId,
+        requestId,
+        `nonce-${requestId}`,
+        RESPONSE_SERVER.serverId,
+        RESPONSE_SERVER.socketPath,
+        RESPONSE_SERVER.serverPid,
+        RESPONSE_SERVER.serverStartTime,
+        RESPONSE_SERVER.paneId,
+        RESPONSE_SERVER.panePid,
+        status === 'sent' ? 0 : 1,
+        status,
+        preparedAtMs,
+        status === 'prepared' ? null : preparedAtMs + 1,
+        status === 'prepared' ? null : preparedAtMs + 2,
+        expiresAtMs,
+        retentionExpiresAtMs,
+        `prompt for ${requestId}`,
+        Buffer.byteLength(`prompt for ${requestId}`),
+        retentionExpiresAtMs
+      );
+  });
+  return {
+    requestId,
+    attemptId,
+    preparedAtMs,
+    v1Receipt: v1Receipt(requestId, attemptId),
+    compactReceipt: compactReceipt(requestId, attemptId),
+  };
+}
+
+export function schemaVersion(file: string): number {
+  return withDatabase(
+    file,
+    (database) => {
+      const row = database
+        .prepare('SELECT COALESCE(MAX(version), 0) AS version FROM _migrations')
+        .get() as { version: number };
+      return row.version;
+    },
+    true
+  );
+}
+
+export function removeAttempt(file: string, requestId: string): void {
+  withDatabase(file, (database) => {
+    const result = database
+      .prepare('DELETE FROM request_attempts WHERE request_id = ?')
+      .run(requestId);
+    if (result.changes !== 1) throw new Error('Expected exactly one retained attempt to remove.');
+  });
+}
+
+export function responseSnapshot(
+  file: string,
+  requestId: string
+): {
+  readonly attempt: Record<string, unknown> | undefined;
+  readonly response: Record<string, unknown> | undefined;
+} {
+  return withDatabase(
+    file,
+    (database) => ({
+      attempt: database
+        .prepare(
+          `SELECT request_id, attempt_id, status, wait_active, preamble_every,
+                inject_preamble, cadence_reserved, prepared_at_ms, sending_at_ms,
+                settled_at_ms, wait_released_at_ms, response_submitted_at_ms,
+                expires_at_ms, retention_days, retention_expires_at_ms,
+                attention_revision, attention_acknowledged_revision,
+                message_text, message_bytes, message_expires_at_ms
+           FROM request_attempts WHERE request_id = ?`
+        )
+        .get(requestId) as Record<string, unknown> | undefined,
+      response: database
+        .prepare(
+          `SELECT request_id, attempt_id, body, body_bytes, submitted_at_ms,
+                response_expires_at_ms
+           FROM request_responses WHERE request_id = ?`
+        )
+        .get(requestId) as Record<string, unknown> | undefined,
+    }),
+    true
+  );
+}

--- a/test/native/response.test.ts
+++ b/test/native/response.test.ts
@@ -1,0 +1,551 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  expectJsonSuccess,
+  initializeDatabase,
+  parseWholeStdout,
+  runCli,
+  type Sandbox,
+  withSandbox,
+} from '../../src/test-support/cli-process.js';
+import {
+  MAX_RESPONSE_BYTES,
+  responseSnapshot,
+  removeAttempt,
+  seedResponse,
+  schemaVersion,
+  v1Receipt,
+  type SeededResponse,
+} from './response-fixture.js';
+
+if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
+
+async function initializeSchema(sandbox: Sandbox): Promise<void> {
+  expectJsonSuccess(await runCli(sandbox, ['identity', 'list', '--json']), { identities: [] });
+  expect(existsSync(sandbox.database)).toBe(true);
+}
+
+function temporaryFile(sandbox: Sandbox, name: string, bytes: string | Uint8Array): string {
+  const file = path.join(sandbox.root, name);
+  writeFileSync(file, bytes);
+  return file;
+}
+
+function installTmuxTripwire(sandbox: Sandbox): string {
+  const directory = path.join(sandbox.root, 'tripwire-bin');
+  const logPath = path.join(sandbox.root, 'tmux-invocations.log');
+  mkdirSync(directory);
+  const executable = path.join(directory, 'tmux');
+  writeFileSync(
+    executable,
+    '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TMT_NATIVE_RESPONSE_TMUX_LOG"\nexit 97\n'
+  );
+  chmodSync(executable, 0o755);
+  sandbox.env.PATH = `${directory}${path.delimiter}${process.env.PATH ?? ''}`;
+  sandbox.env.TMT_NATIVE_RESPONSE_TMUX_LOG = logPath;
+  return logPath;
+}
+
+function malformedConfig(sandbox: Sandbox): void {
+  mkdirSync(sandbox.globalDir, { recursive: true });
+  writeFileSync(sandbox.globalConfig, '{ malformed global config');
+  writeFileSync(sandbox.localConfig, '{ malformed local config');
+}
+
+function assertSubmitted(
+  result: Awaited<ReturnType<typeof runCli>>,
+  seeded: SeededResponse,
+  expectedBodyBytes?: number
+): {
+  readonly submittedAtMs: number;
+} {
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe('');
+  const document = parseWholeStdout(result) as Record<string, unknown>;
+  expect(document).toMatchObject({
+    status: 'submitted',
+    requestId: seeded.requestId,
+    bodyBytes: expect.any(Number),
+    submittedAtMs: expect.any(Number),
+  });
+  expect(Object.keys(document).sort()).toEqual([
+    'bodyBytes',
+    'requestId',
+    'status',
+    'submittedAtMs',
+  ]);
+  if (expectedBodyBytes !== undefined) expect(document.bodyBytes).toBe(expectedBodyBytes);
+  return { submittedAtMs: document.submittedAtMs as number };
+}
+
+function assertCompleted(
+  result: Awaited<ReturnType<typeof runCli>>,
+  seeded: SeededResponse,
+  body: string,
+  submittedAtMs?: number
+): void {
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe('');
+  const document = parseWholeStdout(result) as Record<string, unknown>;
+  expect(document).toMatchObject({
+    status: 'completed',
+    requestId: seeded.requestId,
+    response: body,
+    bodyBytes: Buffer.byteLength(body),
+    submittedAtMs: submittedAtMs ?? expect.any(Number),
+  });
+  expect(Object.keys(document).sort()).toEqual([
+    'bodyBytes',
+    'requestId',
+    'response',
+    'status',
+    'submittedAtMs',
+  ]);
+}
+
+describe('native reply/result process contract', () => {
+  it(
+    'submits exact file, stdin, and empty inline bodies and retrieves each result',
+    { timeout: 30_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        await initializeSchema(sandbox);
+        const fileBody = '\ufefffile\r\n\u0000日本語 😀\r\nRESPONSE-END-fake\n  ';
+        const file = temporaryFile(sandbox, 'response.txt', Buffer.from(fileBody, 'utf8'));
+        const fileSeed = seedResponse(sandbox.database, 'native-file');
+        const fileResult = await runCli(sandbox, [
+          'reply',
+          fileSeed.requestId,
+          '--receipt',
+          fileSeed.v1Receipt,
+          '--file',
+          file,
+          '--json',
+        ]);
+        const fileSubmission = assertSubmitted(fileResult, fileSeed);
+        expect(parseWholeStdout(fileResult)).toMatchObject({
+          bodyBytes: Buffer.byteLength(fileBody),
+        });
+        const fileRetrieved = await runCli(sandbox, ['result', fileSeed.requestId, '--json'], {
+          outputLimitBytes: 2 * 1024 * 1024,
+        });
+        expectJsonSuccess(fileRetrieved, {
+          status: 'completed',
+          requestId: fileSeed.requestId,
+          response: fileBody,
+          bodyBytes: Buffer.byteLength(fileBody),
+          submittedAtMs: fileSubmission.submittedAtMs,
+        });
+
+        const stdinBody = '\ufeffstdin\r\n\u0000日本語 😀\n';
+        const stdinSeed = seedResponse(sandbox.database, 'native-stdin');
+        const stdinResult = await runCli(
+          sandbox,
+          [
+            'reply',
+            stdinSeed.requestId,
+            '--receipt',
+            stdinSeed.compactReceipt,
+            '--stdin',
+            '--json',
+          ],
+          { stdin: Buffer.from(stdinBody, 'utf8'), outputLimitBytes: 2 * 1024 * 1024 }
+        );
+        const stdinSubmission = assertSubmitted(
+          stdinResult,
+          stdinSeed,
+          Buffer.byteLength(stdinBody)
+        );
+        const stdinRetrieved = await runCli(sandbox, ['result', stdinSeed.requestId, '--json']);
+        assertCompleted(stdinRetrieved, stdinSeed, stdinBody, stdinSubmission.submittedAtMs);
+
+        const emptySeed = seedResponse(sandbox.database, 'native-empty');
+        const emptyResult = await runCli(sandbox, [
+          'reply',
+          emptySeed.requestId,
+          '--receipt',
+          emptySeed.compactReceipt,
+          '--message',
+          '',
+          '--json',
+        ]);
+        const emptySubmission = assertSubmitted(emptyResult, emptySeed);
+        assertCompleted(
+          await runCli(sandbox, ['result', emptySeed.requestId, '--json']),
+          emptySeed,
+          '',
+          emptySubmission.submittedAtMs
+        );
+      })
+  );
+
+  it('accepts the one-megabyte stdin boundary without truncation', { timeout: 30_000 }, async () =>
+    withSandbox(async (sandbox) => {
+      await initializeSchema(sandbox);
+      const seeded = seedResponse(sandbox.database, 'native-one-megabyte');
+      const body = 'a'.repeat(MAX_RESPONSE_BYTES);
+      const submitted = await runCli(
+        sandbox,
+        ['reply', seeded.requestId, '--receipt', seeded.compactReceipt, '--stdin', '--json'],
+        { stdin: Buffer.from(body, 'utf8'), outputLimitBytes: 2 * 1024 * 1024 }
+      );
+      const submission = assertSubmitted(submitted, seeded, MAX_RESPONSE_BYTES);
+      const result = await runCli(sandbox, ['result', seeded.requestId, '--json'], {
+        outputLimitBytes: 2 * 1024 * 1024,
+      });
+      assertCompleted(result, seeded, body, submission.submittedAtMs);
+    })
+  );
+
+  it(
+    'keeps identical retries immutable and rejects conflicting bodies without mutation',
+    { timeout: 30_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        await initializeSchema(sandbox);
+        const seeded = seedResponse(sandbox.database, 'native-retry');
+        const firstBody = 'original\r\n日本語';
+        const first = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          seeded.v1Receipt,
+          '--message',
+          firstBody,
+          '--json',
+        ]);
+        const firstDocument = assertSubmitted(first, seeded);
+        const beforeConflict = responseSnapshot(sandbox.database, seeded.requestId);
+        const retry = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          seeded.compactReceipt,
+          '--message',
+          firstBody,
+          '--json',
+        ]);
+        assertSubmitted(retry, seeded, Buffer.byteLength(firstBody));
+        expect(parseWholeStdout(retry)).toMatchObject({
+          status: 'submitted',
+          requestId: seeded.requestId,
+          bodyBytes: Buffer.byteLength(firstBody),
+          submittedAtMs: firstDocument.submittedAtMs,
+        });
+        const rejected = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          seeded.compactReceipt,
+          '--message',
+          'different body',
+          '--json',
+        ]);
+        expect(rejected.status).toBe(5);
+        expectError(rejected, 'RESPONSE_CONFLICT');
+        expect(responseSnapshot(sandbox.database, seeded.requestId)).toEqual(beforeConflict);
+        removeAttempt(sandbox.database, seeded.requestId);
+        const orphanRetry = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          seeded.compactReceipt,
+          '--message',
+          firstBody,
+          '--json',
+        ]);
+        expect(assertSubmitted(orphanRetry, seeded).submittedAtMs).toBe(
+          firstDocument.submittedAtMs
+        );
+        expect(responseSnapshot(sandbox.database, seeded.requestId)).toEqual({
+          attempt: undefined,
+          response: beforeConflict.response,
+        });
+        expectJsonSuccess(await runCli(sandbox, ['result', seeded.requestId, '--json']), {
+          status: 'completed',
+          requestId: seeded.requestId,
+          response: firstBody,
+          bodyBytes: Buffer.byteLength(firstBody),
+          submittedAtMs: firstDocument.submittedAtMs,
+        });
+      })
+  );
+
+  it(
+    'keeps storage-only reply/result independent from malformed config and tmux',
+    { timeout: 30_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        await initializeSchema(sandbox);
+        malformedConfig(sandbox);
+        const tmuxLog = installTmuxTripwire(sandbox);
+        const seeded = seedResponse(sandbox.database, 'native-storage-only');
+        const body = 'storage-only exact result';
+        const submitted = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          seeded.compactReceipt,
+          '--message',
+          body,
+          '--json',
+        ]);
+        expect(submitted.status).toBe(0);
+        expectJsonSuccess(await runCli(sandbox, ['result', seeded.requestId, '--json']), {
+          status: 'completed',
+          requestId: seeded.requestId,
+          response: body,
+          bodyBytes: Buffer.byteLength(body),
+          submittedAtMs: (parseWholeStdout(submitted) as { submittedAtMs: number }).submittedAtMs,
+        });
+        expect(existsSync(tmuxLog)).toBe(false);
+        expect(readFileSync(sandbox.globalConfig, 'utf8')).toBe('{ malformed global config');
+        expect(readFileSync(sandbox.localConfig, 'utf8')).toBe('{ malformed local config');
+      })
+  );
+
+  it('opens a stopped schema8 database through the native public reply path', async () =>
+    withSandbox(async (sandbox) => {
+      initializeDatabase(sandbox);
+      expect(schemaVersion(sandbox.database)).toBe(8);
+      const seeded = seedResponse(sandbox.database, 'native-schema8-reply');
+      const body = 'schema8 migration exact body';
+      const submitted = await runCli(sandbox, [
+        'reply',
+        seeded.requestId,
+        '--receipt',
+        seeded.v1Receipt,
+        '--message',
+        body,
+        '--json',
+      ]);
+      const submission = assertSubmitted(submitted, seeded, Buffer.byteLength(body));
+      assertCompleted(
+        await runCli(sandbox, ['result', seeded.requestId, '--json']),
+        seeded,
+        body,
+        submission.submittedAtMs
+      );
+      expect(schemaVersion(sandbox.database)).toBe(9);
+    }));
+
+  it(
+    'reports unavailable results and sanitized errors for unknown, pending, and expired requests',
+    { timeout: 30_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        await initializeSchema(sandbox);
+        const pending = seedResponse(sandbox.database, 'native-pending', { status: 'prepared' });
+        const expired = seedResponse(sandbox.database, 'native-expired', { expired: true });
+        for (const requestId of [pending.requestId, expired.requestId, 'native-unknown']) {
+          const result = await runCli(sandbox, ['result', requestId, '--json']);
+          expect(result.status).toBe(3);
+          expectError(result, 'RESPONSE_NOT_AVAILABLE');
+          expect(parseWholeStdout(result)).toEqual({
+            status: 'unavailable',
+            requestId,
+            error: { code: 'RESPONSE_NOT_AVAILABLE', message: expect.any(String) },
+          });
+        }
+        const unknown = seedResponse(sandbox.database, 'native-unknown-reply');
+        const unknownReceipt = v1Receipt('unknown-request', unknown.attemptId);
+        const unknownResult = await runCli(sandbox, [
+          'reply',
+          'unknown-request',
+          '--receipt',
+          unknownReceipt,
+          '--message',
+          'body',
+          '--json',
+        ]);
+        expect(unknownResult.status).toBe(3);
+        expectError(unknownResult, 'RESPONSE_REQUEST_NOT_FOUND');
+        const expiredReply = await runCli(sandbox, [
+          'reply',
+          expired.requestId,
+          '--receipt',
+          expired.compactReceipt,
+          '--message',
+          'too late',
+          '--json',
+        ]);
+        expect(expiredReply.status).toBe(1);
+        expectError(expiredReply, 'RESPONSE_EXPIRED');
+        const failed = await runCli(sandbox, ['result', 'x'.repeat(257), '--json']);
+        expect(failed.status).toBe(1);
+        expectError(failed, 'USAGE_ERROR');
+      })
+  );
+
+  it('rejects invalid file and stdin sources before finalization', { timeout: 30_000 }, async () =>
+    withSandbox(async (sandbox) => {
+      await initializeSchema(sandbox);
+      const seeded = seedResponse(sandbox.database, 'native-invalid-input');
+      const before = responseSnapshot(sandbox.database, seeded.requestId);
+      const missing = await runCli(sandbox, [
+        'reply',
+        seeded.requestId,
+        '--receipt',
+        'not-a-receipt',
+        '--file',
+        path.join(sandbox.root, 'missing.txt'),
+        '--json',
+      ]);
+      expect(missing.status).toBe(1);
+      expectError(missing, 'RESPONSE_RECEIPT_INVALID');
+      expect(responseSnapshot(sandbox.database, seeded.requestId)).toEqual(before);
+
+      const malformed = temporaryFile(sandbox, 'malformed.txt', Buffer.from([0xc3, 0x28]));
+      const oversized = temporaryFile(
+        sandbox,
+        'oversized.txt',
+        Buffer.concat([Buffer.alloc(MAX_RESPONSE_BYTES, 0x61), Buffer.from('x')])
+      );
+      for (const [file, code] of [
+        [malformed, 'RESPONSE_INPUT_INVALID'],
+        [oversized, 'RESPONSE_INPUT_TOO_LARGE'],
+      ] as const) {
+        const result = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          seeded.v1Receipt,
+          '--file',
+          file,
+          '--json',
+        ]);
+        expect(result.status).toBe(1);
+        expectError(result, code);
+        expect(responseSnapshot(sandbox.database, seeded.requestId)).toEqual(before);
+      }
+
+      const directoryResult = await runCli(sandbox, [
+        'reply',
+        seeded.requestId,
+        '--receipt',
+        seeded.v1Receipt,
+        '--file',
+        sandbox.root,
+        '--json',
+      ]);
+      expect(directoryResult.status).toBe(1);
+      expectError(directoryResult, 'RESPONSE_FILE_ERROR');
+
+      const fifo = path.join(sandbox.root, 'response.fifo');
+      execFileSync('mkfifo', [fifo], { timeout: 5_000 });
+      const fifoResult = await runCli(sandbox, [
+        'reply',
+        seeded.requestId,
+        '--receipt',
+        seeded.v1Receipt,
+        '--file',
+        fifo,
+        '--json',
+      ]);
+      expect(fifoResult.status).toBe(1);
+      expectError(fifoResult, 'RESPONSE_FILE_ERROR');
+
+      for (const [input, code] of [
+        [Buffer.from([0xc3, 0x28]), 'RESPONSE_INPUT_INVALID'],
+        [
+          Buffer.concat([Buffer.alloc(MAX_RESPONSE_BYTES, 0x61), Buffer.from('x')]),
+          'RESPONSE_INPUT_TOO_LARGE',
+        ],
+      ] as const) {
+        const result = await runCli(
+          sandbox,
+          ['reply', seeded.requestId, '--receipt', seeded.v1Receipt, '--stdin', '--json'],
+          { stdin: input, outputLimitBytes: 2 * 1024 * 1024 }
+        );
+        expect(result.status).toBe(1);
+        expectError(result, code);
+        expect(responseSnapshot(sandbox.database, seeded.requestId)).toEqual(before);
+      }
+    })
+  );
+
+  it(
+    'maps an open stdin past the five-second input deadline without finalizing',
+    { timeout: 15_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        await initializeSchema(sandbox);
+        const seeded = seedResponse(sandbox.database, 'native-stdin-timeout');
+        const before = responseSnapshot(sandbox.database, seeded.requestId);
+        const result = await runCli(
+          sandbox,
+          ['reply', seeded.requestId, '--receipt', seeded.v1Receipt, '--stdin', '--json'],
+          { stdin: Buffer.from('partial'), closeStdin: false, deadlineMs: 8_000 }
+        );
+        expect(result.status).toBe(4);
+        expectError(result, 'RESPONSE_INPUT_TIMEOUT');
+        expect(responseSnapshot(sandbox.database, seeded.requestId)).toEqual(before);
+      })
+  );
+
+  it(
+    'rejects input before creating storage and validates receipts before reading stdin',
+    { timeout: 15_000 },
+    async () =>
+      withSandbox(async (sandbox) => {
+        const requestId = 'not-yet-open';
+        const receipt = v1Receipt(requestId, 'attempt');
+        const malformed = temporaryFile(sandbox, 'bad-body', Buffer.from([0xff]));
+        for (const [input, code] of [
+          [['--file', malformed], 'RESPONSE_INPUT_INVALID'],
+          [['--file', path.join(sandbox.root, 'missing')], 'RESPONSE_FILE_ERROR'],
+        ] as const) {
+          const result = await runCli(sandbox, [
+            'reply',
+            requestId,
+            '--receipt',
+            receipt,
+            ...input,
+            '--json',
+          ]);
+          expect(result.status).toBe(1);
+          expectError(result, code);
+          expect(existsSync(sandbox.database)).toBe(false);
+        }
+        const rejected = await runCli(
+          sandbox,
+          ['reply', requestId, '--receipt', 'malformed', '--stdin', '--json'],
+          { stdin: 'partial', closeStdin: false }
+        );
+        expect(rejected.status).toBe(1);
+        expectError(rejected, 'RESPONSE_RECEIPT_INVALID');
+        expect(existsSync(sandbox.database)).toBe(false);
+        const timeout = await runCli(
+          sandbox,
+          ['reply', requestId, '--receipt', receipt, '--stdin', '--json'],
+          { stdin: 'partial', closeStdin: false, deadlineMs: 8_000 }
+        );
+        expect(timeout.status).toBe(4);
+        expectError(timeout, 'RESPONSE_INPUT_TIMEOUT');
+        expect(existsSync(sandbox.database)).toBe(false);
+      })
+  );
+
+  it('rejects a well-formed compact proof for another request without mutations', async () =>
+    withSandbox(async (sandbox) => {
+      await initializeSchema(sandbox);
+      const target = seedResponse(sandbox.database, 'target');
+      const other = seedResponse(sandbox.database, 'other');
+      const before = responseSnapshot(sandbox.database, target.requestId);
+      const result = await runCli(sandbox, [
+        'reply',
+        target.requestId,
+        '--receipt',
+        other.compactReceipt,
+        '--message',
+        'not authorized by this receipt',
+        '--json',
+      ]);
+      expect(result.status).toBe(1);
+      expectError(result, 'RESPONSE_RECEIPT_MISMATCH');
+      expect(responseSnapshot(sandbox.database, target.requestId)).toEqual(before);
+    }));
+});


### PR DESCRIPTION
## Scope

- Closes #122. Parent #106 remains open; rewrite #93 and installation #82 remain open.
- Wire public native preview `reply` and `result` over the existing request service and receipt codec. Installed TypeScript is unchanged.
- Own bounded exact-text acquisition, command composition, correlated errors, representative process/adapter tests, and current architecture/developer guidance.

## Architecture and review

- Primary review: Codex, reviewed commit `144f94310cd51787feca120ec4ff900c7a28ee75`.
- Reviewed all changed production, tests and documentation against existing parser, RequestService, receipt codec, ConfigPaths, Storage and output/cleanup ownership. No handler SQL, parallel response service, tmux/config discovery or reader thread was introduced.
- Decode receipt and acquire complete UTF-8 input before opening storage. Preserve exact bytes, the 1 MiB cap, EOF requirement, five-second stdin deadline, immutable retries and primary-error precedence. Correlated public errors expose no input paths or receipt/endpoint evidence.
- A real macOS process test reproduced socket-backed stdin returning EOPNOTSUPP from the TTY probe. The fix requires fstat-confirmed socket type; an isolated UnixStream regression test failed before the fix. Other probe errors remain failures.
- Review strengthened pre-storage failure checks, retained-final retry after attempt removal, independent read-only SQL observations, and well-formed wrong-proof rejection. Clippy identified enlarged error values; optional correlation is boxed rather than suppressing the warning. Internal IO and cleanup causes remain retained.
- Existing nix 0.31.3 gains fs/poll features; term is dev-only for a private PTY test. No new locked packages. Runtime feature graph excludes term. Architecture documents exclusive stdin ownership and the limitation that nonblocking flags cannot cancel arbitrary kernel/filesystem stalls.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge.

Commands and results (all local):

CI run 34183679650 completed successfully on reviewed head 144f94310cd51787feca120ec4ff900c7a28ee75 in one attempt: all 11 jobs passed, including the four strict required checks (Code quality, Unit tests, Docker E2E, Native package matrix), Native Rust contracts and all six packed-install targets.

- `cargo test --locked --workspace --manifest-path rust/Cargo.toml`: 205 passed on pinned Rust 1.97.0; repeated with Rust 1.88.0 MSRV, 205 passed.
- `cargo clippy --locked --workspace --all-targets --manifest-path rust/Cargo.toml -- -D warnings`: passed.
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`: passed.
- `cargo build --locked --manifest-path rust/Cargo.toml --bins --examples`: passed.
- `pnpm test:native` with explicit native CLI/storage-probe descriptors: 70 passed across six files. Includes actual five-second open-stdin timeout, exact 1 MiB body, stopped schema-8 migration and v1 receipt handoff. No host tmux.
- `pnpm check`: passed; `pnpm test`: 1,102 passed across 70 files, coverage gates passed (95.66% statements, 89.47% branches).
- `pnpm test:e2e` twice sequentially: each passed 130 native adapter tests and 132 Docker E2E tests, with one existing opt-in skip. Existing public E2E still exercises TypeScript; this is not native talk parity evidence.
- `git diff --check`: passed.

## Project lifecycle

- Updated ARCHITECTURE.md, DEVELOPMENT.md, REQUEST-RESPONSE.md and RUST-REWRITE.md. Installed skill/README stay truthful to the shipped runtime; their native cutover update remains in #106/#93/#82.
- Branch `feat/122-native-reply`, worktree `/Users/benhsieh/dev/tmt-122-native-reply`. Safe cleanup follows merge and verified handoff.
- No release, publication, global installation, user database migration or host tmux interaction.
