### PR TITLE
feat(native): route check through current-server evidence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1156,6 +1156,27 @@ Docker fixture. Fault injection parses the actual tmux command after socket
 options, keeping explicit native and ambient TypeScript calls observable through
 one harness path.
 
+#125 adds current-server routing and public diagnostic check/read. The existing
+`PaneIdentity` observation retains its server and optional binding alongside the
+pane/identity, so later delivery can consume the same evidence rather than
+rediscovering discarded fields. `binding::current_name_presence` performs a
+normalized lookup and one scoped current snapshot under the existing binding
+transaction. It reuses `reconcile`/`evaluate_binding`; foreign socket evidence
+cannot become an active route, and unknown evidence does not authorize cleanup.
+Global `name_presence`/listing remain separate presence reporting, not routing
+permission. No new record port, SQL owner or name-creation policy is introduced.
+
+CLI `target` composes pane-first selector IO and these core projections.
+`binding_error` is the shared presentation translation for binding and target
+callers, not a second policy owner. `check_command` validates configuration,
+opens one Storage handle, resolves the target, captures outside the binding
+transaction, explicitly closes storage, then emits diagnostic output. Only
+public identity name/canonical-name fields enter that report; server/process
+evidence stays internal. Terminal text still never completes a request.
+Native process tests share one calibrated tmux tripwire instead of copying
+host-protection wrappers across command suites. Docker's existing wrapper owns
+capture failure injection after successful target resolution.
+
 #### Native storage and runtime adapters
 
 Native migration 9 adds `lifetime` (default `saved` for existing identities) and

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,7 +35,7 @@ The `rust/` workspace is not the installed runtime yet. It implements only
 help/version/completion, typed grammar, the existing `config` command and
 storage-only `identity create/show/list` under #113, and pane identity
 `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` under #109, plus storage-only
-`reply`/`result` under #122.
+`reply`/`result` under #122, and diagnostic `check`/`read` under #125.
 Other effectful commands still explicitly fail.
 The #118 request/final service is an internal transactional foundation only;
 its public reply/result composition is supplied by #122, not native talk. Its real SQLite
@@ -70,6 +70,13 @@ input and exact no-replay traces for explicit-socket native operations, preserve
 unrelated buffers, and compare diagnostic capture independently. They do not
 make public native talk/check available. Scripted adapter tests reuse the tmux
 test runner to verify caps, stage errors and cleanup precedence without host tmux.
+#125 adds `test/native/check.test.ts` for configuration-before-effects and
+lookup-only misses, plus `test/e2e/native-check.e2e.test.ts` for real public
+diagnostic output, foreign-server rejection, selected-pane cost and capture
+failure propagation. Native command suites reuse `test/native/tmux-tripwire.ts`;
+calibration proves that the task-owned executable would record accidental tmux
+access. Routing storage tests retain full binding evidence and use independent
+read-only SQL to detect unwanted foreign/unknown/unrelated binding touches.
 The separate storage adapter upgrades historical schemas 0–8 to native schema 9,
 tested through a development-only probe rather than an installed command.
 Use isolated test databases only: installed TypeScript cannot reopen schema 9.

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -9,7 +9,8 @@ receipt encoding and old-v1 decoding through that same service. #122 adds public
 native reply/result with bounded input. Native talk and the full #106
 short-receipt transition remain unimplemented.
 #124 adds the bounded native send/capture adapter and isolated real-tmux
-acceptance; public talk/check routing and composition are still pending.
+acceptance. #125 adds shared current-server target resolution and public
+diagnostic check/read. Public talk composition and observation remain pending.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
 The compatibility reference is TypeScript main `cb53533f3a9f19a1a2ab95af59dda20df419200b`
@@ -69,7 +70,7 @@ delegates from native to Node.
 The preview implements help, version, Bash/Zsh completion and the existing
 `config` command plus storage-only `identity create/show/list` (#113) and pane
 identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109), plus storage-only
-`reply`/`result` (#122).
+`reply`/`result` (#122) and diagnostic `check`/`read` (#125).
 Other recognized effectful commands return
 `NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
 storage, tmux or input acquisition. Text-only commands reject JSON. Native

--- a/rust/crates/tmt-adapters/src/storage/bindings/service_tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings/service_tests.rs
@@ -2,3 +2,4 @@ mod endpoint;
 mod presence;
 mod publication;
 mod removal;
+mod routing;

--- a/rust/crates/tmt-adapters/src/storage/bindings/service_tests/routing.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings/service_tests/routing.rs
@@ -1,0 +1,246 @@
+use std::path::Path;
+
+use rusqlite::{Connection, OpenFlags, OptionalExtension};
+use tmt_core::{
+    binding::{BindingRepository, bind_identity, current_name_presence, pane_presence},
+    identity::{IdentityReader, Lifetime, create_or_resolve},
+};
+
+use super::super::test_support::{Fixture, pane};
+use super::endpoint::{FakeEndpoint, server};
+
+fn binding_state(path: &Path, binding_id: &str) -> Option<(String, String, String)> {
+    let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).unwrap();
+    connection
+        .query_row(
+            "SELECT server_id, socket_path, last_verified_at FROM bindings WHERE id = ?",
+            [binding_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()
+        .unwrap()
+}
+
+#[test]
+fn current_name_presence_returns_complete_active_binding_evidence() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let current_server = endpoint.server.clone();
+    let bound = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true).unwrap();
+    let identity = bound.identity;
+    let binding = bound.binding.unwrap();
+    let current_calls = endpoint.current_calls;
+
+    let observed = current_name_presence(&mut storage, &mut endpoint, "  aLiCe  ")
+        .unwrap()
+        .expect("active canonical name resolves on the current server");
+    assert_eq!(observed.server, current_server);
+    assert_eq!(observed.pane.id, "%1");
+    assert_eq!(observed.pane.pane_pid, binding.pane_pid);
+    assert_eq!(observed.identity, Some(identity.clone()));
+    assert_eq!(observed.binding, Some(binding));
+    assert_eq!(endpoint.current_calls, current_calls + 1);
+    assert!(endpoint.probe_calls.is_empty());
+    storage.close().unwrap();
+}
+
+#[test]
+fn current_name_presence_unknown_or_pane_shaped_lookup_does_not_create_identity() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&[]);
+    let before = storage
+        .with_binding_transaction(|records| records.binding_entries())
+        .unwrap();
+
+    for name in ["Unknown", "   ", "%9", "main:1.0"] {
+        assert!(
+            current_name_presence(&mut storage, &mut endpoint, name)
+                .unwrap()
+                .is_none(),
+            "lookup-only routing must not reinterpret or create '{name}'"
+        );
+    }
+
+    let after = storage
+        .with_binding_transaction(|records| records.binding_entries())
+        .unwrap();
+    assert!(before.is_empty());
+    assert!(after.is_empty());
+    assert_eq!(endpoint.current_calls, 0);
+    assert!(storage.find_identity("unknown").unwrap().is_none());
+    storage.close().unwrap();
+}
+
+#[test]
+fn current_name_presence_rejects_foreign_socket_with_equal_server_uuid_without_mutation() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let identity = create_or_resolve(&mut storage, "Alice", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let foreign = server("server-a", "/tmp/tmux-foreign.sock", 41, "foreign-start");
+    let foreign_binding = storage
+        .with_binding_transaction(|records| {
+            records.insert_binding(&identity, &foreign, &pane("%1", 100))
+        })
+        .unwrap();
+    let before_state = binding_state(&fixture.database, &foreign_binding.id).unwrap();
+
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    endpoint.server = server("server-a", "/tmp/tmux-current.sock", 42, "current-start");
+    assert!(
+        current_name_presence(&mut storage, &mut endpoint, "Alice")
+            .unwrap()
+            .is_none()
+    );
+    assert!(endpoint.probe_calls.is_empty());
+
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&identity.id))
+        .unwrap()
+        .unwrap();
+    assert_eq!(entry.identity, identity);
+    assert_eq!(entry.binding, Some(foreign_binding));
+    assert_eq!(
+        binding_state(&fixture.database, &entry.binding.unwrap().id),
+        Some(before_state)
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn current_name_presence_detaches_stale_marker_but_preserves_saved_identity() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let bound = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true).unwrap();
+    let identity = bound.identity;
+    endpoint.pane_mut("%1").marker = None;
+
+    assert!(
+        current_name_presence(&mut storage, &mut endpoint, "Alice")
+            .unwrap()
+            .is_none()
+    );
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&identity.id))
+        .unwrap()
+        .unwrap();
+    assert_eq!(entry.identity, identity);
+    assert!(entry.binding.is_none());
+    storage.close().unwrap();
+}
+
+#[test]
+fn current_name_presence_unknown_server_evidence_preserves_binding() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let bound = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true).unwrap();
+    let identity = bound.identity;
+    let binding = bound.binding.unwrap();
+    let before_state = binding_state(&fixture.database, &binding.id).unwrap();
+    endpoint.server.server_id = "server-b".into();
+
+    assert!(
+        current_name_presence(&mut storage, &mut endpoint, "Alice")
+            .unwrap()
+            .is_none()
+    );
+    assert!(endpoint.probe_calls.is_empty());
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&identity.id))
+        .unwrap()
+        .unwrap();
+    assert_eq!(entry.binding, Some(binding));
+    assert_eq!(
+        binding_state(&fixture.database, &entry.binding.unwrap().id),
+        Some(before_state)
+    );
+    storage.close().unwrap();
+}
+
+#[test]
+fn current_name_presence_scopes_observation_without_reconciling_unrelated_rows() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1", "%2"]);
+    let alice = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true)
+        .unwrap()
+        .identity;
+    let bob = bind_identity(&mut storage, &mut endpoint, "%2", "Bob", true)
+        .unwrap()
+        .identity;
+    let bob_entry_before = storage
+        .with_binding_transaction(|records| records.entry_by_id(&bob.id))
+        .unwrap()
+        .unwrap();
+    let bob_binding_id = bob_entry_before.binding.as_ref().unwrap().id.clone();
+    let bob_state_before = binding_state(&fixture.database, &bob_binding_id).unwrap();
+    endpoint.pane_mut("%2").marker = None;
+
+    let observed = current_name_presence(&mut storage, &mut endpoint, "Alice")
+        .unwrap()
+        .expect("Alice remains active");
+    assert_eq!(observed.identity.unwrap().id, alice.id);
+
+    let bob_entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&bob.id))
+        .unwrap()
+        .unwrap();
+    assert!(bob_entry.binding.is_some());
+    assert_eq!(
+        binding_state(&fixture.database, &bob_binding_id),
+        Some(bob_state_before)
+    );
+    assert!(endpoint.probe_calls.is_empty());
+    storage.close().unwrap();
+}
+
+#[test]
+fn pane_presence_retains_server_pane_identity_and_binding_evidence() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1", "%2"]);
+    let current_server = endpoint.server.clone();
+    let bound = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true).unwrap();
+    let identity = bound.identity;
+    let binding = bound.binding.unwrap();
+
+    let active = pane_presence(&mut storage, &mut endpoint, "%1").unwrap();
+    assert_eq!(active.server, current_server);
+    assert_eq!(active.pane.id, "%1");
+    assert_eq!(active.identity, Some(identity.clone()));
+    assert_eq!(active.binding, Some(binding));
+
+    let unbound = pane_presence(&mut storage, &mut endpoint, "%2").unwrap();
+    assert_eq!(unbound.server, current_server);
+    assert_eq!(unbound.pane.id, "%2");
+    assert_eq!(unbound.identity, None);
+    assert_eq!(unbound.binding, None);
+    storage.close().unwrap();
+}
+
+#[test]
+fn pane_presence_stale_marker_returns_pane_evidence_and_detaches_binding() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let mut endpoint = FakeEndpoint::new(&["%1"]);
+    let bound = bind_identity(&mut storage, &mut endpoint, "%1", "Alice", true).unwrap();
+    let identity = bound.identity;
+    endpoint.pane_mut("%1").marker = None;
+
+    let observed = pane_presence(&mut storage, &mut endpoint, "%1").unwrap();
+    assert_eq!(observed.server, endpoint.server);
+    assert_eq!(observed.pane.id, "%1");
+    assert_eq!(observed.identity, None);
+    assert_eq!(observed.binding, None);
+    let entry = storage
+        .with_binding_transaction(|records| records.entry_by_id(&identity.id))
+        .unwrap()
+        .unwrap();
+    assert!(entry.binding.is_none());
+    storage.close().unwrap();
+}

--- a/rust/crates/tmt-cli/src/binding_command.rs
+++ b/rust/crates/tmt-cli/src/binding_command.rs
@@ -4,17 +4,18 @@
 mod presentation;
 
 use crate::{
+    binding_error::{binding_failure, endpoint_failure},
     invocation::{Invocation, OutputMode},
     output::{Failure, after_cleanup},
 };
 use std::io::{self, Write};
 use tmt_adapters::{
     config::{ConfigFiles, ConfigPaths},
-    storage::{Storage, StorageError},
-    tmux::{BindingSession, CallerEnvironment, OperationOptions, Tmux, TmuxError},
+    storage::Storage,
+    tmux::{BindingSession, CallerEnvironment, OperationOptions, Tmux},
 };
 use tmt_core::{
-    binding::{self, BindingEntry, BindingError, IdentityPresence, UnboundIdentity},
+    binding::{self, BindingEntry, IdentityPresence, UnboundIdentity},
     endpoint::PaneObservation,
     identity::Identity,
     names::is_pane_target,
@@ -42,23 +43,6 @@ enum Report {
         pane: PaneObservation,
         identity: Option<Identity>,
     },
-}
-
-fn endpoint_failure(error: TmuxError) -> Failure {
-    Failure::new("RECONCILIATION_FAILED", error.to_string(), 1).caused_by(error)
-}
-
-fn binding_failure(error: BindingError<StorageError, TmuxError>) -> Failure {
-    let (code, status) = match &error {
-        BindingError::InvalidName(_) => ("INVALID_NAME", 1),
-        BindingError::NameNotFound(_) => ("NAME_NOT_FOUND", 3),
-        BindingError::PaneNotFound(_) => ("PANE_NOT_FOUND", 3),
-        BindingError::NameAlreadyActive => ("NAME_ALREADY_ACTIVE", 5),
-        BindingError::PaneAlreadyBound => ("PANE_ALREADY_BOUND", 5),
-        BindingError::ConfirmationRequired => ("CONFIRMATION_REQUIRED", 5),
-        _ => ("RECONCILIATION_FAILED", 1),
-    };
-    Failure::new(code, error.to_string(), status).caused_by(error)
 }
 
 fn preflight(

--- a/rust/crates/tmt-cli/src/binding_error.rs
+++ b/rust/crates/tmt-cli/src/binding_error.rs
@@ -1,0 +1,22 @@
+//! Shared CLI error translation; binding policy remains in core.
+
+use crate::output::Failure;
+use tmt_adapters::{storage::StorageError, tmux::TmuxError};
+use tmt_core::binding::BindingError;
+
+pub fn endpoint_failure(error: TmuxError) -> Failure {
+    Failure::new("RECONCILIATION_FAILED", error.to_string(), 1).caused_by(error)
+}
+
+pub fn binding_failure(error: BindingError<StorageError, TmuxError>) -> Failure {
+    let (code, status) = match &error {
+        BindingError::InvalidName(_) => ("INVALID_NAME", 1),
+        BindingError::NameNotFound(_) => ("NAME_NOT_FOUND", 3),
+        BindingError::PaneNotFound(_) => ("PANE_NOT_FOUND", 3),
+        BindingError::NameAlreadyActive => ("NAME_ALREADY_ACTIVE", 5),
+        BindingError::PaneAlreadyBound => ("PANE_ALREADY_BOUND", 5),
+        BindingError::ConfirmationRequired => ("CONFIRMATION_REQUIRED", 5),
+        _ => ("RECONCILIATION_FAILED", 1),
+    };
+    Failure::new(code, error.to_string(), status).caused_by(error)
+}

--- a/rust/crates/tmt-cli/src/check_command.rs
+++ b/rust/crates/tmt-cli/src/check_command.rs
@@ -1,0 +1,86 @@
+//! Diagnostic capture composition; terminal content never completes a request.
+
+use crate::{
+    invocation::OutputMode,
+    output::{Failure, after_cleanup},
+    target,
+};
+use std::io::{self, Write};
+use tmt_adapters::{
+    config::{ConfigFiles, ConfigPaths},
+    storage::Storage,
+    tmux::Tmux,
+};
+use tmt_core::binding::PaneIdentity;
+
+struct Report {
+    target: String,
+    observed: PaneIdentity,
+    lines: u64,
+    output: String,
+}
+
+fn run(target: String, lines: Option<u64>) -> Result<Report, Failure> {
+    let paths = ConfigPaths::discover().map_err(Failure::from)?;
+    let settings = ConfigFiles {
+        paths: paths.clone(),
+    }
+    .load()
+    .map_err(Failure::from)?
+    .settings;
+    let lines = lines.unwrap_or(settings.capture_lines);
+    let tmux = Tmux::default();
+    let mut storage = Storage::open(paths.database).map_err(|error| {
+        Failure::new("IDENTITY_ERROR", "Could not open identity storage.", 1).caused_by(error)
+    })?;
+    let pending = target::resolve(&mut storage, &tmux, &target).and_then(|observed| {
+        let output = tmux
+            .capture_on(&observed.server.socket_path, &observed.pane.id, lines)
+            .map_err(|error| {
+                Failure::new(
+                    "ERROR",
+                    format!(
+                        "Failed to capture pane {}. Is tmux running?",
+                        observed.pane.id
+                    ),
+                    1,
+                )
+                .caused_by(error)
+            })?;
+        Ok(Report {
+            target,
+            observed,
+            lines,
+            output,
+        })
+    });
+    after_cleanup(pending, || storage.close())
+}
+
+pub fn execute(target: String, lines: Option<u64>, mode: OutputMode) -> io::Result<u8> {
+    let report = match run(target, lines) {
+        Ok(report) => report,
+        Err(error) => return error.publish(mode),
+    };
+    let mut stdout = io::stdout().lock();
+    if mode.json {
+        let mut document = serde_json::json!({
+            "target": report.target,
+            "pane": report.observed.pane.id,
+            "lines": report.lines,
+            "output": report.output,
+        });
+        if let Some(identity) = report.observed.identity {
+            document["identity"] = serde_json::json!({"name": identity.name, "canonicalName": identity.canonical_name});
+        }
+        writeln!(stdout, "{document}")?;
+    } else {
+        writeln!(
+            stdout,
+            "─── Output from {} ({}) ───",
+            report.target, report.observed.pane.id
+        )?;
+        writeln!(stdout, "{}", report.output)?;
+    }
+    Ok(0)
+}

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -1,4 +1,6 @@
 mod binding_command;
+mod binding_error;
+mod check_command;
 mod config_command;
 mod diagnostics;
 mod grammar;
@@ -7,6 +9,7 @@ mod invocation;
 mod output;
 mod parser;
 mod response_command;
+mod target;
 
 use std::io::{self, Write};
 use std::process::ExitCode;
@@ -35,7 +38,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration, storage-only identity create/show/list and reply/result, and pane identity name/this/add/whoami/unbind/rm/list are available. Transport commands are not implemented yet. Use isolated test state only.\n"
+                "Native development preview: configuration, storage-only identity create/show/list and reply/result, pane identity name/this/add/whoami/unbind/rm/list, and diagnostic check/read are available. Talk is not implemented yet. Use isolated test state only.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -68,6 +71,10 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Identity(request) => {
             drop(stdout);
             return identity_command::execute(request, parsed.mode);
+        }
+        Invocation::Check { target, lines } => {
+            drop(stdout);
+            return check_command::execute(target, lines, parsed.mode);
         }
         request @ (Invocation::Reply { .. } | Invocation::Result { .. }) => {
             drop(stdout);

--- a/rust/crates/tmt-cli/src/target.rs
+++ b/rust/crates/tmt-cli/src/target.rs
@@ -1,0 +1,40 @@
+//! Current-server pane-first routing shared by diagnostic and delivery commands.
+
+use crate::{
+    binding_error::{binding_failure, endpoint_failure},
+    output::Failure,
+};
+use tmt_adapters::{
+    storage::Storage,
+    tmux::{BindingSession, OperationOptions, Tmux},
+};
+use tmt_core::{
+    binding::{self, PaneIdentity},
+    names::is_pane_target,
+};
+
+pub fn resolve(storage: &mut Storage, tmux: &Tmux, input: &str) -> Result<PaneIdentity, Failure> {
+    let mut endpoint = BindingSession::new(tmux);
+    if is_pane_target(input) {
+        let pane = tmux
+            .resolve_target(input, OperationOptions::default())
+            .map_err(endpoint_failure)?
+            .ok_or_else(|| {
+                Failure::new(
+                    "PANE_NOT_FOUND",
+                    format!("Pane target '{input}' was not found."),
+                    3,
+                )
+            })?;
+        return binding::pane_presence(storage, &mut endpoint, &pane).map_err(binding_failure);
+    }
+    binding::current_name_presence(storage, &mut endpoint, input)
+        .map_err(binding_failure)?
+        .ok_or_else(|| {
+            Failure::new(
+                "NAME_NOT_FOUND",
+                format!("Identity '{input}' is not active."),
+                3,
+            )
+        })
+}

--- a/rust/crates/tmt-core/src/binding.rs
+++ b/rust/crates/tmt-core/src/binding.rs
@@ -6,7 +6,9 @@ mod operations;
 #[cfg(test)]
 mod evidence_tests;
 
-pub use observation::{evaluate_binding, list_presence, name_presence, pane_presence};
+pub use observation::{
+    current_name_presence, evaluate_binding, list_presence, name_presence, pane_presence,
+};
 pub use operations::{bind_identity, remove_identity, unbind_identity};
 
 use crate::{
@@ -79,8 +81,10 @@ pub struct IdentityPresence {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaneIdentity {
+    pub server: ServerEvidence,
     pub pane: PaneObservation,
     pub identity: Option<Identity>,
+    pub binding: Option<Binding>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/crates/tmt-core/src/binding/observation.rs
+++ b/rust/crates/tmt-core/src/binding/observation.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     identity::{self, IdentityError, Lifetime},
-    names::validate_name,
+    names::{normalize_name, validate_name},
 };
 use std::collections::BTreeMap;
 
@@ -170,13 +170,55 @@ pub fn pane_presence<R: BindingRepository, O: BindingEndpoint>(
             .cloned()
             .ok_or_else(|| BindingError::PaneNotFound(pane_id.into()))?;
         let entry = records.entry_by_pane(pane_id, &snapshot.server.server_id)?;
-        let identity = match entry {
+        let server = snapshot.server.clone();
+        let active = match entry {
             Some(entry) => reconcile(records, entry, &EndpointProbe::Live(snapshot))?
-                .filter(|row| row.presence == Presence::Active)
-                .map(|row| row.identity),
+                .filter(|row| row.presence == Presence::Active),
             None => None,
         };
-        Ok(PaneIdentity { pane, identity })
+        let (identity, binding) =
+            active.map_or((None, None), |row| (Some(row.identity), row.binding));
+        Ok(PaneIdentity {
+            server,
+            pane,
+            identity,
+            binding,
+        })
+    })
+}
+
+/// Routing is scoped to the current server, unlike global presence reporting.
+/// Lookup does not impose creation-name validation or probe a foreign server.
+pub fn current_name_presence<R: BindingRepository, O: BindingEndpoint>(
+    repository: &mut R,
+    endpoint: &mut O,
+    name: &str,
+) -> Result<Option<PaneIdentity>, BindingError<R::Error, O::Error>> {
+    repository.with_binding_transaction(|records| {
+        endpoint.begin_coordination();
+        let Some(identity) = records.find_identity(&normalize_name(name))? else {
+            return Ok(None);
+        };
+        let Some(entry) = records.entry_by_id(&identity.id)? else {
+            return Ok(None);
+        };
+        let Some(binding) = &entry.binding else {
+            return Ok(None);
+        };
+        let snapshot = endpoint
+            .current_snapshot(std::slice::from_ref(&binding.pane_id))
+            .map_err(BindingError::Endpoint)?;
+        let server = snapshot.server.clone();
+        let active = reconcile(records, entry, &EndpointProbe::Live(snapshot))?
+            .filter(|row| row.presence == Presence::Active);
+        Ok(active.and_then(|row| {
+            row.pane.map(|pane| PaneIdentity {
+                server,
+                pane,
+                identity: Some(row.identity),
+                binding: row.binding,
+            })
+        }))
     })
 }
 

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -70,6 +70,8 @@ export interface CliRunOptions {
   progressFile?: string;
   /** Record transport sequencing without injecting a failure. */
   transportTrace?: boolean;
+  /** Fail only diagnostic capture, after target resolution has succeeded. */
+  captureFault?: 'exit' | 'overflow' | 'timeout';
   /** Inject one transport-stage failure into this CLI process only. */
   transportFault?: {
     /** set-buffer is safe to fall back from; paste and submit are uncertain. */
@@ -215,6 +217,13 @@ for arg in "${'$'}@"; do
     *) tmux_command="${'$'}arg" ;;
   esac
 done
+if [ "${'$'}tmux_command" = "capture-pane" ]; then
+  case "${'$'}{TMT_E2E_CAPTURE_FAULT:-}" in
+    exit) exit 97 ;;
+    overflow) exec head -c 4194305 /dev/zero ;;
+    timeout) exec sleep 5 ;;
+  esac
+fi
 if [ "${'$'}tmux_command" = "set-option" ]; then
   unset_metadata=0
   pane_metadata=0
@@ -394,6 +403,7 @@ exit ${'$'}status
       env.TMT_E2E_FORBIDDEN_TMUX_LOG = this.forbiddenTmuxLogPath;
     }
     if (options.progressFile) env.TMT_E2E_PROGRESS_FILE = options.progressFile;
+    if (options.captureFault) env.TMT_E2E_CAPTURE_FAULT = options.captureFault;
     if (options.transportFault) {
       env.TMT_E2E_TRANSPORT_FAULT_STAGE = options.transportFault.stage;
     }

--- a/test/e2e/native-check.e2e.test.ts
+++ b/test/e2e/native-check.e2e.test.ts
@@ -1,0 +1,166 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type E2EFixture, type E2EFixtureOptions } from './harness.js';
+import { durableState } from './identity-state-oracle.js';
+import { installTmuxTrace } from './tmux-trace.js';
+
+interface Capture {
+  target: string;
+  pane: string;
+  identity?: { name: string; canonicalName: string };
+  lines: number;
+  output: string;
+}
+
+function options(extra: E2EFixtureOptions = {}): E2EFixtureOptions {
+  const native = process.env.TMT_TEST_NATIVE_CLI;
+  if (!native) throw new Error('Native check E2E requires the Docker-built CLI.');
+  return { mode: 'input-log', executableEnv: { TMT_TEST_CLI: native }, ...extra };
+}
+
+async function seedDiagnostic(fixture: E2EFixture, message: string): Promise<void> {
+  fixture.tmux(['send-keys', '-l', '-t', fixture.pane, '--', message]);
+  fixture.tmux(['send-keys', '-t', fixture.pane, 'Enter']);
+  await fixture.waitForEvent(
+    (event) => event.event === 'input' && event.pid === fixture.panePid && event.line === message
+  );
+  // Capture is intentionally terminal diagnostics, not a final reply assertion.
+  await fixture.waitForCapture((output) => output.includes(message));
+}
+
+describe.sequential('native current-server diagnostic routing', () => {
+  it('captures names, stable panes and tmux targets with configured and explicit line counts', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect(await fixture.runJsonCli(['name', 'Alice'])).toMatchObject({
+        code: 0,
+        json: { bound: true },
+      });
+      const marker = 'native-check-causal-marker';
+      await seedDiagnostic(fixture, marker);
+      fs.writeFileSync(
+        path.join(fixture.globalDir, 'config.json'),
+        JSON.stringify({ defaults: { captureLines: 0 } })
+      );
+      const metadata = fixture.paneMetadata();
+      for (const target of ['aLiCe', fixture.pane, fixture.paneTarget(fixture.pane)]) {
+        const captured = await fixture.runJsonCli<Capture>(['check', target]);
+        expect(captured).toMatchObject({
+          code: 0,
+          stderr: '',
+          json: {
+            target,
+            pane: fixture.pane,
+            identity: { name: 'Alice', canonicalName: 'alice' },
+            lines: 0,
+            output: expect.stringContaining(marker),
+          },
+        });
+        expect(Object.keys(captured.json ?? {}).sort()).toEqual([
+          'identity',
+          'lines',
+          'output',
+          'pane',
+          'target',
+        ]);
+      }
+      const maximum = await fixture.runJsonCli<Capture>(['read', 'Alice', '--lines=2147483647']);
+      expect(maximum).toMatchObject({
+        code: 0,
+        json: { lines: 2147483647, output: expect.stringContaining(marker) },
+      });
+      expect(fixture.paneMetadata()).toBe(metadata);
+      const human = await fixture.runCli(['check', 'Alice', '--lines', '0']);
+      expect(human.code).toBe(0);
+      expect(human.stderr).toBe('');
+      expect(human.stdout).toContain(`Output from Alice (${fixture.pane})`);
+      expect(human.stdout).toContain(marker);
+      expect(await fixture.runJsonCli(['unbind'])).toMatchObject({ code: 0 });
+      const unbound = await fixture.runJsonCli<Capture>(['read', fixture.pane, '0']);
+      expect(unbound).toMatchObject({
+        code: 0,
+        json: { pane: fixture.pane, output: expect.stringContaining(marker) },
+      });
+      expect(unbound.json).not.toHaveProperty('identity');
+      const missing = await fixture.runJsonCli(['check', '%999999']);
+      expect(missing).toMatchObject({ code: 3, json: { error: { code: 'PANE_NOT_FOUND' } } });
+    }, options());
+  });
+
+  it.each([false, true])(
+    'does not route to an equal pane ID on a foreign server (copied UUID: %s)',
+    async (copyUuid) => {
+      await withE2EFixture(async (first) => {
+        expect(await first.runJsonCli(['name', 'Foreign'])).toMatchObject({ code: 0 });
+        const serverId = JSON.parse(first.paneMetadata()).globalIdentity.serverId;
+        await withE2EFixture(
+          async (second) => {
+            expect(second.pane).toBe(first.pane);
+            if (copyUuid) second.tmux(['set-option', '-s', '@tmux-team.server-id', serverId]);
+            expect(await second.runJsonCli(['list', 'Foreign'])).toMatchObject({
+              code: 0,
+              json: { identity: { name: 'Foreign' }, presence: 'active' },
+            });
+            const before = durableState(first);
+            const trace = installTmuxTrace(second);
+            const result = await second.runJsonCli(['check', 'Foreign'], { outsideTmux: true });
+            expect(result).toMatchObject({
+              code: 3,
+              stderr: '',
+              json: { error: { code: 'NAME_NOT_FOUND' } },
+            });
+            expect(trace.invocations().some((line) => line.includes('capture-pane'))).toBe(false);
+            expect(durableState(first)).toEqual(before);
+            expect(second.paneMetadata()).toBe('');
+          },
+          options({ globalDir: first.globalDir })
+        );
+      }, options());
+    }
+  );
+
+  it('keeps selected-name inspection bounded among unrelated unbound panes', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect(await fixture.runJsonCli(['name', 'Scoped'])).toMatchObject({ code: 0 });
+      await seedDiagnostic(fixture, 'scoped-native-check');
+      const trace = installTmuxTrace(fixture);
+      const capture = async () => {
+        trace.clear();
+        const result = await fixture.runJsonCli<Capture>(['check', 'Scoped'], {
+          outsideTmux: true,
+        });
+        expect(result).toMatchObject({
+          code: 0,
+          json: { output: expect.stringContaining('scoped-native-check') },
+        });
+        return trace.invocations();
+      };
+      const small = await capture();
+      for (let index = 0; index < 30; index++)
+        fixture.tmux(['new-window', '-d', '-t', 'e2e:', '-n', `unbound-${index}`, 'sleep', '300']);
+      const large = await capture();
+      expect(large).toHaveLength(small.length);
+      expect(small).toHaveLength(3);
+      expect(large.filter((line) => line.includes('capture-pane'))).toHaveLength(1);
+      const paneQueries = large.filter((line) => line.includes('list-panes'));
+      expect(paneQueries).toHaveLength(1);
+      expect(paneQueries[0]).toContain(' -f ');
+      expect(paneQueries[0]).toContain(fixture.pane);
+    }, options());
+  });
+
+  it.each(['exit', 'overflow', 'timeout'] as const)(
+    'returns failure without partial output after capture %s',
+    async (fault) => {
+      await withE2EFixture(async (fixture) => {
+        const result = await fixture.runJsonCli<Capture>(['check', fixture.pane], {
+          captureFault: fault,
+        });
+        expect(result).toMatchObject({ code: 1, stderr: '', json: { error: { code: 'ERROR' } } });
+        expect(result.json).not.toHaveProperty('output');
+        expect(result.stdout).not.toContain('\u0000');
+        expect(fixture.paneMetadata()).toBe('');
+      }, options());
+    }
+  );
+});

--- a/test/native/binding.test.ts
+++ b/test/native/binding.test.ts
@@ -1,12 +1,12 @@
 import Database from 'better-sqlite3';
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { calibrateTmuxTripwire } from './tmux-tripwire.js';
 import {
   expectError,
   parseWholeStdout,
   runCli,
-  type Sandbox,
   withSandbox,
 } from '../../src/test-support/cli-process.js';
 
@@ -46,35 +46,6 @@ function withDatabase<T>(file: string, callback: (database: Database.Database) =
   } finally {
     database.close();
   }
-}
-
-function installTmuxTripwire(sandbox: Sandbox): string {
-  const directory = path.join(sandbox.root, 'task-owned-tripwire');
-  const logPath = path.join(sandbox.root, 'tmux-invocations.log');
-  mkdirSync(directory);
-  const executable = path.join(directory, 'tmux');
-  writeFileSync(executable, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TMT_BINDING_TMUX_LOG"\nexit 97\n');
-  chmodSync(executable, 0o755);
-  sandbox.env.PATH = `${directory}${path.delimiter}${process.env.PATH ?? ''}`;
-  sandbox.env.TMT_BINDING_TMUX_LOG = logPath;
-  return logPath;
-}
-
-async function calibrateTmuxTripwire(sandbox: Sandbox): Promise<string> {
-  const logPath = installTmuxTripwire(sandbox);
-  const tripwire = await runCli(
-    {
-      ...sandbox,
-      cli: { executable: '/usr/bin/env', args: ['tmux'] },
-    },
-    [],
-    { deadlineMs: 2_000 }
-  );
-  expect(tripwire.status).toBe(97);
-  expect(tripwire.stdout).toBe('');
-  expect(tripwire.stderr).toBe('');
-  expect(readFileSync(logPath, 'utf8')).toBe('\n');
-  return logPath;
 }
 
 function seedExchange(database: Database.Database, identityId: string): void {

--- a/test/native/check.test.ts
+++ b/test/native/check.test.ts
@@ -1,0 +1,53 @@
+import Database from 'better-sqlite3';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  fileSnapshot,
+  runCli,
+  withSandbox,
+} from '../../src/test-support/cli-process.js';
+import { calibrateTmuxTripwire } from './tmux-tripwire.js';
+
+if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
+
+describe('native check process preflight', () => {
+  it('validates configuration before any tmux call or storage creation', async () => {
+    for (const local of [false, true]) {
+      await withSandbox(async (sandbox) => {
+        const log = await calibrateTmuxTripwire(sandbox);
+        mkdirSync(sandbox.globalDir, { recursive: true });
+        writeFileSync(local ? sandbox.localConfig : sandbox.globalConfig, '{ invalid config');
+        const before = fileSnapshot(sandbox.root);
+        const result = await runCli(sandbox, ['check', '%14', '--json']);
+        expect(result.status).toBe(1);
+        expectError(result, 'CONFIG_ERROR');
+        expect(result.stderr).toBe('');
+        expect(existsSync(sandbox.database)).toBe(false);
+        expect(readFileSync(log, 'utf8')).toBe('\n');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+      });
+    }
+  });
+
+  it('does not create unknown names or perform endpoint IO for lookup-only misses', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      for (const name of ['NeverCreated', 'bad\nname']) {
+        const result = await runCli(sandbox, ['read', name, '--json']);
+        expect(result.status).toBe(3);
+        expectError(result, 'NAME_NOT_FOUND');
+        expect(result.stderr).toBe('');
+      }
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+      const database = new Database(sandbox.database, { readonly: true });
+      try {
+        expect(database.prepare('SELECT COUNT(*) AS count FROM identities').get()).toEqual({
+          count: 0,
+        });
+      } finally {
+        database.close();
+      }
+    });
+  });
+});

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -62,9 +62,9 @@ describe('native grammar preview process contract', () => {
       expect(help.stderr).toBe('');
       expect(help.stdout).toContain('Native development preview');
       expect(help.stdout).toContain(
-        'configuration, storage-only identity create/show/list and reply/result, and pane identity name/this/add/whoami/unbind/rm/list are available'
+        'configuration, storage-only identity create/show/list and reply/result, pane identity name/this/add/whoami/unbind/rm/list, and diagnostic check/read are available'
       );
-      expect(help.stdout).toContain('Transport commands are not implemented yet.');
+      expect(help.stdout).toContain('Talk is not implemented yet.');
       expect(help.stdout).toContain('Manage identity records without probing tmux');
       expect(help.stdout).toContain('temporary unless saved');
       expect(help.stdout).toContain('rm');
@@ -80,7 +80,6 @@ describe('native grammar preview process contract', () => {
       const before = fileSnapshot(sandbox.root);
       for (const args of [
         ['talk', 'worker', 'hello'],
-        ['check', '%14'],
         ['init'],
         ['role', 'show'],
         ['preamble'],

--- a/test/native/identity.test.ts
+++ b/test/native/identity.test.ts
@@ -1,7 +1,8 @@
 import Database from 'better-sqlite3';
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { calibrateTmuxTripwire } from './tmux-tripwire.js';
 import {
   expectError,
   expectJsonSuccess,
@@ -141,37 +142,6 @@ function dependentSnapshot(
       )
       .get(identityId),
   };
-}
-
-function installTmuxTripwire(sandbox: Sandbox): string {
-  const directory = path.join(sandbox.root, 'task-owned-tripwire');
-  const logPath = path.join(sandbox.root, 'tmux-invocations.log');
-  mkdirSync(directory);
-  const executable = path.join(directory, 'tmux');
-  writeFileSync(
-    executable,
-    '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TMT_IDENTITY_TMUX_LOG"\nexit 97\n'
-  );
-  chmodSync(executable, 0o755);
-  sandbox.env.PATH = `${directory}${path.delimiter}${process.env.PATH ?? ''}`;
-  sandbox.env.TMT_IDENTITY_TMUX_LOG = logPath;
-  return logPath;
-}
-
-async function calibrateTmuxTripwire(sandbox: Sandbox): Promise<string> {
-  const logPath = installTmuxTripwire(sandbox);
-  const tripwire = await runCli(
-    {
-      ...sandbox,
-      cli: { executable: '/usr/bin/env', args: ['tmux'] },
-    },
-    [],
-    { deadlineMs: 2_000 }
-  );
-  expect(tripwire.status).toBe(97);
-  expect(tripwire.stderr).toBe('');
-  expect(readFileSync(logPath, 'utf8')).toBe('\n');
-  return logPath;
 }
 
 describe('native durable identity process boundary', () => {

--- a/test/native/response.test.ts
+++ b/test/native/response.test.ts
@@ -1,7 +1,8 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { installTmuxTripwire } from './tmux-tripwire.js';
 import {
   expectError,
   expectJsonSuccess,
@@ -32,21 +33,6 @@ function temporaryFile(sandbox: Sandbox, name: string, bytes: string | Uint8Arra
   const file = path.join(sandbox.root, name);
   writeFileSync(file, bytes);
   return file;
-}
-
-function installTmuxTripwire(sandbox: Sandbox): string {
-  const directory = path.join(sandbox.root, 'tripwire-bin');
-  const logPath = path.join(sandbox.root, 'tmux-invocations.log');
-  mkdirSync(directory);
-  const executable = path.join(directory, 'tmux');
-  writeFileSync(
-    executable,
-    '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TMT_NATIVE_RESPONSE_TMUX_LOG"\nexit 97\n'
-  );
-  chmodSync(executable, 0o755);
-  sandbox.env.PATH = `${directory}${path.delimiter}${process.env.PATH ?? ''}`;
-  sandbox.env.TMT_NATIVE_RESPONSE_TMUX_LOG = logPath;
-  return logPath;
 }
 
 function malformedConfig(sandbox: Sandbox): void {

--- a/test/native/tmux-tripwire.ts
+++ b/test/native/tmux-tripwire.ts
@@ -1,0 +1,31 @@
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { expect } from 'vitest';
+import { runCli, type Sandbox } from '../../src/test-support/cli-process.js';
+
+/** A task-owned executable that fails visibly instead of touching host tmux. */
+export function installTmuxTripwire(sandbox: Sandbox): string {
+  const directory = path.join(sandbox.root, 'task-owned-tripwire');
+  const logPath = path.join(sandbox.root, 'tmux-invocations.log');
+  mkdirSync(directory);
+  const executable = path.join(directory, 'tmux');
+  writeFileSync(executable, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TMT_TEST_TMUX_LOG"\nexit 97\n');
+  chmodSync(executable, 0o755);
+  sandbox.env.PATH = `${directory}${path.delimiter}${sandbox.env.PATH ?? ''}`;
+  sandbox.env.TMT_TEST_TMUX_LOG = logPath;
+  return logPath;
+}
+
+export async function calibrateTmuxTripwire(sandbox: Sandbox): Promise<string> {
+  const logPath = installTmuxTripwire(sandbox);
+  const result = await runCli(
+    { ...sandbox, cli: { executable: '/usr/bin/env', args: ['tmux'] } },
+    [],
+    { deadlineMs: 2_000 }
+  );
+  expect(result.status).toBe(97);
+  expect(result.stdout).toBe('');
+  expect(result.stderr).toBe('');
+  expect(readFileSync(logPath, 'utf8')).toBe('\n');
+  return logPath;
+}


### PR DESCRIPTION
## Scope

Closes #125. Parent rewrite #93, native talk/short receipts #106 and installation #82 remain open. Adds public native check/read and shared current-server target routing; installed TypeScript and schema are unchanged.

## Architecture and primary review

Reviewed commit: `99646a19330f3b3a6929f024915711ddb543e6a9`.

Personally reviewed all changed production, surrounding binding evaluation and callers, delegated routing tests, shared tripwire extraction, public process tests, Docker harness/scenarios and documentation. Retained existing PaneIdentity server/binding evidence instead of rediscovering it. Current-name routing reuses reconciliation and canonical lookup; global presence is not routing authority. One invocation-owned Storage is closed before output; capture remains diagnostic and outside the binding transaction. Shared binding errors and calibrated tmux tripwire replace existing duplication.

Review strengthened foreign/unknown/unrelated state checks with independent read-only SQL. Corrected scenario expectations to the actual global list JSON and scoped list-panes filter, preserving strict routing/cost assertions rather than adding another implementation. No unresolved findings. Rebase onto merged #124 changed no tested file contents.

## Verification

- [x] Primary reviewed all changed files and relevant callers.
- [x] Local checks completed as recorded below.
- [x] All 11 CI jobs passed on reviewed head `99646a19330f3b3a6929f024915711ddb543e6a9`, run 34186518460, first attempt.

- Rust pinned and MSRV 1.88.0: `cargo test --locked --workspace --manifest-path rust/Cargo.toml` and its MSRV equivalent: each 228 passed (153 adapters, 17 CLI, 19 architecture, 39 core).
- `cargo clippy --locked --workspace --all-targets --manifest-path rust/Cargo.toml -- -D warnings`, rustfmt check, native bins/examples build and `git diff --check`: passed.
- `pnpm test:native` with explicit native descriptors: 72 passed across seven files.
- `pnpm check`: passed. `pnpm test`: 1,102 passed across 70 files; coverage gates passed (95.66% statements, 89.47% branches).
- `pnpm test:e2e` twice locally: each passed 153 native adapter tests and 144 E2E tests, one existing opt-in skip. Seven new public native scenarios cover configured/explicit capture, cross-server rejection including copied UUID, selected-pane cost, and exit/overflow/timeout without partial success.

## Lifecycle

ARCHITECTURE.md, DEVELOPMENT.md and RUST-REWRITE.md describe current implementation and test ownership. Branch feat/125-native-check; dedicated worktree tmt-125-native-check. #127 continues role/preamble prerequisites in a separate worktree. No host tmux, real agent, user database, global install or publication was touched.
