### PR TITLE
feat(native): port role and preamble through shared profile owners

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1177,6 +1177,29 @@ Native process tests share one calibrated tmux tripwire instead of copying
 host-protection wrappers across command suites. Docker's existing wrapper owns
 capture failure injection after successful target resolution.
 
+#127 adds native role/preamble commands. Core `profile` owns one bounded
+normalization contract and a validated content value; exact exchange text remains
+separate. Its profile reader/writer ports share role/preamble mechanics without
+merging their tables or injection semantics. The existing identity record decoder,
+Storage connection and immediate transaction helper remain the SQL owners.
+Writes revalidate the observed non-retired identity ID within the transaction,
+so a retired/reused name cannot receive a stale profile write. Reads and listing
+hide retired owners; profile operations do not promote lifetime or change cadence.
+
+CLI `identity_context` composes explicit canonical lookup or existing verified
+caller/binding evidence, never pane-target routing for an explicit identity.
+`profile_command` acquires role files before opening storage, resolves identity,
+normalizes content, applies the shared operation and closes before presentation.
+Explicit access does not load settings or probe tmux. Role and preamble retain
+their separate public projections and error codes. Native public identity
+projections include the lifetime field established by #109.
+
+Adapter `bounded_file` is the shared regular-file byte acquisition owner for
+role and reply: nonblocking open, regular-file check, maximum-plus-one read,
+and overflow rejection before decoding. Callers retain their respective UTF-8
+and content policies. Reply stdin flags, deadlines and exact-body validation are
+unchanged; role does not gain stdin. This is not a path-confinement boundary.
+
 #### Native storage and runtime adapters
 
 Native migration 9 adds `lifetime` (default `saved` for existing identities) and

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,7 +35,8 @@ The `rust/` workspace is not the installed runtime yet. It implements only
 help/version/completion, typed grammar, the existing `config` command and
 storage-only `identity create/show/list` under #113, and pane identity
 `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` under #109, plus storage-only
-`reply`/`result` under #122, and diagnostic `check`/`read` under #125.
+`reply`/`result` under #122, diagnostic `check`/`read` under #125, and
+`role`/`preamble` under #127.
 Other effectful commands still explicitly fail.
 The #118 request/final service is an internal transactional foundation only;
 its public reply/result composition is supplied by #122, not native talk. Its real SQLite
@@ -77,6 +78,12 @@ failure propagation. Native command suites reuse `test/native/tmux-tripwire.ts`;
 calibration proves that the task-owned executable would record accidental tmux
 access. Routing storage tests retain full binding evidence and use independent
 read-only SQL to detect unwanted foreign/unknown/unrelated binding touches.
+#127 profile tests cover normalized profile text separately from exact exchange
+text, transactional stale-owner rejection and unchanged identity/cadence state.
+`test/native/profile.test.ts` covers offline CLI persistence, configuration/tmux
+independence and bounded role files. `test/e2e/native-profile.e2e.test.ts` covers
+verified implicit selection, explicit override, saved rebind and temporary
+retirement. Reply regression tests continue to exercise the shared file reader.
 The separate storage adapter upgrades historical schemas 0–8 to native schema 9,
 tested through a development-only probe rather than an installed command.
 Use isolated test databases only: installed TypeScript cannot reopen schema 9.

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -10,7 +10,8 @@ native reply/result with bounded input. Native talk and the full #106
 short-receipt transition remain unimplemented.
 #124 adds the bounded native send/capture adapter and isolated real-tmux
 acceptance. #125 adds shared current-server target resolution and public
-diagnostic check/read. Public talk composition and observation remain pending.
+diagnostic check/read. #127 adds native role/preamble and shared bounded profile
+text/file acquisition. Public talk composition and observation remain pending.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
 The compatibility reference is TypeScript main `cb53533f3a9f19a1a2ab95af59dda20df419200b`
@@ -70,7 +71,7 @@ delegates from native to Node.
 The preview implements help, version, Bash/Zsh completion and the existing
 `config` command plus storage-only `identity create/show/list` (#113) and pane
 identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109), plus storage-only
-`reply`/`result` (#122) and diagnostic `check`/`read` (#125).
+`reply`/`result` (#122), diagnostic `check`/`read` (#125), and role/preamble (#127).
 Other recognized effectful commands return
 `NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
 storage, tmux or input acquisition. Text-only commands reject JSON. Native

--- a/rust/crates/tmt-adapters/src/bounded_file.rs
+++ b/rust/crates/tmt-adapters/src/bounded_file.rs
@@ -1,0 +1,56 @@
+//! Shared bounded regular-file acquisition; callers own text semantics.
+
+use nix::fcntl::OFlag;
+use std::{
+    error::Error,
+    fmt,
+    fs::OpenOptions,
+    io::{self, Read},
+    os::unix::fs::OpenOptionsExt,
+    path::Path,
+};
+
+#[derive(Debug)]
+pub enum FileReadError {
+    TooLarge,
+    Io(io::Error),
+}
+impl fmt::Display for FileReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::TooLarge => "File exceeds the input bound.",
+            Self::Io(_) => "Could not read a regular input file.",
+        })
+    }
+}
+impl Error for FileReadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::TooLarge => None,
+        }
+    }
+}
+
+pub fn read(path: &Path, maximum: usize) -> Result<Vec<u8>, FileReadError> {
+    let bound = maximum.checked_add(1).ok_or(FileReadError::TooLarge)?;
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(OFlag::O_NONBLOCK.bits())
+        .open(path)
+        .map_err(FileReadError::Io)?;
+    if !file.metadata().map_err(FileReadError::Io)?.is_file() {
+        return Err(FileReadError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Input must be a regular file.",
+        )));
+    }
+    let mut bytes = Vec::new();
+    file.take(bound as u64)
+        .read_to_end(&mut bytes)
+        .map_err(FileReadError::Io)?;
+    if bytes.len() > maximum {
+        return Err(FileReadError::TooLarge);
+    }
+    Ok(bytes)
+}

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -1,5 +1,7 @@
 //! Concrete native adapters. Application policy must not depend on this crate.
 
+#[cfg(unix)]
+pub mod bounded_file;
 pub mod config;
 mod json_document;
 #[cfg(unix)]

--- a/rust/crates/tmt-adapters/src/response_input.rs
+++ b/rust/crates/tmt-adapters/src/response_input.rs
@@ -10,10 +10,8 @@ use nix::{
 };
 use std::{
     error::Error,
-    fmt,
-    fs::OpenOptions,
-    io::{self, Read},
-    os::{fd::AsFd, unix::fs::OpenOptionsExt},
+    fmt, io,
+    os::fd::AsFd,
     path::Path,
     time::{Duration, Instant},
 };
@@ -114,22 +112,13 @@ fn decode(bytes: &[u8]) -> Result<String, ResponseInputError> {
 }
 
 pub fn read_file(path: &Path) -> Result<String, ResponseInputError> {
-    let file = OpenOptions::new()
-        .read(true)
-        .custom_flags(OFlag::O_NONBLOCK.bits())
-        .open(path)
-        .map_err(|cause| ResponseInputError::io(ResponseInputFailure::File, cause))?;
-    if !file
-        .metadata()
-        .map_err(|cause| ResponseInputError::io(ResponseInputFailure::File, cause))?
-        .is_file()
-    {
-        return Err(ResponseInputFailure::File.into());
-    }
-    let mut bytes = Vec::new();
-    file.take(MAX_EXCHANGE_TEXT_BYTES as u64 + 1)
-        .read_to_end(&mut bytes)
-        .map_err(|cause| ResponseInputError::io(ResponseInputFailure::File, cause))?;
+    let bytes =
+        crate::bounded_file::read(path, MAX_EXCHANGE_TEXT_BYTES).map_err(|error| match error {
+            crate::bounded_file::FileReadError::TooLarge => ResponseInputFailure::TooLarge.into(),
+            crate::bounded_file::FileReadError::Io(cause) => {
+                ResponseInputError::io(ResponseInputFailure::File, cause)
+            }
+        })?;
     decode(&bytes)
 }
 

--- a/rust/crates/tmt-adapters/src/storage/mod.rs
+++ b/rust/crates/tmt-adapters/src/storage/mod.rs
@@ -2,6 +2,7 @@ mod bindings;
 mod errors;
 mod identities;
 mod migrations;
+mod profiles;
 mod requests;
 
 #[cfg(test)]

--- a/rust/crates/tmt-adapters/src/storage/profiles.rs
+++ b/rust/crates/tmt-adapters/src/storage/profiles.rs
@@ -1,0 +1,87 @@
+//! Profile SQL composes over the existing identity records and connection.
+
+#[cfg(test)]
+mod tests;
+
+use super::{
+    Storage, StorageError,
+    errors::classify,
+    identities::{IdentityRecords, identity_row_at, with_immediate_transaction},
+};
+use rusqlite::{OptionalExtension, Row, params};
+use tmt_core::identity::Identity;
+use tmt_core::profile::{Profile, ProfileKind, ProfileReader, ProfileRepository, ProfileWriter};
+
+fn table(kind: ProfileKind) -> &'static str {
+    match kind {
+        ProfileKind::Role => "role_profiles",
+        ProfileKind::Preamble => "identity_preambles",
+    }
+}
+
+fn profile_row_at(row: &Row<'_>, offset: usize) -> rusqlite::Result<Profile> {
+    Ok(Profile {
+        content: row.get(offset)?,
+        updated_at: row.get(offset + 1)?,
+    })
+}
+
+impl ProfileReader for Storage {
+    fn find_profile(
+        &self,
+        identity_id: &str,
+        kind: ProfileKind,
+    ) -> Result<Option<Profile>, StorageError> {
+        self.connection()?.query_row(
+            &format!("SELECT p.content, p.updated_at FROM {} p JOIN identities i ON i.id = p.identity_id WHERE i.id = ? AND i.retired_at_ms IS NULL", table(kind)),
+            [identity_id], |row| profile_row_at(row, 0)
+        ).optional().map_err(|error| classify(error, "Read profile"))
+    }
+
+    fn list_preambles(&self) -> Result<Vec<(Identity, Profile)>, StorageError> {
+        let mut query = self.connection()?.prepare("SELECT i.id, i.name, i.canonical_name, i.lifetime, i.created_at, i.updated_at, p.content, p.updated_at FROM identities i JOIN identity_preambles p ON p.identity_id = i.id WHERE i.retired_at_ms IS NULL ORDER BY i.canonical_name COLLATE BINARY")
+            .map_err(|error| classify(error, "Prepare preamble list"))?;
+        query
+            .query_map([], |row| {
+                Ok((identity_row_at(row, 0)?, profile_row_at(row, 6)?))
+            })
+            .and_then(|rows| rows.collect())
+            .map_err(|error| classify(error, "List preambles"))
+    }
+}
+
+impl ProfileWriter for IdentityRecords<'_> {
+    fn set_profile(
+        &mut self,
+        identity_id: &str,
+        kind: ProfileKind,
+        content: &str,
+    ) -> Result<Profile, StorageError> {
+        self.0.query_row(&format!("INSERT INTO {} (identity_id, content, updated_at) VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) ON CONFLICT(identity_id) DO UPDATE SET content = excluded.content, updated_at = excluded.updated_at RETURNING content, updated_at", table(kind)),
+            params![identity_id, content], |row| profile_row_at(row, 0)).map_err(|error| classify(error, "Set profile"))
+    }
+    fn clear_profile(
+        &mut self,
+        identity_id: &str,
+        kind: ProfileKind,
+    ) -> Result<bool, StorageError> {
+        self.0
+            .execute(
+                &format!("DELETE FROM {} WHERE identity_id = ?", table(kind)),
+                [identity_id],
+            )
+            .map(|count| count > 0)
+            .map_err(|error| classify(error, "Clear profile"))
+    }
+}
+
+impl ProfileRepository for Storage {
+    fn with_profile_transaction<T>(
+        &mut self,
+        operation: impl FnOnce(&mut dyn ProfileWriter<Error = StorageError>) -> Result<T, StorageError>,
+    ) -> Result<T, StorageError> {
+        with_immediate_transaction(self, "profile", |transaction| {
+            operation(&mut IdentityRecords(transaction))
+        })
+    }
+}

--- a/rust/crates/tmt-adapters/src/storage/profiles/tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/profiles/tests.rs
@@ -1,0 +1,379 @@
+use super::super::*;
+use crate::test_support::TestDirectory;
+use rusqlite::{Connection, OpenFlags, params, types::Value};
+use std::path::PathBuf;
+use tmt_core::{
+    identity::{Lifetime, create_or_resolve},
+    profile::{self, ProfileKind, ProfileReader, normalize_content},
+};
+
+struct Fixture {
+    _directory: TestDirectory,
+    database: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = TestDirectory::new();
+        Self {
+            database: directory.path.join("state").join("tmux-team.db"),
+            _directory: directory,
+        }
+    }
+
+    fn open(&self) -> Storage {
+        Storage::open(&self.database).unwrap()
+    }
+
+    fn setup_connection(&self) -> Connection {
+        Connection::open(&self.database).unwrap()
+    }
+
+    fn observe(&self) -> Connection {
+        Connection::open_with_flags(&self.database, OpenFlags::SQLITE_OPEN_READ_ONLY).unwrap()
+    }
+}
+
+fn dependent_snapshot(connection: &Connection, identity_id: &str) -> Vec<Vec<Vec<Value>>> {
+    snapshot_queries(
+        connection,
+        identity_id,
+        &[
+            "SELECT * FROM role_profiles WHERE identity_id = ?",
+            "SELECT * FROM identity_preambles WHERE identity_id = ?",
+            "SELECT * FROM preamble_counters WHERE identity_id = ?",
+            "SELECT * FROM bindings WHERE identity_id = ?",
+        ],
+    )
+}
+
+fn snapshot_queries(
+    connection: &Connection,
+    identity_id: &str,
+    queries: &[&str],
+) -> Vec<Vec<Vec<Value>>> {
+    queries
+        .iter()
+        .map(|query| {
+            let mut statement = connection.prepare(query).unwrap();
+            statement
+                .query_map([identity_id], |row| {
+                    (0..row.as_ref().column_count())
+                        .map(|index| row.get(index))
+                        .collect::<rusqlite::Result<Vec<Value>>>()
+                })
+                .unwrap()
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .unwrap()
+        })
+        .collect()
+}
+
+fn seed_binding_and_cadence(connection: &Connection, identity_id: &str) {
+    connection
+        .execute(
+            "INSERT INTO bindings (
+                id, identity_id, transport, pane_id, server_id, socket_path,
+                server_pid, server_start_time, pane_pid, bound_at, last_verified_at
+             ) VALUES (?, ?, 'tmux', '%1', 'server', '/tmp/tmux.sock', 41,
+                'server-start', 42, 'bound', 'verified')",
+            params!["binding", identity_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO preamble_counters (identity_id, reserved_count, updated_at_ms)
+             VALUES (?, 7, 1234)",
+            [identity_id],
+        )
+        .unwrap();
+}
+
+fn lifecycle_snapshot(connection: &Connection, identity_id: &str) -> Vec<Vec<Vec<Value>>> {
+    snapshot_queries(
+        connection,
+        identity_id,
+        &[
+            "SELECT * FROM preamble_counters WHERE identity_id = ?",
+            "SELECT * FROM bindings WHERE identity_id = ?",
+        ],
+    )
+}
+
+fn identity_lifetime(connection: &Connection, identity_id: &str) -> (String, Option<i64>) {
+    connection
+        .query_row(
+            "SELECT lifetime, retired_at_ms FROM identities WHERE id = ?",
+            [identity_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap()
+}
+
+#[test]
+fn stores_role_and_preamble_independently_across_reopen_and_clear() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let alpha = create_or_resolve(&mut storage, "Alpha", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let beta = create_or_resolve(&mut storage, "beta", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let role = normalize_content("role\r\nbody").unwrap();
+    let preamble = normalize_content("preamble body").unwrap();
+
+    assert_eq!(
+        profile::set_profile(&mut storage, &alpha, ProfileKind::Role, &role)
+            .unwrap()
+            .unwrap()
+            .content,
+        "role\nbody"
+    );
+    assert_eq!(
+        profile::set_profile(&mut storage, &alpha, ProfileKind::Preamble, &preamble)
+            .unwrap()
+            .unwrap()
+            .content,
+        "preamble body"
+    );
+    assert_eq!(
+        profile::set_profile(&mut storage, &beta, ProfileKind::Preamble, &preamble)
+            .unwrap()
+            .unwrap()
+            .content,
+        "preamble body"
+    );
+    assert_eq!(
+        storage
+            .find_profile(&alpha.id, ProfileKind::Role)
+            .unwrap()
+            .unwrap()
+            .content,
+        "role\nbody"
+    );
+    assert!(
+        storage
+            .find_profile(&beta.id, ProfileKind::Role)
+            .unwrap()
+            .is_none()
+    );
+    let listed = storage.list_preambles().unwrap();
+    assert_eq!(
+        listed
+            .iter()
+            .map(|(identity, _)| identity.canonical_name.as_str())
+            .collect::<Vec<_>>(),
+        ["alpha", "beta"]
+    );
+    assert_eq!(
+        profile::clear_profile(&mut storage, &alpha, ProfileKind::Role).unwrap(),
+        Some(true)
+    );
+    assert_eq!(
+        profile::clear_profile(&mut storage, &alpha, ProfileKind::Role).unwrap(),
+        Some(false)
+    );
+    assert_eq!(
+        profile::clear_profile(&mut storage, &beta, ProfileKind::Preamble).unwrap(),
+        Some(true)
+    );
+    assert_eq!(
+        profile::clear_profile(&mut storage, &beta, ProfileKind::Preamble).unwrap(),
+        Some(false)
+    );
+    assert!(
+        storage
+            .find_profile(&alpha.id, ProfileKind::Role)
+            .unwrap()
+            .is_none()
+    );
+    storage.close().unwrap();
+
+    let mut reopened = fixture.open();
+    assert!(
+        reopened
+            .find_profile(&alpha.id, ProfileKind::Role)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        reopened
+            .find_profile(&alpha.id, ProfileKind::Preamble)
+            .unwrap()
+            .unwrap()
+            .content,
+        "preamble body"
+    );
+    assert_eq!(reopened.list_preambles().unwrap().len(), 1);
+    reopened.close().unwrap();
+
+    let verification = fixture.observe();
+    let role_count: i64 = verification
+        .query_row(
+            "SELECT COUNT(*) FROM role_profiles WHERE identity_id = ?",
+            [&alpha.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let preamble_count: i64 = verification
+        .query_row("SELECT COUNT(*) FROM identity_preambles", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(role_count, 0);
+    assert_eq!(preamble_count, 1);
+}
+
+#[test]
+fn stale_retired_or_replaced_observations_do_not_write_or_touch_lifecycle_state() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let old = create_or_resolve(&mut storage, "Stale", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let content = normalize_content("old profile").unwrap();
+    profile::set_profile(&mut storage, &old, ProfileKind::Role, &content)
+        .unwrap()
+        .unwrap();
+    profile::set_profile(&mut storage, &old, ProfileKind::Preamble, &content)
+        .unwrap()
+        .unwrap();
+    {
+        let connection = fixture.setup_connection();
+        seed_binding_and_cadence(&connection, &old.id);
+        connection
+            .execute(
+                "UPDATE identities SET retired_at_ms = 1000 WHERE id = ?",
+                [&old.id],
+            )
+            .unwrap();
+    }
+    let replacement = create_or_resolve(&mut storage, "Stale", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    assert_ne!(old.id, replacement.id);
+    let before_old = dependent_snapshot(&fixture.observe(), &old.id);
+    let before_replacement = dependent_snapshot(&fixture.observe(), &replacement.id);
+
+    assert!(
+        storage
+            .find_profile(&old.id, ProfileKind::Role)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        profile::set_profile(&mut storage, &old, ProfileKind::Role, &content).unwrap(),
+        None
+    );
+    assert_eq!(
+        profile::clear_profile(&mut storage, &old, ProfileKind::Preamble).unwrap(),
+        None
+    );
+    assert!(
+        storage
+            .find_profile(&replacement.id, ProfileKind::Role)
+            .unwrap()
+            .is_none()
+    );
+    storage.close().unwrap();
+
+    let verification = fixture.observe();
+    assert_eq!(dependent_snapshot(&verification, &old.id), before_old);
+    assert_eq!(
+        dependent_snapshot(&verification, &replacement.id),
+        before_replacement
+    );
+    let old_lifetime: (String, Option<i64>) = verification
+        .query_row(
+            "SELECT lifetime, retired_at_ms FROM identities WHERE id = ?",
+            [&old.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    let replacement_lifetime: (String, Option<i64>) = verification
+        .query_row(
+            "SELECT lifetime, retired_at_ms FROM identities WHERE id = ?",
+            [&replacement.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(old_lifetime, ("saved".into(), Some(1000)));
+    assert_eq!(replacement_lifetime, ("saved".into(), None));
+}
+
+#[test]
+fn temporary_profile_overwrites_preserve_lifetime_cadence_and_binding() {
+    let fixture = Fixture::new();
+    let mut storage = fixture.open();
+    let temporary = create_or_resolve(&mut storage, "Temporary", Lifetime::Temporary)
+        .unwrap()
+        .identity;
+    let initial = normalize_content("initial").unwrap();
+    profile::set_profile(&mut storage, &temporary, ProfileKind::Role, &initial)
+        .unwrap()
+        .unwrap();
+    profile::set_profile(&mut storage, &temporary, ProfileKind::Preamble, &initial)
+        .unwrap()
+        .unwrap();
+    {
+        let connection = fixture.setup_connection();
+        seed_binding_and_cadence(&connection, &temporary.id);
+    }
+    let before = fixture.observe();
+    let before_lifecycle = lifecycle_snapshot(&before, &temporary.id);
+    let before_identity = identity_lifetime(&before, &temporary.id);
+    drop(before);
+
+    let replacement = normalize_content("replacement\r\nbody").unwrap();
+    assert_eq!(
+        profile::set_profile(&mut storage, &temporary, ProfileKind::Role, &replacement)
+            .unwrap()
+            .unwrap()
+            .content,
+        "replacement\nbody"
+    );
+    assert_eq!(
+        profile::set_profile(
+            &mut storage,
+            &temporary,
+            ProfileKind::Preamble,
+            &replacement
+        )
+        .unwrap()
+        .unwrap()
+        .content,
+        "replacement\nbody"
+    );
+    storage.close().unwrap();
+
+    let verification = fixture.observe();
+    assert_eq!(
+        lifecycle_snapshot(&verification, &temporary.id),
+        before_lifecycle
+    );
+    assert_eq!(
+        identity_lifetime(&verification, &temporary.id),
+        before_identity
+    );
+    assert_eq!(
+        verification
+            .query_row(
+                "SELECT content FROM role_profiles WHERE identity_id = ?",
+                [&temporary.id],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+        "replacement\nbody"
+    );
+    assert_eq!(
+        verification
+            .query_row(
+                "SELECT content FROM identity_preambles WHERE identity_id = ?",
+                [&temporary.id],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+        "replacement\nbody"
+    );
+}

--- a/rust/crates/tmt-cli/src/identity_context.rs
+++ b/rust/crates/tmt-cli/src/identity_context.rs
@@ -1,0 +1,51 @@
+//! Durable selectors are not pane routing or identity creation.
+
+use crate::{
+    binding_error::{binding_failure, endpoint_failure},
+    output::Failure,
+};
+use tmt_adapters::{
+    storage::Storage,
+    tmux::{BindingSession, CallerEnvironment, Tmux},
+};
+use tmt_core::{
+    binding,
+    identity::{Identity, IdentityReader},
+    names::normalize_name,
+};
+
+pub fn missing(name: &str) -> Failure {
+    Failure::new(
+        "NAME_NOT_FOUND",
+        format!("Identity '{name}' was not found."),
+        3,
+    )
+}
+
+pub fn resolve(storage: &mut Storage, explicit: Option<&str>) -> Result<Identity, Failure> {
+    if let Some(name) = explicit {
+        return storage
+            .find_identity(&normalize_name(name))
+            .map_err(|error| {
+                Failure::new("IDENTITY_ERROR", "Could not read identity storage.", 1)
+                    .caused_by(error)
+            })?
+            .ok_or_else(|| missing(name));
+    }
+    let tmux = Tmux::default();
+    let pane = tmux
+        .caller_pane(&CallerEnvironment::current())
+        .map_err(endpoint_failure)?;
+    if let Some(pane) = pane {
+        let observed = binding::pane_presence(storage, &mut BindingSession::new(&tmux), &pane)
+            .map_err(binding_failure)?;
+        if let Some(identity) = observed.identity {
+            return Ok(identity);
+        }
+    }
+    Err(Failure::new(
+        "IDENTITY_REQUIRED",
+        "An identity is required; use --identity or run from a verified bound pane.",
+        1,
+    ))
+}

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -5,9 +5,11 @@ mod config_command;
 mod diagnostics;
 mod grammar;
 mod identity_command;
+mod identity_context;
 mod invocation;
 mod output;
 mod parser;
+mod profile_command;
 mod response_command;
 mod target;
 
@@ -38,7 +40,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration, storage-only identity create/show/list and reply/result, pane identity name/this/add/whoami/unbind/rm/list, and diagnostic check/read are available. Talk is not implemented yet. Use isolated test state only.\n"
+                "Native development preview: configuration, identity create/show/list, reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, and role/preamble are available. Talk is not implemented yet. Use isolated test state only.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -71,6 +73,10 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Identity(request) => {
             drop(stdout);
             return identity_command::execute(request, parsed.mode);
+        }
+        request @ (Invocation::Role { .. } | Invocation::Preamble(_)) => {
+            drop(stdout);
+            return profile_command::execute(request, parsed.mode);
         }
         Invocation::Check { target, lines } => {
             drop(stdout);

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -33,6 +33,39 @@ fn parsed(values: &[&str]) -> Parsed {
     })
 }
 
+#[test]
+fn preamble_operands_join_without_reparsing_literal_content() {
+    use crate::invocation::PreambleRequest;
+    for (args, content) in [
+        (
+            vec!["preamble", "set", "Alice", "first", "second"],
+            "first second",
+        ),
+        (
+            vec!["preamble", "set", "Alice", "--", "--json", "literal"],
+            "--json literal",
+        ),
+    ] {
+        let parsed = parsed(&args);
+        assert_eq!(
+            parsed.invocation,
+            Invocation::Preamble(PreambleRequest::Set {
+                name: "Alice".into(),
+                content: content.into()
+            })
+        );
+        assert!(!parsed.mode.json);
+    }
+    assert_eq!(
+        parsed(&["preamble"]).invocation,
+        Invocation::Preamble(PreambleRequest::Show(None))
+    );
+    assert_eq!(
+        parsed(&["preamble", "show", "Alice"]).invocation,
+        Invocation::Preamble(PreambleRequest::Show(Some("Alice".into())))
+    );
+}
+
 fn parse_error(values: &[&str]) -> ParseError {
     parse(&args(values)).expect_err("expected arguments to be rejected")
 }

--- a/rust/crates/tmt-cli/src/profile_command.rs
+++ b/rust/crates/tmt-cli/src/profile_command.rs
@@ -1,0 +1,284 @@
+//! Role and preamble presentation over shared profile and identity owners.
+
+use crate::{
+    identity_context,
+    invocation::{ContentInput, Invocation, OutputMode, PreambleRequest, RoleOperation},
+    output::{Failure, after_cleanup, identity_document},
+};
+use std::{
+    io::{self, Write},
+    path::Path,
+};
+use tmt_adapters::{
+    bounded_file::{self, FileReadError},
+    config::ConfigPaths,
+    storage::Storage,
+};
+use tmt_core::{
+    identity::Identity,
+    profile::{self, ContentError, Profile, ProfileKind, ProfileReader},
+};
+
+enum Action {
+    Show,
+    Set(String),
+    Clear,
+}
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Change {
+    Shown,
+    Set,
+    Cleared,
+    NotSet,
+}
+impl Change {
+    fn status(self) -> Option<&'static str> {
+        match self {
+            Self::Shown => None,
+            Self::Set => Some("set"),
+            Self::Cleared => Some("cleared"),
+            Self::NotSet => Some("not_set"),
+        }
+    }
+}
+enum Report {
+    Role {
+        identity: Identity,
+        profile: Option<Profile>,
+        change: Change,
+    },
+    Preamble {
+        name: String,
+        profile: Option<Profile>,
+        change: Change,
+    },
+    List(Vec<(Identity, Profile)>),
+}
+
+fn error_code(kind: ProfileKind) -> &'static str {
+    match kind {
+        ProfileKind::Role => "ROLE_ERROR",
+        ProfileKind::Preamble => "PREAMBLE_ERROR",
+    }
+}
+
+fn input_failure(kind: ProfileKind, error: ContentError) -> Failure {
+    let code = match (kind, error) {
+        (ProfileKind::Role, ContentError::TooLarge) => "ROLE_INPUT_TOO_LARGE",
+        (ProfileKind::Preamble, ContentError::TooLarge) => "PREAMBLE_INPUT_TOO_LARGE",
+        (ProfileKind::Role, _) => "ROLE_INPUT_INVALID",
+        (ProfileKind::Preamble, _) => "PREAMBLE_INPUT_INVALID",
+    };
+    Failure::new(code, error.to_string(), 1).caused_by(error)
+}
+
+fn role_input(input: ContentInput) -> Result<String, Failure> {
+    match input {
+        ContentInput::Inline(content) => Ok(content),
+        ContentInput::File(file) => {
+            let bytes = bounded_file::read(Path::new(&file), profile::MAX_PROFILE_BYTES).map_err(
+                |error| match error {
+                    FileReadError::TooLarge => {
+                        input_failure(ProfileKind::Role, ContentError::TooLarge)
+                    }
+                    error => {
+                        Failure::new("ROLE_FILE_ERROR", "Could not read a regular role file.", 1)
+                            .caused_by(error)
+                    }
+                },
+            )?;
+            String::from_utf8(bytes).map_err(|error| {
+                Failure::new("ROLE_INPUT_INVALID", "Role file must be valid UTF-8.", 1)
+                    .caused_by(error)
+            })
+        }
+        ContentInput::Stdin => Err(Failure::new(
+            "ROLE_INPUT_INVALID",
+            "Role input requires inline text or a regular file.",
+            1,
+        )),
+    }
+}
+
+fn run(request: Invocation) -> Result<Report, Failure> {
+    let (kind, name, action) = match request {
+        Invocation::Role {
+            identity,
+            operation,
+        } => (
+            ProfileKind::Role,
+            identity,
+            match operation {
+                RoleOperation::Show => Some(Action::Show),
+                RoleOperation::Clear => Some(Action::Clear),
+                RoleOperation::Set(input) => Some(Action::Set(role_input(input)?)),
+            },
+        ),
+        Invocation::Preamble(request) => match request {
+            PreambleRequest::Show(name) => (
+                ProfileKind::Preamble,
+                name.clone(),
+                name.map(|_| Action::Show),
+            ),
+            PreambleRequest::Set { name, content } => (
+                ProfileKind::Preamble,
+                Some(name),
+                Some(Action::Set(content)),
+            ),
+            PreambleRequest::Clear(name) => {
+                (ProfileKind::Preamble, Some(name), Some(Action::Clear))
+            }
+        },
+        _ => unreachable!("profile dispatcher accepts only role and preamble"),
+    };
+    let unavailable = |error| {
+        Failure::new(error_code(kind), "Could not access profile storage.", 1).caused_by(error)
+    };
+    let paths = ConfigPaths::discover().map_err(|error| {
+        Failure::new(error_code(kind), "Could not discover profile storage.", 1).caused_by(error)
+    })?;
+    let mut storage = Storage::open(paths.database).map_err(unavailable)?;
+    let pending = (|| {
+        let Some(action) = action else {
+            return storage
+                .list_preambles()
+                .map(Report::List)
+                .map_err(unavailable);
+        };
+        let identity =
+            identity_context::resolve(&mut storage, name.as_deref()).map_err(|error| {
+                if error.code == "IDENTITY_ERROR" {
+                    Failure::new(error_code(kind), "Could not access profile identity.", 1)
+                        .caused_by(error)
+                } else {
+                    error
+                }
+            })?;
+        let (value, change) = match action {
+            Action::Show => (
+                storage
+                    .find_profile(&identity.id, kind)
+                    .map_err(unavailable)?,
+                Change::Shown,
+            ),
+            Action::Set(content) => {
+                let content = profile::normalize_content(&content)
+                    .map_err(|error| input_failure(kind, error))?;
+                let value = profile::set_profile(&mut storage, &identity, kind, &content)
+                    .map_err(unavailable)?
+                    .ok_or_else(|| identity_context::missing(&identity.name))?;
+                (Some(value), Change::Set)
+            }
+            Action::Clear => {
+                let cleared = profile::clear_profile(&mut storage, &identity, kind)
+                    .map_err(unavailable)?
+                    .ok_or_else(|| identity_context::missing(&identity.name))?;
+                (
+                    None,
+                    if cleared {
+                        Change::Cleared
+                    } else {
+                        Change::NotSet
+                    },
+                )
+            }
+        };
+        Ok(match kind {
+            ProfileKind::Role => Report::Role {
+                identity,
+                profile: value,
+                change,
+            },
+            ProfileKind::Preamble => Report::Preamble {
+                name: identity.name,
+                profile: value,
+                change,
+            },
+        })
+    })();
+    after_cleanup(pending, || storage.close())
+}
+
+pub fn execute(request: Invocation, mode: OutputMode) -> io::Result<u8> {
+    let report = match run(request) {
+        Ok(report) => report,
+        Err(error) => return error.publish(mode),
+    };
+    let mut stdout = io::stdout().lock();
+    if mode.json {
+        let value = match report {
+            Report::Role {
+                identity, profile, ..
+            } => {
+                serde_json::json!({"identity": identity_document(&identity), "role": profile.map(|profile| serde_json::json!({"content": profile.content, "updatedAt": profile.updated_at}))})
+            }
+            Report::Preamble {
+                name,
+                profile,
+                change,
+            } => {
+                let mut value = serde_json::json!({"agent": name});
+                if matches!(change, Change::Shown | Change::Set) {
+                    value["preamble"] = profile.map(|profile| profile.content).into();
+                }
+                if let Some(status) = change.status() {
+                    value["status"] = status.into();
+                }
+                value
+            }
+            Report::List(rows) => {
+                serde_json::json!({"preambles": rows.into_iter().map(|(identity, profile)| serde_json::json!({"agent": identity.name, "preamble": profile.content})).collect::<Vec<_>>()})
+            }
+        };
+        writeln!(stdout, "{value}")?;
+    } else {
+        match report {
+            Report::Role {
+                identity,
+                profile,
+                change,
+            } => match change {
+                Change::Set => writeln!(stdout, "Set role profile for '{}'.", identity.name)?,
+                Change::Cleared | Change::NotSet => {
+                    writeln!(stdout, "Cleared role profile for '{}'.", identity.name)?
+                }
+                Change::Shown => {
+                    writeln!(stdout, "Identity '{}'", identity.name)?;
+                    writeln!(
+                        stdout,
+                        "{}",
+                        profile.map_or_else(
+                            || "No role profile is set.".into(),
+                            |profile| profile.content
+                        )
+                    )?;
+                }
+            },
+            Report::Preamble {
+                name,
+                profile,
+                change,
+            } => match change {
+                Change::Set => writeln!(stdout, "Set preamble for {name}")?,
+                Change::Cleared => writeln!(stdout, "Cleared preamble for {name}")?,
+                Change::NotSet => writeln!(stdout, "No preamble was set for {name}")?,
+                Change::Shown => {
+                    if let Some(profile) = profile {
+                        writeln!(stdout, "Preamble for {name}:\n{}", profile.content)?;
+                    } else {
+                        writeln!(stdout, "No preamble set for {name}")?;
+                    }
+                }
+            },
+            Report::List(rows) => {
+                if rows.is_empty() {
+                    writeln!(stdout, "No preambles configured")?;
+                }
+                for (identity, profile) in rows {
+                    writeln!(stdout, "─── {} ───\n{}\n", identity.name, profile.content)?;
+                }
+            }
+        }
+    }
+    Ok(0)
+}

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod exact_text;
 pub mod identity;
 pub mod limits;
 pub mod names;
+pub mod profile;
 pub mod request;
 pub mod retention;
 pub mod settings;

--- a/rust/crates/tmt-core/src/names.rs
+++ b/rust/crates/tmt-core/src/names.rs
@@ -45,7 +45,7 @@ impl Error for NameError {}
 
 // ECMAScript WhiteSpace plus LineTerminator, also used by its regular-expression
 // \s. Rust's is_whitespace differs: it includes NEL and excludes BOM.
-fn ecmascript_space(character: char) -> bool {
+pub(crate) fn ecmascript_space(character: char) -> bool {
     matches!(character,
         '\u{0009}'..='\u{000d}' | '\u{0020}' | '\u{00a0}' | '\u{1680}' |
         '\u{2000}'..='\u{200a}' | '\u{2028}' | '\u{2029}' | '\u{202f}' |

--- a/rust/crates/tmt-core/src/profile.rs
+++ b/rust/crates/tmt-core/src/profile.rs
@@ -1,0 +1,134 @@
+//! Roles and preambles share text/storage mechanics, not injection semantics.
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    identity::{Identity, IdentityReader},
+    names::ecmascript_space,
+};
+use std::{error::Error, fmt};
+
+pub const MAX_PROFILE_BYTES: usize = 65_536;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProfileKind {
+    Role,
+    Preamble,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Profile {
+    pub content: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedContent(String);
+impl NormalizedContent {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentError {
+    TooLarge,
+    Control,
+    Empty,
+}
+
+impl fmt::Display for ContentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::TooLarge => "Content must not exceed 65536 bytes.",
+            Self::Control => "Content must not contain control characters.",
+            Self::Empty => "Content must not be empty or whitespace-only.",
+        })
+    }
+}
+impl Error for ContentError {}
+
+pub fn normalize_content(value: &str) -> Result<NormalizedContent, ContentError> {
+    if value.len() > MAX_PROFILE_BYTES {
+        return Err(ContentError::TooLarge);
+    }
+    let normalized = value.replace("\r\n", "\n").replace('\r', "\n");
+    let normalized = normalized.strip_prefix('\u{feff}').unwrap_or(&normalized);
+    if normalized
+        .chars()
+        .any(|c| (c < '\u{20}' && c != '\t' && c != '\n') || c == '\u{7f}')
+    {
+        return Err(ContentError::Control);
+    }
+    if normalized.trim_matches(ecmascript_space).is_empty() {
+        return Err(ContentError::Empty);
+    }
+    Ok(NormalizedContent(normalized.into()))
+}
+
+pub trait ProfileReader: IdentityReader {
+    fn find_profile(
+        &self,
+        identity_id: &str,
+        kind: ProfileKind,
+    ) -> Result<Option<Profile>, Self::Error>;
+    fn list_preambles(&self) -> Result<Vec<(Identity, Profile)>, Self::Error>;
+}
+
+pub trait ProfileWriter: IdentityReader {
+    fn set_profile(
+        &mut self,
+        identity_id: &str,
+        kind: ProfileKind,
+        content: &str,
+    ) -> Result<Profile, Self::Error>;
+    fn clear_profile(&mut self, identity_id: &str, kind: ProfileKind) -> Result<bool, Self::Error>;
+}
+
+pub trait ProfileRepository: ProfileReader {
+    fn with_profile_transaction<T>(
+        &mut self,
+        operation: impl FnOnce(&mut dyn ProfileWriter<Error = Self::Error>) -> Result<T, Self::Error>,
+    ) -> Result<T, Self::Error>;
+}
+
+/// Recheck ownership in the write transaction. A stale observation must not
+/// recreate a retired profile or write to a newly reused display name.
+pub fn set_profile<R: ProfileRepository>(
+    repository: &mut R,
+    identity: &Identity,
+    kind: ProfileKind,
+    content: &NormalizedContent,
+) -> Result<Option<Profile>, R::Error> {
+    repository.with_profile_transaction(|records| {
+        if !still_owned(records, identity)? {
+            return Ok(None);
+        }
+        records
+            .set_profile(&identity.id, kind, content.as_str())
+            .map(Some)
+    })
+}
+
+pub fn clear_profile<R: ProfileRepository>(
+    repository: &mut R,
+    identity: &Identity,
+    kind: ProfileKind,
+) -> Result<Option<bool>, R::Error> {
+    repository.with_profile_transaction(|records| {
+        if !still_owned(records, identity)? {
+            return Ok(None);
+        }
+        records.clear_profile(&identity.id, kind).map(Some)
+    })
+}
+
+fn still_owned<R: IdentityReader + ?Sized>(
+    records: &R,
+    identity: &Identity,
+) -> Result<bool, R::Error> {
+    records
+        .find_identity(&identity.canonical_name)
+        .map(|current| current.is_some_and(|current| current.id == identity.id))
+}

--- a/rust/crates/tmt-core/src/profile/tests.rs
+++ b/rust/crates/tmt-core/src/profile/tests.rs
@@ -1,0 +1,81 @@
+use super::*;
+use crate::exact_text::{MAX_EXCHANGE_TEXT_BYTES, validate_exact_text};
+
+#[test]
+fn normalizes_profile_text_without_normalizing_exact_exchange_text() {
+    let profile = normalize_content("\u{feff}\u{feff}  first\r\nsecond\rthird\n").unwrap();
+    assert_eq!(profile.as_str(), "\u{feff}  first\nsecond\nthird\n");
+
+    let exact = "\u{feff}\u{feff}  first\r\nsecond\rthird\n\0";
+    assert_eq!(validate_exact_text(exact.as_bytes()).unwrap(), exact);
+    assert_ne!(profile.as_str(), exact);
+}
+
+#[test]
+fn uses_ecmascript_whitespace_for_empty_profiles() {
+    let whitespace = [
+        '\u{9}', '\u{a}', '\u{d}', ' ', '\u{a0}', '\u{1680}', '\u{2000}', '\u{2001}', '\u{2002}',
+        '\u{2003}', '\u{2004}', '\u{2005}', '\u{2006}', '\u{2007}', '\u{2008}', '\u{2009}',
+        '\u{200a}', '\u{2028}', '\u{2029}', '\u{202f}', '\u{205f}', '\u{3000}', '\u{feff}',
+    ];
+    for character in whitespace {
+        assert_eq!(
+            normalize_content(&character.to_string()),
+            Err(ContentError::Empty),
+            "character U+{:04X}",
+            character as u32
+        );
+    }
+    // U+0085 is not ECMAScript whitespace and is retained as meaningful text.
+    assert_eq!(normalize_content("\u{85}").unwrap().as_str(), "\u{85}");
+}
+
+#[test]
+fn rejects_controls_but_allows_tab_and_line_feed() {
+    assert_eq!(
+        normalize_content("tab\tline\n").unwrap().as_str(),
+        "tab\tline\n"
+    );
+    for code in (0..0x20)
+        .filter(|code| *code != 0x09 && *code != 0x0a && *code != 0x0d)
+        .chain([0x7f])
+    {
+        let value = format!("before{}after", char::from_u32(code).unwrap());
+        assert_eq!(
+            normalize_content(&value),
+            Err(ContentError::Control),
+            "U+{code:04X}"
+        );
+    }
+}
+
+#[test]
+fn enforces_utf8_byte_limit_before_normalization() {
+    let exact = "a".repeat(MAX_PROFILE_BYTES);
+    assert_eq!(normalize_content(&exact).unwrap().as_str(), exact);
+    assert_eq!(
+        normalize_content(&format!("{exact}a")),
+        Err(ContentError::TooLarge)
+    );
+
+    let multibyte = "😀".repeat(MAX_PROFILE_BYTES / 4);
+    assert_eq!(multibyte.len(), MAX_PROFILE_BYTES);
+    assert_eq!(normalize_content(&multibyte).unwrap().as_str(), multibyte);
+    assert_eq!(
+        normalize_content(&format!("{multibyte}😀")),
+        Err(ContentError::TooLarge)
+    );
+    let crlf_shrinks_to_limit = format!("{}\r\n", "a".repeat(MAX_PROFILE_BYTES - 1));
+    assert_eq!(crlf_shrinks_to_limit.len(), MAX_PROFILE_BYTES + 1);
+    assert_eq!(
+        normalize_content(&crlf_shrinks_to_limit),
+        Err(ContentError::TooLarge)
+    );
+    let bom_shrinks_to_limit = format!("\u{feff}{}", "a".repeat(MAX_PROFILE_BYTES));
+    assert!(bom_shrinks_to_limit.len() > MAX_PROFILE_BYTES);
+    assert_eq!(
+        normalize_content(&bom_shrinks_to_limit),
+        Err(ContentError::TooLarge)
+    );
+    assert!(validate_exact_text(&"a".repeat(MAX_EXCHANGE_TEXT_BYTES).into_bytes()).is_ok());
+}

--- a/test/e2e/native-profile.e2e.test.ts
+++ b/test/e2e/native-profile.e2e.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture, type E2EFixtureOptions } from './harness.js';
+import { durableState } from './identity-state-oracle.js';
+
+function options(): E2EFixtureOptions {
+  const native = process.env.TMT_TEST_NATIVE_CLI;
+  if (!native) throw new Error('Native profile E2E requires the Docker-built CLI.');
+  return { mode: 'input-log', executableEnv: { TMT_TEST_CLI: native } };
+}
+
+describe.sequential('native profile identity lifecycle', () => {
+  it('uses a verified implicit role and preserves saved profiles across unbind and rebind', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect(await fixture.runJsonCli(['name', 'Alice', '-s'])).toMatchObject({ code: 0 });
+      const initial = await fixture.runJsonCli(['role', 'set', 'saved role']);
+      expect(initial).toMatchObject({
+        code: 0,
+        json: { identity: { name: 'Alice' }, role: { content: 'saved role' } },
+      });
+      expect(
+        await fixture.runJsonCli(['preamble', 'set', 'Alice', 'saved preamble'])
+      ).toMatchObject({ code: 0 });
+      const metadata = fixture.paneMetadata();
+      expect(await fixture.runJsonCli(['identity', 'create', 'Offline'])).toMatchObject({
+        code: 0,
+      });
+      expect(
+        await fixture.runJsonCli(['role', 'set', 'offline role', '--identity', 'Offline'])
+      ).toMatchObject({ code: 0, json: { identity: { name: 'Offline' } } });
+      expect(fixture.paneMetadata()).toBe(metadata);
+      expect((await fixture.runJsonCli(['role', 'show'])).json).toEqual(initial.json);
+      expect(await fixture.runJsonCli(['unbind'])).toMatchObject({ code: 0 });
+      expect(await fixture.runJsonCli(['role', 'set', 'must not write'])).toMatchObject({
+        code: 1,
+        json: { error: { code: 'IDENTITY_REQUIRED' } },
+      });
+      expect(
+        (await fixture.runJsonCli(['role', 'show', '--identity', 'Alice'], { withoutTmux: true }))
+          .json
+      ).toEqual(initial.json);
+      const peer = await fixture.createMockPane('rebound');
+      expect(await fixture.runJsonCli(['add', peer.pane, 'Alice'])).toMatchObject({ code: 0 });
+      expect((await fixture.runJsonCli(['role', 'show', '--identity', 'Alice'])).json).toEqual(
+        initial.json
+      );
+      expect(await fixture.runJsonCli(['preamble', 'show', 'Alice'])).toMatchObject({
+        code: 0,
+        json: { preamble: 'saved preamble' },
+      });
+      expect(await fixture.runJsonCli(['rm', 'Alice', '--force'])).toMatchObject({ code: 0 });
+      expect(await fixture.runJsonCli(['preamble'], { withoutTmux: true })).toMatchObject({
+        code: 0,
+        json: { preambles: [] },
+      });
+      expect(durableState(fixture).profiles).toEqual([
+        expect.objectContaining({ content: 'offline role' }),
+      ]);
+      expect(fixture.paneMetadata(peer.pane)).toBe('');
+    }, options());
+  });
+
+  it('does not mutate profiles when caller metadata no longer verifies', async () => {
+    await withE2EFixture(async (fixture) => {
+      expect(await fixture.runJsonCli(['name', 'Alice', '-s'])).toMatchObject({ code: 0 });
+      const original = await fixture.runJsonCli(['role', 'set', 'preserved']);
+      expect(original.code).toBe(0);
+      const profiles = durableState(fixture).profiles;
+      expect(profiles).toEqual([expect.objectContaining({ content: 'preserved' })]);
+      const metadata = JSON.parse(fixture.paneMetadata());
+      metadata.globalIdentity.bindingId = 'different-binding';
+      fixture.tmux([
+        'set-option',
+        '-p',
+        '-t',
+        fixture.pane,
+        '@tmux-team.agent',
+        JSON.stringify(metadata),
+      ]);
+      const rejected = await fixture.runJsonCli(['role', 'clear']);
+      expect(rejected).toMatchObject({ code: 1, json: { error: { code: 'IDENTITY_REQUIRED' } } });
+      expect(
+        (await fixture.runJsonCli(['role', 'show', '--identity', 'Alice'], { withoutTmux: true }))
+          .json
+      ).toEqual(original.json);
+      expect(durableState(fixture).bindings).toEqual([]);
+      expect(durableState(fixture).profiles).toEqual(profiles);
+      expect(JSON.parse(fixture.paneMetadata())).toEqual(metadata);
+    }, options());
+  });
+
+  it('hides retired temporary profiles without leaking them to a reused name', async () => {
+    await withE2EFixture(async (fixture) => {
+      const old = await fixture.runJsonCli<{ id: string }>(['name', 'Temporary']);
+      expect(old.code).toBe(0);
+      expect(old.json?.id).toEqual(expect.any(String));
+      expect(await fixture.runJsonCli(['role', 'set', 'old role'])).toMatchObject({ code: 0 });
+      expect(
+        await fixture.runJsonCli(['preamble', 'set', 'Temporary', 'old preamble'])
+      ).toMatchObject({ code: 0 });
+      expect(await fixture.runJsonCli(['unbind'])).toMatchObject({
+        code: 0,
+        json: { retired: true },
+      });
+      expect(await fixture.runJsonCli(['preamble'], { withoutTmux: true })).toMatchObject({
+        code: 0,
+        json: { preambles: [] },
+      });
+      expect(
+        await fixture.runJsonCli(['role', 'show', '--identity', 'Temporary'], { withoutTmux: true })
+      ).toMatchObject({ code: 3, json: { error: { code: 'NAME_NOT_FOUND' } } });
+      const fresh = await fixture.runJsonCli<{ id: string }>(['name', 'Temporary']);
+      expect(fresh.code).toBe(0);
+      expect(fresh.json?.id).not.toBe(old.json?.id);
+      expect(await fixture.runJsonCli(['role', 'show'])).toMatchObject({
+        code: 0,
+        json: { role: null },
+      });
+      expect(await fixture.runJsonCli(['preamble', 'show', 'Temporary'])).toMatchObject({
+        code: 0,
+        json: { preamble: null },
+      });
+      expect(durableState(fixture).profiles).toEqual([
+        expect.objectContaining({ identity_id: old.json?.id, content: 'old role' }),
+      ]);
+    }, options());
+  });
+});

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -62,7 +62,7 @@ describe('native grammar preview process contract', () => {
       expect(help.stderr).toBe('');
       expect(help.stdout).toContain('Native development preview');
       expect(help.stdout).toContain(
-        'configuration, storage-only identity create/show/list and reply/result, pane identity name/this/add/whoami/unbind/rm/list, and diagnostic check/read are available'
+        'configuration, identity create/show/list, reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, and role/preamble are available'
       );
       expect(help.stdout).toContain('Talk is not implemented yet.');
       expect(help.stdout).toContain('Manage identity records without probing tmux');
@@ -81,8 +81,6 @@ describe('native grammar preview process contract', () => {
       for (const args of [
         ['talk', 'worker', 'hello'],
         ['init'],
-        ['role', 'show'],
-        ['preamble'],
         ['x', 'ackall'],
         ['install', '--dir', sandbox.cwd],
       ]) {

--- a/test/native/profile.test.ts
+++ b/test/native/profile.test.ts
@@ -1,0 +1,159 @@
+import Database from 'better-sqlite3';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+  type Sandbox,
+} from '../../src/test-support/cli-process.js';
+import { calibrateTmuxTripwire } from './tmux-tripwire.js';
+
+async function json(sandbox: Sandbox, args: string[]): Promise<unknown> {
+  const result = await runCli(sandbox, [...args, '--json']);
+  expect(result.status, result.stdout || result.stderr).toBe(0);
+  expect(result.stderr).toBe('');
+  return parseWholeStdout(result);
+}
+
+describe('native role and preamble process contracts', () => {
+  it('persists independent offline profiles across processes without config or tmux', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      await json(sandbox, ['identity', 'create', 'Alice']);
+      await json(sandbox, ['identity', 'create', 'Bob']);
+      mkdirSync(sandbox.globalDir, { recursive: true });
+      writeFileSync(sandbox.globalConfig, '{ invalid');
+      writeFileSync(sandbox.localConfig, '{ invalid');
+      const original = '\ufeff  role\r\nline\r\tend  ';
+      const normalized = '  role\nline\n\tend  ';
+      const set = await json(sandbox, ['role', '--identity', 'aLiCe', 'set', original]);
+      expect(set).toMatchObject({
+        identity: { name: 'Alice', canonicalName: 'alice', lifetime: 'saved' },
+        role: { content: normalized, updatedAt: expect.any(String) },
+      });
+      expect(await json(sandbox, ['role', 'show', '--identity', 'Alice'])).toEqual(set);
+      expect(await json(sandbox, ['preamble', 'set', 'Bob', 'first', 'second'])).toEqual({
+        agent: 'Bob',
+        preamble: 'first second',
+        status: 'set',
+      });
+      expect(await json(sandbox, ['preamble', 'set', 'Bob', 'beta'])).toEqual({
+        agent: 'Bob',
+        preamble: 'beta',
+        status: 'set',
+      });
+      expect(await json(sandbox, ['preamble', 'set', 'Alice', '\ufeffprefix\r\n'])).toEqual({
+        agent: 'Alice',
+        preamble: 'prefix\n',
+        status: 'set',
+      });
+      expect(await json(sandbox, ['preamble'])).toEqual({
+        preambles: [
+          { agent: 'Alice', preamble: 'prefix\n' },
+          { agent: 'Bob', preamble: 'beta' },
+        ],
+      });
+      expect(await json(sandbox, ['role', 'show', '--identity', 'Bob'])).toMatchObject({
+        role: null,
+      });
+      expect(await json(sandbox, ['role', 'clear', '--identity', 'Alice'])).toMatchObject({
+        role: null,
+      });
+      expect(await json(sandbox, ['role', 'clear', '--identity', 'Alice'])).toMatchObject({
+        role: null,
+      });
+      expect(await json(sandbox, ['preamble', 'show', 'Alice'])).toEqual({
+        agent: 'Alice',
+        preamble: 'prefix\n',
+      });
+      expect(await json(sandbox, ['preamble', 'clear', 'Alice'])).toEqual({
+        agent: 'Alice',
+        status: 'cleared',
+      });
+      expect(await json(sandbox, ['preamble', 'clear', 'Alice'])).toEqual({
+        agent: 'Alice',
+        status: 'not_set',
+      });
+      expect(await json(sandbox, ['preamble', 'show', 'Alice'])).toEqual({
+        agent: 'Alice',
+        preamble: null,
+      });
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+    });
+  });
+
+  it('rejects unknown selectors and invalid text without creating or altering profiles', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      await json(sandbox, ['identity', 'create', 'Alice']);
+      const initial = await json(sandbox, ['role', 'set', 'preserved', '--identity', 'Alice']);
+      for (const args of [
+        ['role', 'show', '--identity', 'bad\nname'],
+        ['preamble', 'show', '%14'],
+      ]) {
+        const result = await runCli(sandbox, [...args, '--json']);
+        expect(result.status).toBe(3);
+        expectError(result, 'NAME_NOT_FOUND');
+      }
+      for (const [content, suffix] of [
+        [' \ufeff\r\n', 'INVALID'],
+        ['bad\u0007', 'INVALID'],
+        ['x'.repeat(65_537), 'TOO_LARGE'],
+      ]) {
+        for (const kind of ['role', 'preamble']) {
+          const args =
+            kind === 'role'
+              ? ['role', 'set', content, '--identity', 'Alice']
+              : ['preamble', 'set', 'Alice', content];
+          const result = await runCli(sandbox, [...args, '--json']);
+          expect(result.status).toBe(1);
+          expectError(result, `${kind.toUpperCase()}_INPUT_${suffix}`);
+        }
+      }
+      expect(await json(sandbox, ['role', 'show', '--identity', 'Alice'])).toEqual(initial);
+      const database = new Database(sandbox.database, { readonly: true });
+      try {
+        expect(database.prepare('SELECT name FROM identities').all()).toEqual([{ name: 'Alice' }]);
+      } finally {
+        database.close();
+      }
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+    });
+  });
+
+  it('reads only bounded regular role files and preserves state on every rejection', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      await json(sandbox, ['identity', 'create', 'Alice']);
+      const file = path.join(sandbox.root, 'role.txt');
+      const text = 'é'.repeat(32_768);
+      writeFileSync(file, text);
+      const original = await json(sandbox, ['role', 'set', '--file', file, '--identity', 'Alice']);
+      expect(original).toMatchObject({ role: { content: text } });
+      const fifo = path.join(sandbox.root, 'role.fifo');
+      execFileSync('mkfifo', [fifo]);
+      for (const [source, content, code] of [
+        [file, Buffer.from([0xff]), 'ROLE_INPUT_INVALID'],
+        [file, Buffer.alloc(65_537, 120), 'ROLE_INPUT_TOO_LARGE'],
+        [sandbox.root, null, 'ROLE_FILE_ERROR'],
+        [fifo, null, 'ROLE_FILE_ERROR'],
+        [path.join(sandbox.root, 'missing'), null, 'ROLE_FILE_ERROR'],
+      ] as const) {
+        if (content) writeFileSync(source, content);
+        const result = await runCli(
+          sandbox,
+          ['role', 'set', '--file', source, '--identity', 'Alice', '--json'],
+          { deadlineMs: 2_000 }
+        );
+        expect(result.status).toBe(1);
+        expectError(result, code);
+        expect(await json(sandbox, ['role', 'show', '--identity', 'Alice'])).toEqual(original);
+      }
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+    });
+  });
+});


### PR DESCRIPTION
## Scope

Closes #127. Parent rewrite #93, native talk #129/#106 and installation #82 remain open. Adds native role/preamble commands without changing installed TypeScript, schema or dependencies.

## Architecture and primary review

Reviewed commit: `109dccf33728b0f7fcec4dff5d8d41bb98a4b750`.

Primary personally reviewed every changed production/test/documentation file and relevant existing TypeScript contracts, native identity/binding/input owners and callers. Core profile normalization returns a validated value; exact exchange text stays separate. Shared profile mechanics retain distinct tables and command projections, one Storage handle, existing identity decoder and transaction helper. Writes revalidate active identity ID under the transaction, preventing stale writes into retired/reused ownership. Explicit selectors are canonical lookup-only and independent of tmux/config. Native role identity JSON includes the lifetime field already established by #109.

Bounded regular-file acquisition is shared by role and reply; only byte acquisition moved, leaving reply stdin/deadline/flags/exact semantics unchanged. CLI closes storage before output. Test observations use independent read-only SQL and the existing Docker fixture/tripwire.

Findings resolved before acceptance:

- Renamed overly generic new core set/clear functions to domain-specific set_profile/clear_profile after the existing architecture guard detected name collisions; no guard exception or weakening.
- Corrected new test grammar to preamble show rather than adding an unsupported shorthand.
- Corrected delegated VT/FF and CR expectations to match actual normalization ordering; strengthened before-normalization byte limits, full-content equality and read-only state oracles.
- Added successful temporary-profile overwrite preservation, variadic/literal preamble parser coverage and public forced saved-removal evidence. Consolidated duplicated snapshot-reading code locally.
- Supplemental Luna review found no production defect and identified the parser/removal test gaps above; primary retains acceptance ownership.

## Verification

- [x] Primary reviewed all changed files and relevant callers.
- [x] Local Rust pinned and MSRV 1.88.0: 236 passed each (156 adapters, 18 CLI, 19 architecture, 43 core).
- [x] Clippy all targets with -D warnings, rustfmt, native build, pnpm check and git diff --check passed.
- [x] Native process suite: 75 passed across eight files. Explicit native descriptors; no host tmux.
- [x] Full TypeScript suite: 1,102 passed across 70 files; coverage gates passed (95.66% statements, 89.47% branches).
- [x] Two final Docker passes on reviewed content: each passed 156 native adapter tests and 147 E2E tests, one existing opt-in skip.
- [x] All 11 CI checks passed on reviewed head 109dccf33728b0f7fcec4dff5d8d41bb98a4b750, run 34188615002, first attempt.

Exact Rust commands: cargo test --locked --workspace --manifest-path rust/Cargo.toml; cargo +1.88.0 test --locked --workspace --manifest-path rust/Cargo.toml; cargo clippy --locked --workspace --all-targets --manifest-path rust/Cargo.toml -- -D warnings; cargo fmt --manifest-path rust/Cargo.toml --all -- --check; cargo build --locked --manifest-path rust/Cargo.toml --bins --examples.

Process/JS commands: pnpm test:native with TMT_TEST_CLI and TMT_TEST_STORAGE_PROBE, pnpm check, pnpm test, pnpm test:e2e twice. Both final Docker runs include the strengthened SQL/removal assertions; earlier exploratory passes are not substituted for this evidence.

## Lifecycle

ARCHITECTURE.md, DEVELOPMENT.md and RUST-REWRITE.md updated with ownership and truthful preview status. Branch feat/127-native-profiles; dedicated worktree /Users/benhsieh/dev/tmt-127-native-profiles. Rebase onto merged #125 changed no tested file contents. #129 implementation continues in a separate worktree; no host tmux, user database, global installation or publication was touched.
