### PR TITLE
feat(native): complete identity-scoped exchange attention

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1237,6 +1237,27 @@ and secondary cleanup causes stay internal. Storage closes before publication;
 close failure cannot publish success. Installed-runtime and skill cutover remain
 separate delivery gates.
 
+#### Native exchange attention
+
+#131 adds `x list/show/ack/ackall` through the same `RequestService` and
+transaction-scoped `RequestRecords`. The attention module defines typed summary
+and detail projections, sharing final-state metadata and acknowledgment rules.
+The existing request adapter owns joined metadata-only list queries and guarded
+updates; it adds no schema, connection, revision allocator or retention policy.
+Detail reuses the original-context projection and reads exact final text only
+for detail, never for listing. Immutable submission markers distinguish expired
+or unavailable bodies from work that has never received a final.
+
+Explicit identity selection is storage-only; implicit selection requires a
+verified caller before request access. Retired-name reuse does not transfer
+UUID-owned history. Reads never acknowledge. Exact-revision ack conflicts with
+a newer final; repeated current ack is idempotent. Ackall captures the current
+identity watermark atomically without a preliminary client read, and later
+revisions remain visible. Final submission plus current acknowledgment defines
+settled state, independently of delivery or observer exit. Cleanup and ack share
+the existing transaction and clock; failure rolls both back. CLI storage closes
+before presentation. Installation and installed-skill cutover remain separate.
+
 #### Native storage and runtime adapters
 
 Native migration 9 adds `lifetime` (default `saved` for existing identities) and

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -174,6 +174,19 @@ their exclusion is not parity evidence. The native suite separately exercises
 configuration validation through `config show`, path discovery, scoped edits,
 no-op clear and file preservation, without starting SQLite or tmux.
 
+Native attention uses the existing request-service SQLite fixtures and bounded
+multi-connection race harness. Verify revision pagination, foreign/retired-name
+isolation, pending acknowledgment followed by a late final, exact-revision
+conflicts, idempotence, and ackall/final races with independent read-only SQL.
+Advance the fixture clock when proving that acknowledgment does not renew
+retention. Injected ack failure must roll back eligible housekeeping as well.
+A deliberately unreadable final body proves that listing reads metadata only.
+`test/native/exchange.test.ts` covers public storage-only selectors, exact JSON,
+retired-name reuse, and implicit selection failure before housekeeping.
+`test/e2e/native-exchange-attention.e2e.test.ts` exercises real native talk and
+gated mock replies with verified pane identity; reuse shared descriptors and
+oracles, and run the Docker lifecycle suite twice before delivery.
+
 Keep Cargo workspace version synchronized with the package version while both
 runtimes coexist. Check the resolved dependency graph's licenses, MSRVs and
 current RustSec advisories when changing Cargo.lock. `tmt-core` must remain free

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -72,7 +72,7 @@ The preview implements help, version, Bash/Zsh completion and the existing
 `config` command plus storage-only `identity create/show/list` (#113) and pane
 identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109), plus storage-only
 `reply`/`result` (#122), diagnostic `check`/`read` (#125), role/preamble (#127), and
-durable `talk` (#129).
+durable `talk` (#129), and identity-scoped `x list/show/ack/ackall` (#131).
 Other recognized effectful commands return
 `NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
 storage, tmux or input acquisition. Text-only commands reject JSON. Native

--- a/rust/crates/tmt-adapters/src/storage/requests.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests.rs
@@ -4,6 +4,7 @@
 //! the bounded SQL mutations while the invocation-owned immediate transaction is
 //! held.
 
+mod attention;
 mod rows;
 
 use rusqlite::{Connection, OptionalExtension, params};
@@ -141,6 +142,37 @@ impl RequestRecords for RequestRows<'_> {
             )
             .optional()
             .map_err(|error| classify(error, "Find request response"))
+    }
+
+    fn find_attention(
+        &self,
+        identity_id: &str,
+        request_id: &str,
+    ) -> Result<Option<tmt_core::request::attention::AttentionRecord>, Self::Error> {
+        attention::find_attention(self.0, identity_id, request_id)
+    }
+
+    fn list_attention(
+        &self,
+        identity_id: &str,
+        after: u64,
+        limit: u64,
+        now_ms: u64,
+    ) -> Result<Vec<tmt_core::request::attention::AttentionRecord>, Self::Error> {
+        attention::list_attention(self.0, identity_id, after, limit, now_ms)
+    }
+
+    fn acknowledge_revision(
+        &mut self,
+        identity_id: &str,
+        request_id: &str,
+        revision: u64,
+    ) -> Result<bool, Self::Error> {
+        attention::acknowledge_revision(self.0, identity_id, request_id, revision)
+    }
+
+    fn acknowledge_through(&mut self, identity_id: &str, latest: u64) -> Result<bool, Self::Error> {
+        attention::acknowledge_through(self.0, identity_id, latest)
     }
 
     fn find_active_request(

--- a/rust/crates/tmt-adapters/src/storage/requests/attention.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/attention.rs
@@ -1,0 +1,126 @@
+//! SQL projections and guarded mutations for retained request attention.
+
+use rusqlite::{Connection, OptionalExtension, params};
+use tmt_core::request::attention::AttentionRecord;
+
+use super::{checked_i64, checked_limit, checked_now, rows};
+use crate::storage::{StorageError, errors::classify};
+
+fn qualified_attempt_columns() -> String {
+    rows::ATTEMPT_COLUMNS
+        .split(',')
+        .map(|column| format!("a.{}", column.trim()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn attention_select(where_clause: &str) -> String {
+    format!(
+        "SELECT {},
+                state.acknowledged_through,
+                response.submitted_at_ms AS response_metadata_submitted_at_ms,
+                response.body_bytes AS response_metadata_body_bytes,
+                response.response_expires_at_ms AS response_metadata_expires_at_ms
+         FROM request_attempts AS a
+         JOIN request_attention_identities AS state
+           ON state.identity_id = a.originator_identity_id
+         LEFT JOIN request_responses AS response
+           ON response.request_id = a.request_id
+         WHERE {where_clause}",
+        qualified_attempt_columns(),
+    )
+}
+
+pub(super) fn find_attention(
+    connection: &Connection,
+    identity_id: &str,
+    request_id: &str,
+) -> Result<Option<AttentionRecord>, StorageError> {
+    connection
+        .query_row(
+            &attention_select(
+                "a.originator_identity_id = ?
+                 AND a.request_id = ?
+                 AND a.attention_revision > 0",
+            ),
+            params![identity_id, request_id],
+            rows::attention_row,
+        )
+        .optional()
+        .map_err(|error| classify(error, "Find request attention"))
+}
+
+pub(super) fn list_attention(
+    connection: &Connection,
+    identity_id: &str,
+    after: u64,
+    limit: u64,
+    now_ms: u64,
+) -> Result<Vec<AttentionRecord>, StorageError> {
+    let query = format!(
+        "{}\n         ORDER BY a.attention_revision, a.request_id\n         LIMIT ?",
+        attention_select(
+            "a.originator_identity_id = ?
+             AND a.attention_revision > 0
+             AND a.attention_revision > ?
+             AND a.retention_expires_at_ms > ?
+             AND a.attention_acknowledged_revision < a.attention_revision
+             AND state.acknowledged_through < a.attention_revision",
+        ),
+    );
+    let mut statement = connection
+        .prepare(&query)
+        .map_err(|error| classify(error, "Prepare request attention query"))?;
+    let records = statement
+        .query_map(
+            params![
+                identity_id,
+                checked_i64(after, "Attention cursor")?,
+                checked_now(now_ms, "Attention retention cutoff")?,
+                checked_limit(limit)?
+            ],
+            rows::attention_row,
+        )
+        .map_err(|error| classify(error, "List request attention"))?;
+    records
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| classify(error, "Decode request attention"))
+}
+
+pub(super) fn acknowledge_revision(
+    connection: &Connection,
+    identity_id: &str,
+    request_id: &str,
+    revision: u64,
+) -> Result<bool, StorageError> {
+    let revision = checked_i64(revision, "Attention revision")?;
+    let changed = connection
+        .execute(
+            "UPDATE request_attempts
+             SET attention_acknowledged_revision = ?
+             WHERE originator_identity_id = ?
+               AND request_id = ?
+               AND attention_revision = ?
+               AND attention_acknowledged_revision < ?",
+            params![revision, identity_id, request_id, revision, revision],
+        )
+        .map_err(|error| classify(error, "Acknowledge request attention"))?;
+    Ok(changed == 1)
+}
+
+pub(super) fn acknowledge_through(
+    connection: &Connection,
+    identity_id: &str,
+    latest: u64,
+) -> Result<bool, StorageError> {
+    let latest = checked_i64(latest, "Latest attention revision")?;
+    let changed = connection
+        .execute(
+            "UPDATE request_attention_identities
+             SET acknowledged_through = MAX(acknowledged_through, ?)
+             WHERE identity_id = ? AND latest_revision = ?",
+            params![latest, identity_id, latest],
+        )
+        .map_err(|error| classify(error, "Acknowledge attention through"))?;
+    Ok(changed == 1)
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/rows.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/rows.rs
@@ -7,6 +7,7 @@ use tmt_core::{
     request::{
         AttemptStatus, FinalResponse, Originator, RawRequestContext, RequestAttempt,
         RequestEndpoint,
+        attention::{AttentionRecord, ResponseMetadata},
     },
 };
 
@@ -143,6 +144,31 @@ pub(super) fn response_row(row: &Row<'_>) -> rusqlite::Result<FinalResponse> {
         body_bytes: u64_at(row, 9)?,
         submitted_at_ms: u64_at(row, 10)?,
         response_expires_at_ms: u64_at(row, 11)?,
+    })
+}
+
+pub(super) fn attention_row(row: &Row<'_>) -> rusqlite::Result<AttentionRecord> {
+    let revision = u64_at(row, 26)?;
+    let acknowledged_revision = u64_at(row, 27)?;
+    let attempt = attempt_row(row)?;
+    let acknowledged_through = u64_at(row, 28)?;
+    let submitted_at_ms = optional_u64_at(row, 29)?;
+    let body_bytes = optional_u64_at(row, 30)?;
+    let expires_at_ms = optional_u64_at(row, 31)?;
+    let response_metadata = match (submitted_at_ms, body_bytes, expires_at_ms) {
+        (None, None, None) => None,
+        (Some(_), Some(body_bytes), Some(expires_at_ms)) => Some(ResponseMetadata {
+            body_bytes,
+            expires_at_ms,
+        }),
+        _ => return Err(invalid_row()),
+    };
+    Ok(AttentionRecord {
+        attempt,
+        revision,
+        acknowledged_revision,
+        acknowledged_through,
+        response_metadata,
     })
 }
 

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests.rs
@@ -1,4 +1,5 @@
 mod acceptance;
+mod attention;
 mod concurrency;
 mod lifecycle;
 mod receipts;

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/attention.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/attention.rs
@@ -1,0 +1,772 @@
+use super::support::{DAY_MS, Fixture, NOW_MS, endpoint, service};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
+use tmt_core::identity::{Lifetime, create_or_resolve};
+use tmt_core::request::attention::{AttentionRejection, Exchange, FinalState};
+use tmt_core::request::{
+    AttemptStatus, Originator, PrepareRequest, RequestError, RequestPrompt, ResponseProof,
+    Settlement, SubmitResponse,
+};
+
+fn prepare_sent(
+    fixture: &mut Fixture,
+    identity_id: &str,
+    request_id: &str,
+    pane_id: &str,
+    pane_pid: u64,
+    message: &str,
+    retention_days: u64,
+) -> (String, tmt_core::request::RequestEndpoint) {
+    let target = endpoint(pane_id, pane_pid);
+    let prepared = service(fixture)
+        .prepare(
+            PrepareRequest {
+                request_id: request_id.into(),
+                message: message.into(),
+                endpoint: target.clone(),
+                wait: false,
+                expires_at_ms: NOW_MS + 3_600_001,
+                originator: Originator::Explicit(identity_id.into()),
+                recipient_identity_id: None,
+                preamble: None,
+            },
+            format!("attempt-{request_id}"),
+            retention_days,
+        )
+        .expect("prepare attention request");
+    service(fixture)
+        .begin_send(&prepared.attempt_id)
+        .expect("begin attention request");
+    service(fixture)
+        .settle(&prepared.attempt_id, Settlement::Sent)
+        .expect("settle attention request");
+    (prepared.attempt_id, target)
+}
+
+fn submit_final(
+    fixture: &mut Fixture,
+    request_id: &str,
+    attempt_id: &str,
+    target: tmt_core::request::RequestEndpoint,
+    body: &str,
+) -> tmt_core::request::FinalResponse {
+    service(fixture)
+        .submit_response(SubmitResponse {
+            request_id: request_id.into(),
+            proof: ResponseProof::Recorded {
+                attempt_id: attempt_id.into(),
+                endpoint: target,
+            },
+            body: body.into(),
+        })
+        .expect("submit attention final")
+}
+
+fn create_identity(fixture: &mut Fixture, name: &str) -> String {
+    create_or_resolve(&mut fixture.storage, name, Lifetime::Saved)
+        .expect("create attention identity")
+        .identity
+        .id
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AttentionSql {
+    counter: Option<(i64, i64)>,
+    attempts: Vec<(String, i64, i64)>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RequestMetadataSql {
+    prompt: Option<String>,
+    prompt_bytes: Option<i64>,
+    prompt_expires_at_ms: Option<i64>,
+    retention_expires_at_ms: i64,
+    response_body: Option<String>,
+    response_body_bytes: Option<i64>,
+    response_submitted_at_ms: Option<i64>,
+    response_expires_at_ms: Option<i64>,
+}
+
+fn attention_sql(fixture: &Fixture, identity_id: &str) -> AttentionSql {
+    let connection =
+        Connection::open_with_flags(&fixture.database, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .expect("open read-only attention oracle");
+    let counter = connection
+        .query_row(
+            "SELECT latest_revision, acknowledged_through
+             FROM request_attention_identities WHERE identity_id = ?",
+            [identity_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .expect("read attention counter");
+    let mut statement = connection
+        .prepare(
+            "SELECT request_id, attention_revision, attention_acknowledged_revision
+             FROM request_attempts WHERE originator_identity_id = ?
+             ORDER BY attention_revision, request_id",
+        )
+        .expect("prepare attention rows");
+    let attempts = statement
+        .query_map([identity_id], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })
+        .expect("query attention rows")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("decode attention rows");
+    AttentionSql { counter, attempts }
+}
+
+fn request_ids(items: &[Exchange]) -> Vec<&str> {
+    items.iter().map(|item| item.request_id.as_str()).collect()
+}
+
+fn request_metadata_sql(fixture: &Fixture, request_id: &str) -> RequestMetadataSql {
+    let connection =
+        Connection::open_with_flags(&fixture.database, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .expect("open read-only request metadata oracle");
+    connection
+        .query_row(
+            "SELECT a.message_text, a.message_bytes, a.message_expires_at_ms,
+                    a.retention_expires_at_ms, r.body, r.body_bytes,
+                    r.submitted_at_ms, r.response_expires_at_ms
+             FROM request_attempts a
+             LEFT JOIN request_responses r ON r.request_id = a.request_id
+             WHERE a.request_id = ?",
+            [request_id],
+            |row| {
+                Ok(RequestMetadataSql {
+                    prompt: row.get(0)?,
+                    prompt_bytes: row.get(1)?,
+                    prompt_expires_at_ms: row.get(2)?,
+                    retention_expires_at_ms: row.get(3)?,
+                    response_body: row.get(4)?,
+                    response_body_bytes: row.get(5)?,
+                    response_submitted_at_ms: row.get(6)?,
+                    response_expires_at_ms: row.get(7)?,
+                })
+            },
+        )
+        .expect("read request metadata")
+}
+
+#[test]
+fn lists_one_identity_in_revision_order_with_bounded_pagination() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    for (request_id, pane_id, pane_pid) in [
+        ("attention-page-1", "%10", 110),
+        ("attention-page-2", "%11", 111),
+        ("attention-page-3", "%12", 112),
+    ] {
+        prepare_sent(
+            &mut fixture,
+            &owner,
+            request_id,
+            pane_id,
+            pane_pid,
+            request_id,
+            7,
+        );
+    }
+
+    let first = service(&mut fixture)
+        .list_exchanges(&owner, Some(2), None)
+        .expect("list first attention page");
+    assert_eq!(
+        request_ids(&first.items),
+        ["attention-page-1", "attention-page-2"]
+    );
+    assert_eq!(first.next_after, Some(2));
+    assert!(first.items.iter().all(|item| {
+        item.delivery == AttemptStatus::Sent
+            && item.final_state == FinalState::NotSubmitted
+            && !item.acknowledged
+            && !item.settled
+    }));
+
+    let second = service(&mut fixture)
+        .list_exchanges(&owner, Some(2), first.next_after)
+        .expect("list second attention page");
+    assert_eq!(request_ids(&second.items), ["attention-page-3"]);
+    assert_eq!(second.next_after, None);
+    let before_invalid = attention_sql(&fixture, &owner);
+    for invalid_limit in [0, 201] {
+        assert!(matches!(
+            service(&mut fixture).list_exchanges(&owner, Some(invalid_limit), None),
+            Err(RequestError::Attention(AttentionRejection::Invalid(_)))
+        ));
+    }
+    assert!(matches!(
+        service(&mut fixture).list_exchanges(&owner, None, Some(9_007_199_254_740_992)),
+        Err(RequestError::Attention(AttentionRejection::Invalid(_)))
+    ));
+    for invalid_revision in [0, 9_007_199_254_740_992] {
+        assert!(matches!(
+            service(&mut fixture).acknowledge_exchange(
+                &owner,
+                "attention-page-1",
+                invalid_revision
+            ),
+            Err(RequestError::Attention(AttentionRejection::Invalid(_)))
+        ));
+    }
+    assert_eq!(attention_sql(&fixture, &owner), before_invalid);
+    assert_eq!(
+        attention_sql(&fixture, &owner),
+        AttentionSql {
+            counter: Some((3, 0)),
+            attempts: vec![
+                ("attention-page-1".into(), 1, 0),
+                ("attention-page-2".into(), 2, 0),
+                ("attention-page-3".into(), 3, 0),
+            ],
+        }
+    );
+}
+
+#[test]
+fn metadata_expiry_hides_show_and_ack_at_deadline_equality() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-expiry",
+        "%19",
+        119,
+        "prompt",
+        7,
+    );
+    let detail = service(&mut fixture)
+        .show_exchange(&owner, "attention-expiry")
+        .unwrap();
+    fixture.set_now(detail.exchange.retention_expires_at_ms);
+    assert!(matches!(
+        service(&mut fixture).show_exchange(&owner, "attention-expiry"),
+        Err(RequestError::Attention(AttentionRejection::NotFound))
+    ));
+    assert!(matches!(
+        service(&mut fixture).acknowledge_exchange(&owner, "attention-expiry", 1),
+        Err(RequestError::Attention(AttentionRejection::NotFound))
+    ));
+    assert!(
+        service(&mut fixture)
+            .list_exchanges(&owner, None, None)
+            .unwrap()
+            .items
+            .is_empty()
+    );
+    assert_eq!(attention_sql(&fixture, &owner).counter, Some((1, 0)));
+}
+
+#[test]
+fn foreign_identity_cannot_list_show_or_ack_another_originator() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    let foreign = create_identity(&mut fixture, "Foreign Attention Owner");
+    let (attempt_id, target) = prepare_sent(
+        &mut fixture,
+        &foreign,
+        "attention-foreign",
+        "%20",
+        120,
+        "foreign prompt",
+        7,
+    );
+    let before = attention_sql(&fixture, &foreign);
+
+    let own = service(&mut fixture)
+        .list_exchanges(&owner, None, None)
+        .expect("list own attention");
+    assert!(own.items.is_empty());
+    assert!(matches!(
+        service(&mut fixture).show_exchange(&owner, "attention-foreign"),
+        Err(RequestError::Attention(AttentionRejection::NotFound))
+    ));
+    assert!(matches!(
+        service(&mut fixture).acknowledge_exchange(&owner, "attention-foreign", 1,),
+        Err(RequestError::Attention(AttentionRejection::NotFound))
+    ));
+    let foreign_page = service(&mut fixture)
+        .list_exchanges(&foreign, None, None)
+        .expect("list foreign attention");
+    assert_eq!(request_ids(&foreign_page.items), ["attention-foreign"]);
+    assert_eq!(attention_sql(&fixture, &foreign), before);
+
+    submit_final(
+        &mut fixture,
+        "attention-foreign",
+        &attempt_id,
+        target,
+        "foreign final",
+    );
+    let detail = service(&mut fixture)
+        .show_exchange(&foreign, "attention-foreign")
+        .expect("show foreign detail");
+    assert!(matches!(
+        detail.exchange.final_state,
+        FinalState::Retained { .. }
+    ));
+}
+
+#[test]
+fn acknowledged_pending_request_reappears_when_a_late_final_advances_revision() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    let (attempt_id, target) = prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-late-final",
+        "%30",
+        130,
+        "pending prompt",
+        7,
+    );
+    let pending = service(&mut fixture)
+        .list_exchanges(&owner, None, None)
+        .expect("list pending attention");
+    assert_eq!(pending.items[0].revision, 1);
+    assert!(matches!(
+        pending.items[0].final_state,
+        FinalState::NotSubmitted
+    ));
+    let retention_expires_at_ms = pending.items[0].retention_expires_at_ms;
+    let acknowledged = service(&mut fixture)
+        .acknowledge_exchange(&owner, "attention-late-final", 1)
+        .expect("acknowledge pending request");
+    assert!(acknowledged.changed);
+    let acknowledged_detail = service(&mut fixture)
+        .show_exchange(&owner, "attention-late-final")
+        .expect("show acknowledged pending request");
+    assert!(acknowledged_detail.exchange.acknowledged);
+    assert!(!acknowledged_detail.exchange.settled);
+    assert!(
+        service(&mut fixture)
+            .list_exchanges(&owner, None, None)
+            .expect("list acknowledged pending request")
+            .items
+            .is_empty()
+    );
+
+    submit_final(
+        &mut fixture,
+        "attention-late-final",
+        &attempt_id,
+        target,
+        "late final",
+    );
+    let late = service(&mut fixture)
+        .list_exchanges(&owner, None, None)
+        .expect("list late final");
+    assert_eq!(request_ids(&late.items), ["attention-late-final"]);
+    assert_eq!(late.items[0].revision, 2);
+    assert_eq!(
+        late.items[0].retention_expires_at_ms,
+        retention_expires_at_ms
+    );
+    assert!(!late.items[0].acknowledged);
+    assert!(!late.items[0].settled);
+    assert!(matches!(
+        late.items[0].final_state,
+        FinalState::Retained { .. }
+    ));
+    assert_eq!(
+        attention_sql(&fixture, &owner),
+        AttentionSql {
+            counter: Some((2, 0)),
+            attempts: vec![("attention-late-final".into(), 2, 1)],
+        }
+    );
+}
+
+#[test]
+fn show_preserves_exact_prompt_and_final_body_detail() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    let prompt = "\u{feff} prompt\r\n\u{0000} 日本語  ";
+    let body = "\u{feff} final\r\n\u{0000}🙂  ";
+    let (attempt_id, target) = prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-exact-detail",
+        "%40",
+        140,
+        prompt,
+        7,
+    );
+    let final_response = submit_final(
+        &mut fixture,
+        "attention-exact-detail",
+        &attempt_id,
+        target,
+        body,
+    );
+    let detail = service(&mut fixture)
+        .show_exchange(&owner, "attention-exact-detail")
+        .expect("show exact attention detail");
+    assert!(matches!(
+        detail.prompt,
+        RequestPrompt::Retained(ref stored)
+            if stored.message == prompt && stored.message_bytes == prompt.len() as u64
+    ));
+    assert!(matches!(
+        detail.exchange.final_state,
+        FinalState::Retained {
+            ref content,
+            submitted_at_ms,
+            body_bytes,
+            expires_at_ms,
+        } if content == body
+            && submitted_at_ms == final_response.submitted_at_ms
+            && body_bytes == body.len() as u64
+            && expires_at_ms == final_response.response_expires_at_ms
+    ));
+    let connection =
+        Connection::open_with_flags(&fixture.database, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .expect("open exact detail oracle");
+    let stored: (String, i64, String, i64) = connection
+        .query_row(
+            "SELECT a.message_text, a.message_bytes, r.body, r.body_bytes
+             FROM request_attempts a JOIN request_responses r ON r.request_id = a.request_id
+             WHERE a.request_id = 'attention-exact-detail'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("read exact prompt and final");
+    assert_eq!(
+        stored,
+        (
+            prompt.into(),
+            prompt.len() as i64,
+            body.into(),
+            body.len() as i64
+        )
+    );
+}
+
+#[test]
+fn list_projects_final_metadata_without_decoding_a_corrupt_body() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    let (attempt_id, target) = prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-corrupt-body",
+        "%45",
+        145,
+        "metadata prompt",
+        7,
+    );
+    submit_final(
+        &mut fixture,
+        "attention-corrupt-body",
+        &attempt_id,
+        target,
+        "valid body",
+    );
+    let writer = Connection::open(&fixture.database).expect("open corrupt-body writer");
+    writer
+        .execute(
+            "UPDATE request_responses
+             SET body = CAST(X'FF' AS BLOB), body_bytes = 1
+             WHERE request_id = ?",
+            params!["attention-corrupt-body"],
+        )
+        .expect("corrupt only final body bytes");
+    drop(writer);
+
+    let page = service(&mut fixture)
+        .list_exchanges(&owner, None, None)
+        .expect("list metadata without loading final body");
+    assert_eq!(request_ids(&page.items), ["attention-corrupt-body"]);
+    assert!(matches!(
+        page.items[0].final_state,
+        FinalState::Retained { body_bytes: 1, .. }
+    ));
+    assert!(matches!(
+        service(&mut fixture).show_exchange(&owner, "attention-corrupt-body"),
+        Err(RequestError::Repository(_))
+    ));
+}
+
+#[test]
+fn stale_ack_conflicts_and_repeated_current_ack_is_idempotent() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    let (attempt_id, target) = prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-stale-ack",
+        "%50",
+        150,
+        "stale ack prompt",
+        7,
+    );
+    let first = service(&mut fixture)
+        .acknowledge_exchange(&owner, "attention-stale-ack", 1)
+        .expect("acknowledge first revision");
+    assert!(first.changed);
+    submit_final(
+        &mut fixture,
+        "attention-stale-ack",
+        &attempt_id,
+        target,
+        "stale ack final",
+    );
+    let stale = service(&mut fixture).acknowledge_exchange(&owner, "attention-stale-ack", 1);
+    assert!(matches!(
+        stale,
+        Err(RequestError::Attention(
+            AttentionRejection::RevisionConflict {
+                current: 2,
+                expected: 1
+            }
+        ))
+    ));
+    assert_eq!(
+        attention_sql(&fixture, &owner),
+        AttentionSql {
+            counter: Some((2, 0)),
+            attempts: vec![("attention-stale-ack".into(), 2, 1)],
+        }
+    );
+
+    fixture.set_now(NOW_MS + DAY_MS);
+    let before_current_ack = request_metadata_sql(&fixture, "attention-stale-ack");
+    let current = service(&mut fixture)
+        .acknowledge_exchange(&owner, "attention-stale-ack", 2)
+        .expect("acknowledge current revision");
+    assert!(current.changed);
+    let repeated = service(&mut fixture)
+        .acknowledge_exchange(&owner, "attention-stale-ack", 2)
+        .expect("repeat current acknowledgment");
+    assert!(!repeated.changed);
+    assert_eq!(attention_sql(&fixture, &owner).attempts[0].2, 2);
+    assert_eq!(
+        request_metadata_sql(&fixture, "attention-stale-ack"),
+        before_current_ack
+    );
+    let settled_detail = service(&mut fixture)
+        .show_exchange(&owner, "attention-stale-ack")
+        .expect("show acknowledged final");
+    assert!(settled_detail.exchange.acknowledged);
+    assert!(settled_detail.exchange.settled);
+}
+
+#[test]
+fn ackall_cutoff_leaves_late_final_and_new_request_unacknowledged() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    let (first_attempt, first_target) = prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-ackall-first",
+        "%60",
+        160,
+        "first prompt",
+        7,
+    );
+    let cutoff = service(&mut fixture)
+        .acknowledge_all_exchanges(&owner)
+        .expect("ackall first cutoff");
+    assert_eq!(cutoff, 1);
+    assert!(
+        service(&mut fixture)
+            .list_exchanges(&owner, None, None)
+            .expect("list after first ackall")
+            .items
+            .is_empty()
+    );
+
+    let (_second_attempt, _second_target) = prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-ackall-second",
+        "%61",
+        161,
+        "second prompt",
+        7,
+    );
+    let second_page = service(&mut fixture)
+        .list_exchanges(&owner, None, None)
+        .expect("list request after cutoff");
+    assert_eq!(request_ids(&second_page.items), ["attention-ackall-second"]);
+    assert_eq!(second_page.items[0].revision, 2);
+
+    submit_final(
+        &mut fixture,
+        "attention-ackall-first",
+        &first_attempt,
+        first_target,
+        "late first final",
+    );
+    let late_page = service(&mut fixture)
+        .list_exchanges(&owner, None, None)
+        .expect("list late first final");
+    assert_eq!(
+        request_ids(&late_page.items),
+        ["attention-ackall-second", "attention-ackall-first"]
+    );
+    assert_eq!(late_page.items[0].revision, 2);
+    assert_eq!(late_page.items[1].revision, 3);
+
+    let second_cutoff = service(&mut fixture)
+        .acknowledge_all_exchanges(&owner)
+        .expect("ackall late cutoff");
+    assert_eq!(second_cutoff, 3);
+    let (_third_attempt, _third_target) = prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-ackall-third",
+        "%62",
+        162,
+        "third prompt",
+        7,
+    );
+    let new_page = service(&mut fixture)
+        .list_exchanges(&owner, None, None)
+        .expect("list request after second cutoff");
+    assert_eq!(request_ids(&new_page.items), ["attention-ackall-third"]);
+    assert_eq!(new_page.items[0].revision, 4);
+    assert!(!new_page.items[0].acknowledged);
+    assert_eq!(attention_sql(&fixture, &owner).counter, Some((4, 3)));
+}
+
+#[test]
+fn final_state_distinguishes_expired_body_from_unavailable_body_at_retention_boundary() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    let (expired_attempt, expired_target) = prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-expired-final",
+        "%70",
+        170,
+        "expired prompt",
+        1,
+    );
+    fixture.set_now(NOW_MS + 2 * DAY_MS);
+    let expired_response = submit_final(
+        &mut fixture,
+        "attention-expired-final",
+        &expired_attempt,
+        expired_target,
+        "expired final",
+    );
+    fixture.set_now(expired_response.response_expires_at_ms);
+    let expired = service(&mut fixture)
+        .show_exchange(&owner, "attention-expired-final")
+        .expect("show expired final");
+    assert!(matches!(
+        expired.exchange.final_state,
+        FinalState::Expired {
+            submitted_at_ms,
+            expires_at_ms,
+        } if submitted_at_ms == expired_response.submitted_at_ms
+            && expires_at_ms == expired_response.response_expires_at_ms
+    ));
+
+    let mut unavailable_fixture = Fixture::new();
+    let unavailable_owner = unavailable_fixture.identity_id.clone();
+    let (unavailable_attempt, unavailable_target) = prepare_sent(
+        &mut unavailable_fixture,
+        &unavailable_owner,
+        "attention-unavailable-final",
+        "%71",
+        171,
+        "unavailable prompt",
+        7,
+    );
+    submit_final(
+        &mut unavailable_fixture,
+        "attention-unavailable-final",
+        &unavailable_attempt,
+        unavailable_target,
+        "unavailable final",
+    );
+    let writer = Connection::open(&unavailable_fixture.database).expect("open fixture writer");
+    writer
+        .execute(
+            "DELETE FROM request_responses WHERE request_id = ?",
+            params!["attention-unavailable-final"],
+        )
+        .expect("remove only unavailable body");
+    drop(writer);
+    let unavailable = service(&mut unavailable_fixture)
+        .show_exchange(&unavailable_owner, "attention-unavailable-final")
+        .expect("show unavailable final");
+    assert!(matches!(
+        unavailable.exchange.final_state,
+        FinalState::Unavailable {
+            submitted_at_ms,
+            expires_at_ms,
+        } if submitted_at_ms == NOW_MS && expires_at_ms == NOW_MS + 7 * DAY_MS
+    ));
+    let oracle = Connection::open_with_flags(
+        &unavailable_fixture.database,
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .expect("open final-state oracle");
+    let marker: Option<i64> = oracle
+        .query_row(
+            "SELECT response_submitted_at_ms FROM request_attempts WHERE request_id = ?",
+            ["attention-unavailable-final"],
+            |row| row.get(0),
+        )
+        .expect("read unavailable marker");
+    assert_eq!(marker, Some(NOW_MS as i64));
+}
+
+#[test]
+fn ackall_trigger_failure_rolls_back_watermark_and_acknowledgments() {
+    let mut fixture = Fixture::new();
+    let owner = fixture.identity_id.clone();
+    let (_attempt_id, _target) = prepare_sent(
+        &mut fixture,
+        &owner,
+        "attention-rollback",
+        "%80",
+        180,
+        "rollback prompt",
+        1,
+    );
+    let before = attention_sql(&fixture, &owner);
+    let metadata_before = request_metadata_sql(&fixture, "attention-rollback");
+    fixture.set_now(NOW_MS + DAY_MS);
+    let writer = Connection::open(&fixture.database).expect("open rollback writer");
+    writer
+        .execute_batch(
+            "CREATE TRIGGER reject_attention_ackall
+             BEFORE UPDATE OF acknowledged_through ON request_attention_identities
+             BEGIN SELECT RAISE(ABORT, 'injected attention failure'); END;",
+        )
+        .expect("install attention rollback trigger");
+    assert!(matches!(
+        service(&mut fixture).acknowledge_all_exchanges(&owner),
+        Err(RequestError::Repository(_))
+    ));
+    assert_eq!(attention_sql(&fixture, &owner), before);
+    assert_eq!(
+        request_metadata_sql(&fixture, "attention-rollback"),
+        metadata_before
+    );
+    writer
+        .execute_batch("DROP TRIGGER reject_attention_ackall")
+        .expect("remove attention rollback trigger");
+    let acknowledged = service(&mut fixture)
+        .acknowledge_all_exchanges(&owner)
+        .expect("ackall after rollback");
+    assert_eq!(acknowledged, 1);
+    assert_eq!(attention_sql(&fixture, &owner).counter, Some((1, 1)));
+    let metadata_after = request_metadata_sql(&fixture, "attention-rollback");
+    assert_eq!(metadata_after.prompt, None);
+    assert_eq!(metadata_after.prompt_bytes, None);
+    assert_eq!(
+        metadata_after.prompt_expires_at_ms,
+        metadata_before.prompt_expires_at_ms
+    );
+    assert_eq!(
+        metadata_after.retention_expires_at_ms,
+        metadata_before.retention_expires_at_ms
+    );
+}

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/concurrency.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/concurrency.rs
@@ -57,6 +57,104 @@ fn concurrent_pair<T: Send>(database: &Path, operations: [Operation<T>; 2]) -> [
 }
 
 #[test]
+fn acknowledgement_racing_a_final_never_silently_consumes_a_later_revision() {
+    for bulk in [false, true] {
+        let mut fixture = Fixture::new();
+        let identity = fixture.identity_id.clone();
+        let target = endpoint("%81", 181);
+        let input = prepare_input(
+            &fixture,
+            "attention-race",
+            target.clone(),
+            false,
+            NOW_MS + 3_600_001,
+            Originator::Explicit(identity.clone()),
+            false,
+        );
+        service(&mut fixture)
+            .prepare(input, "attention-race-attempt".into(), 7)
+            .unwrap();
+        service(&mut fixture)
+            .begin_send("attention-race-attempt")
+            .unwrap();
+        service(&mut fixture)
+            .settle(
+                "attention-race-attempt",
+                tmt_core::request::Settlement::Sent,
+            )
+            .unwrap();
+        let acknowledge: Operation<Result<u64, RequestError<StorageError>>> =
+            Box::new(move |storage| {
+                let mut service = RequestService::new(storage, || NOW_MS);
+                if bulk {
+                    service.acknowledge_all_exchanges(&identity)
+                } else {
+                    service
+                        .acknowledge_exchange(&identity, "attention-race", 1)
+                        .map(|ack| u64::from(ack.changed))
+                }
+            });
+        let submit: Operation<Result<u64, RequestError<StorageError>>> = Box::new(move |storage| {
+            RequestService::new(storage, || NOW_MS)
+                .submit_response(SubmitResponse {
+                    request_id: "attention-race".into(),
+                    proof: ResponseProof::Recorded {
+                        attempt_id: "attention-race-attempt".into(),
+                        endpoint: target,
+                    },
+                    body: "exact racing final\r\n".into(),
+                })
+                .map(|_| 0)
+        });
+        let [ack, submitted] = concurrent_pair(&fixture.database, [acknowledge, submit]);
+        submitted.unwrap();
+        let oracle = rusqlite::Connection::open_with_flags(
+            &fixture.database,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .unwrap();
+        let (latest, through, revision, individual, body): (i64, i64, i64, i64, String) = oracle.query_row(
+            "SELECT s.latest_revision, s.acknowledged_through, a.attention_revision,
+                    a.attention_acknowledged_revision, r.body
+             FROM request_attempts a JOIN request_attention_identities s ON s.identity_id = a.originator_identity_id
+             JOIN request_responses r USING(request_id) WHERE a.request_id = 'attention-race'",
+            [], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        ).unwrap();
+        assert_eq!((latest, revision), (2, 2));
+        assert_eq!(body, "exact racing final\r\n");
+        if bulk {
+            let cutoff = ack.unwrap();
+            assert!([1, 2].contains(&cutoff));
+            assert_eq!((through, individual), (i64::try_from(cutoff).unwrap(), 0));
+        } else {
+            assert_eq!(through, 0);
+            match ack {
+                Ok(changed) => {
+                    assert_eq!(changed, 1);
+                    assert_eq!(individual, 1);
+                }
+                Err(RequestError::Attention(
+                    tmt_core::request::attention::AttentionRejection::RevisionConflict {
+                        current: 2,
+                        expected: 1,
+                    },
+                )) => assert_eq!(individual, 0),
+                unexpected => panic!("unexpected concurrent acknowledgement: {unexpected:?}"),
+            }
+        }
+        let identity = fixture.identity_id.clone();
+        let pending = service(&mut fixture)
+            .list_exchanges(&identity, None, None)
+            .unwrap();
+        assert_eq!(pending.items.len(), usize::from(through < 2));
+        if let Some(item) = pending.items.first() {
+            assert_eq!(item.revision, 2);
+            assert!(!item.acknowledged);
+        }
+    }
+}
+
+#[test]
 fn concurrent_prepare_connections_serialize_cadence_and_preserve_both_attempts() {
     let fixture = Fixture::new();
     let operations: [Operation<Result<PreparedRequest, RequestError<StorageError>>>; 2] =

--- a/rust/crates/tmt-cli/src/exchange_command.rs
+++ b/rust/crates/tmt-cli/src/exchange_command.rs
@@ -1,0 +1,101 @@
+//! Identity-scoped attention presentation over the existing request service.
+
+mod presentation;
+
+use crate::{
+    identity_context,
+    invocation::{ExchangeOperation, OutputMode},
+    output::{Failure, after_cleanup},
+};
+use std::{error::Error, io};
+use tmt_adapters::{
+    config::ConfigPaths,
+    request_runtime::wall_time_ms,
+    storage::{Storage, StorageError},
+};
+use tmt_core::{
+    identity::Identity,
+    request::{
+        RequestError, RequestService,
+        attention::{Acknowledged, ExchangeDetail, ExchangePage},
+    },
+};
+
+enum ResultKind {
+    List(ExchangePage),
+    Show(ExchangeDetail),
+    Ack(Acknowledged),
+    Ackall(u64),
+}
+
+struct Report {
+    identity: Identity,
+    result: ResultKind,
+}
+
+fn unavailable(error: impl Error + 'static) -> Failure {
+    Failure::new("X_ERROR", "Could not complete the exchange operation.", 1).caused_by(error)
+}
+
+fn request_failure(error: RequestError<StorageError>) -> Failure {
+    let (code, status) = match &error {
+        RequestError::Attention(reason) => (
+            reason.code(),
+            match reason {
+                tmt_core::request::attention::AttentionRejection::NotFound => 3,
+                tmt_core::request::attention::AttentionRejection::RevisionConflict { .. } => 5,
+                _ => 1,
+            },
+        ),
+        RequestError::RevisionExhausted => ("X_REVISION_EXHAUSTED", 1),
+        _ => return unavailable(error),
+    };
+    Failure::new(code, error.to_string(), status).caused_by(error)
+}
+
+fn run(identity: Option<String>, operation: ExchangeOperation) -> Result<Report, Failure> {
+    let paths = ConfigPaths::discover().map_err(unavailable)?;
+    let mut storage = Storage::open(paths.database).map_err(unavailable)?;
+    let pending = (|| {
+        let identity =
+            identity_context::resolve(&mut storage, identity.as_deref()).map_err(|error| {
+                if error.code == "IDENTITY_ERROR" {
+                    unavailable(error)
+                } else {
+                    error
+                }
+            })?;
+        let mut service = RequestService::new(&mut storage, wall_time_ms);
+        let result = match operation {
+            ExchangeOperation::List { limit, after } => service
+                .list_exchanges(&identity.id, limit, after)
+                .map(ResultKind::List),
+            ExchangeOperation::Show(request) => service
+                .show_exchange(&identity.id, &request)
+                .map(ResultKind::Show),
+            ExchangeOperation::Ack {
+                request_id,
+                revision,
+            } => service
+                .acknowledge_exchange(&identity.id, &request_id, revision)
+                .map(ResultKind::Ack),
+            ExchangeOperation::Ackall => service
+                .acknowledge_all_exchanges(&identity.id)
+                .map(ResultKind::Ackall),
+        }
+        .map_err(request_failure)?;
+        Ok(Report { identity, result })
+    })();
+    after_cleanup(pending, || storage.close())
+}
+
+pub fn execute(
+    identity: Option<String>,
+    operation: ExchangeOperation,
+    mode: OutputMode,
+) -> io::Result<u8> {
+    match run(identity, operation) {
+        Ok(report) => presentation::publish(report, mode),
+        Err(error) => error.publish(mode),
+    }
+}

--- a/rust/crates/tmt-cli/src/exchange_command/presentation.rs
+++ b/rust/crates/tmt-cli/src/exchange_command/presentation.rs
@@ -1,0 +1,177 @@
+use super::*;
+use crate::output::identity_document;
+use serde_json::{Value, json};
+use std::io::Write;
+use tmt_core::request::{
+    RequestPrompt,
+    attention::{Exchange, FinalState},
+};
+
+fn final_document<T>(state: &FinalState<T>, content: impl FnOnce(&T) -> Option<Value>) -> Value {
+    match state {
+        FinalState::NotSubmitted => json!({"status": "not_submitted"}),
+        FinalState::Expired {
+            submitted_at_ms,
+            expires_at_ms,
+        } => {
+            json!({"status": "expired", "submittedAtMs": submitted_at_ms, "expiresAtMs": expires_at_ms})
+        }
+        FinalState::Unavailable {
+            submitted_at_ms,
+            expires_at_ms,
+        } => {
+            json!({"status": "unavailable", "submittedAtMs": submitted_at_ms, "expiresAtMs": expires_at_ms})
+        }
+        FinalState::Retained {
+            content: body,
+            submitted_at_ms,
+            body_bytes,
+            expires_at_ms,
+        } => {
+            let mut value = json!({"status": "retained", "submittedAtMs": submitted_at_ms, "bodyBytes": body_bytes, "expiresAtMs": expires_at_ms});
+            if let Some(body) = content(body) {
+                value["response"] = body;
+            }
+            value
+        }
+    }
+}
+
+fn prompt_status(prompt: &RequestPrompt) -> &'static str {
+    match prompt {
+        RequestPrompt::Unavailable => "unavailable",
+        RequestPrompt::Expired { .. } => "expired",
+        RequestPrompt::Retained(_) => "retained",
+    }
+}
+
+fn exchange_document<T>(
+    exchange: &Exchange<T>,
+    content: impl FnOnce(&T) -> Option<Value>,
+) -> Value {
+    json!({
+        "requestId": exchange.request_id,
+        "recipientIdentityId": exchange.recipient_identity_id,
+        "preparedAtMs": exchange.prepared_at_ms,
+        "delivery": exchange.delivery.as_str(),
+        "final": final_document(&exchange.final_state, content),
+        "revision": exchange.revision,
+        "acknowledged": exchange.acknowledged,
+        "settled": exchange.settled,
+        "retentionExpiresAtMs": exchange.retention_expires_at_ms,
+    })
+}
+
+fn prompt_document(prompt: &RequestPrompt) -> Value {
+    match prompt {
+        RequestPrompt::Unavailable => json!({"status": "unavailable"}),
+        RequestPrompt::Expired { expires_at_ms } => {
+            json!({"status": "expired", "expiresAtMs": expires_at_ms})
+        }
+        RequestPrompt::Retained(prompt) => {
+            json!({"status": "retained", "message": prompt.message, "messageBytes": prompt.message_bytes, "expiresAtMs": prompt.expires_at_ms})
+        }
+    }
+}
+
+fn document(report: &Report) -> Value {
+    let mut value = json!({"identity": identity_document(&report.identity)});
+    match &report.result {
+        ResultKind::List(page) => {
+            value["items"] = page
+                .items
+                .iter()
+                .map(|item| exchange_document(item, |_| None))
+                .collect();
+            value["nextAfter"] = json!(page.next_after);
+        }
+        ResultKind::Show(detail) => {
+            let mut exchange = exchange_document(&detail.exchange, |body| Some(json!(body)));
+            exchange["prompt"] = prompt_document(&detail.prompt);
+            value["exchange"] = exchange;
+        }
+        ResultKind::Ack(ack) => {
+            value["requestId"] = json!(ack.request_id);
+            value["revision"] = json!(ack.revision);
+            value["acknowledged"] = json!(true);
+            value["changed"] = json!(ack.changed);
+        }
+        ResultKind::Ackall(through) => value["acknowledgedThrough"] = json!(through),
+    }
+    value
+}
+
+pub(super) fn publish(report: Report, mode: OutputMode) -> io::Result<u8> {
+    let mut stdout = io::stdout().lock();
+    if mode.json {
+        writeln!(stdout, "{}", document(&report))?;
+    } else {
+        match &report.result {
+            ResultKind::List(page) => {
+                if page.items.is_empty() {
+                    writeln!(stdout, "No unacknowledged exchanges.")?;
+                } else {
+                    writeln!(stdout, "REQUEST\tRECIPIENT\tDELIVERY\tFINAL\tREVISION")?;
+                    for item in &page.items {
+                        writeln!(
+                            stdout,
+                            "{}\t{}\t{}\t{}\t{}",
+                            item.request_id,
+                            item.recipient_identity_id.as_deref().unwrap_or("-"),
+                            item.delivery.as_str(),
+                            item.final_state.as_str(),
+                            item.revision
+                        )?;
+                    }
+                }
+                if let Some(after) = page.next_after {
+                    writeln!(
+                        stdout,
+                        "More exchanges: repeat x list with the same identity and --after {after}."
+                    )?;
+                }
+            }
+            ResultKind::Show(detail) => {
+                let item = &detail.exchange;
+                writeln!(
+                    stdout,
+                    "REQUEST\tDELIVERY\tFINAL\tREVISION\tACKNOWLEDGED\tSETTLED"
+                )?;
+                writeln!(
+                    stdout,
+                    "{}\t{}\t{}\t{}\t{}\t{}",
+                    item.request_id,
+                    item.delivery.as_str(),
+                    item.final_state.as_str(),
+                    item.revision,
+                    item.acknowledged,
+                    item.settled
+                )?;
+                writeln!(stdout, "Prompt ({}):", prompt_status(&detail.prompt))?;
+                if let RequestPrompt::Retained(prompt) = &detail.prompt {
+                    writeln!(stdout, "{}", prompt.message)?;
+                }
+                if let FinalState::Retained { content, .. } = &item.final_state {
+                    writeln!(stdout, "Final:\n{content}")?;
+                }
+            }
+            ResultKind::Ack(ack) => writeln!(
+                stdout,
+                "Acknowledged {} at revision {}{}",
+                ack.request_id,
+                ack.revision,
+                if ack.changed {
+                    "."
+                } else {
+                    " (already acknowledged)."
+                }
+            )?,
+            ResultKind::Ackall(through) => writeln!(
+                stdout,
+                "Acknowledged identity '{}' through revision {through}. Later revisions remain unacknowledged.",
+                report.identity.name
+            )?,
+        }
+    }
+    Ok(0)
+}

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -3,6 +3,7 @@ mod binding_error;
 mod check_command;
 mod config_command;
 mod diagnostics;
+mod exchange_command;
 mod grammar;
 mod identity_command;
 mod identity_context;
@@ -41,7 +42,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, and role/preamble are available. Installation and attention commands are not implemented yet. Use isolated test state only.\n"
+                "Native development preview: configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, and x attention are available. Installation commands are not implemented yet. Use isolated test state only.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -74,6 +75,13 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Identity(request) => {
             drop(stdout);
             return identity_command::execute(request, parsed.mode);
+        }
+        Invocation::Exchange {
+            identity,
+            operation,
+        } => {
+            drop(stdout);
+            return exchange_command::execute(identity, operation, parsed.mode);
         }
         request @ Invocation::Talk { .. } => {
             drop(stdout);

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -233,7 +233,14 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
             identity: text(m, "identity"),
             operation: ExchangeOperation::List {
                 limit: text(m, "limit")
-                    .map(|value| integer(&value, "--limit", 1, 200))
+                    .map(|value| {
+                        integer(
+                            &value,
+                            "--limit",
+                            1,
+                            tmt_core::request::attention::MAX_LIST_LIMIT,
+                        )
+                    })
                     .transpose()?,
                 after: text(m, "after")
                     .map(|value| integer(&value, "--after", 0, MAX_JS_SAFE_INTEGER))

--- a/rust/crates/tmt-core/src/request.rs
+++ b/rust/crates/tmt-core/src/request.rs
@@ -1,6 +1,7 @@
 //! Durable request policy and transaction-scoped ports. No live endpoint lookup,
 //! configuration loading or external effects belong inside this boundary.
 
+pub mod attention;
 pub mod correlation;
 mod service;
 pub use service::RequestService;
@@ -175,6 +176,27 @@ pub struct RequestContext {
 /// is held. Domain decisions remain in RequestService, not in SQL adapters.
 pub trait RequestRecords {
     type Error;
+    fn find_attention(
+        &self,
+        identity_id: &str,
+        request_id: &str,
+    ) -> Result<Option<attention::AttentionRecord>, Self::Error>;
+    fn list_attention(
+        &self,
+        identity_id: &str,
+        after: u64,
+        limit: u64,
+        now_ms: u64,
+    ) -> Result<Vec<attention::AttentionRecord>, Self::Error>;
+    /// Guard the observed revision; a missing update must not count as an ack.
+    fn acknowledge_revision(
+        &mut self,
+        identity_id: &str,
+        request_id: &str,
+        revision: u64,
+    ) -> Result<bool, Self::Error>;
+    /// Advance the watermark only for the transaction's observed latest revision.
+    fn acknowledge_through(&mut self, identity_id: &str, latest: u64) -> Result<bool, Self::Error>;
     fn find_attempt(&self, attempt_id: &str) -> Result<Option<RequestAttempt>, Self::Error>;
     fn find_request(&self, request_id: &str) -> Result<Option<RequestAttempt>, Self::Error>;
     fn find_context(&self, request_id: &str) -> Result<Option<RawRequestContext>, Self::Error>;
@@ -282,6 +304,7 @@ pub enum RequestError<E> {
     CounterExhausted,
     RevisionExhausted,
     Response(ResponseRejection),
+    Attention(attention::AttentionRejection),
     Repository(E),
 }
 
@@ -304,6 +327,7 @@ impl<E> fmt::Display for RequestError<E> {
                 f.write_str("Exchange attention revision counter is exhausted.")
             }
             Self::Response(reason) => f.write_str(reason.code()),
+            Self::Attention(reason) => reason.fmt(f),
             Self::Repository(_) => f.write_str("Could not access request state."),
         }
     }

--- a/rust/crates/tmt-core/src/request/attention.rs
+++ b/rust/crates/tmt-core/src/request/attention.rs
@@ -1,0 +1,117 @@
+//! Attention is a view over retained requests, not a second request lifecycle.
+
+use super::{AttemptStatus, RequestAttempt, RequestPrompt};
+use std::fmt;
+
+pub const DEFAULT_LIST_LIMIT: u64 = 50;
+pub const MAX_LIST_LIMIT: u64 = 200;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResponseMetadata {
+    pub body_bytes: u64,
+    pub expires_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttentionRecord {
+    pub attempt: RequestAttempt,
+    pub revision: u64,
+    pub acknowledged_revision: u64,
+    pub acknowledged_through: u64,
+    pub response_metadata: Option<ResponseMetadata>,
+}
+
+/// Summary carries unit content; detail carries exact text. Metadata and
+/// state variants therefore have one definition without optional body flags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FinalState<T> {
+    NotSubmitted,
+    Retained {
+        content: T,
+        submitted_at_ms: u64,
+        body_bytes: u64,
+        expires_at_ms: u64,
+    },
+    Expired {
+        submitted_at_ms: u64,
+        expires_at_ms: u64,
+    },
+    Unavailable {
+        submitted_at_ms: u64,
+        expires_at_ms: u64,
+    },
+}
+
+impl<T> FinalState<T> {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::NotSubmitted => "not_submitted",
+            Self::Retained { .. } => "retained",
+            Self::Expired { .. } => "expired",
+            Self::Unavailable { .. } => "unavailable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Exchange<T = ()> {
+    pub request_id: String,
+    pub recipient_identity_id: Option<String>,
+    pub prepared_at_ms: u64,
+    pub delivery: AttemptStatus,
+    pub final_state: FinalState<T>,
+    pub revision: u64,
+    pub acknowledged: bool,
+    pub settled: bool,
+    pub retention_expires_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExchangeDetail {
+    pub exchange: Exchange<String>,
+    pub prompt: RequestPrompt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExchangePage {
+    pub items: Vec<Exchange>,
+    pub next_after: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Acknowledged {
+    pub request_id: String,
+    pub revision: u64,
+    pub changed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttentionRejection {
+    Invalid(&'static str),
+    NotFound,
+    RevisionConflict { current: u64, expected: u64 },
+}
+
+impl AttentionRejection {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Invalid(_) => "X_INPUT_INVALID",
+            Self::NotFound => "X_NOT_FOUND",
+            Self::RevisionConflict { .. } => "X_REVISION_CONFLICT",
+        }
+    }
+}
+
+impl fmt::Display for AttentionRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid(message) => f.write_str(message),
+            Self::NotFound => {
+                f.write_str("Exchange was not found for this identity or is no longer retained.")
+            }
+            Self::RevisionConflict { current, expected } => {
+                write!(f, "Exchange is at revision {current}, not {expected}.")
+            }
+        }
+    }
+}

--- a/rust/crates/tmt-core/src/request/service.rs
+++ b/rust/crates/tmt-core/src/request/service.rs
@@ -1,6 +1,7 @@
 //! Short transactional use cases. The clock is sampled after acquiring the
 //! write lock; callers generate IDs and freeze configuration before entry.
 
+mod attention;
 mod lifecycle;
 mod responses;
 
@@ -128,29 +129,7 @@ impl<'a, R: RequestRepository, C: Fn() -> u64> RequestService<'a, R, C> {
         request_id: &str,
     ) -> Result<Option<RequestContext>, RequestError<R::Error>> {
         nonempty(request_id)?;
-        self.read(|records, now| {
-            let Some(raw) = records.find_context(request_id)? else {
-                return Ok(None);
-            };
-            if now >= raw.attempt.retention_expires_at_ms {
-                return Ok(None);
-            }
-            let prompt = match (raw.expires_at_ms, raw.message, raw.message_bytes) {
-                (None, _, _) => RequestPrompt::Unavailable,
-                (Some(expiry), Some(message), Some(message_bytes)) if now < expiry => {
-                    RequestPrompt::Retained(StoredPrompt {
-                        message,
-                        message_bytes,
-                        expires_at_ms: expiry,
-                    })
-                }
-                (Some(expires_at_ms), _, _) => RequestPrompt::Expired { expires_at_ms },
-            };
-            Ok(Some(RequestContext {
-                attempt: raw.attempt,
-                prompt,
-            }))
-        })
+        self.read(|records, now| context(records, request_id, now))
     }
 
     fn read<T>(
@@ -167,6 +146,34 @@ impl<'a, R: RequestRepository, C: Fn() -> u64> RequestService<'a, R, C> {
             operation(records, now)
         })
     }
+}
+
+fn context<E>(
+    records: &mut dyn RequestRecords<Error = E>,
+    request_id: &str,
+    now: u64,
+) -> Result<Option<RequestContext>, RequestError<E>> {
+    let Some(raw) = records.find_context(request_id)? else {
+        return Ok(None);
+    };
+    if now >= raw.attempt.retention_expires_at_ms {
+        return Ok(None);
+    }
+    let prompt = match (raw.expires_at_ms, raw.message, raw.message_bytes) {
+        (None, _, _) => RequestPrompt::Unavailable,
+        (Some(expiry), Some(message), Some(message_bytes)) if now < expiry => {
+            RequestPrompt::Retained(StoredPrompt {
+                message,
+                message_bytes,
+                expires_at_ms: expiry,
+            })
+        }
+        (Some(expires_at_ms), _, _) => RequestPrompt::Expired { expires_at_ms },
+    };
+    Ok(Some(RequestContext {
+        attempt: raw.attempt,
+        prompt,
+    }))
 }
 
 fn nonempty<E>(value: &str) -> Result<(), RequestError<E>> {

--- a/rust/crates/tmt-core/src/request/service/attention.rs
+++ b/rust/crates/tmt-core/src/request/service/attention.rs
@@ -1,0 +1,185 @@
+use super::*;
+use crate::request::attention::{
+    Acknowledged, AttentionRecord, AttentionRejection, DEFAULT_LIST_LIMIT, Exchange,
+    ExchangeDetail, ExchangePage, FinalState, MAX_LIST_LIMIT,
+};
+
+fn selector<E>(value: &str) -> Result<(), RequestError<E>> {
+    if value.is_empty() {
+        Err(RequestError::Attention(AttentionRejection::Invalid(
+            "Identifiers must be non-empty.",
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn missing<E>() -> RequestError<E> {
+    RequestError::Attention(AttentionRejection::NotFound)
+}
+
+fn retained<E>(
+    records: &mut dyn RequestRecords<Error = E>,
+    identity: &str,
+    request: &str,
+    now: u64,
+) -> Result<AttentionRecord, RequestError<E>> {
+    records
+        .find_attention(identity, request)?
+        .filter(|record| now < record.attempt.retention_expires_at_ms)
+        .ok_or_else(missing)
+}
+
+fn final_state<T, E>(
+    record: &AttentionRecord,
+    now: u64,
+    content: Option<T>,
+) -> Result<FinalState<T>, RequestError<E>> {
+    let Some(submitted_at_ms) = record.attempt.response_submitted_at_ms else {
+        return Ok(FinalState::NotSubmitted);
+    };
+    let expires_at_ms = match &record.response_metadata {
+        Some(metadata) => metadata.expires_at_ms,
+        None => retention_deadline(submitted_at_ms, record.attempt.retention_days)
+            .ok_or(RequestError::Invalid("Invalid retained final horizon."))?,
+    };
+    if now >= expires_at_ms {
+        return Ok(FinalState::Expired {
+            submitted_at_ms,
+            expires_at_ms,
+        });
+    }
+    Ok(match (&record.response_metadata, content) {
+        (Some(metadata), Some(content)) => FinalState::Retained {
+            content,
+            submitted_at_ms,
+            body_bytes: metadata.body_bytes,
+            expires_at_ms,
+        },
+        _ => FinalState::Unavailable {
+            submitted_at_ms,
+            expires_at_ms,
+        },
+    })
+}
+
+fn exchange<T>(record: AttentionRecord, final_state: FinalState<T>) -> Exchange<T> {
+    let acknowledged = record.acknowledged_revision >= record.revision
+        || record.acknowledged_through >= record.revision;
+    Exchange {
+        request_id: record.attempt.request_id,
+        recipient_identity_id: record.attempt.recipient_identity_id,
+        prepared_at_ms: record.attempt.prepared_at_ms,
+        delivery: record.attempt.status,
+        final_state,
+        revision: record.revision,
+        acknowledged,
+        settled: acknowledged && record.attempt.response_submitted_at_ms.is_some(),
+        retention_expires_at_ms: record.attempt.retention_expires_at_ms,
+    }
+}
+
+impl<R: RequestRepository, C: Fn() -> u64> RequestService<'_, R, C> {
+    pub fn list_exchanges(
+        &mut self,
+        identity: &str,
+        limit: Option<u64>,
+        after: Option<u64>,
+    ) -> Result<ExchangePage, RequestError<R::Error>> {
+        selector(identity)?;
+        let limit = limit.unwrap_or(DEFAULT_LIST_LIMIT);
+        let after = after.unwrap_or(0);
+        if limit == 0 || limit > MAX_LIST_LIMIT || after > MAX_JS_SAFE_INTEGER {
+            return Err(RequestError::Attention(AttentionRejection::Invalid(
+                "Invalid exchange list limit or cursor.",
+            )));
+        }
+        self.read(|records, now| {
+            let mut rows = records.list_attention(identity, after, limit + 1, now)?;
+            let more = rows.len() as u64 > limit;
+            rows.truncate(limit as usize);
+            let next_after = more.then(|| rows.last().expect("nonzero limit").revision);
+            let items = rows
+                .into_iter()
+                .map(|record| {
+                    let state = final_state(&record, now, Some(()))?;
+                    Ok(exchange(record, state))
+                })
+                .collect::<Result<_, RequestError<R::Error>>>()?;
+            Ok(ExchangePage { items, next_after })
+        })
+    }
+
+    pub fn show_exchange(
+        &mut self,
+        identity: &str,
+        request: &str,
+    ) -> Result<ExchangeDetail, RequestError<R::Error>> {
+        selector(identity)?;
+        selector(request)?;
+        self.read(|records, now| {
+            let record = retained(records, identity, request, now)?;
+            let context = context(records, request, now)?.ok_or_else(missing)?;
+            let response = records
+                .find_response(request)?
+                .filter(|response| now < response.response_expires_at_ms);
+            let state = final_state(&record, now, response.map(|response| response.body))?;
+            Ok(ExchangeDetail {
+                exchange: exchange(record, state),
+                prompt: context.prompt,
+            })
+        })
+    }
+
+    pub fn acknowledge_exchange(
+        &mut self,
+        identity: &str,
+        request: &str,
+        revision: u64,
+    ) -> Result<Acknowledged, RequestError<R::Error>> {
+        selector(identity)?;
+        selector(request)?;
+        if revision == 0 || revision > MAX_JS_SAFE_INTEGER {
+            return Err(RequestError::Attention(AttentionRejection::Invalid(
+                "Revision must be a positive safe integer.",
+            )));
+        }
+        self.read(|records, now| {
+            let record = retained(records, identity, request, now)?;
+            if record.revision != revision {
+                return Err(RequestError::Attention(
+                    AttentionRejection::RevisionConflict {
+                        current: record.revision,
+                        expected: revision,
+                    },
+                ));
+            }
+            let changed =
+                record.acknowledged_revision < revision && record.acknowledged_through < revision;
+            if changed && !records.acknowledge_revision(identity, request, revision)? {
+                return Err(RequestError::StateInvalid);
+            }
+            Ok(Acknowledged {
+                request_id: request.into(),
+                revision,
+                changed,
+            })
+        })
+    }
+
+    pub fn acknowledge_all_exchanges(
+        &mut self,
+        identity: &str,
+    ) -> Result<u64, RequestError<R::Error>> {
+        selector(identity)?;
+        self.read(|records, _| {
+            let Some(latest) = records.attention_counter(identity)? else {
+                return Ok(0);
+            };
+            if !records.acknowledge_through(identity, latest)? {
+                return Err(RequestError::StateInvalid);
+            }
+            Ok(latest)
+        })
+    }
+}

--- a/test/e2e/native-exchange-attention.e2e.test.ts
+++ b/test/e2e/native-exchange-attention.e2e.test.ts
@@ -1,0 +1,320 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  withE2EFixture,
+  type CliResult,
+  type E2EFixture,
+  type E2EFixtureOptions,
+} from './harness.js';
+import { durableState } from './identity-state-oracle.js';
+import { requestAttempts, requestResponses, type AttemptRow } from './request-state-oracle.js';
+
+interface Identity {
+  readonly id: string;
+  readonly name: string;
+  readonly canonicalName: string;
+  readonly lifetime: 'saved' | 'temporary';
+}
+
+interface TalkOutput {
+  readonly status?: string;
+  readonly requestId?: string;
+  readonly response?: string;
+  readonly bodyBytes?: number;
+  readonly submittedAtMs?: number;
+  readonly identity?: Identity;
+  readonly error?: { readonly code?: string; readonly message?: string };
+}
+
+interface AttentionAttemptRow extends AttemptRow {
+  readonly attention_revision: number;
+  readonly attention_acknowledged_revision: number;
+}
+
+function options(extra: E2EFixtureOptions = {}): E2EFixtureOptions {
+  const native = process.env.TMT_TEST_NATIVE_CLI;
+  if (!native) throw new Error('Native exchange-attention E2E requires the Docker-built CLI.');
+  return {
+    mode: 'respond',
+    executableEnv: { TMT_TEST_CLI: native },
+    ...extra,
+  };
+}
+
+function success<T>(result: CliResult<T>): T {
+  expect(result.code, result.stderr || result.stdout).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.json).toBeDefined();
+  return result.json as T;
+}
+
+function attentionAttempt(fixture: E2EFixture, requestId: string): AttentionAttemptRow {
+  const attempt = requestAttempts(fixture).find((row) => row.request_id === requestId);
+  expect(attempt).toBeDefined();
+  return attempt as AttentionAttemptRow;
+}
+
+describe.sequential('native exchange attention through Docker/tmux', () => {
+  it('keeps implicit attribution, explicit offline attention, watermark cutoffs, and late revisions causal', async () => {
+    const original = 'native attention original prompt';
+    const body = '\uFEFFlate native final\r\n日本語🙂  ';
+
+    await withE2EFixture(
+      async (fixture) => {
+        const created = success(
+          await fixture.runJsonCli<{ identity: Identity; created: boolean }>(
+            ['identity', 'create', 'AttentionOwner'],
+            { withoutTmux: true }
+          )
+        );
+        expect(created).toMatchObject({
+          created: true,
+          identity: {
+            id: expect.any(String),
+            name: 'AttentionOwner',
+            canonicalName: 'attentionowner',
+            lifetime: 'saved',
+          },
+        });
+        expect(success(await fixture.runJsonCli(['name', 'AttentionOwner']))).toMatchObject({
+          bound: true,
+          name: 'AttentionOwner',
+          pane: fixture.pane,
+        });
+
+        const detached = success(
+          await fixture.runJsonCli<TalkOutput>([
+            'talk',
+            fixture.pane,
+            original,
+            '--no-preamble',
+            '--detach',
+          ])
+        );
+        expect(detached).toMatchObject({
+          status: 'sent',
+          requestId: expect.stringMatching(/^req_[0-9a-f-]+$/),
+        });
+        const requestId = detached.requestId!;
+        const requestEvent = await fixture.waitForEvent(
+          (event) => event.event === 'request' && event.requestId === requestId,
+          5_000
+        );
+        expect(requestEvent.message).toBe(original);
+        expect(fixture.events().some((event) => event.event === 'child-start')).toBe(false);
+
+        const initialAttempt = attentionAttempt(fixture, requestId);
+        expect(initialAttempt).toMatchObject({
+          request_id: requestId,
+          originator_kind: 'verified',
+          originator_identity_id: created.identity.id,
+          message_text: original,
+          message_bytes: Buffer.byteLength(original),
+          attention_revision: 1,
+          attention_acknowledged_revision: 0,
+        });
+        expect(requestResponses(fixture)).toEqual([]);
+        expect(
+          fixture
+            .events()
+            .filter((event) => event.event === 'submitted' && event.requestId === requestId)
+        ).toHaveLength(0);
+
+        // Remove caller binding before all attention reads: explicit saved identity selection is
+        // storage-only and must work offline without silently falling back to pane discovery.
+        expect(success(await fixture.runJsonCli(['unbind']))).toMatchObject({
+          unbound: true,
+          name: 'AttentionOwner',
+        });
+        expect(durableState(fixture).bindings).toEqual([]);
+
+        // This is deliberately the first x operation; ackall uses its identity watermark and
+        // does not require a preceding list, show, token, or body read.
+        const acknowledged = success<{ identity: Identity; acknowledgedThrough: number }>(
+          await fixture.runJsonCli(['x', 'ackall', '--identity', 'attentionowner'], {
+            withoutTmux: true,
+          })
+        );
+        expect(acknowledged).toEqual({
+          identity: created.identity,
+          acknowledgedThrough: 1,
+        });
+        expect(attentionAttempt(fixture, requestId).attention_acknowledged_revision).toBe(0);
+
+        const beforeFinal = success<{
+          identity: Identity;
+          items: unknown[];
+          nextAfter: number | null;
+        }>(
+          await fixture.runJsonCli(['x', 'list', '--identity', 'AttentionOwner'], {
+            withoutTmux: true,
+          })
+        );
+        expect(beforeFinal).toEqual({
+          identity: created.identity,
+          items: [],
+          nextAfter: null,
+        });
+
+        fixture.releaseReplyGate(requestId);
+        await fixture.waitForEvent(
+          (event) => event.event === 'child-start' && event.requestId === requestId,
+          5_000
+        );
+        const submitted = await fixture.waitForEvent(
+          (event) => event.event === 'submitted' && event.requestId === requestId,
+          5_000
+        );
+        expect(submitted.body).toBe(body);
+        expect(submitted.bodyBytes).toBe(Buffer.byteLength(body));
+        expect(requestResponses(fixture)).toEqual([
+          expect.objectContaining({
+            request_id: requestId,
+            body,
+            submitted_at_ms: submitted.submittedAtMs,
+          }),
+        ]);
+
+        const reopened = success<{
+          identity: Identity;
+          items: Array<{
+            requestId: string;
+            revision: number;
+            acknowledged: boolean;
+            settled: boolean;
+            final: Record<string, unknown>;
+          }>;
+          nextAfter: number | null;
+        }>(
+          await fixture.runJsonCli(['x', 'list', '--identity', 'AttentionOwner'], {
+            withoutTmux: true,
+          })
+        );
+        expect(reopened.identity).toEqual(created.identity);
+        expect(reopened.items).toEqual([
+          expect.objectContaining({
+            requestId,
+            preparedAtMs: expect.any(Number),
+            delivery: 'sent',
+            final: {
+              status: 'retained',
+              submittedAtMs: expect.any(Number),
+              bodyBytes: Buffer.byteLength(body),
+              expiresAtMs: expect.any(Number),
+            },
+            revision: 2,
+            acknowledged: false,
+            settled: false,
+            retentionExpiresAtMs: expect.any(Number),
+          }),
+        ]);
+        expect(reopened.nextAfter).toBeNull();
+        expect(reopened.items[0].final).not.toHaveProperty('response');
+        expect(reopened.items[0]).not.toHaveProperty('prompt');
+        expect(attentionAttempt(fixture, requestId)).toMatchObject({
+          attention_revision: 2,
+          attention_acknowledged_revision: 0,
+        });
+
+        const stale = await fixture.runJsonCli<TalkOutput>(
+          ['x', 'ack', requestId, '--identity', 'AttentionOwner', '--revision', '1'],
+          { withoutTmux: true }
+        );
+        expect(stale).toMatchObject({
+          code: 5,
+          stderr: '',
+          json: { error: { code: 'X_REVISION_CONFLICT' } },
+        });
+        expect(attentionAttempt(fixture, requestId).attention_acknowledged_revision).toBe(0);
+
+        const current = success<{
+          identity: Identity;
+          requestId: string;
+          revision: number;
+          changed: boolean;
+        }>(
+          await fixture.runJsonCli(
+            ['x', 'ack', requestId, '--identity', 'AttentionOwner', '--revision', '2'],
+            { withoutTmux: true }
+          )
+        );
+        expect(current).toEqual({
+          identity: created.identity,
+          requestId,
+          revision: 2,
+          acknowledged: true,
+          changed: true,
+        });
+        expect(attentionAttempt(fixture, requestId).attention_acknowledged_revision).toBe(2);
+
+        const shown = success<{
+          identity: Identity;
+          exchange: {
+            requestId: string;
+            acknowledged: boolean;
+            settled: boolean;
+            prompt: { status: string; message: string; messageBytes: number };
+            final: {
+              status: string;
+              response?: string;
+              bodyBytes?: number;
+              submittedAtMs?: number;
+              expiresAtMs?: number;
+            };
+          };
+        }>(
+          await fixture.runJsonCli(['x', 'show', requestId, '--identity', 'AttentionOwner'], {
+            withoutTmux: true,
+          })
+        );
+        expect(shown).toEqual({
+          identity: created.identity,
+          exchange: {
+            requestId,
+            recipientIdentityId: created.identity.id,
+            preparedAtMs: expect.any(Number),
+            delivery: 'sent',
+            final: {
+              status: 'retained',
+              response: body,
+              bodyBytes: Buffer.byteLength(body),
+              submittedAtMs: submitted.submittedAtMs,
+              expiresAtMs: expect.any(Number),
+            },
+            revision: 2,
+            acknowledged: true,
+            settled: true,
+            retentionExpiresAtMs: expect.any(Number),
+            prompt: {
+              status: 'retained',
+              message: original,
+              messageBytes: Buffer.byteLength(original),
+              expiresAtMs: expect.any(Number),
+            },
+          },
+        });
+        // Rebinding the same saved UUID restores implicit access to the same
+        // retained exchange, without a second identity or attention owner.
+        success(await fixture.runJsonCli(['name', 'AttentionOwner']));
+        expect(success(await fixture.runJsonCli(['x', 'show', requestId]))).toEqual(shown);
+        expect(
+          fixture
+            .events()
+            .filter((event) => event.event === 'request' && event.requestId === requestId)
+        ).toHaveLength(1);
+        expect(
+          fixture
+            .events()
+            .filter((event) => event.event === 'child-start' && event.requestId === requestId)
+        ).toHaveLength(1);
+        expect(
+          fixture
+            .events()
+            .filter((event) => event.event === 'submitted' && event.requestId === requestId)
+        ).toHaveLength(1);
+        expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);
+      },
+      options({ replyGate: true, responseBodyBase64: Buffer.from(body).toString('base64') })
+    );
+  }, 25_000);
+});

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -62,9 +62,9 @@ describe('native grammar preview process contract', () => {
       expect(help.stderr).toBe('');
       expect(help.stdout).toContain('Native development preview');
       expect(help.stdout).toContain(
-        'configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, and role/preamble are available'
+        'configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, and x attention are available'
       );
-      expect(help.stdout).toContain('Installation and attention commands are not implemented yet.');
+      expect(help.stdout).toContain('Installation commands are not implemented yet.');
       expect(help.stdout).toContain('Manage identity records without probing tmux');
       expect(help.stdout).toContain('temporary unless saved');
       expect(help.stdout).toContain('rm');
@@ -78,7 +78,7 @@ describe('native grammar preview process contract', () => {
   it('explicitly rejects effects for every recognized command family', async () => {
     await withSandbox(async (sandbox) => {
       const before = fileSnapshot(sandbox.root);
-      for (const args of [['init'], ['x', 'ackall'], ['install', '--dir', sandbox.cwd]]) {
+      for (const args of [['init'], ['install', '--dir', sandbox.cwd]]) {
         const result = await runCli(sandbox, [...args, '--json']);
         expect(result.status, args.join(' ')).toBe(1);
         expectError(result, 'NATIVE_NOT_IMPLEMENTED');

--- a/test/native/exchange.test.ts
+++ b/test/native/exchange.test.ts
@@ -1,0 +1,304 @@
+import Database from 'better-sqlite3';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+  type Sandbox,
+} from '../../src/test-support/cli-process.js';
+import { seedResponse, responseSnapshot } from './response-fixture.js';
+import { calibrateTmuxTripwire } from './tmux-tripwire.js';
+
+async function json(sandbox: Sandbox, args: string[]) {
+  const result = await runCli(sandbox, [...args, '--json']);
+  expect(result.status, result.stdout || result.stderr).toBe(0);
+  return parseWholeStdout(result);
+}
+
+function attentionFixture(sandbox: Sandbox, owner: string, requestId: string) {
+  const seeded = seedResponse(sandbox.database, requestId);
+  const database = new Database(sandbox.database);
+  try {
+    database.transaction(() => {
+      database
+        .prepare(
+          'INSERT INTO request_attention_identities (identity_id, latest_revision, acknowledged_through) VALUES (?, 1, 0)'
+        )
+        .run(owner);
+      database
+        .prepare(
+          "UPDATE request_attempts SET originator_kind = 'explicit', originator_identity_id = ?, attention_revision = 1 WHERE request_id = ?"
+        )
+        .run(owner, requestId);
+    })();
+  } finally {
+    database.close();
+  }
+  return seeded;
+}
+
+describe('native exchange attention process contract', () => {
+  it('keeps retired-name history with its original UUID rather than the replacement identity', async () => {
+    await withSandbox(async (sandbox) => {
+      await calibrateTmuxTripwire(sandbox);
+      const owner = (await json(sandbox, ['identity', 'create', 'Reusable'])).identity as {
+        id: string;
+      };
+      attentionFixture(sandbox, owner.id, 'old-owner-request');
+      const before = responseSnapshot(sandbox.database, 'old-owner-request');
+      await json(sandbox, ['rm', 'Reusable', '--force']);
+      const replacement = (await json(sandbox, ['identity', 'create', 'Reusable'])).identity as {
+        id: string;
+      };
+      expect(replacement.id).not.toBe(owner.id);
+      expect(await json(sandbox, ['x', '--identity', 'Reusable'])).toMatchObject({ items: [] });
+      expect(await json(sandbox, ['x', 'ackall', '--identity', 'Reusable'])).toMatchObject({
+        acknowledgedThrough: 0,
+      });
+      const hidden = await runCli(sandbox, [
+        'x',
+        'show',
+        'old-owner-request',
+        '--identity',
+        'Reusable',
+        '--json',
+      ]);
+      expect(hidden.status).toBe(3);
+      expectError(hidden, 'X_NOT_FOUND');
+      expect(responseSnapshot(sandbox.database, 'old-owner-request')).toEqual(before);
+      const oracle = new Database(sandbox.database, { readonly: true });
+      try {
+        expect(oracle.prepare('SELECT originator_identity_id FROM request_attempts').get()).toEqual(
+          { originator_identity_id: owner.id }
+        );
+        expect(
+          oracle
+            .prepare('SELECT identity_id, acknowledged_through FROM request_attention_identities')
+            .all()
+        ).toEqual([{ identity_id: owner.id, acknowledged_through: 0 }]);
+      } finally {
+        oracle.close();
+      }
+    });
+  });
+
+  it('rejects an unverified implicit caller before request housekeeping', async () => {
+    await withSandbox(async (sandbox) => {
+      await calibrateTmuxTripwire(sandbox);
+      await json(sandbox, ['identity', 'create', 'Offline']);
+      seedResponse(sandbox.database, 'unread-expired-prompt');
+      const writer = new Database(sandbox.database);
+      try {
+        writer
+          .prepare('UPDATE request_attempts SET message_expires_at_ms = ? WHERE request_id = ?')
+          .run(Date.now() - 1000, 'unread-expired-prompt');
+      } finally {
+        writer.close();
+      }
+      const before = responseSnapshot(sandbox.database, 'unread-expired-prompt');
+      for (const operation of [[], ['show', 'unread-expired-prompt'], ['ackall']]) {
+        const result = await runCli(sandbox, ['x', ...operation, '--json']);
+        expect(result.status).toBe(1);
+        expectError(result, 'IDENTITY_REQUIRED');
+        expect(responseSnapshot(sandbox.database, 'unread-expired-prompt')).toEqual(before);
+      }
+      // Calibrate the housekeeping oracle: valid explicit access must scrub it.
+      await json(sandbox, ['x', '--identity', 'Offline']);
+      expect(
+        responseSnapshot(sandbox.database, 'unread-expired-prompt').attempt?.message_text
+      ).toBeNull();
+    });
+  });
+
+  it('uses explicit offline identity without config or tmux and keeps reads separate from acknowledgment', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      const created = await json(sandbox, ['identity', 'create', 'Owner']);
+      const identity = created.identity as {
+        id: string;
+        name: string;
+        canonicalName: string;
+        lifetime: string;
+      };
+      expect(identity).toMatchObject({
+        id: expect.any(String),
+        name: 'Owner',
+        canonicalName: 'owner',
+        lifetime: 'saved',
+      });
+      const seeded = attentionFixture(sandbox, identity.id, 'native-attention');
+      writeFileSync(sandbox.globalConfig, '{ invalid config');
+      writeFileSync(sandbox.localConfig, '{ invalid config');
+      const listed = await json(sandbox, ['x', '--identity', 'OWNER']);
+      expect(listed).toMatchObject({
+        identity,
+        nextAfter: null,
+        items: [
+          {
+            requestId: seeded.requestId,
+            revision: 1,
+            delivery: 'sent',
+            final: { status: 'not_submitted' },
+            acknowledged: false,
+            settled: false,
+          },
+        ],
+      });
+      const shown = await json(sandbox, ['x', 'show', seeded.requestId, '--identity', 'Owner']);
+      expect(shown).toMatchObject({
+        identity,
+        exchange: {
+          revision: 1,
+          prompt: { status: 'retained', message: `prompt for ${seeded.requestId}` },
+        },
+      });
+      expect(await json(sandbox, ['x', '--identity', 'Owner'])).toEqual(listed);
+      expect(await json(sandbox, ['x', 'ackall', '--identity', 'Owner'])).toEqual({
+        identity,
+        acknowledgedThrough: 1,
+      });
+      expect(await json(sandbox, ['x', '--identity', 'Owner'])).toEqual({
+        identity,
+        items: [],
+        nextAfter: null,
+      });
+      const body = '\uFEFF exact final\r\n日本語  ';
+      await json(sandbox, [
+        'reply',
+        seeded.requestId,
+        '--receipt',
+        seeded.compactReceipt,
+        '--message',
+        body,
+      ]);
+      const after = await json(sandbox, ['x', 'list', '--identity', 'Owner']);
+      expect(after).toMatchObject({
+        items: [
+          {
+            revision: 2,
+            acknowledged: false,
+            settled: false,
+            final: { status: 'retained', bodyBytes: Buffer.byteLength(body) },
+          },
+        ],
+      });
+      expect(JSON.stringify(after)).not.toContain('exact final');
+      expect(JSON.stringify(after)).not.toContain('prompt for');
+      expect(JSON.stringify(after)).not.toContain('receipt');
+      const stale = await runCli(sandbox, [
+        'x',
+        'ack',
+        seeded.requestId,
+        '--revision',
+        '1',
+        '--identity',
+        'Owner',
+        '--json',
+      ]);
+      expect(stale.status).toBe(5);
+      expectError(stale, 'X_REVISION_CONFLICT');
+      expect(
+        await json(sandbox, [
+          'x',
+          'ack',
+          seeded.requestId,
+          '--revision',
+          '2',
+          '--identity',
+          'Owner',
+        ])
+      ).toEqual({
+        identity,
+        requestId: seeded.requestId,
+        revision: 2,
+        acknowledged: true,
+        changed: true,
+      });
+      expect(
+        await json(sandbox, [
+          'x',
+          'ack',
+          seeded.requestId,
+          '--revision',
+          '2',
+          '--identity',
+          'Owner',
+        ])
+      ).toMatchObject({ changed: false });
+      expect(
+        await json(sandbox, ['x', 'show', seeded.requestId, '--identity', 'Owner'])
+      ).toMatchObject({
+        exchange: {
+          acknowledged: true,
+          settled: true,
+          final: { status: 'retained', response: body },
+        },
+      });
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+      const oracle = new Database(sandbox.database, { readonly: true });
+      try {
+        expect(
+          oracle
+            .prepare(
+              'SELECT latest_revision, acknowledged_through FROM request_attention_identities'
+            )
+            .get()
+        ).toEqual({ latest_revision: 2, acknowledged_through: 1 });
+        expect(
+          oracle
+            .prepare(
+              'SELECT attention_revision, attention_acknowledged_revision FROM request_attempts'
+            )
+            .get()
+        ).toEqual({ attention_revision: 2, attention_acknowledged_revision: 2 });
+      } finally {
+        oracle.close();
+      }
+    });
+  });
+
+  it('rejects unknown and foreign selectors without creating identities or acknowledging another owner', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      const owner = (await json(sandbox, ['identity', 'create', 'Owner'])).identity as {
+        id: string;
+      };
+      expect(owner.id).toEqual(expect.any(String));
+      await json(sandbox, ['identity', 'create', 'Foreign']);
+      attentionFixture(sandbox, owner.id, 'private-exchange');
+      const identitiesBefore = await json(sandbox, ['identity', 'list']);
+      const before = responseSnapshot(sandbox.database, 'private-exchange');
+      for (const operation of [
+        ['show', 'private-exchange'],
+        ['ack', 'private-exchange', '--revision', '1'],
+      ]) {
+        const result = await runCli(sandbox, [
+          'x',
+          ...operation,
+          '--identity',
+          'Foreign',
+          '--json',
+        ]);
+        expect(result.status).toBe(3);
+        expectError(result, 'X_NOT_FOUND');
+      }
+      const missing = await runCli(sandbox, [
+        'x',
+        'ackall',
+        '--identity',
+        'NeverCreated',
+        '--json',
+      ]);
+      expect(missing.status).toBe(3);
+      expectError(missing, 'NAME_NOT_FOUND');
+      expect(await json(sandbox, ['x', 'ackall', '--identity', 'Foreign'])).toMatchObject({
+        acknowledgedThrough: 0,
+      });
+      expect(responseSnapshot(sandbox.database, 'private-exchange')).toEqual(before);
+      expect(await json(sandbox, ['identity', 'list'])).toEqual(identitiesBefore);
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+    });
+  });
+});


### PR DESCRIPTION
## Scope

Closes #131. Completes native `x list/show/ack/ackall` through the existing request service, transaction-scoped storage adapter and identity selector. No schema, dependency, daemon, inbox, installed-runtime switch or publication is added.

## Architecture and primary review

- Reviewed commit: `8b6acecf427ea53ae92e077636a854ed807a964b`.
- Primary: Codex. Personally inspected all 20 changed files, surrounding request lifecycle/final/revision/cleanup code, row decoding and SQL, identity selection, CLI grammar/output, shared fixture/oracle and gated mock behavior.
- Core attention owns projections, exact-revision policy and watermark semantics; adapter modules own metadata-only SQL and guarded updates. Detail reuses original context. The CLI only selects identity, invokes the service, closes storage and presents results. No parallel connection, retention algorithm, revision allocator or identity selector.
- Reads do not acknowledge. Pending acknowledgment is not settled; a later final advances the revision and reappears. A stale ack exits 5 without consuming a newer final. Ackall needs no preliminary list and atomically captures the current identity watermark. Retired-name reuse cannot acquire old UUID-owned history.
- Primary findings corrected: removed unnecessary helper visibility; strengthened retention tests with an advanced clock and independent SQL; proved rollback includes eligible housekeeping; corrupt-body fixture proves list does not decode bodies; added public name-reuse and no-read implicit failure checks; corrected mock gate ordering, result-wrapper assertions, watermark-versus-row-ack expectations and an escaping-related false-positive assertion. No weakened checks or sleeps were introduced.
- Architecture, development verification guidance and native preview inventory updated in this PR. Installed skill/installation remains #133/#82; this PR does not claim native distribution readiness.

## Verification

- [x] Primary reviewer inspected every changed file and relevant callers/tests.
- [x] Exact commands and results recorded below.
- [x] All 11 required CI checks passed on this exact reviewed head, run `34193431838`, attempt 1.

Local environment: Node 24.20.0, pnpm 10.33.0, Rust 1.97.0 and MSRV 1.88.0.

- `cargo fmt --all --check`: pass.
- `cargo test --workspace --all-targets`: 263 passed (172 adapters, 29 CLI, 19 architecture, 43 core).
- `cargo +1.88.0 test --workspace --all-targets`: same 263 passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: pass.
- `pnpm check`: pass.
- `pnpm test:run`: 1,102 passed across 70 files; coverage thresholds passed. Existing calibrated process-ancestry guards require local process-inspection access; the restricted run failed their calibration, and the authorized run passed without changing those tests.
- `pnpm test:native` with both native CLI and native storage-probe JSON descriptors: 81 passed across 10 files. Initial harness invocations omitted/misformatted descriptors; corrected invocations exercised the selected native binaries, without fallback.
- Two final `pnpm test:e2e` runs: each passed 172 Linux adapter tests and 159 Docker scenarios, plus the existing optional performance skip. First final run 305.57s; second 302.95s. The exploratory run caught an incorrect gated-mock test order, fixed before both final passes. Real tmux and deterministic native reply children run only inside network-isolated containers; fixtures and images cleaned up.
- `git diff --check`: pass. No user/global installation or host tmux was touched.

Logs: `/private/tmp/tmt-131-{rust-final-2,msrv-final-2,clippy-final-2,quality-final-2,ts-final,native-3,docker-final-1,docker-final-2}.log`.

## Lifecycle

GitHub #131 owns this branch/worktree/PR. #93 reflects completed #129 and current #131. #133 is the next bounded skill-installation issue under the same installation roadmap. Merge only after all required checks pass on the reviewed head; then record delivery and remove only the clean, safely pushed task worktree. No release publication is authorized.
