### PR TITLE
Complete native durable talk and compact reply instructions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1059,8 +1059,8 @@ bounded housekeeping. `RequestRecords` is available only inside the existing
 Storage immediate transaction. The clock is sampled after acquiring that lock;
 the concrete caller supplies attempt IDs and frozen settings before entry.
 There is no service-owned connection, tmux lookup, file input or configuration
-loader. #122 supplies public native reply/result composition; native talk remains
-unimplemented in this preview.
+loader. #122 supplies public native reply/result composition; #129 composes
+public talk over the same service and bounded transport.
 
 `core::retention` is the shared settings/runtime owner for day limits and checked
 JavaScript-safe deadlines. Historical migration arithmetic remains frozen.
@@ -1102,8 +1102,8 @@ The reviewed pure SHA-256 dependency is permitted only in core; base64 is
 permitted only in adapters. Existing serde_json handles bounded v1 envelopes,
 not v2 digest serialization. Architecture tests enforce these dependency edges
 with positive and adverse cases. This is local correlation, not remote access
-control. #106 still owns native talk integration and installed recipient instructions;
-#93 retains native message transport integration.
+control. #129 uses compact receipts in native talk; #106 still owns the installed
+recipient-instruction transition before native cutover.
 
 #122 adds `response_command` for public storage-only reply/result. It consumes
 the parser's existing typed invocation and the codec before any input acquisition.
@@ -1149,8 +1149,8 @@ uses one second and 4 MiB per stream. These are per-command bounds, not an
 overall send/observer deadline: configured Enter delay remains separate. Capture
 is complete diagnostic text or failure, never a completion signal. Both paths
 use the same process group/deadline/reaping owner as endpoint evidence, with no
-new process runner or dependencies. Public talk/check composition, response
-observation and installed-runtime promotion remain separate integration work.
+new process runner or dependencies. Public check and talk composition are supplied
+by #125 and #129 respectively; installed-runtime promotion remains separate work.
 The development-only tmux probe exercises these APIs in the existing private
 Docker fixture. Fault injection parses the actual tmux command after socket
 options, keeping explicit native and ambient TypeScript calls observable through
@@ -1199,6 +1199,43 @@ role and reply: nonblocking open, regular-file check, maximum-plus-one read,
 and overflow rejection before decoding. Callers retain their respective UTF-8
 and content policies. Reply stdin flags, deadlines and exact-body validation are
 unchanged; role does not gain stdin. This is not a path-confinement boundary.
+
+#### Native durable talk composition
+
+#129 adds `talk_command`, with preparation, observation and presentation local
+to that use case. It reuses `target`, `identity_context`, profile reads,
+`RequestService`, compact receipts and `Tmux` transport; no handler SQL or
+parallel lifecycle is introduced. Config and exact original input validate
+before endpoint/storage effects. Optional attribution permits an unknown caller;
+explicit selection stays lookup-only. After pre-send delay, a fresh scoped
+snapshot passes through the existing binding evaluator before preparation.
+This is evidence, not a processing lease.
+
+Preparation persists the exact original prompt; only transport payload adds
+reserved preamble and reply guidance. Roles are never injected. Independent
+request/attempt UUIDs feed the existing 25-character v2 encoder. Begin-send and
+settlement remain separate service commits around transport. Proven preparation
+failure maps to `DELIVERY_PREPARATION_FAILED`; uncertain paste/literal/submit
+maps to `DELIVERY_UNCERTAIN`, with stage and request correlation. Neither retries.
+Every post-preparation waiting path releases only its waiter; late finals remain
+eligible. A monotonic deadline begins before begin-send, includes transport, and
+is checked before/after reads. Crossing reads lose without rereading. Positive
+polling intervals round up to a millisecond and clip to the remaining deadline.
+The shared adapter wall clock is separately sampled inside service transactions.
+
+Adapter `interrupt` owns SIGINT registrations through pinned `signal-hook` and
+a nonblocking Unix self-pipe waited through existing nix poll. No worker thread
+or second process runner is added. First SIGINT wakes observation; a second
+retains emergency termination during blocked synchronous work. Bounded process/
+SQLite operations and configured Enter delay are not instantly cancellable.
+The guard stays through waiter/storage cleanup and publication, then unregisters
+its callbacks and closes descriptors. The library's OS dispatcher remains until
+process exit; this is a CLI lifetime, not host-application signal restoration.
+
+Shared failure output carries public target/request/stage fields, while primary
+and secondary cleanup causes stay internal. Storage closes before publication;
+close failure cannot publish success. Installed-runtime and skill cutover remain
+separate delivery gates.
 
 #### Native storage and runtime adapters
 
@@ -1291,15 +1328,15 @@ optional/unknown results, but failed subprocess cleanup propagates as an error.
 It cannot trigger fallback server initialization or be hidden by best-effort
 observation. Metadata reads remain fatal before writes; unknown siblings survive
 marker replacement/clear. Binding coordination uses the application port above;
-there is still no native message transport.
+message transport uses the same bounded runner under #124.
 
 The non-installed `tmux-probe` example exposes only narrow adapter operations
 and counts runner calls. The existing Docker fixture selects it through the
 shared executable descriptor. The same pinned Debian image builds native
 artifacts, runs adapter unit tests under `--init`, and executes real private-tmux
 scenarios with mock agents and no network. These are adapter integration tests,
-not evidence that unported native talk commands work. The same image separately
-builds the native CLI and selects it for the identity lifecycle suite under #109.
+not public command acceptance on their own. The same image separately selects
+the native CLI for identity lifecycle (#109) and durable talk (#129) scenarios.
 
 The [Rust rewrite decision](RUST-REWRITE.md) records the proposed native package
 boundaries, compatibility/test matrix, data coexistence gates and dependency

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,10 +36,10 @@ help/version/completion, typed grammar, the existing `config` command and
 storage-only `identity create/show/list` under #113, and pane identity
 `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` under #109, plus storage-only
 `reply`/`result` under #122, diagnostic `check`/`read` under #125, and
-`role`/`preamble` under #127.
+`role`/`preamble` under #127, and durable `talk` under #129.
 Other effectful commands still explicitly fail.
-The #118 request/final service is an internal transactional foundation only;
-its public reply/result composition is supplied by #122, not native talk. Its real SQLite
+The #118 request/final service is the shared transactional foundation;
+public reply/result composition is supplied by #122 and talk by #129. Its real SQLite
 tests run in ordinary adapter Cargo tests and therefore in the existing Docker
 adapter-test stage. They must verify committed rows independently of service
 reads, since those reads can perform housekeeping. Inject clocks for deadline
@@ -69,7 +69,7 @@ adapter deadlines. This is public storage-only acceptance, not native talk.
 and the existing development-only tmux probe. These scenarios assert causal mock
 input and exact no-replay traces for explicit-socket native operations, preserve
 unrelated buffers, and compare diagnostic capture independently. They do not
-make public native talk/check available. Scripted adapter tests reuse the tmux
+establish public native talk/check acceptance alone. Scripted adapter tests reuse the tmux
 test runner to verify caps, stage errors and cleanup precedence without host tmux.
 #125 adds `test/native/check.test.ts` for configuration-before-effects and
 lookup-only misses, plus `test/e2e/native-check.e2e.test.ts` for real public
@@ -84,6 +84,14 @@ text, transactional stale-owner rejection and unchanged identity/cadence state.
 independence and bounded role files. `test/e2e/native-profile.e2e.test.ts` covers
 verified implicit selection, explicit override, saved rebind and temporary
 retirement. Reply regression tests continue to exercise the shared file reader.
+#129 adds `test/native/talk.test.ts` preflight checks and public native
+`test/e2e/native-talk.e2e.test.ts` scenarios. Keep native selection in nested
+mock replies and use independent SQL for original prompts, provenance, cadence,
+and waiter release. Deterministic observer tests prove deadline equality,
+crossing reads and interruption without sleeps. Signal adapter tests use only
+task-owned subprocesses; never send signals to the runner or host agents.
+Timeout/interruption evidence must include a later retained final, and uncertain
+transport evidence must prove no replay, not merely a nonzero exit.
 The separate storage adapter upgrades historical schemas 0–8 to native schema 9,
 tested through a development-only probe rather than an installed command.
 Use isolated test databases only: installed TypeScript cannot reopen schema 9.

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -144,7 +144,7 @@ does not undo or justify repeating an accepted final.
 
 ### Native compact receipt preview (#120 under #106)
 
-The native internal codec emits exactly 25 ASCII characters: `v2_` plus
+Native talk (#129) uses the shared codec to emit exactly 25 ASCII characters: `v2_` plus
 canonical unpadded base64url of the first 16 SHA-256 digest bytes. The preimage
 starts with ASCII `tmux-team/reply-receipt/v2` and NUL, followed in order by
 request ID, attempt ID, server ID, socket path, server PID, server start time,
@@ -186,9 +186,10 @@ input before storage. Both v1 and v2 receipts work without tmux or current confi
 The same submitted/completed/unavailable output and exit contracts apply; a
 stopped schema-8 fixture can migrate through native reply while retaining its v1
 instruction. This is not permission to mix writers after schema-9 migration.
-Native talk is still absent. Parent #106 owns generated instruction measurements,
-canonical installed guidance and full private-tmux/mock-agent acceptance before
-cutover; installed skill/README instructions remain unchanged for now.
+Native talk (#129) emits compact instructions through the same codec and proves
+the public flow with private-tmux/native mock replies. Parent #106 still owns
+canonical installed guidance before cutover; installed skill/README instructions
+remain unchanged for now.
 
 ### TMT-39 live durable completion
 

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -6,12 +6,12 @@ storage-only identity commands (#113), and pane identity lifecycle (#109)
 are implemented in the development preview, not a shipped Rust runtime.
 #118 adds the internal transactional request/final foundation; #120 adds compact
 receipt encoding and old-v1 decoding through that same service. #122 adds public
-native reply/result with bounded input. Native talk and the full #106
-short-receipt transition remain unimplemented.
+native reply/result with bounded input. #129 adds native talk; the full #106
+installed short-receipt instruction transition remains pending.
 #124 adds the bounded native send/capture adapter and isolated real-tmux
 acceptance. #125 adds shared current-server target resolution and public
 diagnostic check/read. #127 adds native role/preamble and shared bounded profile
-text/file acquisition. Public talk composition and observation remain pending.
+text/file acquisition. #129 adds public talk composition and bounded observation.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
 The compatibility reference is TypeScript main `cb53533f3a9f19a1a2ab95af59dda20df419200b`
@@ -71,7 +71,8 @@ delegates from native to Node.
 The preview implements help, version, Bash/Zsh completion and the existing
 `config` command plus storage-only `identity create/show/list` (#113) and pane
 identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109), plus storage-only
-`reply`/`result` (#122), diagnostic `check`/`read` (#125), and role/preamble (#127).
+`reply`/`result` (#122), diagnostic `check`/`read` (#125), role/preamble (#127), and
+durable `talk` (#129).
 Other recognized effectful commands return
 `NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
 storage, tmux or input acquisition. Text-only commands reject JSON. Native

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -138,6 +138,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +526,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +631,7 @@ dependencies = [
  "nix",
  "rusqlite",
  "serde_json",
+ "signal-hook",
  "subprocess",
  "tmt-core",
  "uuid",
@@ -730,6 +761,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "writeable"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,6 +24,7 @@ icu_casemap = { version = "=2.3.0", default-features = false, features = ["compi
 icu_locale_core = { version = "=2.3.0", default-features = false }
 sha2 = { version = "=0.11.0", default-features = false }
 base64 = { version = "=0.22.1", default-features = false, features = ["alloc"] }
+signal-hook = { version = "=0.4.4", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -16,6 +16,7 @@ uuid = { workspace = true, features = ["v4"] }
 [target.'cfg(unix)'.dependencies]
 subprocess.workspace = true
 nix.workspace = true
+signal-hook.workspace = true
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { workspace = true, features = ["term"] }

--- a/rust/crates/tmt-adapters/src/interrupt.rs
+++ b/rust/crates/tmt-adapters/src/interrupt.rs
@@ -1,0 +1,92 @@
+//! Invocation-owned SIGINT notification without a worker thread or busy polling.
+
+use nix::{
+    errno::Errno,
+    poll::{PollFd, PollFlags, PollTimeout, poll},
+};
+use signal_hook::{SigId, consts::SIGINT, flag, low_level};
+use std::{
+    io,
+    os::{fd::AsFd, unix::net::UnixStream},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Instant,
+};
+
+pub struct Interrupt {
+    reader: UnixStream,
+    interrupted: Arc<AtomicBool>,
+    registrations: Vec<SigId>,
+}
+
+impl Interrupt {
+    pub fn install() -> io::Result<Self> {
+        let (reader, writer) = UnixStream::pair()?;
+        reader.set_nonblocking(true)?;
+        writer.set_nonblocking(true)?;
+        let mut guard = Self {
+            reader,
+            interrupted: Arc::new(AtomicBool::new(false)),
+            registrations: Vec::new(),
+        };
+        // Registration order is significant: a second SIGINT keeps the default
+        // emergency termination behavior even during blocked synchronous work.
+        guard.registrations.push(flag::register_conditional_default(
+            SIGINT,
+            guard.interrupted.clone(),
+        )?);
+        guard
+            .registrations
+            .push(flag::register(SIGINT, guard.interrupted.clone())?);
+        guard
+            .registrations
+            .push(low_level::pipe::register(SIGINT, writer)?);
+        Ok(guard)
+    }
+
+    pub fn is_interrupted(&self) -> bool {
+        self.interrupted.load(Ordering::SeqCst)
+    }
+
+    pub fn wait_until(&self, deadline: Instant) -> io::Result<()> {
+        while !self.is_interrupted() {
+            let Some(remaining) = deadline
+                .checked_duration_since(Instant::now())
+                .filter(|remaining| !remaining.is_zero())
+            else {
+                return Ok(());
+            };
+            let millis = remaining
+                .as_millis()
+                .saturating_add(1)
+                .min(i32::MAX as u128);
+            let timeout = PollTimeout::try_from(millis).map_err(io::Error::other)?;
+            let mut events = [PollFd::new(self.reader.as_fd(), PollFlags::POLLIN)];
+            match poll(&mut events, timeout) {
+                Err(Errno::EINTR) => continue,
+                Err(error) => return Err(error.into()),
+                Ok(_) => {}
+            }
+            let ready = events[0]
+                .revents()
+                .ok_or_else(|| io::Error::other("Invalid interrupt descriptor state"))?;
+            if ready.intersects(PollFlags::POLLERR | PollFlags::POLLNVAL | PollFlags::POLLHUP) {
+                return Err(io::Error::other("Interrupt notification failed"));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Interrupt {
+    fn drop(&mut self) {
+        for registration in self.registrations.drain(..).rev() {
+            low_level::unregister(registration);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-adapters/src/interrupt/tests.rs
+++ b/rust/crates/tmt-adapters/src/interrupt/tests.rs
@@ -1,0 +1,236 @@
+use super::Interrupt;
+use crate::test_support::TestDirectory;
+use nix::{
+    sys::signal::{Signal, kill},
+    unistd::Pid,
+};
+use std::{
+    env, fs,
+    os::unix::process::ExitStatusExt,
+    path::Path,
+    process::{Child, Command, ExitStatus, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+const FIXTURE_TEST: &str = "interrupt::tests::subprocess_fixture";
+const FIXTURE_MODE: &str = "TMT_INTERRUPT_TEST_MODE";
+const FIXTURE_READY: &str = "TMT_INTERRUPT_TEST_READY";
+const FIXTURE_EVENT: &str = "TMT_INTERRUPT_TEST_EVENT";
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(2);
+const EXIT_TIMEOUT: Duration = Duration::from_secs(3);
+
+struct Fixture {
+    _directory: TestDirectory,
+    ready: std::path::PathBuf,
+    event: std::path::PathBuf,
+    child: Child,
+}
+
+impl Fixture {
+    fn start(mode: &str) -> Self {
+        let directory = TestDirectory::new();
+        let ready = directory.path.join("ready");
+        let event = directory.path.join("event");
+        let executable = env::current_exe().expect("locate adapter test executable");
+        let child = Command::new(executable)
+            .args(["--exact", FIXTURE_TEST, "--nocapture", "--test-threads=1"])
+            .env(FIXTURE_MODE, mode)
+            .env(FIXTURE_READY, &ready)
+            .env(FIXTURE_EVENT, &event)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn task-owned interrupt fixture");
+        Self {
+            _directory: directory,
+            ready,
+            event,
+            child,
+        }
+    }
+
+    fn wait_for_content(&mut self, path: &Path, expected: &str, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if fs::read_to_string(path).ok().as_deref() == Some(expected) {
+                return;
+            }
+            if let Some(status) = self
+                .child
+                .try_wait()
+                .expect("inspect interrupt fixture status")
+            {
+                panic!(
+                    "interrupt fixture exited before {}: {status}",
+                    path.display()
+                );
+            }
+            assert!(
+                Instant::now() < deadline,
+                "interrupt fixture did not publish {expected:?} to {}",
+                path.display(),
+            );
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+
+    fn wait_for_exit(&mut self, timeout: Duration) -> ExitStatus {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = self
+                .child
+                .try_wait()
+                .expect("inspect interrupt fixture status")
+            {
+                return status;
+            }
+            assert!(Instant::now() < deadline, "interrupt fixture did not exit");
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn fixture_pid(fixture: &Fixture) -> Pid {
+    Pid::from_raw(i32::try_from(fixture.child.id()).expect("fixture PID fits in pid_t"))
+}
+
+fn event(fixture: &Fixture) -> String {
+    fs::read_to_string(&fixture.event).expect("interrupt fixture wrote its event")
+}
+
+fn open_fd_count() -> usize {
+    fs::read_dir("/dev/fd")
+        .expect("the Unix test host exposes /dev/fd")
+        .count()
+}
+
+#[test]
+fn sigint_wakes_a_task_owned_wait() {
+    let mut fixture = Fixture::start("wake");
+    fixture.wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
+    kill(fixture_pid(&fixture), Signal::SIGINT).expect("send SIGINT to fixture child");
+
+    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    assert!(status.success(), "fixture failed after SIGINT: {status}");
+    assert_eq!(event(&fixture), "interrupted");
+}
+
+#[test]
+fn second_sigint_uses_the_emergency_default() {
+    let mut fixture = Fixture::start("second");
+    fixture.wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
+    kill(fixture_pid(&fixture), Signal::SIGINT).expect("send first SIGINT to fixture child");
+    fixture.wait_for_content(&fixture.event.clone(), "first-interrupted", STARTUP_TIMEOUT);
+    assert_eq!(event(&fixture), "first-interrupted");
+
+    kill(fixture_pid(&fixture), Signal::SIGINT).expect("send second SIGINT to fixture child");
+    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    assert_eq!(
+        status.signal(),
+        Some(Signal::SIGINT as i32),
+        "second SIGINT must terminate the fixture"
+    );
+}
+
+#[test]
+fn deadline_returns_without_a_signal() {
+    let mut fixture = Fixture::start("deadline");
+    fixture.wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
+
+    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    assert!(status.success(), "deadline fixture failed: {status}");
+    assert_eq!(event(&fixture), "deadline-no-signal");
+}
+
+#[test]
+fn guard_drop_releases_descriptors_and_allows_reinstallation() {
+    let mut fixture = Fixture::start("drop");
+    fixture.wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
+
+    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    assert!(status.success(), "drop fixture failed: {status}");
+    assert_eq!(event(&fixture), "reinstalled");
+}
+
+#[test]
+fn subprocess_fixture() {
+    let Some(mode) = env::var_os(FIXTURE_MODE) else {
+        return;
+    };
+    let ready = env::var_os(FIXTURE_READY)
+        .map(std::path::PathBuf::from)
+        .expect("fixture ready path");
+    let event = env::var_os(FIXTURE_EVENT)
+        .map(std::path::PathBuf::from)
+        .expect("fixture event path");
+    let mode = mode.to_str().expect("fixture mode is UTF-8");
+    let interrupt = Interrupt::install().expect("install interrupt fixture");
+    fs::write(&ready, b"ready").expect("publish interrupt fixture readiness");
+
+    match mode {
+        "wake" => {
+            interrupt
+                .wait_until(Instant::now() + Duration::from_secs(5))
+                .expect("SIGINT wait should not fail");
+            assert!(interrupt.is_interrupted());
+            fs::write(event, b"interrupted").expect("publish interrupt event");
+        }
+        "second" => {
+            interrupt
+                .wait_until(Instant::now() + Duration::from_secs(5))
+                .expect("first SIGINT wait should not fail");
+            assert!(interrupt.is_interrupted());
+            fs::write(event, b"first-interrupted").expect("publish first interrupt event");
+            thread::sleep(Duration::from_secs(30));
+        }
+        "deadline" => {
+            let deadline = Instant::now() + Duration::from_millis(200);
+            interrupt
+                .wait_until(deadline)
+                .expect("deadline wait should not fail");
+            assert!(
+                Instant::now() >= deadline,
+                "wait returned before its deadline"
+            );
+            assert!(!interrupt.is_interrupted());
+            fs::write(event, b"deadline-no-signal").expect("publish deadline event");
+        }
+        "drop" => {
+            let original_interrupted = interrupt.interrupted.clone();
+            let with_guard = open_fd_count();
+            assert!(with_guard >= 2, "interrupt guard descriptors are present");
+            drop(interrupt);
+            assert_eq!(
+                open_fd_count(),
+                with_guard - 2,
+                "guard drop closes both interrupt descriptors"
+            );
+
+            let replacement = Interrupt::install().expect("reinstall interrupt after drop");
+            assert_eq!(
+                open_fd_count(),
+                with_guard,
+                "reinstallation restores the interrupt descriptors"
+            );
+            kill(Pid::this(), Signal::SIGINT).expect("signal task-owned fixture process");
+            replacement
+                .wait_until(Instant::now() + Duration::from_secs(2))
+                .expect("reinstalled interrupt should wake");
+            assert!(replacement.is_interrupted());
+            assert!(!original_interrupted.load(std::sync::atomic::Ordering::SeqCst));
+            fs::write(event, b"reinstalled").expect("publish reinstall event");
+        }
+        _ => panic!("unknown interrupt fixture mode: {mode}"),
+    }
+}

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -3,10 +3,13 @@
 #[cfg(unix)]
 pub mod bounded_file;
 pub mod config;
+#[cfg(unix)]
+pub mod interrupt;
 mod json_document;
 #[cfg(unix)]
 pub mod process;
 pub mod reply_receipt;
+pub mod request_runtime;
 #[cfg(unix)]
 pub mod response_input;
 pub mod storage;

--- a/rust/crates/tmt-adapters/src/request_runtime.rs
+++ b/rust/crates/tmt-adapters/src/request_runtime.rs
@@ -1,0 +1,19 @@
+//! Runtime entropy and wall-clock sampling for the existing request service.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Invalid clocks fail closed through the service's safe-integer validation.
+pub fn wall_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|time| u64::try_from(time.as_millis()).ok())
+        .unwrap_or(0)
+}
+
+pub fn request_ids() -> (String, String) {
+    (
+        format!("req_{}", uuid::Uuid::new_v4()),
+        uuid::Uuid::new_v4().to_string(),
+    )
+}

--- a/rust/crates/tmt-cli/src/identity_context.rs
+++ b/rust/crates/tmt-cli/src/identity_context.rs
@@ -23,6 +23,20 @@ pub fn missing(name: &str) -> Failure {
 }
 
 pub fn resolve(storage: &mut Storage, explicit: Option<&str>) -> Result<Identity, Failure> {
+    optional(storage, &Tmux::default(), explicit)?.ok_or_else(|| {
+        Failure::new(
+            "IDENTITY_REQUIRED",
+            "An identity is required; use --identity or run from a verified bound pane.",
+            1,
+        )
+    })
+}
+
+pub fn optional(
+    storage: &mut Storage,
+    tmux: &Tmux,
+    explicit: Option<&str>,
+) -> Result<Option<Identity>, Failure> {
     if let Some(name) = explicit {
         return storage
             .find_identity(&normalize_name(name))
@@ -30,22 +44,18 @@ pub fn resolve(storage: &mut Storage, explicit: Option<&str>) -> Result<Identity
                 Failure::new("IDENTITY_ERROR", "Could not read identity storage.", 1)
                     .caused_by(error)
             })?
-            .ok_or_else(|| missing(name));
+            .ok_or_else(|| missing(name))
+            .map(Some);
     }
-    let tmux = Tmux::default();
     let pane = tmux
         .caller_pane(&CallerEnvironment::current())
         .map_err(endpoint_failure)?;
     if let Some(pane) = pane {
-        let observed = binding::pane_presence(storage, &mut BindingSession::new(&tmux), &pane)
+        let observed = binding::pane_presence(storage, &mut BindingSession::new(tmux), &pane)
             .map_err(binding_failure)?;
         if let Some(identity) = observed.identity {
-            return Ok(identity);
+            return Ok(Some(identity));
         }
     }
-    Err(Failure::new(
-        "IDENTITY_REQUIRED",
-        "An identity is required; use --identity or run from a verified bound pane.",
-        1,
-    ))
+    Ok(None)
 }

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -11,6 +11,7 @@ mod output;
 mod parser;
 mod profile_command;
 mod response_command;
+mod talk_command;
 mod target;
 
 use std::io::{self, Write};
@@ -40,7 +41,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration, identity create/show/list, reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, and role/preamble are available. Talk is not implemented yet. Use isolated test state only.\n"
+                "Native development preview: configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, and role/preamble are available. Installation and attention commands are not implemented yet. Use isolated test state only.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -73,6 +74,10 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Identity(request) => {
             drop(stdout);
             return identity_command::execute(request, parsed.mode);
+        }
+        request @ Invocation::Talk { .. } => {
+            drop(stdout);
+            return talk_command::execute(request, parsed.mode);
         }
         request @ (Invocation::Role { .. } | Invocation::Preamble(_)) => {
             drop(stdout);

--- a/rust/crates/tmt-cli/src/output.rs
+++ b/rust/crates/tmt-cli/src/output.rs
@@ -12,9 +12,24 @@ pub struct Failure {
     pub code: &'static str,
     pub message: String,
     pub status: u8,
-    cause: Option<Box<dyn Error>>,
+    diagnostics: Option<Box<Diagnostics>>,
     suggestion: Option<String>,
     request: Option<Box<(String, Option<&'static str>)>>,
+    target: Option<Box<TargetDetails>>,
+    stage: Option<&'static str>,
+}
+
+#[derive(Debug, Default)]
+struct Diagnostics {
+    cause: Option<Box<dyn Error>>,
+    secondary: Vec<Box<dyn Error>>,
+}
+
+#[derive(Debug)]
+struct TargetDetails {
+    target: String,
+    pane: String,
+    identity: Option<(String, String)>,
 }
 
 impl Failure {
@@ -23,14 +38,16 @@ impl Failure {
             code,
             message: message.into(),
             status,
-            cause: None,
+            diagnostics: None,
             suggestion: None,
             request: None,
+            target: None,
+            stage: None,
         }
     }
 
     pub fn caused_by(mut self, cause: impl Error + 'static) -> Self {
-        self.cause = Some(Box::new(cause));
+        self.diagnostics.get_or_insert_default().cause = Some(Box::new(cause));
         self
     }
 
@@ -39,10 +56,38 @@ impl Failure {
         self
     }
 
+    pub fn with_secondary_error(mut self, error: impl Error + 'static) -> Self {
+        self.diagnostics
+            .get_or_insert_default()
+            .secondary
+            .push(Box::new(error));
+        self
+    }
+
     /// Only explicit public correlation is carried into an error document;
     /// bodies, receipt proofs and endpoint evidence are never included.
     pub fn with_request(mut self, request_id: String, status: Option<&'static str>) -> Self {
         self.request = Some(Box::new((request_id, status)));
+        self
+    }
+
+    pub fn with_target(
+        mut self,
+        target: &str,
+        pane: &str,
+        identity: Option<&tmt_core::identity::Identity>,
+    ) -> Self {
+        self.target = Some(Box::new(TargetDetails {
+            target: target.into(),
+            pane: pane.into(),
+            identity: identity
+                .map(|identity| (identity.name.clone(), identity.canonical_name.clone())),
+        }));
+        self
+    }
+
+    pub fn at_stage(mut self, stage: &'static str) -> Self {
+        self.stage = Some(stage);
         self
     }
 
@@ -59,6 +104,17 @@ impl Failure {
                 if let Some(status) = status {
                     document["status"] = (*status).into();
                 }
+            }
+            if let Some(target) = &self.target {
+                document["target"] = target.target.clone().into();
+                document["pane"] = target.pane.clone().into();
+                if let Some((name, canonical_name)) = &target.identity {
+                    document["identity"] =
+                        serde_json::json!({"name": name, "canonicalName": canonical_name});
+                }
+            }
+            if let Some(stage) = self.stage {
+                document["error"]["stage"] = stage.into();
             }
             writeln!(io::stdout().lock(), "{document}")?;
         } else {
@@ -84,7 +140,9 @@ impl fmt::Display for Failure {
 
 impl Error for Failure {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.cause.as_deref()
+        self.diagnostics
+            .as_ref()
+            .and_then(|details| details.cause.as_deref())
     }
 }
 
@@ -97,7 +155,10 @@ pub fn after_cleanup<T, E: Error + 'static>(
 ) -> Result<T, Failure> {
     let cleanup = cleanup();
     match pending {
-        Err(primary) => Err(primary),
+        Err(primary) => Err(match cleanup {
+            Ok(()) => primary,
+            Err(secondary) => primary.with_secondary_error(secondary),
+        }),
         Ok(report) => cleanup.map(|()| report).map_err(|error| {
             Failure::new(
                 "CLEANUP_ERROR",
@@ -166,6 +227,11 @@ mod tests {
             assert_eq!(failure.message, "Missing identity");
             assert_eq!(failure.status, 3);
             assert_eq!(failure.source().unwrap().to_string(), "primary cause");
+            let diagnostics = failure.diagnostics.as_ref().unwrap();
+            assert_eq!(diagnostics.secondary.len(), usize::from(fail_cleanup));
+            if fail_cleanup {
+                assert_eq!(diagnostics.secondary[0].to_string(), "cleanup cause");
+            }
         }
     }
 }

--- a/rust/crates/tmt-cli/src/response_command.rs
+++ b/rust/crates/tmt-cli/src/response_command.rs
@@ -10,11 +10,11 @@ use std::{
     error::Error,
     io::{self, Write},
     path::Path,
-    time::{SystemTime, UNIX_EPOCH},
 };
 use tmt_adapters::{
     config::ConfigPaths,
     reply_receipt::decode_reply_receipt,
+    request_runtime::wall_time_ms,
     response_input::{ResponseInputError, ResponseInputFailure, read_file, read_stdin},
     storage::{Storage, StorageError},
 };
@@ -115,13 +115,7 @@ fn run(request: Invocation) -> Result<Report, Failure> {
     let mut storage = Storage::open(paths.database).map_err(unavailable)?;
     // Invalid clocks fail closed through the service's safe-integer validation.
     // Sample inside its transaction, not once before acquiring the writer lock.
-    let mut service = RequestService::new(&mut storage, || {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .ok()
-            .and_then(|time| u64::try_from(time.as_millis()).ok())
-            .unwrap_or(0)
-    });
+    let mut service = RequestService::new(&mut storage, wall_time_ms);
     let pending = match submission {
         Some(input) => service
             .submit_response(input)

--- a/rust/crates/tmt-cli/src/talk_command.rs
+++ b/rust/crates/tmt-cli/src/talk_command.rs
@@ -1,0 +1,294 @@
+//! Native talk composition over existing request, identity and transport owners.
+
+mod observation;
+mod preparation;
+mod presentation;
+
+use crate::{
+    invocation::{Invocation, OutputMode, TalkOptions},
+    output::{Failure, after_cleanup},
+};
+use std::{
+    io,
+    time::{Duration, Instant},
+};
+use tmt_adapters::{
+    config::{ConfigFiles, ConfigPaths},
+    interrupt::Interrupt,
+    request_runtime::wall_time_ms,
+    storage::{Storage, StorageError},
+    tmux::Tmux,
+};
+use tmt_core::{
+    exact_text::validate_exact_text,
+    identity::Identity,
+    request::{FinalResponse, RequestEndpoint, RequestError, RequestService, Settlement},
+    settings::Settings,
+};
+
+struct Input {
+    target: String,
+    message: String,
+    originator: Option<String>,
+    options: TalkOptions,
+}
+#[derive(Clone)]
+struct Correlation {
+    request_id: String,
+    target: String,
+    pane: String,
+    identity: Option<Identity>,
+}
+struct Prepared {
+    correlation: Correlation,
+    attempt_id: String,
+    endpoint: RequestEndpoint,
+    payload: String,
+    previous_request_id: Option<String>,
+}
+struct Report {
+    correlation: Correlation,
+    response: Option<FinalResponse>,
+}
+
+impl Correlation {
+    fn error(&self, code: &'static str, message: impl Into<String>, status: u8) -> Failure {
+        Failure::new(code, message, status)
+            .with_request(self.request_id.clone(), None)
+            .with_target(&self.target, &self.pane, self.identity.as_ref())
+    }
+    fn inspection(&self) -> String {
+        format!(
+            "Inspect with 'tmt result {}' and 'tmt check {}' before deciding whether to retry.",
+            self.request_id, self.target
+        )
+    }
+    fn state_error(&self, error: RequestError<StorageError>, possible_delivery: bool) -> Failure {
+        self.error(
+            "REQUEST_STATE_ERROR",
+            if possible_delivery {
+                "Request state failed after transport; delivery may have occurred."
+            } else {
+                "Request state failed before transport; no message was sent."
+            },
+            1,
+        )
+        .suggestion(self.inspection())
+        .caused_by(error)
+    }
+    fn interrupted(&self) -> Failure {
+        self.error(
+            "INTERRUPTED",
+            "Interrupted while waiting for a durable reply.",
+            1,
+        )
+        .suggestion(self.inspection())
+    }
+}
+
+fn deliver(
+    storage: &mut Storage,
+    tmux: &Tmux,
+    prepared: &Prepared,
+    input: &Input,
+    settings: &Settings,
+    interrupt: Option<&Interrupt>,
+) -> Result<Option<FinalResponse>, Failure> {
+    let correlation = &prepared.correlation;
+    let mut service = RequestService::new(storage, wall_time_ms);
+    let wait = !input.options.detach;
+    let timeout = input.options.timeout_seconds.unwrap_or(settings.timeout);
+    let deadline = Instant::now() + Duration::from_secs_f64(timeout);
+    let pending = (|| {
+        if interrupt.is_some_and(Interrupt::is_interrupted) {
+            service
+                .settle(&prepared.attempt_id, Settlement::DefinitelyFailed)
+                .map_err(|error| correlation.state_error(error, false))?;
+            return Err(correlation.interrupted());
+        }
+        if let Err(primary) = service.begin_send(&prepared.attempt_id) {
+            // Settlement is idempotent; the primary failure remains diagnostic.
+            let primary = correlation.state_error(primary, false);
+            return Err(
+                match service.settle(&prepared.attempt_id, Settlement::DefinitelyFailed) {
+                    Ok(()) => primary,
+                    Err(secondary) => primary.with_secondary_error(secondary),
+                },
+            );
+        }
+        let delivered = tmux.send_on(
+            &prepared.endpoint.server.socket_path,
+            &prepared.endpoint.pane_id,
+            &prepared.payload,
+            Duration::from_secs_f64(settings.paste_enter_delay_ms / 1000.0),
+        );
+        match delivered {
+            Ok(()) => service
+                .settle(&prepared.attempt_id, Settlement::Sent)
+                .map_err(|error| correlation.state_error(error, true))?,
+            Err(error) => {
+                let uncertain = error.uncertain();
+                if let Err(state) = service.settle(
+                    &prepared.attempt_id,
+                    if uncertain {
+                        Settlement::Uncertain
+                    } else {
+                        Settlement::DefinitelyFailed
+                    },
+                ) {
+                    return Err(correlation
+                        .state_error(state, uncertain)
+                        .with_secondary_error(error));
+                }
+                return Err(correlation
+                    .error(
+                        if uncertain {
+                            "DELIVERY_UNCERTAIN"
+                        } else {
+                            "DELIVERY_PREPARATION_FAILED"
+                        },
+                        error.to_string(),
+                        1,
+                    )
+                    .at_stage(error.stage.as_str())
+                    .suggestion(correlation.inspection())
+                    .caused_by(error));
+            }
+        }
+        if !wait {
+            return Ok(None);
+        }
+        observation::observe(
+            || {
+                service
+                    .get_response(&correlation.request_id)
+                    .map_err(|error| correlation.state_error(error, true))
+            },
+            correlation,
+            deadline,
+            timeout,
+            settings.poll_interval,
+            interrupt.expect("wait owns interrupt guard"),
+        )
+        .map(Some)
+    })();
+    let released = if wait {
+        service
+            .release_wait(&prepared.attempt_id)
+            .map_err(|error| correlation.state_error(error, true))
+    } else {
+        Ok(())
+    };
+    // Waiter release always runs, including rejected transport and read errors.
+    match pending {
+        Err(primary) => Err(match released {
+            Ok(()) => primary,
+            Err(secondary) => primary.with_secondary_error(secondary),
+        }),
+        Ok(value) => released.map(|()| value),
+    }
+}
+
+fn run(
+    input: Input,
+    paths: ConfigPaths,
+    settings: Settings,
+    interrupt: Option<&Interrupt>,
+    mode: OutputMode,
+) -> Result<Report, Failure> {
+    let mut storage = Storage::open(paths.database).map_err(|error| {
+        Failure::new(
+            "REQUEST_STATE_ERROR",
+            "Could not open request storage; no message was sent.",
+            1,
+        )
+        .caused_by(error)
+    })?;
+    let tmux = Tmux::default();
+    let mut cleanup_correlation = None;
+    let pending = preparation::prepare(&mut storage, &tmux, &input, &settings, interrupt).and_then(|prepared| {
+        cleanup_correlation = Some(prepared.correlation.clone());
+        if !mode.json && !input.options.detach && !input.options.force && let Some(previous) = &prepared.previous_request_id {
+            eprintln!("Another recent request exists for '{}' (id: {previous}). Input processing is not serialized; durable results remain associated by request ID.", input.target);
+        }
+        let response = deliver(&mut storage, &tmux, &prepared, &input, &settings, interrupt);
+        let correlation = prepared.correlation;
+        response.map(|response| Report { correlation, response })
+    });
+    after_cleanup(pending, || storage.close()).map_err(|error| {
+        if error.code == "CLEANUP_ERROR"
+            && let Some(correlation) = cleanup_correlation
+        {
+            error
+                .with_request(correlation.request_id, None)
+                .with_target(
+                    &correlation.target,
+                    &correlation.pane,
+                    correlation.identity.as_ref(),
+                )
+        } else {
+            error
+        }
+    })
+}
+
+pub fn execute(request: Invocation, mode: OutputMode) -> io::Result<u8> {
+    let Invocation::Talk {
+        target,
+        message,
+        originator,
+        options,
+    } = request
+    else {
+        unreachable!("talk dispatch")
+    };
+    let input = Input {
+        target,
+        message,
+        originator,
+        options,
+    };
+    let preflight: Result<_, Failure> = (|| {
+        let paths = ConfigPaths::discover().map_err(Failure::from)?;
+        let settings = ConfigFiles {
+            paths: paths.clone(),
+        }
+        .load()
+        .map_err(Failure::from)?
+        .settings;
+        validate_exact_text(input.message.as_bytes()).map_err(|_| {
+            Failure::new(
+                "REQUEST_INPUT_TOO_LARGE",
+                "Original request exceeds the UTF-8 byte limit.",
+                1,
+            )
+        })?;
+        Ok((paths, settings))
+    })();
+    let (paths, settings) = match preflight {
+        Ok(value) => value,
+        Err(error) => return error.publish(mode),
+    };
+    // Keep callbacks alive through waiter/storage cleanup and output. A second
+    // SIGINT retains emergency termination if synchronous work cannot finish.
+    let interrupt = if input.options.detach {
+        None
+    } else {
+        match Interrupt::install() {
+            Ok(guard) => Some(guard),
+            Err(error) => {
+                return Failure::new(
+                    "ERROR",
+                    "Could not install observer interruption handling.",
+                    1,
+                )
+                .caused_by(error)
+                .publish(mode);
+            }
+        }
+    };
+    match run(input, paths, settings, interrupt.as_ref(), mode) {
+        Ok(report) => presentation::publish(report, mode),
+        Err(error) => error.publish(mode),
+    }
+}

--- a/rust/crates/tmt-cli/src/talk_command/observation.rs
+++ b/rust/crates/tmt-cli/src/talk_command/observation.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+#[cfg(test)]
+mod tests;
+
+pub(super) trait ObserverRuntime {
+    fn now(&self) -> Instant;
+    fn interrupted(&self) -> bool;
+    fn wait_until(&self, deadline: Instant) -> io::Result<()>;
+}
+
+impl ObserverRuntime for Interrupt {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+    fn interrupted(&self) -> bool {
+        self.is_interrupted()
+    }
+    fn wait_until(&self, deadline: Instant) -> io::Result<()> {
+        Interrupt::wait_until(self, deadline)
+    }
+}
+
+pub(super) fn observe(
+    mut read: impl FnMut() -> Result<Option<FinalResponse>, Failure>,
+    correlation: &Correlation,
+    deadline: Instant,
+    timeout: f64,
+    poll_seconds: f64,
+    runtime: &impl ObserverRuntime,
+) -> Result<FinalResponse, Failure> {
+    let timed_out = || {
+        correlation
+            .error(
+                "TIMEOUT",
+                format!(
+                    "Timed out waiting for {} after {timeout}s",
+                    correlation.target
+                ),
+                4,
+            )
+            .with_request(correlation.request_id.clone(), Some("timeout"))
+            .suggestion(correlation.inspection())
+    };
+    loop {
+        if runtime.interrupted() {
+            return Err(correlation.interrupted());
+        }
+        if runtime.now() >= deadline {
+            return Err(timed_out());
+        }
+        let response = read()?;
+        if runtime.interrupted() {
+            return Err(correlation.interrupted());
+        }
+        if runtime.now() >= deadline {
+            return Err(timed_out());
+        }
+        if let Some(response) = response {
+            return Ok(response);
+        }
+        let now = runtime.now();
+        let remaining = deadline.saturating_duration_since(now);
+        // The reference timer has millisecond granularity. Positive sub-ms
+        // intervals must not become a zero-duration CPU spin in native code.
+        let poll_ms = (poll_seconds.min(timeout) * 1000.0).ceil().max(1.0) as u64;
+        let wake = now + Duration::from_millis(poll_ms).min(remaining);
+        runtime.wait_until(wake).map_err(|error| {
+            correlation
+                .error("ERROR", "Could not wait for a durable reply.", 1)
+                .caused_by(error)
+        })?;
+    }
+}

--- a/rust/crates/tmt-cli/src/talk_command/observation/tests.rs
+++ b/rust/crates/tmt-cli/src/talk_command/observation/tests.rs
@@ -1,0 +1,340 @@
+use super::*;
+use std::{
+    cell::{Cell, RefCell},
+    error::Error,
+    io,
+    time::{Duration, Instant},
+};
+use tmt_core::{
+    endpoint::ServerEvidence,
+    request::{FinalResponse, RequestEndpoint},
+};
+
+struct FakeRuntime {
+    base: Instant,
+    elapsed_ms: Cell<u64>,
+    interrupted: Cell<bool>,
+    waits: RefCell<Vec<Instant>>,
+    fail_wait: Cell<bool>,
+}
+
+impl FakeRuntime {
+    fn new() -> Self {
+        Self {
+            base: Instant::now(),
+            elapsed_ms: Cell::new(0),
+            interrupted: Cell::new(false),
+            waits: RefCell::new(Vec::new()),
+            fail_wait: Cell::new(false),
+        }
+    }
+
+    fn at(&self, elapsed_ms: u64) -> Instant {
+        self.base + Duration::from_millis(elapsed_ms)
+    }
+
+    fn set_elapsed(&self, elapsed_ms: u64) {
+        self.elapsed_ms.set(elapsed_ms);
+    }
+
+    fn waited_ms(&self) -> Vec<u64> {
+        self.waits
+            .borrow()
+            .iter()
+            .map(|deadline| deadline.duration_since(self.base).as_millis() as u64)
+            .collect()
+    }
+}
+
+impl ObserverRuntime for FakeRuntime {
+    fn now(&self) -> Instant {
+        self.at(self.elapsed_ms.get())
+    }
+
+    fn interrupted(&self) -> bool {
+        self.interrupted.get()
+    }
+
+    fn wait_until(&self, deadline: Instant) -> io::Result<()> {
+        self.waits.borrow_mut().push(deadline);
+        if self.fail_wait.get() {
+            return Err(io::Error::other("wait failed"));
+        }
+        self.set_elapsed(deadline.duration_since(self.base).as_millis() as u64);
+        Ok(())
+    }
+}
+
+fn correlation() -> Correlation {
+    Correlation {
+        request_id: "request-observe".into(),
+        target: "worker".into(),
+        pane: "%1".into(),
+        identity: None,
+    }
+}
+
+fn response(body: &str) -> FinalResponse {
+    FinalResponse {
+        request_id: "request-observe".into(),
+        attempt_id: "attempt-observe".into(),
+        endpoint: RequestEndpoint {
+            server: ServerEvidence {
+                server_id: "server".into(),
+                socket_path: "/tmp/tmux.sock".into(),
+                server_pid: 41,
+                server_start_time: "server-start".into(),
+            },
+            pane_id: "%1".into(),
+            pane_pid: 42,
+        },
+        body: body.into(),
+        body_bytes: body.len() as u64,
+        submitted_at_ms: 123,
+        response_expires_at_ms: 456,
+    }
+}
+
+fn assert_failure(failure: &Failure, code: &'static str, status: u8, message: &str) {
+    assert_eq!(failure.code, code);
+    assert_eq!(failure.status, status);
+    assert_eq!(failure.message, message);
+}
+
+fn assert_correlated(failure: &Failure) {
+    let debug = format!("{failure:?}");
+    assert!(
+        debug.contains("request-observe"),
+        "missing request correlation: {debug}"
+    );
+    assert!(
+        debug.contains("worker"),
+        "missing target correlation: {debug}"
+    );
+    assert!(debug.contains("%1"), "missing pane correlation: {debug}");
+}
+
+#[test]
+fn returns_the_exact_final_response_before_the_deadline() {
+    let runtime = FakeRuntime::new();
+    let expected = response("\u{feff} exact\r\nbody\0");
+    let reads = Cell::new(0);
+    let actual = observe(
+        || {
+            reads.set(reads.get() + 1);
+            Ok(Some(expected.clone()))
+        },
+        &correlation(),
+        runtime.at(1_000),
+        1.0,
+        0.25,
+        &runtime,
+    )
+    .unwrap();
+
+    assert_eq!(actual, expected);
+    assert_eq!(reads.get(), 1);
+    assert!(runtime.waited_ms().is_empty());
+}
+
+#[test]
+fn does_not_read_when_deadline_is_already_equal() {
+    let runtime = FakeRuntime::new();
+    runtime.set_elapsed(1_000);
+    let reads = Cell::new(0);
+    let failure = observe(
+        || {
+            reads.set(reads.get() + 1);
+            Ok(None)
+        },
+        &correlation(),
+        runtime.at(1_000),
+        1.0,
+        0.25,
+        &runtime,
+    )
+    .unwrap_err();
+
+    assert_failure(
+        &failure,
+        "TIMEOUT",
+        4,
+        "Timed out waiting for worker after 1s",
+    );
+    assert_eq!(reads.get(), 0);
+    assert_correlated(&failure);
+}
+
+#[test]
+fn response_read_crossing_deadline_is_lost_without_a_second_read() {
+    let runtime = FakeRuntime::new();
+    let reads = Cell::new(0);
+    let expected = response("arrived at the deadline");
+    let failure = observe(
+        || {
+            reads.set(reads.get() + 1);
+            runtime.set_elapsed(1_000);
+            Ok(Some(expected.clone()))
+        },
+        &correlation(),
+        runtime.at(1_000),
+        1.0,
+        0.25,
+        &runtime,
+    )
+    .unwrap_err();
+
+    assert_failure(
+        &failure,
+        "TIMEOUT",
+        4,
+        "Timed out waiting for worker after 1s",
+    );
+    assert_eq!(reads.get(), 1);
+}
+
+#[test]
+fn interruption_before_or_after_read_wins_without_waiting() {
+    let runtime = FakeRuntime::new();
+    runtime.interrupted.set(true);
+    let reads = Cell::new(0);
+    let before = observe(
+        || {
+            reads.set(reads.get() + 1);
+            Ok(None)
+        },
+        &correlation(),
+        runtime.at(1_000),
+        1.0,
+        0.25,
+        &runtime,
+    )
+    .unwrap_err();
+    assert_failure(
+        &before,
+        "INTERRUPTED",
+        1,
+        "Interrupted while waiting for a durable reply.",
+    );
+    assert_eq!(reads.get(), 0);
+
+    runtime.interrupted.set(false);
+    let after_reads = Cell::new(0);
+    let after = observe(
+        || {
+            after_reads.set(after_reads.get() + 1);
+            runtime.interrupted.set(true);
+            Ok(Some(response("too late")))
+        },
+        &correlation(),
+        runtime.at(1_000),
+        1.0,
+        0.25,
+        &runtime,
+    )
+    .unwrap_err();
+    assert_failure(
+        &after,
+        "INTERRUPTED",
+        1,
+        "Interrupted while waiting for a durable reply.",
+    );
+    assert_eq!(after_reads.get(), 1);
+    assert!(runtime.waited_ms().is_empty());
+}
+
+#[test]
+fn preserves_read_failure_without_polling_or_rewriting_it() {
+    let runtime = FakeRuntime::new();
+    let reads = Cell::new(0);
+    let failure = observe(
+        || {
+            reads.set(reads.get() + 1);
+            Err(Failure::new("READ_ERROR", "read failed", 7)
+                .caused_by(io::Error::other("read cause")))
+        },
+        &correlation(),
+        runtime.at(1_000),
+        1.0,
+        0.25,
+        &runtime,
+    )
+    .unwrap_err();
+
+    assert_failure(&failure, "READ_ERROR", 7, "read failed");
+    assert_eq!(failure.source().unwrap().to_string(), "read cause");
+    assert_eq!(reads.get(), 1);
+}
+
+#[test]
+fn clips_no_response_polling_to_the_deadline() {
+    let runtime = FakeRuntime::new();
+    let reads = Cell::new(0);
+    let failure = observe(
+        || {
+            reads.set(reads.get() + 1);
+            Ok(None)
+        },
+        &correlation(),
+        runtime.at(1_000),
+        1.0,
+        0.4,
+        &runtime,
+    )
+    .unwrap_err();
+
+    assert_failure(
+        &failure,
+        "TIMEOUT",
+        4,
+        "Timed out waiting for worker after 1s",
+    );
+    assert_eq!(reads.get(), 3);
+    assert_eq!(runtime.waited_ms(), [400, 800, 1_000]);
+}
+
+#[test]
+fn rounds_positive_submillisecond_polling_to_a_progressing_wait() {
+    let runtime = FakeRuntime::new();
+    let reads = Cell::new(0);
+    let failure = observe(
+        || {
+            reads.set(reads.get() + 1);
+            Ok(None)
+        },
+        &correlation(),
+        runtime.at(3),
+        0.003,
+        0.0001,
+        &runtime,
+    )
+    .unwrap_err();
+
+    assert_failure(
+        &failure,
+        "TIMEOUT",
+        4,
+        "Timed out waiting for worker after 0.003s",
+    );
+    assert_eq!(reads.get(), 3);
+    assert_eq!(runtime.waited_ms(), [1, 2, 3]);
+}
+
+#[test]
+fn retains_wait_failure_and_correlation() {
+    let runtime = FakeRuntime::new();
+    runtime.fail_wait.set(true);
+    let failure = observe(
+        || Ok(None),
+        &correlation(),
+        runtime.at(1_000),
+        1.0,
+        0.25,
+        &runtime,
+    )
+    .unwrap_err();
+
+    assert_failure(&failure, "ERROR", 1, "Could not wait for a durable reply.");
+    assert_correlated(&failure);
+    assert_eq!(failure.source().unwrap().to_string(), "wait failed");
+}

--- a/rust/crates/tmt-cli/src/talk_command/preparation.rs
+++ b/rust/crates/tmt-cli/src/talk_command/preparation.rs
@@ -1,0 +1,127 @@
+use super::*;
+use crate::{identity_context, target};
+use tmt_adapters::{reply_receipt::encode_short_receipt, request_runtime::request_ids};
+use tmt_core::{
+    profile::{ProfileKind, ProfileReader},
+    request::{Originator, PreambleReservation, PrepareRequest},
+    retention::{REQUEST_MIN_EXPIRY_MS, checked_deadline},
+    settings::PreambleMode,
+};
+
+pub(super) fn prepare(
+    storage: &mut Storage,
+    tmux: &Tmux,
+    input: &Input,
+    settings: &Settings,
+    interrupt: Option<&Interrupt>,
+) -> Result<Prepared, Failure> {
+    let observed = target::resolve(storage, tmux, &input.target)?;
+    let originator = identity_context::optional(storage, tmux, input.originator.as_deref())?
+        .map_or(Originator::Unknown, |identity| {
+            if input.originator.is_some() {
+                Originator::Explicit(identity.id)
+            } else {
+                Originator::Verified(identity.id)
+            }
+        });
+    let (request_id, attempt_id) = request_ids();
+    let correlation = Correlation {
+        request_id,
+        target: input.target.clone(),
+        pane: observed.pane.id.clone(),
+        identity: observed.identity.clone(),
+    };
+    if let Some(delay) = input.options.delay_seconds {
+        let delay = Duration::from_secs_f64(delay);
+        if let Some(interrupt) = interrupt {
+            interrupt
+                .wait_until(Instant::now() + delay)
+                .map_err(|error| {
+                    correlation
+                        .error("ERROR", "Could not wait before delivery.", 1)
+                        .caused_by(error)
+                })?;
+        } else {
+            std::thread::sleep(delay);
+        }
+    }
+    if interrupt.is_some_and(Interrupt::is_interrupted) {
+        return Err(correlation.interrupted());
+    }
+    let preamble = if input.options.no_preamble
+        || settings.preamble_mode == PreambleMode::Disabled
+        || settings.preamble_every == 0
+    {
+        None
+    } else if let Some(identity) = &observed.identity {
+        storage
+            .find_profile(&identity.id, ProfileKind::Preamble)
+            .map_err(|error| {
+                Failure::new("PREAMBLE_ERROR", "Could not read recipient preamble.", 1)
+                    .caused_by(error)
+            })?
+            .filter(|profile| !profile.content.is_empty())
+            .map(|profile| (identity.id.clone(), profile.content))
+    } else {
+        None
+    };
+    let endpoint = target::refresh(tmux, &observed)?;
+    let timeout_ms = if input.options.detach {
+        0
+    } else {
+        (input.options.timeout_seconds.unwrap_or(settings.timeout) * 1000.0).ceil() as u64
+    };
+    let budget = timeout_ms + settings.paste_enter_delay_ms.ceil() as u64 + 1000;
+    let expires_at_ms = checked_deadline(wall_time_ms(), budget.max(REQUEST_MIN_EXPIRY_MS))
+        .ok_or_else(|| {
+            correlation.error(
+                "CONFIG_ERROR",
+                "Request expiry is outside the supported range.",
+                1,
+            )
+        })?;
+    let prepared = RequestService::new(storage, wall_time_ms)
+        .prepare(
+            PrepareRequest {
+                request_id: correlation.request_id.clone(),
+                message: input.message.clone(),
+                endpoint: endpoint.clone(),
+                wait: !input.options.detach,
+                expires_at_ms,
+                originator,
+                recipient_identity_id: observed
+                    .identity
+                    .as_ref()
+                    .map(|identity| identity.id.clone()),
+                preamble: preamble
+                    .as_ref()
+                    .map(|(identity_id, _)| PreambleReservation {
+                        identity_id: identity_id.clone(),
+                        every: settings.preamble_every,
+                    }),
+            },
+            attempt_id.clone(),
+            settings.retention_days,
+        )
+        .map_err(|error| correlation.state_error(error, false))?;
+    let receipt = encode_short_receipt(&correlation.request_id, &attempt_id, &endpoint);
+    let message = if prepared.inject_preamble {
+        preamble.map_or_else(
+            || input.message.clone(),
+            |(_, content)| format!("[SYSTEM: {content}]\n\n{}", input.message),
+        )
+    } else {
+        input.message.clone()
+    };
+    let payload = format!(
+        "{message}\n\n<tmt-reply>\ntmt reply {} --receipt {receipt} --message <text>\n</tmt-reply>\nSubmit your response with the command above. Chat output alone does not complete the request. After successful submission, show a brief summary; report submission errors.",
+        correlation.request_id
+    );
+    Ok(Prepared {
+        correlation,
+        attempt_id,
+        endpoint,
+        payload,
+        previous_request_id: prepared.previous_request_id,
+    })
+}

--- a/rust/crates/tmt-cli/src/talk_command/presentation.rs
+++ b/rust/crates/tmt-cli/src/talk_command/presentation.rs
@@ -1,0 +1,42 @@
+use super::*;
+use std::io::Write;
+
+pub(super) fn publish(report: Report, mode: OutputMode) -> io::Result<u8> {
+    let correlation = report.correlation;
+    let mut stdout = io::stdout().lock();
+    if mode.json {
+        let mut value = serde_json::json!({"requestId": correlation.request_id, "target": correlation.target, "pane": correlation.pane});
+        if let Some(identity) = correlation.identity {
+            value["identity"] = serde_json::json!({"name": identity.name, "canonicalName": identity.canonical_name});
+        }
+        if let Some(response) = report.response {
+            value["status"] = "completed".into();
+            value["response"] = response.body.into();
+            value["bodyBytes"] = response.body_bytes.into();
+            value["submittedAtMs"] = response.submitted_at_ms.into();
+        } else {
+            value["status"] = "sent".into();
+        }
+        writeln!(stdout, "{value}")?;
+    } else {
+        if let Some(response) = report.response {
+            writeln!(
+                stdout,
+                "Completed request {} for {} ({}).\n{}",
+                correlation.request_id, correlation.target, correlation.pane, response.body
+            )?;
+        } else {
+            writeln!(
+                stdout,
+                "Sent request {} to {} ({}).",
+                correlation.request_id, correlation.target, correlation.pane
+            )?;
+        }
+        writeln!(
+            stdout,
+            "Retrieve later with 'tmt result {}'.",
+            correlation.request_id
+        )?;
+    }
+    Ok(0)
+}

--- a/rust/crates/tmt-cli/src/target.rs
+++ b/rust/crates/tmt-cli/src/target.rs
@@ -10,8 +10,13 @@ use tmt_adapters::{
 };
 use tmt_core::{
     binding::{self, PaneIdentity},
+    endpoint::EndpointSnapshot,
     names::is_pane_target,
+    request::RequestEndpoint,
 };
+
+#[cfg(test)]
+mod tests;
 
 pub fn resolve(storage: &mut Storage, tmux: &Tmux, input: &str) -> Result<PaneIdentity, Failure> {
     let mut endpoint = BindingSession::new(tmux);
@@ -37,4 +42,60 @@ pub fn resolve(storage: &mut Storage, tmux: &Tmux, input: &str) -> Result<PaneId
                 3,
             )
         })
+}
+
+/// A fresh observation before preparation is not a lease on later processing.
+pub fn refresh(tmux: &Tmux, observed: &PaneIdentity) -> Result<RequestEndpoint, Failure> {
+    let scope = [observed.pane.id.clone()];
+    let snapshot = tmux
+        .snapshot(OperationOptions {
+            pane_ids: Some(&scope),
+            ..Default::default()
+        })
+        .map_err(endpoint_failure)?;
+    refreshed_endpoint(observed, snapshot)
+}
+
+fn refreshed_endpoint(
+    observed: &PaneIdentity,
+    snapshot: EndpointSnapshot,
+) -> Result<RequestEndpoint, Failure> {
+    use tmt_core::{
+        binding::{BindingEntry, BindingEvidence, evaluate_binding},
+        endpoint::EndpointProbe,
+    };
+    let pane = if let Some(identity) = &observed.identity {
+        let entry = BindingEntry {
+            identity: identity.clone(),
+            binding: observed.binding.clone(),
+        };
+        match evaluate_binding(&entry, &EndpointProbe::Live(snapshot.clone())) {
+            BindingEvidence::Active(pane) => *pane,
+            _ => {
+                return Err(Failure::new(
+                    "RECONCILIATION_FAILED",
+                    "Recipient identity changed before request preparation.",
+                    1,
+                ));
+            }
+        }
+    } else {
+        snapshot
+            .panes
+            .iter()
+            .find(|pane| pane.id == observed.pane.id)
+            .cloned()
+            .ok_or_else(|| {
+                Failure::new(
+                    "PANE_NOT_FOUND",
+                    "Recipient pane disappeared before request preparation.",
+                    3,
+                )
+            })?
+    };
+    Ok(RequestEndpoint {
+        server: snapshot.server,
+        pane_id: pane.id,
+        pane_pid: pane.pane_pid,
+    })
 }

--- a/rust/crates/tmt-cli/src/target/tests.rs
+++ b/rust/crates/tmt-cli/src/target/tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use tmt_core::{
+    binding::Binding,
+    endpoint::{PaneObservation, ServerEvidence},
+    identity::{Identity, Lifetime},
+};
+
+fn recipient() -> PaneIdentity {
+    let server = ServerEvidence {
+        server_id: "6c57fcc9-96b1-4022-b071-870b81288814".into(),
+        socket_path: "/tmp/target-test.sock".into(),
+        server_pid: 41,
+        server_start_time: "1000".into(),
+    };
+    let identity = Identity {
+        id: "identity-one".into(),
+        name: "Alice".into(),
+        canonical_name: "alice".into(),
+        lifetime: Lifetime::Temporary,
+        created_at: "created".into(),
+        updated_at: "updated".into(),
+    };
+    let binding = Binding {
+        id: "binding-one".into(),
+        identity_id: identity.id.clone(),
+        server: server.clone(),
+        pane_id: "%14".into(),
+        pane_pid: 42,
+    };
+    let pane = PaneObservation {
+        id: binding.pane_id.clone(),
+        target: Some("10.3".into()),
+        cwd: None,
+        command: "mock-agent".into(),
+        pane_pid: binding.pane_pid,
+        suggested_name: None,
+        marker: Some(binding.marker(&identity)),
+    };
+    PaneIdentity {
+        server,
+        pane,
+        identity: Some(identity),
+        binding: Some(binding),
+    }
+}
+
+fn snapshot(observed: &PaneIdentity) -> EndpointSnapshot {
+    EndpointSnapshot {
+        server: observed.server.clone(),
+        panes: vec![observed.pane.clone()],
+    }
+}
+
+#[test]
+fn preserves_stable_pane_routing_when_layout_changes() {
+    let observed = recipient();
+    let mut fresh = snapshot(&observed);
+    fresh.panes[0].target = Some("20.1".into());
+    let endpoint = refreshed_endpoint(&observed, fresh).unwrap();
+    assert_eq!(endpoint.server, observed.server);
+    assert_eq!(endpoint.pane_id, "%14");
+    assert_eq!(endpoint.pane_pid, 42);
+}
+
+#[test]
+fn refuses_changed_bound_recipient_before_request_preparation() {
+    let observed = recipient();
+    let mutations: [fn(&mut EndpointSnapshot); 7] = [
+        |s| s.server.socket_path = "/tmp/copied-server-uuid.sock".into(),
+        |s| s.server.server_pid += 1,
+        |s| s.server.server_start_time = "restarted".into(),
+        |s| s.panes.clear(),
+        |s| s.panes[0].pane_pid += 1,
+        |s| s.panes[0].marker = None,
+        |s| s.panes[0].marker.as_mut().unwrap().binding_id = "replacement".into(),
+    ];
+    for mutate in mutations {
+        let mut fresh = snapshot(&observed);
+        mutate(&mut fresh);
+        let error = refreshed_endpoint(&observed, fresh).unwrap_err();
+        assert_eq!(error.code, "RECONCILIATION_FAILED");
+        assert_eq!(error.status, 1);
+    }
+}
+
+#[test]
+fn raw_pane_refresh_uses_fresh_process_evidence_but_never_invents_a_missing_pane() {
+    let mut observed = recipient();
+    observed.identity = None;
+    observed.binding = None;
+    let mut fresh = snapshot(&observed);
+    fresh.panes[0].marker = None;
+    fresh.panes[0].pane_pid = 99;
+    assert_eq!(
+        refreshed_endpoint(&observed, fresh.clone())
+            .unwrap()
+            .pane_pid,
+        99
+    );
+    fresh.panes.clear();
+    let error = refreshed_endpoint(&observed, fresh).unwrap_err();
+    assert_eq!(error.code, "PANE_NOT_FOUND");
+    assert_eq!(error.status, 3);
+}

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -28,6 +28,7 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
             "uuid",
             "subprocess",
             "nix",
+            "signal-hook",
         ],
         "tmt-cli" => &[
             "tmt-core",

--- a/test/e2e/native-talk.e2e.test.ts
+++ b/test/e2e/native-talk.e2e.test.ts
@@ -1,0 +1,675 @@
+import { describe, expect, it } from 'vitest';
+import {
+  withE2EFixture,
+  type CliResult,
+  type E2EFixture,
+  type E2EFixtureOptions,
+  type MockEvent,
+} from './harness.js';
+import { preambleCounters, requestAttempts } from './request-state-oracle.js';
+import { durableState } from './identity-state-oracle.js';
+
+interface TalkOutput {
+  requestId?: string;
+  target?: string;
+  pane?: string;
+  identity?: { name: string; canonicalName: string };
+  status?: string;
+  response?: string;
+  bodyBytes?: number;
+  submittedAtMs?: number;
+  error?: { code: string; message: string; stage?: string };
+}
+
+function options(extra: E2EFixtureOptions = {}): E2EFixtureOptions {
+  const native = process.env.TMT_TEST_NATIVE_CLI;
+  if (!native) throw new Error('Native talk E2E requires the Docker-built CLI.');
+  return { executableEnv: { TMT_TEST_CLI: native }, ...extra };
+}
+
+function success<T>(result: CliResult<T>): T {
+  expect(result.code, result.stderr || result.stdout).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.json).toBeDefined();
+  return result.json as T;
+}
+
+async function nativeRequest(fixture: E2EFixture, requestId: string): Promise<MockEvent> {
+  const request = await fixture.waitForEvent(
+    (event) => event.event === 'request' && event.requestId === requestId,
+    5_000
+  );
+  expect(request.receipt).toEqual(expect.stringMatching(/^v2_[A-Za-z0-9_-]{22}$/));
+  expect(request.receipt).toHaveLength(25);
+  await fixture.waitForEvent(
+    (event) => event.event === 'child-start' && event.requestId === requestId,
+    5_000
+  );
+  return request;
+}
+
+async function submittedBody(
+  fixture: E2EFixture,
+  requestId: string,
+  body: string
+): Promise<MockEvent> {
+  const child = await fixture.waitForEvent(
+    (event) => event.event === 'child-start' && event.requestId === requestId,
+    5_000
+  );
+  expect(child?.replyInput).toBe('stdin');
+  const submitted = await fixture.waitForEvent(
+    (event) => event.event === 'submitted' && event.requestId === requestId,
+    5_000
+  );
+  expect(submitted.body).toBe(body);
+  expect(submitted.bodyBytes).toBe(Buffer.byteLength(body));
+  return submitted;
+}
+
+describe.sequential('native public talk/reply/result', () => {
+  it.each([
+    ['empty', ''],
+    ['whitespace', ' \t  \n\r\n '],
+    ['Unicode and marker-like text', '\uFEFF日本語🙂\u0000\r\nRESPONSE-END-fake-marker'],
+  ])(
+    'returns the exact %s nested native reply',
+    async (_label, body) => {
+      await withE2EFixture(
+        async (fixture) => {
+          const talk = success(
+            await fixture.runJsonCli<TalkOutput>([
+              'talk',
+              fixture.pane,
+              'exact native reply',
+              '--no-preamble',
+              '--timeout',
+              '8',
+            ])
+          );
+          expect(talk).toMatchObject({
+            status: 'completed',
+            response: body,
+            bodyBytes: Buffer.byteLength(body),
+            requestId: expect.stringMatching(/^req_[0-9a-f-]+$/),
+          });
+          const request = await nativeRequest(fixture, talk.requestId ?? '');
+          expect(request.message).toBe('exact native reply');
+          const submitted = await submittedBody(fixture, talk.requestId ?? '', body);
+          expect(submitted.submittedAtMs).toBe(talk.submittedAtMs);
+
+          const result = success(
+            await fixture.runJsonCli<TalkOutput>(['result', talk.requestId ?? ''], {
+              withoutTmux: true,
+            })
+          );
+          expect(result).toEqual({
+            status: 'completed',
+            requestId: talk.requestId,
+            response: body,
+            bodyBytes: Buffer.byteLength(body),
+            submittedAtMs: talk.submittedAtMs,
+          });
+        },
+        options({
+          responseBodyBase64: Buffer.from(body, 'utf8').toString('base64'),
+          replyInput: 'stdin',
+        })
+      );
+    },
+    20_000
+  );
+
+  it('supports detach followed by storage-only result through the native nested reply', async () => {
+    const body = 'detached 日本語\r\nreply';
+    await withE2EFixture(
+      async (fixture) => {
+        const sent = success(
+          await fixture.runJsonCli<TalkOutput>([
+            'talk',
+            fixture.pane,
+            'detached native request',
+            '--no-preamble',
+            '--detach',
+          ])
+        );
+        expect(sent).toMatchObject({
+          status: 'sent',
+          requestId: expect.stringMatching(/^req_[0-9a-f-]+$/),
+          target: fixture.pane,
+          pane: fixture.pane,
+        });
+        expect(sent).not.toHaveProperty('response');
+        await nativeRequest(fixture, sent.requestId ?? '');
+        await submittedBody(fixture, sent.requestId ?? '', body);
+
+        const result = success(
+          await fixture.runJsonCli<TalkOutput>(['result', sent.requestId ?? ''], {
+            withoutTmux: true,
+          })
+        );
+        expect(result).toMatchObject({
+          status: 'completed',
+          requestId: sent.requestId,
+          response: body,
+          bodyBytes: Buffer.byteLength(body),
+        });
+      },
+      options({
+        responseBodyBase64: Buffer.from(body, 'utf8').toString('base64'),
+        replyInput: 'stdin',
+      })
+    );
+  }, 15_000);
+
+  it('returns timeout while retaining a late native final for result', async () => {
+    const body = 'late native final';
+    await withE2EFixture(
+      async (fixture) => {
+        const process = fixture.runCliProcess<TalkOutput>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'native timeout request',
+          '--no-preamble',
+          '--timeout',
+          '1',
+        ]);
+        const timedOut = await process.result;
+        expect(timedOut.code).toBe(4);
+        expect(timedOut.stderr).toBe('');
+        expect(timedOut.json).toMatchObject({
+          status: 'timeout',
+          requestId: expect.stringMatching(/^req_[0-9a-f-]+$/),
+          error: { code: 'TIMEOUT' },
+        });
+        expect(timedOut.json).not.toHaveProperty('response');
+
+        const request = await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.requestId === timedOut.json?.requestId,
+          5_000
+        );
+        expect(request.receipt).toEqual(expect.stringMatching(/^v2_[A-Za-z0-9_-]{22}$/));
+        expect(
+          fixture
+            .events()
+            .some(
+              (event) =>
+                (event.event === 'child-start' || event.event === 'submitted') &&
+                event.requestId === timedOut.json?.requestId
+            )
+        ).toBe(false);
+        await fixture.waitFor(
+          () => {
+            const attempt = requestAttempts(fixture).find(
+              (item) => item.request_id === timedOut.json?.requestId
+            );
+            return attempt?.status === 'sent' && attempt.wait_active === 0;
+          },
+          5_000,
+          'native timeout waiter cleanup'
+        );
+        expect(
+          fixture
+            .events()
+            .some(
+              (event) =>
+                (event.event === 'child-start' || event.event === 'submitted') &&
+                event.requestId === timedOut.json?.requestId
+            )
+        ).toBe(false);
+        fixture.releaseReplyGate(timedOut.json?.requestId);
+        await submittedBody(fixture, timedOut.json?.requestId ?? '', body);
+        const result = success(
+          await fixture.runJsonCli<TalkOutput>(['result', timedOut.json?.requestId ?? ''], {
+            withoutTmux: true,
+          })
+        );
+        expect(result.response).toBe(body);
+        expect(result.bodyBytes).toBe(Buffer.byteLength(body));
+      },
+      options({
+        replyGate: true,
+        responseBodyBase64: Buffer.from(body).toString('base64'),
+      })
+    );
+  }, 10_000);
+
+  it('interrupts only the observer, releases its wait, and accepts the late native final', async () => {
+    const body = 'late final after SIGINT';
+    await withE2EFixture(
+      async (fixture) => {
+        const process = fixture.runCliProcess<TalkOutput>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'native interrupt request',
+          '--no-preamble',
+          '--timeout',
+          '20',
+        ]);
+        const request = await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.message === 'native interrupt request',
+          5_000
+        );
+        await fixture.waitFor(
+          () => {
+            const attempt = requestAttempts(fixture).find(
+              (item) => item.request_id === request.requestId
+            );
+            return attempt?.status === 'sent';
+          },
+          5_000,
+          'native interrupt request settlement'
+        );
+        process.kill('SIGINT');
+
+        const interrupted = await process.result;
+        expect(interrupted.code).toBe(1);
+        expect(interrupted.stderr).toBe('');
+        expect(interrupted.json).toMatchObject({
+          requestId: request.requestId,
+          error: { code: 'INTERRUPTED' },
+        });
+        await fixture.waitFor(
+          () =>
+            requestAttempts(fixture).find((item) => item.request_id === request.requestId)
+              ?.wait_active === 0,
+          5_000,
+          'native SIGINT waiter cleanup'
+        );
+
+        expect(
+          fixture
+            .events()
+            .some(
+              (event) =>
+                (event.event === 'child-start' || event.event === 'submitted') &&
+                event.requestId === request.requestId
+            )
+        ).toBe(false);
+        fixture.releaseReplyGate(request.requestId);
+        await submittedBody(fixture, request.requestId ?? '', body);
+        const result = success(
+          await fixture.runJsonCli<TalkOutput>(['result', request.requestId ?? ''], {
+            withoutTmux: true,
+          })
+        );
+        expect(result).toMatchObject({
+          status: 'completed',
+          requestId: request.requestId,
+          response: body,
+          bodyBytes: Buffer.byteLength(body),
+        });
+      },
+      options({
+        replyGate: true,
+        responseBodyBase64: Buffer.from(body).toString('base64'),
+      })
+    );
+  }, 12_000);
+
+  it('delivers a compact v2 receipt and retrieves a manually submitted native result', async () => {
+    const original = 'receipt guidance request';
+    const body = 'manual native final';
+    await withE2EFixture(
+      async (fixture) => {
+        const sent = success(
+          await fixture.runJsonCli<TalkOutput>([
+            'talk',
+            fixture.pane,
+            original,
+            '--no-preamble',
+            '--detach',
+          ])
+        );
+        const guidance = await fixture.waitForEvent(
+          (event) =>
+            event.event === 'input' &&
+            event.pid === fixture.panePid &&
+            event.line?.startsWith('tmt reply ') === true,
+          5_000
+        );
+        const match = guidance.line?.match(
+          /^tmt reply (req_[0-9a-f-]+) --receipt (v2_[A-Za-z0-9_-]{22}) --message <text>$/
+        );
+        expect(match).not.toBeNull();
+        expect(match?.[1]).toBe(sent.requestId);
+        const receipt = match?.[2] ?? '';
+        expect(receipt).toHaveLength(25);
+        expect(receipt).toMatch(/^v2_[A-Za-z0-9_-]{22}$/);
+        expect(
+          requestAttempts(fixture).find((row) => row.request_id === sent.requestId)
+        ).toMatchObject({
+          message_text: original,
+          status: 'sent',
+          wait_active: 0,
+        });
+
+        const reply = success(
+          await fixture.runJsonCli<TalkOutput>(
+            ['reply', sent.requestId ?? '', '--receipt', receipt, '--message', body],
+            { outsideTmux: true }
+          )
+        );
+        expect(reply).toMatchObject({
+          status: 'submitted',
+          requestId: sent.requestId,
+          bodyBytes: Buffer.byteLength(body),
+        });
+        const result = success(
+          await fixture.runJsonCli<TalkOutput>(['result', sent.requestId ?? ''], {
+            withoutTmux: true,
+          })
+        );
+        expect(result).toMatchObject({
+          status: 'completed',
+          requestId: sent.requestId,
+          response: body,
+          bodyBytes: Buffer.byteLength(body),
+          submittedAtMs: reply.submittedAtMs,
+        });
+      },
+      options({ mode: 'input-log' })
+    );
+  }, 15_000);
+
+  it('preserves the original prompt while preamble and bang protection affect only delivery', async () => {
+    const original = 'if (!ready) { return; }';
+    // The mock agent reconstructs received non-empty lines and therefore drops
+    // the intentional blank separator from the delivered preamble payload.
+    const delivered = '[SYSTEM: Review before answering.]\nif (！ready) { return; }';
+    const body = `mock-agent response: ${delivered}`;
+    await withE2EFixture(async (fixture) => {
+      const peer = await fixture.createMockPane('native-peer');
+      expect((await fixture.runJsonCli(['name', 'NativeCaller', '-s'])).code).toBe(0);
+      expect((await fixture.runJsonCli(['add', peer.pane, 'NativePeer'])).code).toBe(0);
+      expect(
+        (await fixture.runJsonCli(['preamble', 'set', 'NativePeer', 'Review before answering.']))
+          .code
+      ).toBe(0);
+      expect(
+        (
+          await fixture.runJsonCli([
+            'role',
+            'set',
+            'ROLE_MUST_NOT_BE_INJECTED',
+            '--identity',
+            'NativePeer',
+          ])
+        ).code
+      ).toBe(0);
+
+      const talk = success(
+        await fixture.runJsonCli<TalkOutput>(['talk', 'NativePeer', original, '--timeout', '8'])
+      );
+      const request = await nativeRequest(fixture, talk.requestId ?? '');
+      expect(request.message).toBe(delivered);
+      const submitted = await submittedBody(fixture, talk.requestId ?? '', body);
+      expect(submitted.body).not.toBe(original);
+      expect(talk.response).toBe(body);
+
+      const attempt = requestAttempts(fixture).find((row) => row.request_id === talk.requestId);
+      expect(attempt).toMatchObject({
+        request_id: talk.requestId,
+        message_text: original,
+        message_bytes: Buffer.byteLength(original),
+        originator_kind: 'verified',
+        inject_preamble: 1,
+        wait_active: 0,
+        status: 'sent',
+      });
+      const identities = durableState(fixture).identities;
+      const callerIdentity = identities.find((identity) => identity.name === 'NativeCaller');
+      const peerIdentity = identities.find((identity) => identity.name === 'NativePeer');
+      expect(callerIdentity?.id).toEqual(expect.any(String));
+      expect(peerIdentity?.id).toEqual(expect.any(String));
+      expect(callerIdentity?.id).not.toBe(peerIdentity?.id);
+      expect(attempt?.originator_identity_id).toBe(callerIdentity?.id);
+      expect(attempt?.recipient_identity_id).toBe(peerIdentity?.id);
+      expect(preambleCounters(fixture)[peerIdentity?.id as string]).toBe(1);
+
+      // A raw stable pane resolves the same bound identity and cadence owner.
+      // The default cadence does not inject again on its second reservation.
+      const direct = success(
+        await fixture.runJsonCli<TalkOutput>(['talk', peer.pane, original, '--timeout', '8'])
+      );
+      expect(direct.identity).toEqual({ name: 'NativePeer', canonicalName: 'nativepeer' });
+      const directRequest = await nativeRequest(fixture, direct.requestId ?? '');
+      expect(directRequest.message).toBe('if (！ready) { return; }');
+      expect(direct.response).toBe('mock-agent response: if (！ready) { return; }');
+      expect(
+        requestAttempts(fixture).find((row) => row.request_id === direct.requestId)
+      ).toMatchObject({
+        recipient_identity_id: peerIdentity?.id,
+        inject_preamble: 0,
+        message_text: original,
+      });
+      expect(preambleCounters(fixture)[peerIdentity?.id as string]).toBe(2);
+    }, options());
+  }, 20_000);
+
+  it('honors an explicit offline originator and rejects a missing one before sending', async () => {
+    await withE2EFixture(async (fixture) => {
+      const peer = await fixture.createMockPane('explicit-originator-peer');
+      expect((await fixture.runJsonCli(['name', 'NativeCaller', '-s'])).code).toBe(0);
+      expect((await fixture.runJsonCli(['identity', 'create', 'OfflineOriginator'])).code).toBe(0);
+      const before = requestAttempts(fixture);
+      const missing = await fixture.runJsonCli<TalkOutput>([
+        'talk',
+        peer.pane,
+        'missing originator must not send',
+        '--identity',
+        'DoesNotExist',
+        '--no-preamble',
+        '--detach',
+      ]);
+      expect(missing).toMatchObject({
+        code: 3,
+        stderr: '',
+        json: { error: { code: 'NAME_NOT_FOUND' } },
+      });
+      expect(requestAttempts(fixture)).toEqual(before);
+      expect(
+        fixture
+          .events()
+          .some(
+            (event) =>
+              event.event === 'request' && event.message === 'missing originator must not send'
+          )
+      ).toBe(false);
+      expect(
+        fixture
+          .events()
+          .some(
+            (event) => event.event === 'input' && event.line === 'missing originator must not send'
+          )
+      ).toBe(false);
+
+      const sent = success(
+        await fixture.runJsonCli<TalkOutput>([
+          'talk',
+          peer.pane,
+          'explicit offline originator',
+          '--identity',
+          'OfflineOriginator',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ])
+      );
+      const request = await nativeRequest(fixture, sent.requestId ?? '');
+      expect(request.message).toBe('explicit offline originator');
+      await submittedBody(
+        fixture,
+        sent.requestId ?? '',
+        'mock-agent response: explicit offline originator'
+      );
+      const identities = durableState(fixture).identities;
+      const caller = identities.find((identity) => identity.name === 'NativeCaller');
+      const originator = identities.find((identity) => identity.name === 'OfflineOriginator');
+      const attempt = requestAttempts(fixture).find((row) => row.request_id === sent.requestId);
+      expect(caller?.id).toEqual(expect.any(String));
+      expect(originator?.id).toEqual(expect.any(String));
+      expect(originator?.id).not.toBe(caller?.id);
+      expect(attempt).toMatchObject({
+        originator_kind: 'explicit',
+        originator_identity_id: originator?.id,
+        recipient_identity_id: null,
+        status: 'sent',
+        wait_active: 0,
+      });
+    }, options());
+  }, 20_000);
+
+  it('keeps overlapping native requests independently gated and correlated', async () => {
+    await withE2EFixture(
+      async (fixture) => {
+        const slow = fixture.runCliProcess<TalkOutput>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'native slow overlap',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        const fast = fixture.runCliProcess<TalkOutput>([
+          '--json',
+          'talk',
+          fixture.pane,
+          'native fast overlap',
+          '--no-preamble',
+          '--timeout',
+          '8',
+        ]);
+        const slowRequest = await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.message === 'native slow overlap',
+          5_000
+        );
+        const fastRequest = await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.message === 'native fast overlap',
+          5_000
+        );
+        expect(slowRequest.requestId).toEqual(expect.stringMatching(/^req_[0-9a-f-]+$/));
+        expect(fastRequest.requestId).toEqual(expect.stringMatching(/^req_[0-9a-f-]+$/));
+        expect(slowRequest.requestId).not.toBe(fastRequest.requestId);
+        await fixture.waitFor(
+          () =>
+            requestAttempts(fixture).filter(
+              (row) =>
+                (row.request_id === slowRequest.requestId ||
+                  row.request_id === fastRequest.requestId) &&
+                row.status === 'sent' &&
+                row.wait_active === 1
+            ).length === 2,
+          5_000,
+          'overlapping native requests to settle independently'
+        );
+
+        fixture.releaseReplyGate(fastRequest.requestId);
+        await submittedBody(
+          fixture,
+          fastRequest.requestId ?? '',
+          'mock-agent response: native fast overlap'
+        );
+        expect(
+          fixture
+            .events()
+            .some(
+              (event) => event.event === 'submitted' && event.requestId === slowRequest.requestId
+            )
+        ).toBe(false);
+        const fastResult = await fast.result;
+        expect(fastResult).toMatchObject({
+          code: 0,
+          json: {
+            status: 'completed',
+            requestId: fastRequest.requestId,
+            response: 'mock-agent response: native fast overlap',
+          },
+        });
+
+        fixture.releaseReplyGate(slowRequest.requestId);
+        await submittedBody(
+          fixture,
+          slowRequest.requestId ?? '',
+          'mock-agent response: native slow overlap'
+        );
+        const slowResult = await slow.result;
+        expect(slowResult).toMatchObject({
+          code: 0,
+          json: {
+            status: 'completed',
+            requestId: slowRequest.requestId,
+            response: 'mock-agent response: native slow overlap',
+          },
+        });
+        expect(requestAttempts(fixture)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              request_id: slowRequest.requestId,
+              status: 'sent',
+              wait_active: 0,
+            }),
+            expect.objectContaining({
+              request_id: fastRequest.requestId,
+              status: 'sent',
+              wait_active: 0,
+            }),
+          ])
+        );
+      },
+      options({ replyGate: true })
+    );
+  }, 25_000);
+
+  it('reports ambiguous paste without replaying native talk input', async () => {
+    const original = 'ambiguous! send';
+    await withE2EFixture(
+      async (fixture) => {
+        const result = await fixture.runJsonCli<TalkOutput>(
+          ['talk', fixture.pane, original, '--no-preamble', '--detach'],
+          { transportFault: { stage: 'paste' } }
+        );
+        expect(result).toMatchObject({
+          code: 1,
+          stderr: '',
+          json: { error: { code: 'DELIVERY_UNCERTAIN', stage: 'paste' } },
+        });
+        const requestId = result.json?.requestId ?? '';
+        await fixture.waitForEvent(
+          (event) => event.event === 'input' && event.pid === fixture.panePid,
+          5_000
+        );
+        const protectedInput = 'ambiguous！ send';
+        expect(
+          fixture
+            .events()
+            .filter(
+              (event) =>
+                event.event === 'input' &&
+                event.pid === fixture.panePid &&
+                event.line === protectedInput
+            )
+        ).toHaveLength(1);
+        expect(fixture.transportTrace().map((line) => line.split('|', 1)[0])).toEqual([
+          'set-buffer.before',
+          'set-buffer.after.0',
+          'paste-buffer.before',
+          'paste-buffer.after.0',
+          'paste-buffer.fault-after',
+        ]);
+        expect(fixture.events().some((event) => event.event === 'submitted')).toBe(false);
+        expect(fixture.events().some((event) => event.event === 'child-start')).toBe(false);
+        expect(requestAttempts(fixture).find((row) => row.request_id === requestId)).toMatchObject({
+          request_id: requestId,
+          status: 'uncertain',
+          wait_active: 0,
+          message_text: original,
+        });
+      },
+      options({ mode: 'input-log' })
+    );
+  }, 15_000);
+});

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -62,9 +62,9 @@ describe('native grammar preview process contract', () => {
       expect(help.stderr).toBe('');
       expect(help.stdout).toContain('Native development preview');
       expect(help.stdout).toContain(
-        'configuration, identity create/show/list, reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, and role/preamble are available'
+        'configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, and role/preamble are available'
       );
-      expect(help.stdout).toContain('Talk is not implemented yet.');
+      expect(help.stdout).toContain('Installation and attention commands are not implemented yet.');
       expect(help.stdout).toContain('Manage identity records without probing tmux');
       expect(help.stdout).toContain('temporary unless saved');
       expect(help.stdout).toContain('rm');
@@ -78,12 +78,7 @@ describe('native grammar preview process contract', () => {
   it('explicitly rejects effects for every recognized command family', async () => {
     await withSandbox(async (sandbox) => {
       const before = fileSnapshot(sandbox.root);
-      for (const args of [
-        ['talk', 'worker', 'hello'],
-        ['init'],
-        ['x', 'ackall'],
-        ['install', '--dir', sandbox.cwd],
-      ]) {
+      for (const args of [['init'], ['x', 'ackall'], ['install', '--dir', sandbox.cwd]]) {
         const result = await runCli(sandbox, [...args, '--json']);
         expect(result.status, args.join(' ')).toBe(1);
         expectError(result, 'NATIVE_NOT_IMPLEMENTED');

--- a/test/native/talk.test.ts
+++ b/test/native/talk.test.ts
@@ -1,0 +1,60 @@
+import Database from 'better-sqlite3';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  fileSnapshot,
+  runCli,
+  withSandbox,
+} from '../../src/test-support/cli-process.js';
+import { calibrateTmuxTripwire } from './tmux-tripwire.js';
+
+describe('native talk preflight', () => {
+  it('rejects invalid config and timing before storage or endpoint effects', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      for (const args of [
+        ['talk', '%14', 'hello', '--timeout', '0'],
+        ['talk', '%14', 'hello', '--delay', '-1'],
+      ]) {
+        const before = fileSnapshot(sandbox.root);
+        const result = await runCli(sandbox, [...args, '--json']);
+        expect(result.status).toBe(1);
+        expectError(result, 'USAGE_ERROR');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+      }
+      mkdirSync(sandbox.globalDir, { recursive: true });
+      writeFileSync(sandbox.globalConfig, '{ invalid');
+      const before = fileSnapshot(sandbox.root);
+      const result = await runCli(sandbox, ['talk', '%14', 'hello', '--json']);
+      expect(result.status).toBe(1);
+      expectError(result, 'CONFIG_ERROR');
+      expect(existsSync(sandbox.database)).toBe(false);
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+    });
+  });
+
+  it('does not invent unknown targets or prepare exchanges on lookup misses', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      for (const name of ['NeverCreated', 'invalid\nname']) {
+        const result = await runCli(sandbox, ['talk', name, 'hello', '--json']);
+        expect(result.status).toBe(3);
+        expectError(result, 'NAME_NOT_FOUND');
+        expect(result.stderr).toBe('');
+      }
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+      const database = new Database(sandbox.database, { readonly: true });
+      try {
+        for (const table of ['identities', 'request_responses', 'request_attempts']) {
+          expect(database.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()).toEqual({
+            count: 0,
+          });
+        }
+      } finally {
+        database.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #129. Parent #93 and the installed-skill transition in #106 remain open.

Complete native talk/send using the existing request service, scoped target/binding evaluation, profile reader, transport and compact receipt codec. Default waiting ends only on a durable final; timeout and SIGINT release the observer without cancelling work. Native installation is not ready yet and installed TypeScript remains unchanged.

## Architecture and primary review

Reviewed head: b1e8ac1fc20b1d95aeac38a3ae7aeeb247e70468. The primary personally reviewed all production changes, tests, relevant TypeScript contracts and native callers, including request preparation/settlement, identity selection, target refresh, transport failures, profile cadence, response composition and cleanup output. No handler SQL, duplicate lifecycle, second process runner or schema was added.

- Local preparation/observation/presentation modules compose shared owners. Exact original prompts remain separate from injected/protected transport. Fresh bound recipient evidence fails closed; raw panes retain explicit routing semantics.
- Reuse UUID entropy and a shared transaction-sampled wall clock. Native guidance emits the existing 25-character v2 receipt. Roles are not injected; name/direct-pane delivery shares one preamble reservation owner.
- Signal-hook 0.4.4 is pinned with default features disabled and permitted only in Unix adapters. Safe owned self-pipe registrations reuse nix poll; no worker thread/runtime is added. First SIGINT wakes observation; second preserves emergency termination. Existing synchronous IO/delay bounds remain explicit. Owned callbacks/descriptors are removed, not the library's process-lifetime OS dispatcher.
- Dependency review is recorded in #129. Resolved registry 1.4.8 and errno 0.3.14 have MIT/Apache licensing and declared MSRVs below 1.88; both actual toolchains pass. Windows lock-only transitive packages are not Unix runtime dependencies. Targeted advisory review is not a whole-dependency security audit.
- Cleanup runs before publication. Public correlation excludes receipt/body/internal endpoint causes. Secondary cleanup diagnostics are retained lazily so shared Result errors remain small; no Clippy rule was disabled.

Review findings resolved: observer fake-clock edge cases; a test that could pass on an early deadline return; direct stale-callback detection; signal fixture partial-marker publication; a late-child event race; mock peer blank-line reconstruction versus exact retained prompt; deterministic gated late replies instead of delay races; direct-pane cadence, role non-injection, explicit originator, and independent overlapping request coverage. Pure refresh tests cover layout changes, copied sockets, server/process/marker changes and missing raw panes. No unresolved findings from this review.

## Verification

- [x] Pinned Rust and MSRV 1.88.0: 252 tests each (161 adapters, 29 CLI, 19 architecture, 43 core).
- [x] Strict all-target Clippy, rustfmt, native bins/examples build, pnpm check and git diff --check.
- [x] Native process suite: 77 tests in nine files, explicit native descriptors and calibrated no-host-tmux tripwire.
- [x] Full TypeScript regression: 1102 tests across 70 files with coverage gates passing.
- [x] First final Docker lifecycle run: 161 adapter tests and 158 E2E tests passed; one existing optional benchmark skipped.
- [x] Second final Docker lifecycle run: 161 adapter tests and 158 E2E tests passed; one existing optional benchmark skipped.
- [x] All 11 CI checks passed on reviewed b1e8ac1fc20b1d95aeac38a3ae7aeeb247e70468, run 34190820628, attempt 1.

Commands: cargo test --locked --workspace --manifest-path rust/Cargo.toml; cargo +1.88.0 test --locked --workspace --manifest-path rust/Cargo.toml; cargo clippy --locked --workspace --all-targets --manifest-path rust/Cargo.toml -- -D warnings; cargo fmt --manifest-path rust/Cargo.toml --all -- --check; cargo build --locked --manifest-path rust/Cargo.toml --bins --examples; pnpm check; pnpm test; pnpm test:native with native CLI/storage-probe descriptors; pnpm test:e2e twice. Exploratory Docker exposed two test-oracle races/expectations; the corrected final runs, not the exploratory run, are acceptance evidence.

## Delivery lifecycle

ARCHITECTURE.md, DEVELOPMENT.md, REQUEST-RESPONSE.md and RUST-REWRITE.md describe the new ownership and truthful preview status. Branch feat/129-native-talk; worktree /Users/benhsieh/dev/tmt-129-native-talk. Rebase onto merged #127 changed no tested file contents (0394bd0 and reviewed head have identical trees). No host tmux, user DB, global installation, release or publication was touched. #131 continues native attention in a separate worktree; installer/skill cutover remains pending.
