### PR TITLE
feat(native): add bounded tmux send and capture adapters

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1133,6 +1133,29 @@ other probe failures stay errors. Public messages remain bounded and exclude pat
 and OS causes. Existing nix adds only fs/poll runtime features; term is test-only
 for an isolated pseudoterminal rejection case, with no new locked packages.
 
+#124 adds `tmux::transport` on the existing Tmux/CommandRunner boundary. Its
+explicit socket and stable pane inputs are routing results, not permission or
+fresh identity evidence. The caller retains the original prompt; this adapter
+alone protects ASCII exclamation marks and ensures a trailing newline for pane
+transport. An invocation owns a UUID-named buffer, one paste (or one literal
+fallback after set-buffer failure), the configured delay and one Enter. A failed
+paste, literal input or Enter is uncertain delivery and must never be replayed.
+Ordinary owned-buffer cleanup is best effort; failed subprocess cleanup is
+retained and prevents fallback. Delivery errors keep primary and secondary
+cleanup causes without exposing payloads or endpoint paths.
+
+Send commands retain a one-second, 64 KiB-per-stream subprocess budget; capture
+uses one second and 4 MiB per stream. These are per-command bounds, not an
+overall send/observer deadline: configured Enter delay remains separate. Capture
+is complete diagnostic text or failure, never a completion signal. Both paths
+use the same process group/deadline/reaping owner as endpoint evidence, with no
+new process runner or dependencies. Public talk/check composition, response
+observation and installed-runtime promotion remain separate integration work.
+The development-only tmux probe exercises these APIs in the existing private
+Docker fixture. Fault injection parses the actual tmux command after socket
+options, keeping explicit native and ambient TypeScript calls observable through
+one harness path.
+
 #### Native storage and runtime adapters
 
 Native migration 9 adds `lifetime` (default `saved` for existing identities) and

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,6 +64,12 @@ flag restoration and an isolated test-only pseudoterminal. The Darwin socket
 case must reproduce the unsupported terminal probe, not weaken the public stdin
 assertion. Keep the real five-second CLI timeout separately from short injected
 adapter deadlines. This is public storage-only acceptance, not native talk.
+#124 adds adapter send/capture coverage through `test/e2e/native-transport.e2e.test.ts`
+and the existing development-only tmux probe. These scenarios assert causal mock
+input and exact no-replay traces for explicit-socket native operations, preserve
+unrelated buffers, and compare diagnostic capture independently. They do not
+make public native talk/check available. Scripted adapter tests reuse the tmux
+test runner to verify caps, stage errors and cleanup precedence without host tmux.
 The separate storage adapter upgrades historical schemas 0–8 to native schema 9,
 tested through a development-only probe rather than an installed command.
 Use isolated test databases only: installed TypeScript cannot reopen schema 9.

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -8,6 +8,8 @@ are implemented in the development preview, not a shipped Rust runtime.
 receipt encoding and old-v1 decoding through that same service. #122 adds public
 native reply/result with bounded input. Native talk and the full #106
 short-receipt transition remain unimplemented.
+#124 adds the bounded native send/capture adapter and isolated real-tmux
+acceptance; public talk/check routing and composition are still pending.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
 The compatibility reference is TypeScript main `cb53533f3a9f19a1a2ab95af59dda20df419200b`

--- a/rust/crates/tmt-adapters/examples/tmux-probe.rs
+++ b/rust/crates/tmt-adapters/examples/tmux-probe.rs
@@ -9,24 +9,26 @@ use std::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
+    time::Duration,
 };
 
 use tmt_adapters::{
     process::{CommandOutput, CommandRequest, CommandRunner, UnixCommandRunner},
-    tmux::{CallerEnvironment, OperationOptions, Tmux, TmuxError},
+    tmux::{CallerEnvironment, DeliveryError, OperationOptions, Tmux, TmuxError},
 };
 use tmt_core::endpoint::{
     BindingMarker, EndpointProbe, EndpointSnapshot, PaneObservation, ServerEvidence,
     valid_process_id,
 };
 
-const USAGE: &str = "Usage: tmux-probe [--json] caller | snapshot [pane-id ...] | server | probe <socket> <pid> [pane-id ...] | probe-server <socket> <pid> | target <target> | set-marker <pane> <name> <canonical-name> <identity-id> <binding-id> <server-id> <pane-pid> | clear-marker <pane> <binding-id>";
+const USAGE: &str = "Usage: tmux-probe [--json] caller | snapshot [pane-id ...] | server | probe <socket> <pid> [pane-id ...] | probe-server <socket> <pid> | target <target> | set-marker <pane> <name> <canonical-name> <identity-id> <binding-id> <server-id> <pane-pid> | clear-marker <pane> <binding-id> | send <socket> <pane> <message> | capture <socket> <pane> <lines>";
 
 #[derive(Debug)]
 enum ProbeError {
     Environment,
     Usage(&'static str),
     Tmux(TmuxError),
+    Delivery(DeliveryError),
 }
 
 impl ProbeError {
@@ -35,6 +37,8 @@ impl ProbeError {
             Self::Environment => "ENVIRONMENT_ERROR",
             Self::Usage(_) => "USAGE_ERROR",
             Self::Tmux(_) => "TMUX_ERROR",
+            Self::Delivery(error) if error.uncertain() => "DELIVERY_UNCERTAIN",
+            Self::Delivery(_) => "DELIVERY_PREPARATION_FAILED",
         }
     }
 
@@ -43,6 +47,7 @@ impl ProbeError {
             Self::Environment => "TMT_E2E_SOCKET must be set for the isolated probe.".into(),
             Self::Usage(message) => (*message).into(),
             Self::Tmux(error) => error.to_string(),
+            Self::Delivery(error) => error.to_string(),
         }
     }
 }
@@ -50,6 +55,12 @@ impl ProbeError {
 impl From<TmuxError> for ProbeError {
     fn from(error: TmuxError) -> Self {
         Self::Tmux(error)
+    }
+}
+
+impl From<DeliveryError> for ProbeError {
+    fn from(error: DeliveryError) -> Self {
+        Self::Delivery(error)
     }
 }
 
@@ -142,6 +153,16 @@ fn run(args: &[String], tmux: &Tmux<CountingRunner>) -> Result<serde_json::Value
         return Err(ProbeError::Usage(USAGE));
     };
     match mode {
+        "send" if args.len() == 4 => {
+            tmux.send_on(&args[1], &args[2], &args[3], Duration::ZERO)?;
+            Ok(serde_json::json!({"sent": true}))
+        }
+        "capture" if args.len() == 4 => {
+            let lines = args[3]
+                .parse::<u64>()
+                .map_err(|_| ProbeError::Usage("Capture lines must be an unsigned integer."))?;
+            Ok(serde_json::json!({"output": tmux.capture_on(&args[1], &args[2], lines)?}))
+        }
         "caller" if args.len() == 1 => Ok(serde_json::json!({
             "pane": tmux.caller_pane(&CallerEnvironment::current())?,
         })),

--- a/rust/crates/tmt-adapters/src/tmux/io_tests.rs
+++ b/rust/crates/tmt-adapters/src/tmux/io_tests.rs
@@ -1,69 +1,8 @@
+use super::test_support::{ScriptedRunner, failure};
 use super::*;
 use crate::process::CommandOutput;
-use std::{cell::RefCell, collections::VecDeque, io};
 
 const SERVER_ID: &str = "123e4567-e89b-42d3-a456-426614174000";
-
-#[derive(Debug)]
-struct Invocation {
-    program: String,
-    args: Vec<String>,
-    deadline: Instant,
-    max_output_bytes: usize,
-}
-
-#[derive(Default)]
-struct ScriptedRunner {
-    results: RefCell<VecDeque<Result<CommandOutput, CommandError>>>,
-    calls: RefCell<Vec<Invocation>>,
-}
-
-impl ScriptedRunner {
-    fn new(results: impl IntoIterator<Item = Result<&'static str, CommandError>>) -> Self {
-        Self {
-            results: RefCell::new(
-                results
-                    .into_iter()
-                    .map(|result| {
-                        result.map(|text| CommandOutput {
-                            stdout: text.as_bytes().to_vec(),
-                            stderr: Vec::new(),
-                        })
-                    })
-                    .collect(),
-            ),
-            ..Self::default()
-        }
-    }
-}
-
-impl CommandRunner for ScriptedRunner {
-    fn execute(&self, request: CommandRequest<'_>) -> Result<CommandOutput, CommandError> {
-        assert!(request.input.is_empty());
-        self.calls.borrow_mut().push(Invocation {
-            program: request.program.to_str().unwrap().into(),
-            args: request
-                .args
-                .iter()
-                .map(|value| value.to_str().unwrap().into())
-                .collect(),
-            deadline: request.deadline,
-            max_output_bytes: request.max_output_bytes,
-        });
-        self.results
-            .borrow_mut()
-            .pop_front()
-            .expect("unexpected extra subprocess")
-    }
-}
-
-fn failure(cleanup_failed: bool) -> CommandError {
-    let mut error = CommandError::new(CommandFailure::Timeout);
-    if cleanup_failed {
-        error.cleanup_error = Some(io::Error::from_raw_os_error(Errno::EPERM as i32));
-    }
-    error
-}
 
 fn full_environment() -> CallerEnvironment {
     CallerEnvironment {

--- a/rust/crates/tmt-adapters/src/tmux/mod.rs
+++ b/rust/crates/tmt-adapters/src/tmux/mod.rs
@@ -5,12 +5,16 @@ mod binding;
 mod caller;
 mod evidence;
 mod metadata;
+mod transport;
 pub use binding::BindingSession;
+pub use transport::{DeliveryError, DeliveryStage};
 
 #[cfg(test)]
 mod evidence_tests;
 #[cfg(test)]
 mod io_tests;
+#[cfg(test)]
+mod test_support;
 
 pub use caller::CallerEnvironment;
 

--- a/rust/crates/tmt-adapters/src/tmux/test_support.rs
+++ b/rust/crates/tmt-adapters/src/tmux/test_support.rs
@@ -1,0 +1,79 @@
+use crate::process::{CommandError, CommandFailure, CommandOutput, CommandRequest, CommandRunner};
+use std::{cell::RefCell, collections::VecDeque, io};
+
+#[derive(Debug)]
+pub(super) struct Invocation {
+    pub(super) program: String,
+    pub(super) args: Vec<String>,
+    pub(super) input: Vec<u8>,
+    pub(super) deadline: std::time::Instant,
+    pub(super) max_output_bytes: usize,
+}
+
+#[derive(Default)]
+pub(super) struct ScriptedRunner {
+    pub(super) results: RefCell<VecDeque<Result<CommandOutput, CommandError>>>,
+    pub(super) calls: RefCell<Vec<Invocation>>,
+}
+
+impl ScriptedRunner {
+    pub(super) fn new(
+        results: impl IntoIterator<Item = Result<&'static str, CommandError>>,
+    ) -> Self {
+        Self {
+            results: RefCell::new(
+                results
+                    .into_iter()
+                    .map(|result| {
+                        result.map(|text| CommandOutput {
+                            stdout: text.as_bytes().to_vec(),
+                            stderr: Vec::new(),
+                        })
+                    })
+                    .collect(),
+            ),
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn push_output(&self, stdout: Vec<u8>, stderr: Vec<u8>) {
+        self.results
+            .borrow_mut()
+            .push_back(Ok(CommandOutput { stdout, stderr }));
+    }
+}
+
+impl CommandRunner for ScriptedRunner {
+    fn execute(&self, request: CommandRequest<'_>) -> Result<CommandOutput, CommandError> {
+        assert!(request.input.is_empty());
+        self.calls.borrow_mut().push(Invocation {
+            program: request.program.to_str().unwrap().into(),
+            args: request
+                .args
+                .iter()
+                .map(|value| value.to_str().unwrap().into())
+                .collect(),
+            input: request.input.to_vec(),
+            deadline: request.deadline,
+            max_output_bytes: request.max_output_bytes,
+        });
+        self.results
+            .borrow_mut()
+            .pop_front()
+            .expect("unexpected extra subprocess")
+    }
+}
+
+pub(super) fn failure(cleanup_failed: bool) -> CommandError {
+    failure_with_kind(CommandFailure::Timeout, cleanup_failed)
+}
+
+pub(super) fn failure_with_kind(kind: CommandFailure, cleanup_failed: bool) -> CommandError {
+    let mut error = CommandError::new(kind);
+    if cleanup_failed {
+        error.cleanup_error = Some(io::Error::from_raw_os_error(
+            nix::errno::Errno::EPERM as i32,
+        ));
+    }
+    error
+}

--- a/rust/crates/tmt-adapters/src/tmux/transport.rs
+++ b/rust/crates/tmt-adapters/src/tmux/transport.rs
@@ -1,0 +1,229 @@
+//! Pane IO only: callers own routing, endpoint verification and request state.
+
+use super::{CommandRunner, OPERATION_TIMEOUT, Tmux, TmuxError, TmuxFailure, socket_args};
+use std::{
+    fmt,
+    time::{Duration, Instant},
+};
+use tmt_core::{endpoint::valid_pane_id, limits::is_valid_capture_lines};
+
+const SEND_MAX_OUTPUT: usize = 64 * 1024;
+const CAPTURE_MAX_OUTPUT: usize = 4 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryStage {
+    Prepare,
+    Paste,
+    Literal,
+    Submit,
+}
+
+impl DeliveryStage {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Prepare => "prepare",
+            Self::Paste => "paste",
+            Self::Literal => "literal",
+            Self::Submit => "submit",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DeliveryError {
+    pub stage: DeliveryStage,
+    cause: TmuxError,
+    cleanup_error: Option<Box<TmuxError>>,
+}
+
+impl DeliveryError {
+    fn new(stage: DeliveryStage, cause: TmuxError) -> Self {
+        Self {
+            stage,
+            cause,
+            cleanup_error: None,
+        }
+    }
+
+    pub fn uncertain(&self) -> bool {
+        self.stage != DeliveryStage::Prepare
+    }
+
+    pub fn cleanup_failed(&self) -> bool {
+        self.cause.cleanup_failed()
+            || self
+                .cleanup_error
+                .as_ref()
+                .is_some_and(|error| error.cleanup_failed())
+    }
+}
+
+impl fmt::Display for DeliveryError {
+    fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.uncertain() {
+            write!(
+                output,
+                "Message delivery is uncertain during {}.",
+                self.stage.as_str()
+            )?;
+        } else {
+            write!(output, "Message preparation failed before pane input.")?;
+        }
+        if self.cleanup_failed() {
+            write!(output, " Subprocess cleanup also failed.")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for DeliveryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.cause)
+    }
+}
+
+fn validate_target(socket: &str, pane: &str) -> Result<(), TmuxError> {
+    if socket.is_empty() || socket.contains('\0') || !valid_pane_id(pane) {
+        return Err(TmuxError::evidence("Invalid explicit transport endpoint"));
+    }
+    Ok(())
+}
+
+fn protected_payload(message: &str) -> String {
+    // Coding-agent shells can interpret ASCII ! as bash mode before input reaches the agent.
+    let mut payload = message.replace('!', "\u{ff01}");
+    if !payload.ends_with('\n') {
+        payload.push('\n');
+    }
+    payload
+}
+
+impl<R: CommandRunner> Tmux<R> {
+    fn transport_run(
+        &self,
+        socket: &str,
+        args: Vec<String>,
+        cap: usize,
+    ) -> Result<String, TmuxError> {
+        let mut scoped = socket_args(Some(socket));
+        scoped.extend(args);
+        self.run(
+            "tmux",
+            scoped,
+            Instant::now() + OPERATION_TIMEOUT,
+            cap,
+            TmuxFailure::Command,
+        )
+    }
+
+    /// Diagnostic terminal text, never a completion signal or a partial success.
+    pub fn capture_on(&self, socket: &str, pane: &str, lines: u64) -> Result<String, TmuxError> {
+        validate_target(socket, pane)?;
+        if !is_valid_capture_lines(lines) {
+            return Err(TmuxError::evidence("Invalid capture line count"));
+        }
+        self.transport_run(
+            socket,
+            vec![
+                "capture-pane".into(),
+                "-t".into(),
+                pane.into(),
+                "-p".into(),
+                "-S".into(),
+                format!("-{lines}"),
+            ],
+            CAPTURE_MAX_OUTPUT,
+        )
+    }
+
+    /// Send once to the explicit endpoint; the caller owns the original prompt.
+    pub fn send_on(
+        &self,
+        socket: &str,
+        pane: &str,
+        message: &str,
+        enter_delay: Duration,
+    ) -> Result<(), DeliveryError> {
+        self.send_with_wait(socket, pane, message, enter_delay, std::thread::sleep)
+    }
+
+    fn send_with_wait(
+        &self,
+        socket: &str,
+        pane: &str,
+        message: &str,
+        enter_delay: Duration,
+        wait: impl FnOnce(Duration),
+    ) -> Result<(), DeliveryError> {
+        validate_target(socket, pane)
+            .map_err(|cause| DeliveryError::new(DeliveryStage::Prepare, cause))?;
+        if message.contains('\0') {
+            return Err(DeliveryError::new(
+                DeliveryStage::Prepare,
+                TmuxError::evidence("Transport text cannot contain NUL"),
+            ));
+        }
+        let payload = protected_payload(message);
+        let buffer = format!("tmt-{}-{}", std::process::id(), uuid::Uuid::new_v4());
+        let run = |args| {
+            self.transport_run(socket, args, SEND_MAX_OUTPUT)
+                .map(|_| ())
+        };
+        let cleanup = || run(vec!["delete-buffer".into(), "-b".into(), buffer.clone()]);
+        match run(vec![
+            "set-buffer".into(),
+            "-b".into(),
+            buffer.clone(),
+            "--".into(),
+            payload.clone(),
+        ]) {
+            Ok(()) => {
+                if let Err(cause) = run(vec![
+                    "paste-buffer".into(),
+                    "-b".into(),
+                    buffer.clone(),
+                    "-d".into(),
+                    "-t".into(),
+                    pane.into(),
+                    "-p".into(),
+                ]) {
+                    let mut error = DeliveryError::new(DeliveryStage::Paste, cause);
+                    error.cleanup_error = cleanup()
+                        .err()
+                        .filter(TmuxError::cleanup_failed)
+                        .map(Box::new);
+                    return Err(error);
+                }
+            }
+            Err(cause) => {
+                // Only set-buffer failure is safe to fall back from: no pane input was attempted.
+                let cleanup_error = cleanup().err().filter(TmuxError::cleanup_failed);
+                if cause.cleanup_failed() || cleanup_error.is_some() {
+                    let mut error = DeliveryError::new(DeliveryStage::Prepare, cause);
+                    error.cleanup_error = cleanup_error.map(Box::new);
+                    return Err(error);
+                }
+                run(vec![
+                    "send-keys".into(),
+                    "-l".into(),
+                    "-t".into(),
+                    pane.into(),
+                    "--".into(),
+                    payload,
+                ])
+                .map_err(|cause| DeliveryError::new(DeliveryStage::Literal, cause))?;
+            }
+        }
+        wait(enter_delay);
+        run(vec![
+            "send-keys".into(),
+            "-t".into(),
+            pane.into(),
+            "Enter".into(),
+        ])
+        .map_err(|cause| DeliveryError::new(DeliveryStage::Submit, cause))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-adapters/src/tmux/transport/tests.rs
+++ b/rust/crates/tmt-adapters/src/tmux/transport/tests.rs
@@ -1,0 +1,370 @@
+use super::super::test_support::{ScriptedRunner, failure, failure_with_kind};
+use super::*;
+use crate::process::CommandFailure;
+use std::{
+    cell::RefCell,
+    time::{Duration, Instant},
+};
+use tmt_core::limits::MAX_CAPTURE_LINES;
+
+const SOCKET: &str = "/tmp/private.sock";
+const PANE: &str = "%9";
+
+fn assert_deadlines_and_cap(runner: &ScriptedRunner, expected_cap: usize, started: Instant) {
+    let now = Instant::now();
+    let calls = runner.calls.borrow();
+    assert!(!calls.is_empty());
+    for call in calls.iter() {
+        assert_eq!(call.program, "tmux");
+        assert_eq!(call.input, Vec::<u8>::new());
+        assert_eq!(call.max_output_bytes, expected_cap);
+        assert!(call.deadline >= started + Duration::from_secs(1));
+        assert!(call.deadline <= now + Duration::from_secs(1));
+    }
+}
+
+fn assert_socket(calls: &[super::super::test_support::Invocation]) {
+    for call in calls {
+        assert_eq!(&call.args[..2], ["-S", SOCKET]);
+    }
+}
+
+#[test]
+fn send_uses_explicit_socket_protected_payload_owned_buffer_and_one_enter() {
+    let runner = ScriptedRunner::new([Ok(""), Ok(""), Ok("")]);
+    let tmux = Tmux::new(runner);
+    let waited = RefCell::new(Vec::new());
+    // Deliberately includes ASCII punctuation, Unicode, and an existing newline.
+    let message = "if (!ready)!\n尾";
+    let started = Instant::now();
+
+    tmux.send_with_wait(SOCKET, PANE, message, Duration::from_millis(731), |delay| {
+        assert_eq!(tmux.runner.calls.borrow().len(), 2);
+        waited.borrow_mut().push(delay);
+    })
+    .unwrap();
+
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 3);
+    assert_socket(&calls);
+    assert_eq!(&calls[0].args[..4], ["-S", SOCKET, "set-buffer", "-b"]);
+    assert_eq!(&calls[0].args[5..], ["--", "if (！ready)！\n尾\n"]);
+    assert_eq!(&calls[1].args[..4], ["-S", SOCKET, "paste-buffer", "-b"]);
+    assert_eq!(calls[1].args[4], calls[0].args[4]);
+    assert_eq!(&calls[1].args[5..], ["-d", "-t", PANE, "-p"]);
+    assert_eq!(
+        &calls[2].args[..],
+        ["-S", SOCKET, "send-keys", "-t", PANE, "Enter"]
+    );
+    assert_eq!(*waited.borrow(), [Duration::from_millis(731)]);
+    drop(calls);
+    assert_deadlines_and_cap(&tmux.runner, 64 * 1024, started);
+}
+
+#[test]
+fn send_assigns_unique_buffer_names_across_messages() {
+    let runner = ScriptedRunner::new([Ok(""), Ok(""), Ok(""), Ok(""), Ok(""), Ok("")]);
+    let tmux = Tmux::new(runner);
+
+    tmux.send_with_wait(SOCKET, PANE, "one\n", Duration::ZERO, |_| {})
+        .unwrap();
+    tmux.send_with_wait(SOCKET, PANE, "two\n", Duration::ZERO, |_| {})
+        .unwrap();
+
+    let calls = tmux.runner.calls.borrow();
+    assert_ne!(calls[0].args[4], calls[3].args[4]);
+    assert!(calls[0].args[4].starts_with("tmt-"));
+    assert_eq!(calls[1].args[4], calls[0].args[4]);
+    assert_eq!(calls[4].args[4], calls[3].args[4]);
+}
+
+#[test]
+fn set_buffer_failure_has_one_literal_fallback_with_the_same_payload() {
+    let runner = ScriptedRunner::new([Err(failure(false)), Ok(""), Ok(""), Ok("")]);
+    let tmux = Tmux::new(runner);
+    let waited = RefCell::new(Vec::new());
+
+    tmux.send_with_wait(
+        SOCKET,
+        PANE,
+        "-n weird!\nLine",
+        Duration::from_millis(17),
+        |delay| {
+            assert_eq!(tmux.runner.calls.borrow().len(), 3);
+            waited.borrow_mut().push(delay);
+        },
+    )
+    .unwrap();
+
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 4);
+    assert_socket(&calls);
+    assert_eq!(calls[0].args[2], "set-buffer");
+    assert_eq!(
+        &calls[1].args[..],
+        [
+            "-S",
+            SOCKET,
+            "delete-buffer",
+            "-b",
+            calls[0].args[4].as_str()
+        ]
+    );
+    assert_eq!(
+        &calls[2].args[2..],
+        ["send-keys", "-l", "-t", PANE, "--", "-n weird！\nLine\n"]
+    );
+    assert_eq!(
+        &calls[3].args[..],
+        ["-S", SOCKET, "send-keys", "-t", PANE, "Enter"]
+    );
+    assert_eq!(calls[2].args.last(), calls[0].args.last());
+    assert_eq!(*waited.borrow(), [Duration::from_millis(17)]);
+}
+
+#[test]
+fn payload_preserves_empty_existing_newline_and_crlf_inputs() {
+    for (message, expected) in [
+        ("", "\n"),
+        ("already\n", "already\n"),
+        ("crlf\r\n", "crlf\r\n"),
+    ] {
+        let tmux = Tmux::new(ScriptedRunner::new([Ok(""), Ok(""), Ok("")]));
+        tmux.send_with_wait(SOCKET, PANE, message, Duration::ZERO, |_| {})
+            .unwrap();
+        let calls = tmux.runner.calls.borrow();
+        assert_eq!(calls[0].args.last().map(String::as_str), Some(expected));
+    }
+}
+
+#[test]
+fn paste_failure_preserves_primary_uncertainty_and_never_replays() {
+    let runner = ScriptedRunner::new([
+        Ok(""),
+        Err(failure(false)),
+        Err(failure_with_kind(
+            CommandFailure::Exit {
+                code: Some(7),
+                signal: None,
+            },
+            false,
+        )),
+    ]);
+    let tmux = Tmux::new(runner);
+
+    let error = tmux
+        .send_with_wait(SOCKET, PANE, "body", Duration::ZERO, |_| {})
+        .unwrap_err();
+    assert_eq!(error.stage, DeliveryStage::Paste);
+    assert!(error.uncertain());
+    assert!(!error.cleanup_failed());
+    assert_eq!(error.cause.kind, TmuxFailure::Command);
+    assert_eq!(
+        error.cause.cause.as_ref().unwrap().kind,
+        CommandFailure::Timeout
+    );
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[2].args[2], "delete-buffer");
+}
+
+#[test]
+fn paste_cleanup_failure_remains_observable_without_fallback() {
+    let runner = ScriptedRunner::new([Ok(""), Err(failure(false)), Err(failure(true))]);
+    let tmux = Tmux::new(runner);
+
+    let error = tmux
+        .send_with_wait(SOCKET, PANE, "body", Duration::ZERO, |_| {})
+        .unwrap_err();
+    assert_eq!(error.stage, DeliveryStage::Paste);
+    assert!(error.uncertain());
+    assert!(error.cleanup_failed());
+    assert!(error.cleanup_error.is_some());
+    assert_eq!(tmux.runner.calls.borrow().len(), 3);
+}
+
+#[test]
+fn literal_failure_never_sends_enter_or_replays_payload() {
+    let runner = ScriptedRunner::new([
+        Err(failure(false)),
+        Ok(""),
+        Err(failure_with_kind(
+            CommandFailure::Exit {
+                code: Some(7),
+                signal: None,
+            },
+            false,
+        )),
+    ]);
+    let tmux = Tmux::new(runner);
+
+    let error = tmux
+        .send_with_wait(SOCKET, PANE, "body", Duration::ZERO, |_| {})
+        .unwrap_err();
+    assert_eq!(error.stage, DeliveryStage::Literal);
+    assert!(error.uncertain());
+    assert_eq!(tmux.runner.calls.borrow().len(), 3);
+}
+
+#[test]
+fn failed_child_cleanup_suppresses_literal_fallback_and_keeps_both_causes() {
+    let runner = ScriptedRunner::new([Err(failure(true)), Err(failure(true))]);
+    let tmux = Tmux::new(runner);
+
+    let error = tmux
+        .send_with_wait(SOCKET, PANE, "body", Duration::ZERO, |_| {})
+        .unwrap_err();
+    assert_eq!(error.stage, DeliveryStage::Prepare);
+    assert!(!error.uncertain());
+    assert!(error.cleanup_failed());
+    assert!(error.cause.cleanup_failed());
+    assert!(error.cleanup_error.is_some());
+    assert_eq!(tmux.runner.calls.borrow().len(), 2);
+}
+
+#[test]
+fn primary_cleanup_failure_alone_suppresses_literal_fallback() {
+    let runner = ScriptedRunner::new([Err(failure(true)), Ok("")]);
+    let tmux = Tmux::new(runner);
+
+    let error = tmux
+        .send_with_wait(SOCKET, PANE, "body", Duration::ZERO, |_| {})
+        .unwrap_err();
+    assert_eq!(error.stage, DeliveryStage::Prepare);
+    assert!(error.cause.cleanup_failed());
+    assert!(error.cleanup_error.is_none());
+    assert!(error.cleanup_failed());
+    assert_eq!(tmux.runner.calls.borrow().len(), 2);
+}
+
+#[test]
+fn secondary_cleanup_failure_alone_suppresses_literal_fallback() {
+    let runner = ScriptedRunner::new([Err(failure(false)), Err(failure(true))]);
+    let tmux = Tmux::new(runner);
+
+    let error = tmux
+        .send_with_wait(SOCKET, PANE, "body", Duration::ZERO, |_| {})
+        .unwrap_err();
+    assert_eq!(error.stage, DeliveryStage::Prepare);
+    assert!(!error.cause.cleanup_failed());
+    assert!(error.cleanup_error.is_some());
+    assert!(error.cleanup_failed());
+    assert_eq!(tmux.runner.calls.borrow().len(), 2);
+}
+
+#[test]
+fn submit_failure_is_uncertain_and_does_not_replay_enter() {
+    let runner = ScriptedRunner::new([Ok(""), Ok(""), Err(failure(false))]);
+    let tmux = Tmux::new(runner);
+    let waits = RefCell::new(0);
+
+    let error = tmux
+        .send_with_wait(SOCKET, PANE, "body", Duration::from_millis(12), |_| {
+            *waits.borrow_mut() += 1;
+        })
+        .unwrap_err();
+    assert_eq!(error.stage, DeliveryStage::Submit);
+    assert!(error.uncertain());
+    assert_eq!(*waits.borrow(), 1);
+    assert_eq!(tmux.runner.calls.borrow().len(), 3);
+}
+
+#[test]
+fn invalid_send_targets_text_and_capture_lines_spawn_nothing() {
+    for (socket, pane, message) in [
+        ("", PANE, "body"),
+        ("/tmp/\0sock", PANE, "body"),
+        (SOCKET, "main:1.0", "body"),
+        (SOCKET, PANE, "nul\0body"),
+    ] {
+        let runner = ScriptedRunner::default();
+        let tmux = Tmux::new(runner);
+        let error = tmux
+            .send_with_wait(socket, pane, message, Duration::ZERO, |_| {})
+            .unwrap_err();
+        assert_eq!(error.stage, DeliveryStage::Prepare);
+        assert!(!error.uncertain());
+        assert!(tmux.runner.calls.borrow().is_empty());
+    }
+
+    let runner = ScriptedRunner::default();
+    let tmux = Tmux::new(runner);
+    let error = tmux.capture_on("", PANE, 0).unwrap_err();
+    assert_eq!(error.kind, TmuxFailure::Evidence);
+    assert!(tmux.runner.calls.borrow().is_empty());
+
+    let runner = ScriptedRunner::default();
+    let tmux = Tmux::new(runner);
+    let error = tmux.capture_on(SOCKET, "main:1.0", 0).unwrap_err();
+    assert_eq!(error.kind, TmuxFailure::Evidence);
+    assert!(tmux.runner.calls.borrow().is_empty());
+
+    let runner = ScriptedRunner::default();
+    let tmux = Tmux::new(runner);
+    let error = tmux
+        .capture_on(SOCKET, PANE, MAX_CAPTURE_LINES + 1)
+        .unwrap_err();
+    assert_eq!(error.kind, TmuxFailure::Evidence);
+    assert!(tmux.runner.calls.borrow().is_empty());
+}
+
+#[test]
+fn capture_uses_explicit_socket_preserves_complete_output_and_replaces_invalid_utf8() {
+    let runner = ScriptedRunner::default();
+    let mut bytes = "line one\n尾\n".as_bytes().to_vec();
+    bytes.push(0xff);
+    runner.push_output(bytes, Vec::new());
+    let tmux = Tmux::new(runner);
+    let started = Instant::now();
+
+    let output = tmux.capture_on(SOCKET, PANE, 0).unwrap();
+    assert_eq!(output, "line one\n尾\n�");
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        &calls[0].args[..],
+        ["-S", SOCKET, "capture-pane", "-t", PANE, "-p", "-S", "-0"]
+    );
+    drop(calls);
+    assert_deadlines_and_cap(&tmux.runner, 4 * 1024 * 1024, started);
+}
+
+#[test]
+fn capture_propagates_output_overflow_and_timeout_without_partial_success() {
+    for kind in [CommandFailure::OutputLimit, CommandFailure::Timeout] {
+        let runner = ScriptedRunner::new([Err(failure_with_kind(kind, false))]);
+        let tmux = Tmux::new(runner);
+        let error = tmux.capture_on(SOCKET, PANE, 100).unwrap_err();
+        assert_eq!(error.kind, TmuxFailure::Command);
+        assert_eq!(error.cause.as_ref().unwrap().kind, kind);
+        assert_eq!(tmux.runner.calls.borrow().len(), 1);
+    }
+}
+
+#[test]
+fn capture_accepts_maximum_lines_and_a_complete_four_mib_body() {
+    let runner = ScriptedRunner::default();
+    runner.push_output(vec![b'x'; 4 * 1024 * 1024], Vec::new());
+    let tmux = Tmux::new(runner);
+
+    let output = tmux.capture_on(SOCKET, PANE, MAX_CAPTURE_LINES).unwrap();
+    assert_eq!(output.len(), 4 * 1024 * 1024);
+    assert!(output.bytes().all(|byte| byte == b'x'));
+    let calls = tmux.runner.calls.borrow();
+    assert_eq!(calls.len(), 1);
+    let expected_lines = format!("-{MAX_CAPTURE_LINES}");
+    assert_eq!(
+        &calls[0].args[..],
+        [
+            "-S",
+            SOCKET,
+            "capture-pane",
+            "-t",
+            PANE,
+            "-p",
+            "-S",
+            expected_lines.as_str(),
+        ]
+    );
+    assert_eq!(calls[0].max_output_bytes, 4 * 1024 * 1024);
+}

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -68,6 +68,8 @@ export interface CliRunOptions {
   };
   /** Touch this file when the child has made its first tmux invocation. */
   progressFile?: string;
+  /** Record transport sequencing without injecting a failure. */
+  transportTrace?: boolean;
   /** Inject one transport-stage failure into this CLI process only. */
   transportFault?: {
     /** set-buffer is safe to fall back from; paste and submit are uncertain. */
@@ -194,16 +196,23 @@ if [ -n "${'$'}{TMT_E2E_PROGRESS_FILE:-}" ]; then
 fi
 metadata_write=0
 metadata_clear=0
-# Keep explicit-socket native calls visible to the same publication barrier.
+# Keep explicit-socket native calls visible to the same barriers and fault injection.
 # Inspect the command without changing argv passed to the real tmux binary.
 tmux_command=""
+tmux_command_arg_count=0
+tmux_last_arg=""
 skip_option_value=0
 for arg in "${'$'}@"; do
+  if [ -n "${'$'}tmux_command" ]; then
+    tmux_command_arg_count=${'$'}((tmux_command_arg_count + 1))
+    tmux_last_arg="${'$'}arg"
+    continue
+  fi
   if [ "${'$'}skip_option_value" = "1" ]; then skip_option_value=0; continue; fi
   case "${'$'}arg" in
     -S|-L|-f) skip_option_value=1 ;;
     -*) ;;
-    *) tmux_command="${'$'}arg"; break ;;
+    *) tmux_command="${'$'}arg" ;;
   esac
 done
 if [ "${'$'}tmux_command" = "set-option" ]; then
@@ -253,11 +262,11 @@ trace_transport() {
   printf '%s|%s\n' "${'$'}trace_stage" "${'$'}trace_argv" >> "${'$'}TMT_E2E_TRANSPORT_TRACE_FILE"
 }
 transport_stage=""
-case "${'$'}1" in
+case "${'$'}tmux_command" in
   set-buffer) transport_stage="set-buffer" ;;
   paste-buffer) transport_stage="paste-buffer" ;;
   send-keys)
-    if [ "${'$'}#" -eq 4 ] && [ "${'$'}4" = "Enter" ]; then
+    if [ "${'$'}tmux_command_arg_count" -eq 3 ] && [ "${'$'}tmux_last_arg" = "Enter" ]; then
       transport_stage="submit"
     else
       transport_stage="literal-input"
@@ -387,6 +396,8 @@ exit ${'$'}status
     if (options.progressFile) env.TMT_E2E_PROGRESS_FILE = options.progressFile;
     if (options.transportFault) {
       env.TMT_E2E_TRANSPORT_FAULT_STAGE = options.transportFault.stage;
+    }
+    if (options.transportTrace || options.transportFault) {
       env.TMT_E2E_TRANSPORT_TRACE_FILE = this.transportTracePath;
     }
     const child = spawn(this.executables.cli.executable, [...this.executables.cli.args, ...args], {

--- a/test/e2e/native-transport.e2e.test.ts
+++ b/test/e2e/native-transport.e2e.test.ts
@@ -1,0 +1,169 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type E2EFixture, type E2EFixtureOptions } from './harness.js';
+
+function options(): E2EFixtureOptions {
+  const probe = process.env.TMT_TEST_TMUX_PROBE;
+  if (!probe) throw new Error('Native transport E2E requires the Docker-built adapter probe.');
+  return { mode: 'input-log', executableEnv: { TMT_TEST_CLI: probe } };
+}
+
+function traceStages(fixture: E2EFixture, start: number): string[] {
+  return fixture
+    .transportTrace()
+    .slice(start)
+    .map((line) => line.split('|', 1)[0]);
+}
+
+function inputLines(fixture: E2EFixture, pid: number): (string | undefined)[] {
+  return fixture
+    .events()
+    .filter((event) => event.event === 'input' && event.pid === pid)
+    .map((event) => event.line);
+}
+
+describe.sequential('native message transport adapter (not public talk parity)', () => {
+  it.each([false, true])(
+    'delivers protected text once and preserves unrelated buffers (fallback: %s)',
+    async (fallback) => {
+      await withE2EFixture(async (fixture) => {
+        const sentinel = 'tmt-e2e-native-transport-sentinel';
+        fixture.tmux(['set-buffer', '-b', sentinel, '--', 'keep-me']);
+        // Non-ASCII text is intentional transport data, not repository prose.
+        const message =
+          '! Native 日本語\nEnter C-c --leading-dash "quotes" $dollar `literal`\nend!';
+        const start = fixture.transportTrace().length;
+        const result = await fixture.runJsonCli(
+          ['send', fixture.socketPath, fixture.pane, message],
+          fallback ? { transportFault: { stage: 'set-buffer' } } : { transportTrace: true }
+        );
+        expect(result).toMatchObject({
+          code: 0,
+          stderr: '',
+          json: { sent: true, commandCount: fallback ? 4 : 3 },
+        });
+        await fixture.waitForEvent(
+          (event) =>
+            event.event === 'input' && event.pid === fixture.panePid && event.line === 'end！'
+        );
+        expect(inputLines(fixture, fixture.panePid).filter((line) => line !== '')).toEqual([
+          '！ Native 日本語',
+          'Enter C-c --leading-dash "quotes" $dollar `literal`',
+          'end！',
+        ]);
+        expect(traceStages(fixture, start)).toEqual(
+          fallback
+            ? [
+                'set-buffer.fault-before',
+                'literal-input.before',
+                'literal-input.after.0',
+                'submit.before',
+                'submit.after.0',
+              ]
+            : [
+                'set-buffer.before',
+                'set-buffer.after.0',
+                'paste-buffer.before',
+                'paste-buffer.after.0',
+                'submit.before',
+                'submit.after.0',
+              ]
+        );
+        expect(fixture.tmux(['show-buffer', '-b', sentinel]).trimEnd()).toBe('keep-me');
+        expect(fixture.tmux(['list-buffers', '-F', '#{buffer_name}']).trim()).toBe(sentinel);
+        expect(fs.existsSync(path.join(fixture.globalDir, 'tmux-team.db'))).toBe(false);
+      }, options());
+    }
+  );
+
+  it.each(['paste', 'submit'] as const)(
+    'reports uncertain %s after real pane delivery without replay',
+    async (stage) => {
+      await withE2EFixture(async (fixture) => {
+        const start = fixture.transportTrace().length;
+        const result = await fixture.runJsonCli(
+          ['send', fixture.socketPath, fixture.pane, 'causal-input!'],
+          { transportFault: { stage } }
+        );
+        expect(result).toMatchObject({
+          code: 1,
+          stderr: '',
+          json: {
+            error: {
+              code: 'DELIVERY_UNCERTAIN',
+              message: `Message delivery is uncertain during ${stage}.`,
+            },
+          },
+        });
+        await fixture.waitForEvent(
+          (event) =>
+            event.event === 'input' &&
+            event.pid === fixture.panePid &&
+            event.line === 'causal-input！'
+        );
+        expect(
+          inputLines(fixture, fixture.panePid).filter((line) => line === 'causal-input！')
+        ).toHaveLength(1);
+        expect(traceStages(fixture, start)).toEqual(
+          stage === 'paste'
+            ? [
+                'set-buffer.before',
+                'set-buffer.after.0',
+                'paste-buffer.before',
+                'paste-buffer.after.0',
+                'paste-buffer.fault-after',
+              ]
+            : [
+                'set-buffer.before',
+                'set-buffer.after.0',
+                'paste-buffer.before',
+                'paste-buffer.after.0',
+                'submit.before',
+                'submit.after.0',
+                'submit.fault-after',
+              ]
+        );
+        expect(fixture.tmux(['list-buffers', '-F', '#{buffer_name}']).trim()).toBe('');
+      }, options());
+    }
+  );
+
+  it('captures diagnostic text independently and fails for a missing pane', async () => {
+    await withE2EFixture(async (fixture) => {
+      const marker = 'native-diagnostic-marker';
+      expect(
+        await fixture.runJsonCli(['send', fixture.socketPath, fixture.pane, marker])
+      ).toMatchObject({ code: 0, json: { sent: true } });
+      await fixture.waitForEvent(
+        (event) => event.event === 'input' && event.pid === fixture.panePid && event.line === marker
+      );
+      await fixture.waitForCapture((output) => output.includes(marker));
+      const expected = fixture.tmux(['capture-pane', '-t', fixture.pane, '-p', '-S', '-0']);
+      expect(expected).toContain(marker);
+      const result = await fixture.runJsonCli(['capture', fixture.socketPath, fixture.pane, '0']);
+      expect(result).toMatchObject({
+        code: 0,
+        stderr: '',
+        json: { output: expected, commandCount: 1 },
+      });
+      const missing = await fixture.runJsonCli([
+        'send',
+        fixture.socketPath,
+        '%999999',
+        'must-not-arrive',
+      ]);
+      expect(missing).toMatchObject({ code: 1, json: { error: { code: 'DELIVERY_UNCERTAIN' } } });
+      expect(inputLines(fixture, fixture.panePid)).not.toContain('must-not-arrive');
+      expect(fixture.tmux(['list-buffers', '-F', '#{buffer_name}']).trim()).toBe('');
+      const captureMissing = await fixture.runJsonCli([
+        'capture',
+        fixture.socketPath,
+        '%999999',
+        '20',
+      ]);
+      expect(captureMissing).toMatchObject({ code: 1, json: { error: { code: 'TMUX_ERROR' } } });
+      expect(captureMissing.json).not.toHaveProperty('output');
+    }, options());
+  });
+});


### PR DESCRIPTION
## Scope

- Closes #124. Parent rewrite #93, short receipts #106 and installation #82 remain open.
- Add native explicit-socket send/capture adapters, typed delivery-stage uncertainty and representative private-tmux acceptance. Public native talk/check remain subsequent integration; #125 owns current-server routing/check.
- Installed TypeScript, schema and dependencies are unchanged.

## Architecture and review

- Primary reviewer: Codex. Reviewed commit: `c8a2674a1a37676ab786470a82cd55434772b1a3`.
- Personally reviewed all production, shared test-support extraction, existing callers, probe, harness, scenario assertions and documentation. Reused Tmux/CommandRunner, stable pane validation, shared capture-line policy, existing UUID dependency and Docker fixture. No parallel process runner or persistence layer.
- One protected transport payload owns ASCII exclamation replacement and trailing newline. Only failed set-buffer can fall back; uncertain paste/literal/Enter never replays. Ordinary buffer cleanup cannot replace delivery outcome; failed child cleanup is retained and blocks fallback. Capture is complete diagnostic text, never reply completion.
- Preserved one-second per-subprocess bounds (send 64 KiB per stream; capture 4 MiB), not a new overall observer deadline. Current-server routing and fresh endpoint identity verification belong to later application composition.
- Primary strengthened delegated tests with independent one-second bounds, exact fallback payload equality, separate primary/secondary cleanup failures, strict existing runner assertions and all-byte 4 MiB checks. Supplemental Luna read-only review inspected production and real fault-injection paths; primary retains acceptance ownership.
- First local Docker pass caught a test setup defect: healthy transmission did not opt into tracing. Added trace-only opt-in rather than weakening exact no-replay assertions. The harness now identifies the tmux command after socket flags through its existing parser, preserving argv and TypeScript coverage.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge: all 11 jobs passed on `c8a2674a1a37676ab786470a82cd55434772b1a3` (run 34185612826, first attempt).

Commands and results:

- `cargo test --locked --workspace --manifest-path rust/Cargo.toml`: 220 passed (145 adapters, 17 CLI, 19 architecture, 39 core), including 15 transport cases.
- `cargo +1.88.0 test --locked --workspace --manifest-path rust/Cargo.toml`: 220 passed on MSRV.
- `cargo clippy --locked --workspace --all-targets --manifest-path rust/Cargo.toml -- -D warnings`: passed.
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`: passed.
- `cargo build --locked --manifest-path rust/Cargo.toml --bins --examples`: passed.
- `pnpm test:native` with explicit native CLI/storage-probe descriptors: 70 passed across six files; no host tmux.
- `pnpm check`: passed. `pnpm test`: 1,102 passed across 70 files; coverage gates passed (95.66% statements, 89.46% branches).
- Final `pnpm test:e2e` twice sequentially after the local trace correction: each passed 145 native adapter tests and 137 E2E tests, one existing opt-in skip. New scenarios exercise actual native transport through the development probe and causal mock input; this is not public native talk parity evidence.
- `git diff --check`: passed. Rebase onto merged main changed no tested file contents.

## Project lifecycle

- ARCHITECTURE.md, DEVELOPMENT.md and RUST-REWRITE.md updated with ownership, limits and truthful preview status.
- #124 records design, test finding, fixes and evidence. Branch `feat/124-native-transport`, worktree `/Users/benhsieh/dev/tmt-124-native-transport`; safe cleanup follows verified merge/handoff.
- No host tmux, user database, global installation, publication or release was touched.
