### PR TITLE
feat(native): embed guidance and safely install managed skills

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -717,7 +717,8 @@ is `/tmux-team`, not a separately maintained slash-command contract.
 The educational learn guide points to the canonical viewer and grammar-backed
 help rather than owning another command inventory.
 
-The ordered provider list and its derived type live in `skill-installation.ts`.
+For the installed TypeScript reference, the ordered provider list and its derived
+type live in `skill-installation.ts`.
 Installer acceptance, install-all expansion and completion consume that owner;
 provider environment detection and Codex-specific backup rules remain installer
 policies. Command and option grammar still belongs to the parser.
@@ -743,7 +744,7 @@ Before mutation, source/destination overlap is rejected, including destination
 parents that alias the bundled source through symlinks. Force is not permission
 to move the installed package source or create a recursive self-link.
 
-`src/skill-installation.ts` owns shared package-root, bundled-source, managed-target,
+In that reference runtime, `src/skill-installation.ts` owns shared package-root, bundled-source, managed-target,
 and legacy directory candidate resolution used by install, the viewer and local
 drift inspection. Candidate resolution operates without package-root discovery,
 preserves installer preference order, deduplicates equivalent paths, and excludes
@@ -783,6 +784,46 @@ infrastructure, not another migration runner or application service. Test files
 and test-support workers are excluded from the package; runtime TypeScript and
 the canonical skill remains distributed. Retired command/plugin assets are rejected
 by the package inventory check rather than maintained as compatibility copies.
+
+### Rust preview installation ownership (#133)
+
+The preview embeds the same authored skill bytes at compile time. The core
+`skill_provider::Provider` inventory owns native names/order and feeds grammar,
+completion and adapter selection. `skill_installation::ProviderEnvironment`
+captures provider path inputs once; its target and legacy candidates are shared
+by installation and passive drift inspection. TypeScript remains a temporary
+reference owner until cutover, not a runtime fallback or permanent shared manifest.
+
+The adapter materializes exact bytes at
+`<global-dir>/skill-assets/<sha256>/tmux-team/SKILL.md`. Digest and exact directory
+inventory establish local managed-source evidence, not remote authentication.
+Sources and digest directories cannot be symlink substitutions. A modified current
+bundled source blocks installation even under force. Modified older sources remain
+preserved; their links are unmanaged conflicts eligible only for forced link backup.
+Valid older managed links
+can refresh to a new source without force; unmanaged targets require explicit
+recoverable backup outside active discovery. Legacy backups use that same native
+backup owner, unlike the installed reference's adjacent command-file policy.
+
+A stable OS-locked file serializes cooperating installers without a PID registry
+or database. Resolve target parents before source-overlap checks; publication
+replaces the leaf entry rather than following its symlink. Stage source directories
+and replacement links on their destination filesystem. Installer intents are
+bounded to 4096 paths/1 MiB in versioned `skill-installations.json`, written before
+links so custom targets remain discoverable after partial failure. Recorded paths
+are not overwrite authority: refresh must verify actual managed links again.
+Errors identify completed targets and recoverable backups. There is no atomic
+transaction across providers or power-loss rollback guarantee. Old sources and
+abandoned stages are preserved; never remove them merely by matching a filename.
+
+Only interactive, non-JSON human commands inspect deduplicated known provider
+and legacy paths. Help/version/completion, init, learn, install, upgrade and
+machine invocations skip passive inspection. It performs no network, tmux,
+SQLite, executable lookup or custom-intent scan, and never changes command success.
+The CLI owns this reminder policy and presentation; the adapter owns observation.
+Explicit install and future #82 update own custom-target refresh. `init` separately
+reuses ConfigPaths and exclusive local file creation; it creates no other state.
+Neither this boundary nor tests imply native release publication or network upgrade.
 
 ## Current module map
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,8 +36,9 @@ help/version/completion, typed grammar, the existing `config` command and
 storage-only `identity create/show/list` under #113, and pane identity
 `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` under #109, plus storage-only
 `reply`/`result` under #122, diagnostic `check`/`read` under #125, and
-`role`/`preamble` under #127, and durable `talk` under #129.
-Other effectful commands still explicitly fail.
+`role`/`preamble` under #127, durable `talk` under #129, X attention under #131,
+and `init`/`learn`/managed skill installation under #133.
+Native network `upgrade` still explicitly fails.
 The #118 request/final service is the shared transactional foundation;
 public reply/result composition is supplied by #122 and talk by #129. Its real SQLite
 tests run in ordinary adapter Cargo tests and therefore in the existing Docker
@@ -494,7 +495,8 @@ inventory rejects retired provider/plugin assets. Semantic review remains
 necessary: byte equality does not prove correct agent behavior.
 `tmt learn --skill` is the exact viewer; plain `learn` is the short guide.
 
-Provider names and ordering belong to `src/skill-installation.ts`. Installation
+For the installed TypeScript reference, provider names and ordering belong to
+`src/skill-installation.ts`. Installation
 and completion consume that inventory; provider detection and legacy-backup
 policy remain in their existing adapters. Test derivation with an altered
 inventory, not only matching copies of the current provider names.
@@ -509,6 +511,21 @@ loader or live discovery evidence separately from TMT's filesystem tests.
 Use provider-native locations when the supported installed baseline does not
 discover newer shared paths; never add a second content source or silently edit
 provider configuration to make a smoke test pass.
+
+The Rust preview uses `tmt-core::skill_provider::Provider` for the native name/order
+inventory and `tmt-adapters::skill_installation` for provider locations, embedded
+assets, path guards, lock, bounded installation intents, publication and local
+drift inspection. It never calls the TypeScript installer. `test/native/installation.test.ts`
+runs a moved binary with task-owned PATH, exact canonical bytes, isolated state,
+every provider/custom target, concurrent init, conflicts and recoverable backups.
+Adapter tests exercise refresh, source modification, alias overlap, lock release,
+and real partial effects around an injected link-publication failure. Inspect
+backup bytes and registry JSON independently rather than matching log strings.
+Only interactive non-JSON human commands inspect known provider paths for drift;
+machine/setup invocations skip the inspection. No custom registry or executable
+PATH scan belongs on ordinary commands. Run the full native process suite and
+two Docker lifecycle passes when changing publication/cleanup. These tests do
+not establish remote release availability or native binary update acceptance.
 
 ## Packed native-install verification
 

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -12,6 +12,9 @@ installed short-receipt instruction transition remains pending.
 acceptance. #125 adds shared current-server target resolution and public
 diagnostic check/read. #127 adds native role/preamble and shared bounded profile
 text/file acquisition. #129 adds public talk composition and bounded observation.
+#131 adds identity-scoped X attention; #133 adds exclusive local initialization,
+embedded guidance and managed provider/custom skill installation. Native network
+installation/self-update and runtime cutover remain separate delivery gates.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
 The compatibility reference is TypeScript main `cb53533f3a9f19a1a2ab95af59dda20df419200b`
@@ -72,8 +75,8 @@ The preview implements help, version, Bash/Zsh completion and the existing
 `config` command plus storage-only `identity create/show/list` (#113) and pane
 identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109), plus storage-only
 `reply`/`result` (#122), diagnostic `check`/`read` (#125), role/preamble (#127), and
-durable `talk` (#129), and identity-scoped `x list/show/ack/ackall` (#131).
-Other recognized effectful commands return
+durable `talk` (#129), identity-scoped `x list/show/ack/ackall` (#131), and
+`init`/`learn`/`install` (#133). Native network `upgrade` returns
 `NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
 storage, tmux or input acquisition. Text-only commands reject JSON. Native
 `name`/`this`/`add` create temporary bindings unless `-s`/`--save` promotes or

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "nix",
  "rusqlite",
  "serde_json",
+ "sha2",
  "signal-hook",
  "subprocess",
  "tmt-core",

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -12,6 +12,7 @@ rusqlite.workspace = true
 serde_json.workspace = true
 base64.workspace = true
 uuid = { workspace = true, features = ["v4"] }
+sha2.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 subprocess.workspace = true

--- a/rust/crates/tmt-adapters/src/config/initialization_tests.rs
+++ b/rust/crates/tmt-adapters/src/config/initialization_tests.rs
@@ -1,0 +1,134 @@
+use super::{ConfigFiles, ConfigPaths};
+use crate::test_support::TestDirectory;
+use std::{
+    fs,
+    path::Path,
+    sync::{Arc, Barrier},
+};
+
+fn files(directory: &Path) -> ConfigFiles {
+    ConfigFiles {
+        paths: ConfigPaths::resolve(directory, directory, Some(&directory.join("global")), None),
+    }
+}
+
+#[test]
+fn initialize_local_writes_exact_bytes_without_other_state() {
+    let directory = TestDirectory::new();
+    let config = files(&directory.path);
+
+    config.initialize_local().unwrap();
+
+    assert_eq!(fs::read(&config.paths.local_config).unwrap(), b"{}\n");
+    assert!(!config.paths.global_config.exists());
+    assert!(!config.paths.database.exists());
+    let entries = fs::read_dir(&directory.path)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect::<Vec<_>>();
+    assert_eq!(entries, vec![config.paths.local_config.clone()]);
+}
+
+#[test]
+fn initialize_local_refuses_existing_file_and_directory_without_mutation() {
+    let directory = TestDirectory::new();
+    let config = files(&directory.path);
+    let path = &config.paths.local_config;
+
+    fs::write(path, b"{malformed\n").unwrap();
+    let error = config.initialize_local().unwrap_err();
+    assert_eq!(error.code, "ERROR");
+    assert!(error.message.contains(&path.display().to_string()));
+    assert_eq!(fs::read(path).unwrap(), b"{malformed\n");
+
+    fs::remove_file(path).unwrap();
+    fs::create_dir(path).unwrap();
+    let error = config.initialize_local().unwrap_err();
+    assert_eq!(error.code, "ERROR");
+    assert!(path.is_dir());
+}
+
+#[cfg(unix)]
+#[test]
+fn initialize_local_refuses_existing_symlink_without_mutation() {
+    use std::os::unix::fs::symlink;
+
+    let directory = TestDirectory::new();
+    let config = files(&directory.path);
+    let path = &config.paths.local_config;
+    let destination = directory.path.join("existing-settings.json");
+    fs::write(&destination, b"user-owned\n").unwrap();
+    symlink(&destination, path).unwrap();
+
+    let error = config.initialize_local().unwrap_err();
+    assert_eq!(error.code, "ERROR");
+    assert_eq!(fs::read(path).unwrap(), b"user-owned\n");
+    assert_eq!(fs::read_link(path).unwrap(), destination);
+    assert_eq!(fs::read(&destination).unwrap(), b"user-owned\n");
+}
+
+#[test]
+fn concurrent_initialization_has_one_winner_and_no_partial_state() {
+    let directory = TestDirectory::new();
+    let config = Arc::new(files(&directory.path));
+    let barrier = Arc::new(Barrier::new(8));
+
+    let results = std::thread::scope(|scope| {
+        let handles = (0..8)
+            .map(|_| {
+                let config = Arc::clone(&config);
+                let barrier = Arc::clone(&barrier);
+                scope.spawn(move || {
+                    barrier.wait();
+                    config.initialize_local()
+                })
+            })
+            .collect::<Vec<_>>();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("initialization worker must not panic"))
+            .collect::<Vec<_>>()
+    });
+
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(results.iter().filter(|result| result.is_err()).count(), 7);
+    for result in &results {
+        if let Err(error) = result {
+            assert_eq!(error.code, "ERROR");
+        }
+    }
+    assert_eq!(fs::read(&config.paths.local_config).unwrap(), b"{}\n");
+    assert!(!config.paths.global_config.exists());
+    assert!(!config.paths.database.exists());
+}
+
+#[test]
+fn failure_cleanup_removes_only_the_owned_partial_file_and_preserves_replacements() {
+    let directory = TestDirectory::new();
+    let path = directory.path.join("tmux-team.json");
+    let owned = fs::File::create_new(&path).unwrap();
+    let error = super::finish_initialization_failure(
+        &path,
+        &owned,
+        std::io::Error::other("injected write failure"),
+    );
+    assert!(error.message.contains("injected write failure"));
+    assert!(!path.exists());
+    drop(owned);
+
+    let owned = fs::File::create_new(&path).unwrap();
+    let detached = directory.path.join("owned-partial");
+    fs::rename(&path, &detached).unwrap();
+    fs::write(&path, b"replacement owned by another writer").unwrap();
+    let error = super::finish_initialization_failure(
+        &path,
+        &owned,
+        std::io::Error::other("injected sync failure"),
+    );
+    assert!(error.message.contains("injected sync failure"));
+    assert_eq!(
+        fs::read(&path).unwrap(),
+        b"replacement owned by another writer"
+    );
+    assert!(detached.exists());
+}

--- a/rust/crates/tmt-adapters/src/config/mod.rs
+++ b/rust/crates/tmt-adapters/src/config/mod.rs
@@ -4,7 +4,11 @@
 mod document;
 mod paths;
 
+#[cfg(test)]
+mod initialization_tests;
+
 pub use paths::ConfigPaths;
+pub(crate) use paths::normalize;
 use std::{fmt, path::Path};
 pub use tmt_core::settings::Scope;
 use tmt_core::settings::{LocalClear, ResolvedSettings, Setting};
@@ -39,6 +43,23 @@ impl ConfigError {
             message: format!("Invalid JSON in {}: {cause}", path.display()),
         }
     }
+
+    fn initialization(path: &Path, cause: impl fmt::Display) -> Self {
+        Self {
+            code: "ERROR",
+            message: format!("Could not initialize {}: {cause}", path.display()),
+        }
+    }
+
+    fn already_initialized(path: &Path) -> Self {
+        Self {
+            code: "ERROR",
+            message: format!(
+                "{} already exists. Remove it first if you want to reinitialize.",
+                path.display()
+            ),
+        }
+    }
 }
 
 impl fmt::Display for ConfigError {
@@ -54,6 +75,12 @@ pub struct ConfigFiles {
 }
 
 impl ConfigFiles {
+    /// Create the workspace-local settings file without reading or initializing
+    /// any other configuration or storage state.
+    pub fn initialize_local(&self) -> Result<(), ConfigError> {
+        initialize_local_file(&self.paths.local_config)
+    }
+
     pub fn load(&self) -> Result<ResolvedSettings, ConfigError> {
         let read_layer = |scope| {
             let path = self.path(scope);
@@ -88,4 +115,63 @@ impl ConfigFiles {
             Scope::Local => &self.paths.local_config,
         }
     }
+}
+
+fn initialize_local_file(path: &Path) -> Result<(), ConfigError> {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    let mut file = match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(ConfigError::already_initialized(path));
+        }
+        Err(error) => return Err(ConfigError::initialization(path, error)),
+    };
+
+    if let Err(error) = file.write_all(b"{}\n") {
+        return Err(finish_initialization_failure(path, &file, error));
+    }
+    if let Err(error) = file.sync_all() {
+        return Err(finish_initialization_failure(path, &file, error));
+    }
+    drop(file);
+    Ok(())
+}
+
+fn finish_initialization_failure(
+    path: &Path,
+    file: &std::fs::File,
+    error: std::io::Error,
+) -> ConfigError {
+    match remove_owned_partial_file(path, file) {
+        Ok(()) => ConfigError::initialization(path, error),
+        Err(cleanup) => ConfigError::initialization(
+            path,
+            format!("{error}; could not remove partial file: {cleanup}"),
+        ),
+    }
+}
+
+#[cfg(unix)]
+fn remove_owned_partial_file(path: &Path, file: &std::fs::File) -> std::io::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let owned = file.metadata()?;
+    let current = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if current.dev() == owned.dev() && current.ino() == owned.ino() {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn remove_owned_partial_file(_path: &Path, _file: &std::fs::File) -> std::io::Result<()> {
+    // Native installation targets are Unix. On other targets preserve the
+    // path rather than risk deleting a replacement that arrived concurrently.
+    Ok(())
 }

--- a/rust/crates/tmt-adapters/src/config/paths.rs
+++ b/rust/crates/tmt-adapters/src/config/paths.rs
@@ -69,7 +69,7 @@ impl ConfigPaths {
 
 /// Lexical normalization matches path.join without requiring the destination
 /// (or a discarded parent component) to exist. Do not canonicalize symlinks.
-fn normalize(path: &Path) -> PathBuf {
+pub(crate) fn normalize(path: &Path) -> PathBuf {
     let mut result = PathBuf::new();
     for component in path.components() {
         match component {

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -12,6 +12,8 @@ pub mod reply_receipt;
 pub mod request_runtime;
 #[cfg(unix)]
 pub mod response_input;
+#[cfg(unix)]
+pub mod skill_installation;
 pub mod storage;
 #[cfg(unix)]
 pub mod tmux;

--- a/rust/crates/tmt-adapters/src/skill_installation/assets.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/assets.rs
@@ -1,0 +1,130 @@
+//! One embedded authored source, materialized without a checkout dependency.
+
+use crate::bounded_file;
+use sha2::{Digest, Sha256};
+use std::{
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+use uuid::Uuid;
+
+pub(super) const SKILL: &[u8] = include_bytes!("../../../../../skills/tmux-team/SKILL.md");
+
+fn digest(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn invalid(path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "Managed skill source has been modified or is invalid: {}",
+            path.display()
+        ),
+    )
+}
+
+/// Exact source inventory matters: an unexpected provider-readable file is not
+/// made trusted merely because SKILL.md still matches its original digest.
+fn source_bytes(source: &Path) -> io::Result<Vec<u8>> {
+    let parent = source.parent().ok_or_else(|| invalid(source))?;
+    if !fs::symlink_metadata(parent)?.is_dir() || !fs::symlink_metadata(source)?.is_dir() {
+        return Err(invalid(source));
+    }
+    let mut entries = fs::read_dir(source)?;
+    let entry = entries.next().ok_or_else(|| invalid(source))??;
+    if entry.file_name() != "SKILL.md" || !entry.file_type()?.is_file() || entries.next().is_some()
+    {
+        return Err(invalid(source));
+    }
+    bounded_file::read(&entry.path(), 1_048_576)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+pub(super) struct SkillAssets {
+    root: PathBuf,
+}
+
+impl SkillAssets {
+    pub(super) fn root(&self) -> &Path {
+        &self.root
+    }
+    pub(super) fn new(global: &Path) -> Self {
+        Self {
+            root: global.join("skill-assets"),
+        }
+    }
+
+    pub(super) fn source(&self) -> PathBuf {
+        self.root.join(digest(SKILL)).join("tmux-team")
+    }
+
+    /// This is local managed-file evidence, not authentication of remote code.
+    pub(super) fn owns(&self, source: &Path) -> bool {
+        let Some(version) = source.parent() else {
+            return false;
+        };
+        if version.parent() != Some(self.root.as_path())
+            || source.file_name().is_none_or(|name| name != "tmux-team")
+        {
+            return false;
+        }
+        let Some(expected) = version.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+        expected.len() == 64
+            && expected.bytes().all(|byte| byte.is_ascii_hexdigit())
+            && source_bytes(source).is_ok_and(|bytes| digest(&bytes) == expected)
+    }
+
+    /// Called while the installer lock is held. Existing sources are never
+    /// overwritten, even with force; that flag authorizes target backups only.
+    pub(super) fn materialize(&self) -> io::Result<PathBuf> {
+        let destination = self.source();
+        if fs::symlink_metadata(&destination).is_ok() {
+            if source_bytes(&destination)? != SKILL {
+                return Err(invalid(&destination));
+            }
+            return Ok(destination);
+        }
+        fs::create_dir_all(&self.root)?;
+        let stage = self.root.join(format!(".stage-{}", Uuid::new_v4()));
+        fs::create_dir(&stage)?;
+        let pending = (|| {
+            let directory = stage.join("tmux-team");
+            fs::create_dir(&directory)?;
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(directory.join("SKILL.md"))?;
+            file.write_all(SKILL)?;
+            file.sync_all()?;
+            drop(file);
+            let parent = destination.parent().expect("digest source directory");
+            // An invalid digest directory is not disposable user data.
+            if fs::symlink_metadata(parent).is_ok() {
+                return Err(invalid(parent));
+            }
+            fs::rename(&stage, parent)?;
+            Ok(destination)
+        })();
+        if stage.exists()
+            && let Err(cleanup) = fs::remove_dir_all(&stage)
+        {
+            return Err(io::Error::other(format!(
+                "{}; could not remove owned staging directory {}: {cleanup}",
+                pending
+                    .as_ref()
+                    .err()
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| "Skill publication failed".into()),
+                stage.display()
+            )));
+        }
+        pending
+    }
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/assets_tests.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/assets_tests.rs
@@ -1,0 +1,83 @@
+use super::assets::{SKILL, SkillAssets};
+use crate::test_support::TestDirectory;
+use std::fs;
+
+#[test]
+fn materialized_source_is_exact_and_repeated_install_preserves_it() {
+    let root = TestDirectory::new();
+    let assets = SkillAssets::new(&root.path);
+    let source = assets.materialize().unwrap();
+    assert_eq!(fs::read(source.join("SKILL.md")).unwrap(), SKILL);
+    assert!(assets.owns(&source));
+    assert_eq!(assets.materialize().unwrap(), source);
+    assert_eq!(
+        fs::read_dir(root.path.join("skill-assets"))
+            .unwrap()
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn modified_or_extended_source_is_neither_overwritten_nor_trusted() {
+    for extra in [false, true] {
+        let root = TestDirectory::new();
+        let assets = SkillAssets::new(&root.path);
+        let source = assets.materialize().unwrap();
+        let changed = source.join(if extra { "unexpected.md" } else { "SKILL.md" });
+        fs::write(&changed, b"user-owned content").unwrap();
+        assert!(!assets.owns(&source));
+        assert!(assets.materialize().is_err());
+        assert_eq!(fs::read(changed).unwrap(), b"user-owned content");
+        assert_eq!(
+            fs::read_dir(root.path.join("skill-assets"))
+                .unwrap()
+                .count(),
+            1
+        );
+    }
+}
+
+#[test]
+fn occupied_digest_path_is_preserved_and_failed_staging_is_removed() {
+    let root = TestDirectory::new();
+    let assets = SkillAssets::new(&root.path);
+    let occupied = assets.source().parent().unwrap().to_path_buf();
+    fs::create_dir_all(occupied.parent().unwrap()).unwrap();
+    fs::write(&occupied, b"unrelated file").unwrap();
+    assert!(assets.materialize().is_err());
+    assert_eq!(fs::read(&occupied).unwrap(), b"unrelated file");
+    assert_eq!(fs::read_dir(occupied.parent().unwrap()).unwrap().count(), 1);
+}
+
+#[test]
+fn external_source_and_symlinked_skill_file_never_establish_managed_ownership() {
+    use std::os::unix::fs::symlink;
+    let root = TestDirectory::new();
+    let assets = SkillAssets::new(&root.path);
+    let source = assets.materialize().unwrap();
+    let external = root.path.join("outside");
+    fs::create_dir(&external).unwrap();
+    fs::write(external.join("SKILL.md"), SKILL).unwrap();
+    assert!(!assets.owns(&external));
+    fs::remove_file(source.join("SKILL.md")).unwrap();
+    symlink(external.join("SKILL.md"), source.join("SKILL.md")).unwrap();
+    assert!(!assets.owns(&source));
+    assert!(assets.materialize().is_err());
+    assert_eq!(fs::read(external.join("SKILL.md")).unwrap(), SKILL);
+}
+
+#[test]
+fn symlinked_digest_directory_is_not_a_managed_source() {
+    let root = TestDirectory::new();
+    let assets = SkillAssets::new(&root.path);
+    let source = assets.materialize().unwrap();
+    let version = source.parent().unwrap();
+    let outside = root.path.join("external-version");
+    fs::rename(version, &outside).unwrap();
+    std::os::unix::fs::symlink(&outside, version).unwrap();
+    assert!(!assets.owns(&source));
+    assert!(assets.materialize().is_err());
+    assert_eq!(fs::read(outside.join("tmux-team/SKILL.md")).unwrap(), SKILL);
+    assert_eq!(fs::read_link(version).unwrap(), outside);
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/drift.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/drift.rs
@@ -1,0 +1,80 @@
+//! Read-only, fixed-provider inspection. Never scan custom installation intents
+//! or executable search paths on ordinary commands.
+
+use super::{ProviderEnvironment, assets::SkillAssets, files, managed_link};
+use std::{
+    collections::BTreeSet,
+    io,
+    path::{Path, PathBuf},
+};
+use tmt_core::skill_provider::Provider;
+
+pub fn inspect_local_drift(env: &ProviderEnvironment, global: &Path) -> io::Result<Vec<PathBuf>> {
+    let assets = SkillAssets::new(&files::resolved(global)?);
+    let current = assets.source();
+    let mut seen = BTreeSet::new();
+    let mut drift = Vec::new();
+    for provider in Provider::ALL {
+        let target = env.target(provider);
+        for (path, legacy) in std::iter::once((target, false)).chain(
+            env.legacy_targets(provider)
+                .into_iter()
+                .map(|path| (path, true)),
+        ) {
+            if !seen.insert(path.clone()) || !files::exists(&path)? {
+                continue;
+            }
+            if legacy || managed_link(&path, &assets)?.as_ref() != Some(&current) {
+                drift.push(path);
+            }
+        }
+    }
+    Ok(drift)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{skill_installation::install, test_support::TestDirectory};
+    use std::fs;
+
+    #[test]
+    fn missing_and_current_targets_are_quiet_while_legacy_and_modified_links_are_reported_once() {
+        let root = TestDirectory::new();
+        let home = root.path.join("home");
+        fs::create_dir(&home).unwrap();
+        let global = root.path.join("global");
+        let env = ProviderEnvironment::from_parts(
+            home.clone(),
+            root.path.clone(),
+            Vec::new(),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(inspect_local_drift(&env, &global).unwrap().is_empty());
+        assert!(!global.exists());
+        install(&env, &global, Some("all"), None, false).unwrap();
+        assert!(inspect_local_drift(&env, &global).unwrap().is_empty());
+        // Deliberately corrupt intents: passive inspection must not read them.
+        fs::write(global.join("skill-installations.json"), b"invalid").unwrap();
+        let shared = home.join(".agents/skills/tmux-team");
+        fs::remove_file(&shared).unwrap();
+        std::os::unix::fs::symlink(home.join("missing"), &shared).unwrap();
+        let legacy = home.join(".claude/commands/team.md");
+        fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        fs::write(&legacy, b"legacy user content").unwrap();
+        assert_eq!(
+            inspect_local_drift(&env, &global).unwrap(),
+            vec![legacy.clone(), shared.clone()]
+        );
+        assert_eq!(fs::read(&legacy).unwrap(), b"legacy user content");
+        assert_eq!(fs::read_link(&shared).unwrap(), home.join("missing"));
+        assert_eq!(
+            fs::read(global.join("skill-installations.json")).unwrap(),
+            b"invalid"
+        );
+        assert!(!global.join("state.db").exists());
+    }
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/files.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/files.rs
@@ -1,0 +1,165 @@
+//! Installer-local file publication and path guards. No command execution.
+
+use crate::config::normalize;
+use nix::fcntl::{Flock, FlockArg, OFlag};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{self, Write},
+    os::unix::fs::OpenOptionsExt,
+    path::{Path, PathBuf},
+};
+use uuid::Uuid;
+
+pub(super) fn lock(global: &Path) -> io::Result<Flock<File>> {
+    fs::create_dir_all(global)?;
+    // Keep this entry stable: unlinking it would split concurrent lock domains.
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags((OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK).bits())
+        .open(global.join("skill-install.lock"))?;
+    if !file.metadata()?.is_file() {
+        return Err(io::Error::other(
+            "Skill installation lock is not a regular file.",
+        ));
+    }
+    Flock::lock(file, FlockArg::LockExclusiveNonblock).map_err(|(_, error)| {
+        io::Error::new(io::Error::from_raw_os_error(error as i32).kind(), format!("Cannot acquire the skill installation lock; another installer may be running: {error}"))
+    })
+}
+
+/// Resolve existing ancestors while retaining a nonexistent suffix. Lexical
+/// normalization alone cannot detect source overlap through symlink aliases.
+pub(super) fn resolved(path: &Path) -> io::Result<PathBuf> {
+    let absolute = normalize(&std::env::current_dir()?.join(path));
+    let mut ancestor = absolute.as_path();
+    let mut suffix = Vec::new();
+    loop {
+        match fs::canonicalize(ancestor) {
+            Ok(mut real) => {
+                for component in suffix.iter().rev() {
+                    real.push(component);
+                }
+                return Ok(real);
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                suffix.push(ancestor.file_name().ok_or(error)?);
+                ancestor = ancestor
+                    .parent()
+                    .ok_or_else(|| io::Error::other("Cannot resolve installation path."))?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+pub(super) fn safe_target(source_root: &Path, target: &Path) -> io::Result<()> {
+    // Publication replaces the leaf entry, not its symlink destination. Resolve
+    // its parent so a correct managed link remains a valid no-op destination.
+    let target_location = entry_location(target)?;
+    let source = resolved(source_root)?;
+    if source.starts_with(&target_location) || target_location.starts_with(&source) {
+        return Err(io::Error::other(format!(
+            "Skill target overlaps bundled source: {}",
+            target.display()
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn entry_location(target: &Path) -> io::Result<PathBuf> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| io::Error::other("Skill target has no parent."))?;
+    let leaf = target
+        .file_name()
+        .ok_or_else(|| io::Error::other("Skill target has no name."))?;
+    Ok(resolved(parent)?.join(leaf))
+}
+
+pub(super) fn exists(path: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+pub(super) fn backup(target: &Path) -> io::Result<PathBuf> {
+    let parent = target
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| io::Error::other("Skill backup location has no parent."))?;
+    let directory = parent.join(".tmt-skill-backups");
+    fs::create_dir_all(&directory)?;
+    let name = target
+        .file_name()
+        .ok_or_else(|| io::Error::other("Skill target has no name."))?;
+    let mut filename = name.to_os_string();
+    filename.push(format!(
+        ".backup-{}-{}",
+        crate::request_runtime::wall_time_ms(),
+        Uuid::new_v4()
+    ));
+    let destination = directory.join(filename);
+    if exists(&destination)? {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "Skill backup path is occupied.",
+        ));
+    }
+    fs::rename(target, &destination)?;
+    Ok(destination)
+}
+
+pub(super) fn atomic_write(destination: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = destination
+        .parent()
+        .ok_or_else(|| io::Error::other("Publication path has no parent."))?;
+    fs::create_dir_all(parent)?;
+    let stage = parent.join(format!(".tmt-install-{}", Uuid::new_v4()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&stage)?;
+    let pending = (|| {
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&stage, destination)
+    })();
+    finish_stage(&stage, pending)
+}
+
+pub(super) fn link(destination: &Path, source: &Path) -> io::Result<()> {
+    let parent = destination
+        .parent()
+        .ok_or_else(|| io::Error::other("Skill target has no parent."))?;
+    fs::create_dir_all(parent)?;
+    if !exists(destination)? {
+        return std::os::unix::fs::symlink(source, destination);
+    }
+    let stage = parent.join(format!(".tmt-install-{}", Uuid::new_v4()));
+    std::os::unix::fs::symlink(source, &stage)?;
+    let pending = fs::rename(&stage, destination);
+    finish_stage(&stage, pending)
+}
+
+fn finish_stage(stage: &Path, pending: io::Result<()>) -> io::Result<()> {
+    match fs::remove_file(stage) {
+        Ok(()) => pending,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => pending,
+        Err(error) => Err(io::Error::other(format!(
+            "{}; could not remove owned staging entry {}: {error}",
+            pending
+                .err()
+                .map(|error| error.to_string())
+                .unwrap_or_else(|| "Publication completed".into()),
+            stage.display()
+        ))),
+    }
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/files_tests.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/files_tests.rs
@@ -1,0 +1,93 @@
+use super::files;
+use crate::test_support::TestDirectory;
+use std::{fs, path::PathBuf};
+
+#[test]
+fn safe_target_rejects_exact_ancestor_descendant_and_symlink_aliases() {
+    let root = TestDirectory::new();
+    let source = root.path.join("source");
+    fs::create_dir_all(source.join("..nested")).unwrap();
+    fs::write(source.join("SKILL.md"), b"canonical").unwrap();
+
+    for target in [
+        source.clone(),
+        source.join("child/target"),
+        source.parent().unwrap().to_path_buf(),
+        source.join("..nested/target"),
+    ] {
+        let error = files::safe_target(&source, &target).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("Skill target overlaps bundled source: {}", target.display())
+        );
+    }
+
+    let alias = root.path.join("source-alias");
+    std::os::unix::fs::symlink(source.parent().unwrap(), &alias).unwrap();
+    let target = alias.join("source/target");
+    let error = files::safe_target(&source, &target).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        format!("Skill target overlaps bundled source: {}", target.display())
+    );
+}
+
+#[test]
+fn safe_target_allows_dot_dot_lookalike_sibling_and_unrelated_paths() {
+    let root = TestDirectory::new();
+    let source = root.path.join("source");
+    fs::create_dir_all(&source).unwrap();
+    let lookalike = root.path.join("source..nested/target");
+    let unrelated = root.path.join("other/target");
+    assert!(files::safe_target(&source, &lookalike).is_ok());
+    assert!(files::safe_target(&source, &unrelated).is_ok());
+}
+
+#[test]
+fn lock_is_exclusive_and_releases_after_guard_drop() {
+    let root = TestDirectory::new();
+    let first = files::lock(&root.path).unwrap();
+    let second = match files::lock(&root.path) {
+        Ok(_) => panic!("a second installer acquired the lock"),
+        Err(error) => error,
+    };
+    assert_eq!(second.kind(), std::io::ErrorKind::WouldBlock);
+    drop(first);
+    let third = files::lock(&root.path).unwrap();
+    drop(third);
+}
+
+#[test]
+fn backup_preserves_regular_directory_and_broken_symlink_entries() {
+    let root = TestDirectory::new();
+    let target = root.path.join("skills/tmux-team");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("user.md"), b"user").unwrap();
+    let backup = files::backup(&target).unwrap();
+    assert!(!target.exists());
+    assert_eq!(fs::read(backup.join("user.md")).unwrap(), b"user");
+    assert!(backup.starts_with(root.path.join(".tmt-skill-backups")));
+
+    let broken = root.path.join("skills/broken");
+    std::os::unix::fs::symlink(root.path.join("missing"), &broken).unwrap();
+    let broken_backup = files::backup(&broken).unwrap();
+    assert_eq!(
+        fs::read_link(broken_backup).unwrap(),
+        root.path.join("missing")
+    );
+}
+
+#[test]
+fn atomic_write_replaces_manifest_without_leaving_staging_files() {
+    let root = TestDirectory::new();
+    let destination = root.path.join("nested/manifest.json");
+    fs::create_dir_all(destination.parent().unwrap()).unwrap();
+    fs::write(&destination, br#"{"version":0}"#).unwrap();
+    files::atomic_write(&destination, br#"{"version":1}"#).unwrap();
+    assert_eq!(fs::read(&destination).unwrap(), br#"{"version":1}"#);
+    let entries = fs::read_dir(destination.parent().unwrap())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect::<Vec<_>>();
+    assert_eq!(entries, vec![PathBuf::from("manifest.json")]);
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/install_tests.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/install_tests.rs
@@ -1,0 +1,342 @@
+use super::{InstallFailure, ProviderEnvironment, bundled_skill, install};
+use crate::test_support::TestDirectory;
+use sha2::{Digest, Sha256};
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+use tmt_core::skill_provider::Provider;
+
+fn fixture() -> (TestDirectory, ProviderEnvironment, PathBuf, PathBuf) {
+    let directory = TestDirectory::new();
+    let home = directory.path.join("home");
+    let cwd = directory.path.join("cwd");
+    let global = directory.path.join("global");
+    fs::create_dir(&home).unwrap();
+    fs::create_dir(&cwd).unwrap();
+    let home_for_return = home.clone();
+    (
+        directory,
+        ProviderEnvironment::from_parts(home, cwd, Vec::new(), None, None, None, None),
+        global,
+        home_for_return,
+    )
+}
+
+fn assert_link(path: &Path) -> PathBuf {
+    assert!(fs::symlink_metadata(path).unwrap().is_symlink());
+    fs::read_link(path).unwrap()
+}
+
+fn assert_failure_preserves(failure: &InstallFailure, expected: &str) {
+    assert!(failure.to_string().contains(expected), "{failure}");
+    assert!(failure.report.installed.is_empty());
+    assert!(failure.pending_backup.is_none());
+}
+
+#[test]
+fn neutral_install_is_exact_repeat_noop_and_records_one_target() {
+    let (_directory, environment, global, home) = fixture();
+    let first = install(&environment, &global, None, None, false).unwrap();
+    assert_eq!(first.installed.len(), 1);
+    assert_eq!(first.installed[0].agent, None);
+    assert!(first.installed[0].changed);
+    let universal = home.join(".agents/skills/tmux-team");
+    let source = assert_link(&universal);
+    assert_eq!(fs::read(source.join("SKILL.md")).unwrap(), bundled_skill());
+
+    let registry = fs::read(global.join("skill-installations.json")).unwrap();
+    let second = install(&environment, &global, None, None, false).unwrap();
+    assert_eq!(second.installed.len(), 1);
+    assert!(!second.installed[0].changed);
+    assert_eq!(second.installed[0].backup, None);
+    assert_eq!(assert_link(&universal), source);
+    assert_eq!(
+        fs::read(global.join("skill-installations.json")).unwrap(),
+        registry
+    );
+    assert_eq!(fs::read(source.join("SKILL.md")).unwrap(), bundled_skill());
+}
+
+#[test]
+fn custom_install_uses_exact_target_and_does_not_invent_provider() {
+    let (directory, environment, global, _home) = fixture();
+    let custom_root = PathBuf::from("custom skills");
+    let report = install(&environment, &global, None, Some(&custom_root), false).unwrap();
+    assert_eq!(report.installed.len(), 1);
+    assert_eq!(report.installed[0].agent, None);
+    assert!(report.installed[0].changed);
+    let custom = directory.path.join("cwd/custom skills/tmux-team");
+    assert_eq!(report.installed[0].target, custom);
+    let source = assert_link(&custom);
+    assert_eq!(fs::read(source.join("SKILL.md")).unwrap(), bundled_skill());
+    assert_eq!(fs::read_dir(custom.parent().unwrap()).unwrap().count(), 1);
+}
+
+#[test]
+fn all_install_deduplicates_shared_targets_but_reports_stable_provider_order() {
+    let (_directory, environment, global, home) = fixture();
+    let report = install(&environment, &global, Some("all"), None, false).unwrap();
+    assert_eq!(
+        report
+            .installed
+            .iter()
+            .map(|item| item.agent.unwrap().as_str())
+            .collect::<Vec<_>>(),
+        vec!["claude", "codex", "gemini", "agy", "pi", "opencode"]
+    );
+    assert_eq!(
+        report.installed.iter().filter(|item| item.changed).count(),
+        4
+    );
+    for provider in Provider::ALL {
+        assert!(
+            fs::symlink_metadata(environment.target(provider))
+                .unwrap()
+                .is_symlink()
+        );
+    }
+    let registry: serde_json::Value =
+        serde_json::from_slice(&fs::read(global.join("skill-installations.json")).unwrap())
+            .unwrap();
+    assert_eq!(registry["version"], 1);
+    let actual = registry["targets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|value| PathBuf::from(value.as_str().unwrap()))
+        .collect::<BTreeSet<_>>();
+    assert_eq!(registry["targets"].as_array().unwrap().len(), 4);
+    let expected = [
+        home.join(".claude/skills/tmux-team"),
+        home.join(".agents/skills/tmux-team"),
+        home.join(".gemini/config/skills/tmux-team"),
+        home.join(".pi/agent/skills/tmux-team"),
+    ]
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn unmanaged_file_directory_broken_and_wrong_links_refuse_without_force() {
+    for kind in 0..4 {
+        let (_directory, environment, global, home) = fixture();
+        let target = home.join(".claude/skills/tmux-team");
+        fs::create_dir_all(target.parent().unwrap()).unwrap();
+        match kind {
+            0 => fs::write(&target, b"user file").unwrap(),
+            1 => {
+                fs::create_dir(&target).unwrap();
+                fs::write(target.join("user.md"), b"user directory").unwrap();
+            }
+            2 => std::os::unix::fs::symlink(home.join("missing"), &target).unwrap(),
+            _ => {
+                let wrong = home.join("wrong-skill");
+                fs::create_dir(&wrong).unwrap();
+                fs::write(wrong.join("SKILL.md"), b"wrong skill").unwrap();
+                std::os::unix::fs::symlink(&wrong, &target).unwrap();
+            }
+        }
+        let before = fs::read_dir(target.parent().unwrap())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        let failure = install(&environment, &global, Some("claude"), None, false).unwrap_err();
+        assert_failure_preserves(&failure, "Refusing to replace existing unmanaged path");
+        assert_eq!(
+            fs::read_dir(target.parent().unwrap())
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name())
+                .collect::<Vec<_>>(),
+            before
+        );
+        match kind {
+            0 => assert_eq!(fs::read(&target).unwrap(), b"user file"),
+            1 => assert_eq!(fs::read(target.join("user.md")).unwrap(), b"user directory"),
+            2 => assert_eq!(fs::read_link(&target).unwrap(), home.join("missing")),
+            _ => {
+                assert_eq!(fs::read_link(&target).unwrap(), home.join("wrong-skill"));
+                assert_eq!(
+                    fs::read(home.join("wrong-skill/SKILL.md")).unwrap(),
+                    b"wrong skill"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn force_preserves_unmanaged_directory_and_broken_link_outside_discovery() {
+    let (_directory, environment, global, home) = fixture();
+    let target = home.join(".claude/skills/tmux-team");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("user.md"), b"user-owned").unwrap();
+    let report = install(&environment, &global, Some("claude"), None, true).unwrap();
+    let backup = report.installed[0].backup.as_ref().unwrap();
+    assert_eq!(
+        backup.parent().unwrap(),
+        home.join(".claude/.tmt-skill-backups")
+    );
+    assert!(backup.strip_prefix(home.join(".claude/skills")).is_err());
+    assert_eq!(fs::read(backup.join("user.md")).unwrap(), b"user-owned");
+    assert_eq!(
+        fs::read(assert_link(&target).join("SKILL.md")).unwrap(),
+        bundled_skill()
+    );
+
+    fs::remove_file(&target).unwrap();
+    let missing = home.join("missing-skill");
+    std::os::unix::fs::symlink(&missing, &target).unwrap();
+    let broken_report = install(&environment, &global, Some("claude"), None, true).unwrap();
+    let broken_backup = broken_report.installed[0].backup.as_ref().unwrap();
+    assert!(fs::symlink_metadata(broken_backup).unwrap().is_symlink());
+    assert_eq!(fs::read_link(broken_backup).unwrap(), missing);
+
+    fs::remove_file(&target).unwrap();
+    fs::write(&target, b"user file").unwrap();
+    let file_report = install(&environment, &global, Some("claude"), None, true).unwrap();
+    let file_backup = file_report.installed[0].backup.as_ref().unwrap();
+    assert_eq!(fs::read(file_backup).unwrap(), b"user file");
+}
+
+#[test]
+fn claude_legacy_is_warned_then_force_backed_up_without_touching_content() {
+    let (_directory, environment, global, home) = fixture();
+    let legacy = home.join(".claude/commands/team.md");
+    fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+    fs::write(&legacy, b"legacy command").unwrap();
+    let warning = install(&environment, &global, Some("claude"), None, false).unwrap();
+    assert_eq!(fs::read(&legacy).unwrap(), b"legacy command");
+    assert_eq!(warning.warnings.len(), 1);
+    assert!(warning.warnings[0].contains("--force"));
+    let forced = install(&environment, &global, Some("claude"), None, true).unwrap();
+    let backup = forced.installed[0].legacy_backups.first().unwrap();
+    assert_eq!(fs::read(backup).unwrap(), b"legacy command");
+    assert!(backup.starts_with(home.join(".claude/.tmt-skill-backups")));
+    assert!(!backup.starts_with(home.join(".claude/commands")));
+    assert!(!legacy.exists());
+}
+
+#[test]
+fn overlap_guards_run_before_materialization_or_target_backup() {
+    let (_directory, environment, global, home) = fixture();
+    let source_root = global.join("skill-assets");
+    let target = home.join(".claude/skills/tmux-team");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("user.md"), b"preserve").unwrap();
+    let exact_root = source_root.clone();
+    let exact = PathBuf::from("../global/skill-assets");
+    let failure = install(&environment, &global, None, Some(&exact), true).unwrap_err();
+    assert_failure_preserves(&failure, "overlaps bundled source");
+    assert_eq!(fs::read(target.join("user.md")).unwrap(), b"preserve");
+    assert!(!exact_root.exists());
+}
+
+#[test]
+fn invalid_or_oversized_registry_is_preserved_and_prevents_materialization() {
+    for bytes in [
+        br#"{"version":2,"targets":[]}"#.to_vec(),
+        vec![b'{'; 1_048_577],
+    ] {
+        let (_directory, environment, global, home) = fixture();
+        fs::create_dir_all(&global).unwrap();
+        let manifest = global.join("skill-installations.json");
+        fs::write(&manifest, &bytes).unwrap();
+        let failure = install(&environment, &global, Some("claude"), None, true).unwrap_err();
+        assert_failure_preserves(&failure, "Invalid or oversized skill installation manifest");
+        assert_eq!(fs::read(&manifest).unwrap(), bytes);
+        assert!(global.join("skill-install.lock").exists());
+        assert!(!home.join(".claude/skills/tmux-team").exists());
+        assert!(!global.join("skill-assets").exists());
+    }
+}
+
+#[test]
+fn installer_error_releases_lock_for_a_following_success() {
+    let (_directory, environment, global, home) = fixture();
+    let target = home.join(".claude/skills/tmux-team");
+    fs::create_dir_all(target.parent().unwrap()).unwrap();
+    fs::write(&target, b"user-owned").unwrap();
+    let failure = install(&environment, &global, Some("claude"), None, false).unwrap_err();
+    assert_failure_preserves(&failure, "Refusing to replace existing unmanaged path");
+    fs::remove_file(&target).unwrap();
+    let success = install(&environment, &global, Some("claude"), None, false).unwrap();
+    assert!(success.installed[0].changed);
+    assert!(fs::symlink_metadata(&target).unwrap().is_symlink());
+}
+
+fn digest(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[test]
+fn valid_old_digest_source_refreshes_to_current_source_without_backup() {
+    let (_directory, environment, global, home) = fixture();
+    let old = b"old canonical skill\n";
+    let asset_root = super::files::resolved(&global)
+        .unwrap()
+        .join("skill-assets");
+    let old_source = asset_root.join(digest(old)).join("tmux-team");
+    fs::create_dir_all(&old_source).unwrap();
+    fs::write(old_source.join("SKILL.md"), old).unwrap();
+    let target = home.join(".claude/skills/tmux-team");
+    fs::create_dir_all(target.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&old_source, &target).unwrap();
+
+    let report = install(&environment, &global, Some("claude"), None, false).unwrap();
+    assert!(report.installed[0].changed);
+    assert_eq!(report.installed[0].backup, None);
+    let current = assert_link(&target);
+    assert_ne!(current, old_source);
+    assert_eq!(fs::read(current.join("SKILL.md")).unwrap(), bundled_skill());
+    assert_eq!(fs::read(old_source.join("SKILL.md")).unwrap(), old);
+}
+
+#[test]
+fn modified_old_digest_source_is_unmanaged_and_refuses_replacement() {
+    let (_directory, environment, global, home) = fixture();
+    let original = b"old canonical skill\n";
+    let modified = b"tampered old skill\n";
+    let old_source = super::files::resolved(&global)
+        .unwrap()
+        .join("skill-assets")
+        .join(digest(original))
+        .join("tmux-team");
+    fs::create_dir_all(&old_source).unwrap();
+    fs::write(old_source.join("SKILL.md"), modified).unwrap();
+    let target = home.join(".claude/skills/tmux-team");
+    fs::create_dir_all(target.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&old_source, &target).unwrap();
+
+    let failure = install(&environment, &global, Some("claude"), None, false).unwrap_err();
+    assert_failure_preserves(&failure, "Refusing to replace existing unmanaged path");
+    assert_eq!(fs::read_link(&target).unwrap(), old_source);
+    assert_eq!(fs::read(old_source.join("SKILL.md")).unwrap(), modified);
+    let forced = install(&environment, &global, Some("claude"), None, true).unwrap();
+    let backup = forced.installed[0].backup.as_ref().unwrap();
+    assert_eq!(fs::read_link(backup).unwrap(), old_source);
+    assert_eq!(fs::read(old_source.join("SKILL.md")).unwrap(), modified);
+    assert_eq!(fs::read(target.join("SKILL.md")).unwrap(), bundled_skill());
+}
+
+#[test]
+fn modified_current_asset_blocks_force_before_target_backup() {
+    let (_directory, env, global, home) = fixture();
+    install(&env, &global, Some("claude"), None, false).unwrap();
+    let target = home.join(".claude/skills/tmux-team");
+    let source = assert_link(&target);
+    fs::write(source.join("SKILL.md"), b"user-edited current source").unwrap();
+    let failure = install(&env, &global, Some("claude"), None, true).unwrap_err();
+    assert_failure_preserves(&failure, "Managed skill source has been modified");
+    assert_eq!(assert_link(&target), source);
+    assert_eq!(
+        fs::read(source.join("SKILL.md")).unwrap(),
+        b"user-edited current source"
+    );
+    assert!(!home.join(".claude/.tmt-skill-backups").exists());
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/mod.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/mod.rs
@@ -1,0 +1,226 @@
+//! Managed local agent guidance; independent of identities, SQLite and tmux.
+
+mod assets;
+mod drift;
+mod files;
+mod providers;
+mod registry;
+pub use drift::inspect_local_drift;
+pub use providers::ProviderEnvironment;
+#[cfg(test)]
+mod assets_tests;
+#[cfg(test)]
+mod files_tests;
+#[cfg(test)]
+mod install_tests;
+#[cfg(test)]
+mod publication_tests;
+
+pub fn bundled_skill() -> &'static [u8] {
+    assets::SKILL
+}
+
+use std::{
+    error::Error,
+    fmt, fs, io,
+    path::{Path, PathBuf},
+};
+use tmt_core::skill_provider::Provider;
+
+#[derive(Debug)]
+pub struct InstalledSkill {
+    pub agent: Option<Provider>,
+    pub target: PathBuf,
+    pub changed: bool,
+    pub backup: Option<PathBuf>,
+    pub legacy_backups: Vec<PathBuf>,
+}
+
+#[derive(Debug, Default)]
+pub struct InstallReport {
+    pub installed: Vec<InstalledSkill>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct InstallFailure {
+    cause: io::Error,
+    pub report: InstallReport,
+    pub pending_backup: Option<PathBuf>,
+}
+
+impl fmt::Display for InstallFailure {
+    fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(output, "Skill installation failed: {}", self.cause)?;
+        for item in &self.report.installed {
+            write!(output, "; installed target: {}", item.target.display())?;
+            for backup in item.backup.iter().chain(&item.legacy_backups) {
+                write!(output, "; recoverable backup: {}", backup.display())?;
+            }
+        }
+        if let Some(backup) = &self.pending_backup {
+            write!(
+                output,
+                "; failed target's recoverable backup: {}",
+                backup.display()
+            )?;
+        }
+        Ok(())
+    }
+}
+impl Error for InstallFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.cause)
+    }
+}
+
+fn selected(
+    env: &ProviderEnvironment,
+    provider: Option<&str>,
+    directory: Option<&Path>,
+) -> io::Result<Vec<(Option<Provider>, PathBuf)>> {
+    if let Some(directory) = directory {
+        if provider.is_some() || directory.as_os_str().is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Use a non-empty --dir without a provider or all.",
+            ));
+        }
+        return Ok(vec![(None, env.custom_target(directory))]);
+    }
+    let providers = match provider {
+        None => env.detect(),
+        Some(value) if value.eq_ignore_ascii_case("all") => Provider::ALL.to_vec(),
+        Some(value) => vec![Provider::parse(value).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Unknown agent: {value}"),
+            )
+        })?],
+    };
+    if providers.is_empty() {
+        return Ok(vec![(None, env.universal_target())]);
+    }
+    Ok(providers
+        .into_iter()
+        .map(|provider| (Some(provider), env.target(provider)))
+        .collect())
+}
+
+fn managed_link(target: &Path, assets: &assets::SkillAssets) -> io::Result<Option<PathBuf>> {
+    if !files::exists(target)? || !fs::symlink_metadata(target)?.is_symlink() {
+        return Ok(None);
+    }
+    let source = crate::config::normalize(
+        &target
+            .parent()
+            .expect("selected target parent")
+            .join(fs::read_link(target)?),
+    );
+    Ok(assets.owns(&source).then_some(source))
+}
+
+/// Materialize and publish only requested integrations. The lock covers all
+/// cooperating native installers; this is not a hostile-filesystem sandbox.
+pub fn install(
+    env: &ProviderEnvironment,
+    global: &Path,
+    provider: Option<&str>,
+    directory: Option<&Path>,
+    force: bool,
+) -> Result<InstallReport, InstallFailure> {
+    install_with_publisher(env, global, provider, directory, force, files::link)
+}
+
+// Keep publication at the existing file boundary so failure tests exercise the
+// real selection, backup, registry, report, and lock lifecycle around it.
+fn install_with_publisher(
+    env: &ProviderEnvironment,
+    global: &Path,
+    provider: Option<&str>,
+    directory: Option<&Path>,
+    force: bool,
+    mut publish: impl FnMut(&Path, &Path) -> io::Result<()>,
+) -> Result<InstallReport, InstallFailure> {
+    let mut report = InstallReport::default();
+    let mut pending_backup = None;
+    let pending = (|| {
+        let targets = selected(env, provider, directory)?;
+        let global = files::resolved(global)?;
+        let assets = assets::SkillAssets::new(&global);
+        // These guards precede even lock/cache creation or forced backups.
+        for (_, target) in &targets {
+            files::safe_target(assets.root(), target)?;
+        }
+        let lock = files::lock(&global)?;
+        let operation = (|| {
+            registry::read(&global)?;
+            let source = assets.materialize()?;
+            registry::remember(&global, targets.iter().map(|(_, target)| target.clone()))?;
+            for (agent, target) in targets {
+                let prior = managed_link(&target, &assets)?;
+                let changed = prior.as_ref() != Some(&source);
+                if changed {
+                    if prior.is_none() && files::exists(&target)? {
+                        if !force {
+                            return Err(io::Error::other(format!(
+                                "Refusing to replace existing unmanaged path: {} (use --force)",
+                                target.display()
+                            )));
+                        }
+                        pending_backup = Some(files::backup(&target)?);
+                    }
+                    publish(&target, &source)?;
+                }
+                report.installed.push(InstalledSkill {
+                    agent,
+                    target: target.clone(),
+                    changed,
+                    backup: pending_backup.take(),
+                    legacy_backups: Vec::new(),
+                });
+                if let Some(agent) = agent {
+                    for legacy in env.legacy_targets(agent) {
+                        if !files::exists(&legacy)?
+                            || files::entry_location(&legacy)? == files::entry_location(&target)?
+                        {
+                            continue;
+                        }
+                        if force {
+                            files::safe_target(assets.root(), &legacy)?;
+                            let backup = files::backup(&legacy)?;
+                            report
+                                .installed
+                                .last_mut()
+                                .expect("published skill")
+                                .legacy_backups
+                                .push(backup);
+                        } else {
+                            report.warnings.push(format!("Legacy {} guidance found at {}; keeping it. Inspect before running tmt install {} --force.", agent.as_str(), legacy.display(), agent.as_str()));
+                        }
+                    }
+                }
+            }
+            Ok(())
+        })();
+        let released = lock.unlock().map_err(|(guard, error)| {
+            drop(guard);
+            io::Error::other(format!(
+                "Could not release skill installation lock: {error}"
+            ))
+        });
+        match (operation, released) {
+            (Err(primary), Err(cleanup)) => Err(io::Error::other(format!("{primary}; {cleanup}"))),
+            (Err(error), _) | (_, Err(error)) => Err(error),
+            _ => Ok(()),
+        }
+    })();
+    match pending {
+        Ok(()) => Ok(report),
+        Err(cause) => Err(InstallFailure {
+            cause,
+            report,
+            pending_backup,
+        }),
+    }
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/providers.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/providers.rs
@@ -1,0 +1,403 @@
+//! Provider-specific skill locations and environment detection.
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+use tmt_core::skill_provider::Provider;
+
+#[derive(Debug, Clone)]
+pub struct ProviderEnvironment {
+    home: PathBuf,
+    cwd: PathBuf,
+    path: Vec<PathBuf>,
+    codex_home: Option<PathBuf>,
+    pi_coding_agent_dir: Option<PathBuf>,
+    opencode_config_dir: Option<PathBuf>,
+    xdg_config_home: Option<PathBuf>,
+}
+
+impl ProviderEnvironment {
+    /// Capture process state once at the invocation boundary.
+    pub fn capture() -> std::io::Result<Self> {
+        Ok(Self::from_parts(
+            env::home_dir().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "Cannot determine the home directory",
+                )
+            })?,
+            env::current_dir()?,
+            env::var_os("PATH")
+                .map(|value| env::split_paths(&value).collect())
+                .unwrap_or_default(),
+            non_empty_env_path("CODEX_HOME"),
+            non_empty_env_path("PI_CODING_AGENT_DIR"),
+            non_empty_env_path("OPENCODE_CONFIG_DIR"),
+            non_empty_env_path("XDG_CONFIG_HOME"),
+        ))
+    }
+
+    pub fn from_parts(
+        home: impl Into<PathBuf>,
+        cwd: impl Into<PathBuf>,
+        path: Vec<PathBuf>,
+        codex_home: Option<PathBuf>,
+        pi_coding_agent_dir: Option<PathBuf>,
+        opencode_config_dir: Option<PathBuf>,
+        xdg_config_home: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            home: home.into(),
+            cwd: cwd.into(),
+            path,
+            codex_home: non_empty_path(codex_home),
+            pi_coding_agent_dir: non_empty_path(pi_coding_agent_dir),
+            opencode_config_dir: non_empty_path(opencode_config_dir),
+            xdg_config_home: non_empty_path(xdg_config_home),
+        }
+    }
+
+    pub fn detect(&self) -> Vec<Provider> {
+        Provider::ALL
+            .into_iter()
+            .filter(|provider| self.detected(*provider))
+            .collect()
+    }
+
+    pub fn target(&self, provider: Provider) -> PathBuf {
+        let universal = self.universal_target();
+        match provider {
+            Provider::Claude => self.home.join(".claude/skills/tmux-team"),
+            Provider::Codex | Provider::Gemini | Provider::Opencode => universal,
+            Provider::Agy => self.home.join(".gemini/config/skills/tmux-team"),
+            Provider::Pi => self.pi_coding_agent_directory().join("skills/tmux-team"),
+        }
+    }
+
+    pub fn universal_target(&self) -> PathBuf {
+        self.home.join(".agents/skills/tmux-team")
+    }
+
+    pub fn custom_target(&self, root: impl AsRef<Path>) -> PathBuf {
+        self.resolve_path(root.as_ref()).join("tmux-team")
+    }
+
+    pub fn legacy_targets(&self, provider: Provider) -> Vec<PathBuf> {
+        match provider {
+            Provider::Claude => vec![self.home.join(".claude/commands/team.md")],
+            Provider::Codex => {
+                let active = self.universal_target();
+                let candidates = [
+                    self.codex_home().join("skills/tmux-team"),
+                    self.home.join(".codex/skills/tmux-team"),
+                ];
+                let mut result = Vec::new();
+                for candidate in candidates {
+                    let candidate = self.resolve_path(&candidate);
+                    if candidate == active || result.iter().any(|path| path == &candidate) {
+                        continue;
+                    }
+                    result.push(candidate);
+                }
+                result
+            }
+            Provider::Gemini | Provider::Agy | Provider::Pi | Provider::Opencode => Vec::new(),
+        }
+    }
+
+    fn detected(&self, provider: Provider) -> bool {
+        let directory_found = match provider {
+            Provider::Claude => self.exists(self.home.join(".claude")),
+            Provider::Codex => {
+                self.exists(self.home.join(".codex"))
+                    || (self.resolve_path(&self.codex_home()) != self.home.join(".agents")
+                        && self.exists(self.codex_home()))
+            }
+            Provider::Gemini => self.exists(self.home.join(".gemini")),
+            Provider::Agy => self.exists(self.agy_config_directory()),
+            Provider::Pi => self.exists(self.pi_coding_agent_directory()),
+            Provider::Opencode => self.exists(self.opencode_config_directory()),
+        };
+        directory_found || self.command_exists(provider.as_str())
+    }
+
+    fn command_exists(&self, command: &str) -> bool {
+        self.path.iter().any(|directory| {
+            fs::metadata(self.resolve_path(&directory.join(command)))
+                .map(|metadata| metadata.is_file())
+                .unwrap_or(false)
+        })
+    }
+
+    fn codex_home(&self) -> PathBuf {
+        self.codex_home
+            .clone()
+            .map(|path| self.resolve_path(&path))
+            .unwrap_or_else(|| self.home.join(".codex"))
+    }
+
+    fn agy_config_directory(&self) -> PathBuf {
+        self.home.join(".gemini/config")
+    }
+
+    fn pi_coding_agent_directory(&self) -> PathBuf {
+        let Some(configured) = self.pi_coding_agent_dir.as_deref() else {
+            return self.home.join(".pi/agent");
+        };
+        if configured == Path::new("~") {
+            return self.home.clone();
+        }
+        if let Ok(relative) = configured.strip_prefix("~/") {
+            return self.home.join(relative);
+        }
+        self.resolve_path(configured)
+    }
+
+    fn opencode_config_directory(&self) -> PathBuf {
+        if let Some(configured) = self.opencode_config_dir.as_deref() {
+            return self.resolve_path(configured);
+        }
+        self.xdg_config_home
+            .clone()
+            .map(|path| self.resolve_path(&path).join("opencode"))
+            .unwrap_or_else(|| self.home.join(".config/opencode"))
+    }
+
+    fn exists(&self, path: PathBuf) -> bool {
+        self.resolve_path(&path).exists()
+    }
+
+    fn resolve_path(&self, path: &Path) -> PathBuf {
+        crate::config::normalize(&self.cwd.join(path))
+    }
+}
+
+fn non_empty_env_path(name: &str) -> Option<PathBuf> {
+    non_empty_path(env::var_os(name).map(PathBuf::from))
+}
+
+fn non_empty_path(path: Option<PathBuf>) -> Option<PathBuf> {
+    path.filter(|path| !path.as_os_str().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestDirectory;
+
+    fn environment(directory: &TestDirectory) -> ProviderEnvironment {
+        let home = directory.path.join("home");
+        let cwd = directory.path.join("cwd");
+        fs::create_dir(&home).unwrap();
+        fs::create_dir(&cwd).unwrap();
+        ProviderEnvironment::from_parts(home, cwd, Vec::new(), None, None, None, None)
+    }
+
+    #[test]
+    fn target_paths_match_the_canonical_provider_locations() {
+        let directory = TestDirectory::new();
+        let environment = environment(&directory);
+        let home = directory.path.join("home");
+        let expected = [
+            (Provider::Claude, home.join(".claude/skills/tmux-team")),
+            (Provider::Codex, home.join(".agents/skills/tmux-team")),
+            (Provider::Gemini, home.join(".agents/skills/tmux-team")),
+            (Provider::Agy, home.join(".gemini/config/skills/tmux-team")),
+            (Provider::Pi, home.join(".pi/agent/skills/tmux-team")),
+            (Provider::Opencode, home.join(".agents/skills/tmux-team")),
+        ];
+        for (provider, target) in expected {
+            assert_eq!(environment.target(provider), target, "{provider:?}");
+        }
+        assert_eq!(
+            environment.universal_target(),
+            home.join(".agents/skills/tmux-team")
+        );
+        assert_eq!(
+            environment.custom_target("custom skills"),
+            directory.path.join("cwd/custom skills/tmux-team")
+        );
+    }
+
+    #[test]
+    fn pi_directory_expands_home_forms_and_relative_overrides_from_cwd() {
+        let directory = TestDirectory::new();
+        let base = environment(&directory);
+        let home = directory.path.join("home");
+        let cwd = directory.path.join("cwd");
+        for (configured, expected) in [
+            (PathBuf::from("~"), home.join("skills/tmux-team")),
+            (
+                PathBuf::from("~/custom-pi"),
+                home.join("custom-pi/skills/tmux-team"),
+            ),
+            (
+                PathBuf::from("relative-pi"),
+                cwd.join("relative-pi/skills/tmux-team"),
+            ),
+        ] {
+            let environment = ProviderEnvironment::from_parts(
+                &home,
+                &cwd,
+                Vec::new(),
+                None,
+                Some(configured),
+                None,
+                None,
+            );
+            assert_eq!(environment.target(Provider::Pi), expected);
+        }
+        assert_eq!(
+            base.target(Provider::Pi),
+            home.join(".pi/agent/skills/tmux-team")
+        );
+    }
+
+    #[test]
+    fn legacy_targets_preserve_claude_and_codex_migration_candidates() {
+        let directory = TestDirectory::new();
+        let home = directory.path.join("home");
+        let cwd = directory.path.join("cwd");
+        fs::create_dir(&home).unwrap();
+        fs::create_dir(&cwd).unwrap();
+        let codex_home = home.join("custom-codex");
+        let environment = ProviderEnvironment::from_parts(
+            &home,
+            &cwd,
+            Vec::new(),
+            Some(codex_home.clone()),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(
+            environment.legacy_targets(Provider::Claude),
+            vec![home.join(".claude/commands/team.md")]
+        );
+        assert_eq!(
+            environment.legacy_targets(Provider::Codex),
+            vec![
+                codex_home.join("skills/tmux-team"),
+                home.join(".codex/skills/tmux-team"),
+            ]
+        );
+
+        let shared = ProviderEnvironment::from_parts(
+            &home,
+            &cwd,
+            Vec::new(),
+            Some(home.join(".agents")),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(
+            shared.legacy_targets(Provider::Codex),
+            vec![home.join(".codex/skills/tmux-team")]
+        );
+    }
+
+    #[test]
+    fn detection_is_ordered_and_shared_agents_state_is_neutral() {
+        let directory = TestDirectory::new();
+        let environment = environment(&directory);
+        let home = directory.path.join("home");
+        fs::create_dir(home.join(".agents")).unwrap();
+        assert!(environment.detect().is_empty());
+
+        fs::create_dir(home.join(".claude")).unwrap();
+        fs::create_dir(home.join(".codex")).unwrap();
+        fs::create_dir(home.join(".gemini")).unwrap();
+        fs::create_dir_all(home.join(".gemini/config")).unwrap();
+        fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        fs::create_dir_all(home.join(".config/opencode")).unwrap();
+        assert_eq!(
+            environment.detect(),
+            vec![
+                Provider::Claude,
+                Provider::Codex,
+                Provider::Gemini,
+                Provider::Agy,
+                Provider::Pi,
+                Provider::Opencode,
+            ]
+        );
+    }
+
+    #[test]
+    fn detection_supports_executables_and_provider_directory_overrides() {
+        let directory = TestDirectory::new();
+        let home = directory.path.join("home");
+        let cwd = directory.path.join("cwd");
+        let bin = directory.path.join("bin");
+        fs::create_dir(&home).unwrap();
+        fs::create_dir(&cwd).unwrap();
+        fs::create_dir(&bin).unwrap();
+        fs::write(bin.join("opencode"), b"regular executable marker").unwrap();
+        let executable =
+            ProviderEnvironment::from_parts(&home, &cwd, vec![bin.clone()], None, None, None, None);
+        assert_eq!(executable.detect(), vec![Provider::Opencode]);
+
+        let pi_root = directory.path.join("pi-override");
+        let pi = ProviderEnvironment::from_parts(
+            &home,
+            &cwd,
+            Vec::new(),
+            None,
+            Some(pi_root.clone()),
+            None,
+            None,
+        );
+        fs::create_dir(&pi_root).unwrap();
+        assert_eq!(pi.detect(), vec![Provider::Pi]);
+        assert_eq!(pi.target(Provider::Pi), pi_root.join("skills/tmux-team"));
+
+        let opencode_root = directory.path.join("opencode-override");
+        let opencode = ProviderEnvironment::from_parts(
+            &home,
+            &cwd,
+            Vec::new(),
+            None,
+            None,
+            Some(opencode_root.clone()),
+            None,
+        );
+        fs::create_dir(&opencode_root).unwrap();
+        assert_eq!(opencode.detect(), vec![Provider::Opencode]);
+
+        let xdg_root = directory.path.join("xdg");
+        fs::create_dir_all(xdg_root.join("opencode")).unwrap();
+        let xdg = ProviderEnvironment::from_parts(
+            &home,
+            &cwd,
+            Vec::new(),
+            None,
+            None,
+            None,
+            Some(xdg_root),
+        );
+        assert_eq!(xdg.detect(), vec![Provider::Opencode]);
+    }
+
+    #[test]
+    fn codex_home_under_shared_agents_does_not_create_codex_detection() {
+        let directory = TestDirectory::new();
+        let home = directory.path.join("home");
+        let cwd = directory.path.join("cwd");
+        fs::create_dir(&home).unwrap();
+        fs::create_dir(&cwd).unwrap();
+        let shared = home.join(".agents");
+        fs::create_dir(&shared).unwrap();
+        let environment = ProviderEnvironment::from_parts(
+            &home,
+            &cwd,
+            Vec::new(),
+            Some(shared),
+            None,
+            None,
+            None,
+        );
+        assert!(environment.detect().is_empty());
+    }
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/publication_tests.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/publication_tests.rs
@@ -1,0 +1,84 @@
+use super::{ProviderEnvironment, files, install, install_with_publisher};
+use crate::test_support::TestDirectory;
+use std::{fs, io};
+
+#[test]
+fn failed_publication_reports_prior_success_and_recoverable_backup_then_releases_lock() {
+    let root = TestDirectory::new();
+    let home = root.path.join("home");
+    let global = root.path.join("global");
+    fs::create_dir(&home).unwrap();
+    let env = ProviderEnvironment::from_parts(
+        home.clone(),
+        root.path.clone(),
+        Vec::new(),
+        None,
+        None,
+        None,
+        None,
+    );
+    let first = home.join(".claude/skills/tmux-team");
+    let second = home.join(".agents/skills/tmux-team");
+    fs::create_dir_all(&second).unwrap();
+    fs::write(second.join("user.md"), b"irreplaceable user content").unwrap();
+    let mut publications = 0;
+    let failure =
+        install_with_publisher(&env, &global, Some("all"), None, true, |target, source| {
+            publications += 1;
+            if target == second {
+                // The real backup has already happened. Fail only the file boundary.
+                assert!(!target.exists());
+                return Err(io::Error::other("injected publication failure"));
+            }
+            files::link(target, source)
+        })
+        .unwrap_err();
+    assert_eq!(publications, 2);
+    assert_eq!(failure.report.installed.len(), 1);
+    assert_eq!(failure.report.installed[0].target, first);
+    assert!(fs::symlink_metadata(&first).unwrap().is_symlink());
+    let backup = failure.pending_backup.as_ref().unwrap();
+    assert_eq!(
+        fs::read(backup.join("user.md")).unwrap(),
+        b"irreplaceable user content"
+    );
+    assert!(!second.exists());
+    let message = failure.to_string();
+    assert!(message.contains("injected publication failure"));
+    assert!(message.contains(first.to_str().unwrap()));
+    assert!(message.contains(backup.to_str().unwrap()));
+    // Intent remains discoverable, but failed targets are not reported installed.
+    assert!(super::registry::read(&global).unwrap().contains(&second));
+    let retry = install(&env, &global, Some("all"), None, false).unwrap();
+    assert!(!retry.installed[0].changed);
+    assert!(retry.installed[1].changed);
+    assert!(fs::symlink_metadata(&second).unwrap().is_symlink());
+    assert_eq!(
+        fs::read(backup.join("user.md")).unwrap(),
+        b"irreplaceable user content"
+    );
+}
+
+#[test]
+fn abandoned_stage_is_preserved_without_blocking_a_new_install() {
+    let root = TestDirectory::new();
+    let global = root.path.join("global");
+    let stage = global.join("skill-assets/.stage-abandoned");
+    fs::create_dir_all(&stage).unwrap();
+    fs::write(stage.join("partial"), b"preserve for inspection").unwrap();
+    let env = ProviderEnvironment::from_parts(
+        root.path.join("home"),
+        root.path.clone(),
+        Vec::new(),
+        None,
+        None,
+        None,
+        None,
+    );
+    let result = install(&env, &global, None, None, false).unwrap();
+    assert!(result.installed[0].changed);
+    assert_eq!(
+        fs::read(stage.join("partial")).unwrap(),
+        b"preserve for inspection"
+    );
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/registry.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/registry.rs
@@ -1,0 +1,150 @@
+//! Bounded installer intents for rediscovering custom managed targets.
+//! A recorded path never authorizes overwriting it; links must prove ownership.
+
+use super::files;
+use crate::bounded_file;
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeSet,
+    io,
+    path::{Path, PathBuf},
+};
+
+const MAXIMUM_BYTES: usize = 1_048_576;
+const MAXIMUM_TARGETS: usize = 4096;
+
+fn invalid() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "Invalid or oversized skill installation manifest; preserve it for inspection.",
+    )
+}
+
+fn path(global: &Path) -> PathBuf {
+    global.join("skill-installations.json")
+}
+
+pub(super) fn read(global: &Path) -> io::Result<BTreeSet<PathBuf>> {
+    let file = path(global);
+    if !files::exists(&file)? {
+        return Ok(BTreeSet::new());
+    }
+    if !std::fs::symlink_metadata(&file)?.is_file() {
+        return Err(invalid());
+    }
+    let bytes = bounded_file::read(&file, MAXIMUM_BYTES).map_err(|_| invalid())?;
+    let document: Value = serde_json::from_slice(&bytes).map_err(|_| invalid())?;
+    if document.as_object().is_none_or(|object| object.len() != 2) || document["version"] != 1 {
+        return Err(invalid());
+    }
+    let entries = document["targets"].as_array().ok_or_else(invalid)?;
+    if entries.len() > MAXIMUM_TARGETS {
+        return Err(invalid());
+    }
+    entries
+        .iter()
+        .map(|value| {
+            let entry = PathBuf::from(value.as_str().ok_or_else(invalid)?);
+            if !entry.is_absolute() || entry.file_name().is_none() {
+                return Err(invalid());
+            }
+            Ok(entry)
+        })
+        .collect()
+}
+
+/// Persist intent before links so a crash cannot lose a custom target. Later
+/// refresh checks the actual link; a failed intent is not automatic authority.
+pub(super) fn remember(
+    global: &Path,
+    targets: impl IntoIterator<Item = PathBuf>,
+) -> io::Result<()> {
+    let mut entries = read(global)?;
+    let before = entries.clone();
+    entries.extend(targets);
+    if entries == before {
+        return Ok(());
+    }
+    if entries.len() > MAXIMUM_TARGETS {
+        return Err(invalid());
+    }
+    let strings = entries
+        .iter()
+        .map(|path| {
+            if !path.is_absolute() || path.file_name().is_none() {
+                return Err(invalid());
+            }
+            path.to_str().ok_or_else(invalid)
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    let bytes =
+        serde_json::to_vec(&json!({"version": 1, "targets": strings})).map_err(|_| invalid())?;
+    if bytes.len() > MAXIMUM_BYTES {
+        return Err(invalid());
+    }
+    files::atomic_write(&path(global), &bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestDirectory;
+    use std::fs;
+
+    #[test]
+    fn invalid_documents_and_symlink_entries_are_preserved() {
+        let root = TestDirectory::new();
+        let file = path(&root.path);
+        for document in [
+            json!(null),
+            json!({"version":1,"targets":["relative"]}),
+            json!({"version":1,"targets":["/"]}),
+            json!({"version":1,"targets":[3]}),
+            json!({"version":1,"targets":[],"extra":true}),
+        ] {
+            let bytes = serde_json::to_vec(&document).unwrap();
+            fs::write(&file, &bytes).unwrap();
+            assert_eq!(
+                read(&root.path).unwrap_err().kind(),
+                io::ErrorKind::InvalidData
+            );
+            assert_eq!(fs::read(&file).unwrap(), bytes);
+        }
+        fs::remove_file(&file).unwrap();
+        let external = root.path.join("external.json");
+        fs::write(&external, br#"{"version":1,"targets":[]}"#).unwrap();
+        std::os::unix::fs::symlink(&external, &file).unwrap();
+        assert_eq!(
+            read(&root.path).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(fs::read_link(&file).unwrap(), external);
+        assert_eq!(
+            fs::read(external).unwrap(),
+            br#"{"version":1,"targets":[]}"#
+        );
+    }
+
+    #[test]
+    fn capacity_and_invalid_new_paths_fail_without_changing_retained_intents() {
+        let root = TestDirectory::new();
+        remember(
+            &root.path,
+            (0..MAXIMUM_TARGETS).map(|index| root.path.join(format!("target-{index}"))),
+        )
+        .unwrap();
+        let before = fs::read(path(&root.path)).unwrap();
+        assert_eq!(read(&root.path).unwrap().len(), MAXIMUM_TARGETS);
+        let error = remember(&root.path, [root.path.join("one-too-many")]).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(fs::read(path(&root.path)).unwrap(), before);
+        let empty = TestDirectory::new();
+        assert_eq!(
+            remember(&empty.path, [PathBuf::from("relative")])
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert!(!path(&empty.path).exists());
+    }
+}

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -184,7 +184,9 @@ pub fn grammar() -> Command {
                 general("install", "Install or refresh agent skills"),
                 &["force", "dir"],
             )
-            .arg(operand("agent", false)),
+            .arg(operand("agent", false).value_parser(
+                tmt_core::skill_provider::Provider::ALL.into_iter().map(|provider| provider.as_str()).chain(["all"]).collect::<Vec<_>>()
+            ).ignore_case(true)),
         )
         .subcommand(general("completion", "Generate shell completion").arg(operand("shell", false)))
         .subcommand(general("upgrade", "Upgrade the CLI and refresh skills"))

--- a/rust/crates/tmt-cli/src/guidance_command.rs
+++ b/rust/crates/tmt-cli/src/guidance_command.rs
@@ -1,0 +1,50 @@
+//! Exact canonical skill viewing and a deliberately short native quick start.
+
+use std::io::{self, Write};
+use tmt_core::skill_provider::Provider;
+
+pub fn execute(skill: bool) -> io::Result<u8> {
+    let mut output = io::stdout().lock();
+    if skill {
+        output.write_all(tmt_adapters::skill_installation::bundled_skill())?;
+    } else {
+        writeln!(
+            output,
+            "TMT — collaborate with terminal agents through durable exchanges.\n"
+        )?;
+        writeln!(
+            output,
+            "Native development preview: use isolated state until native cutover.\n"
+        )?;
+        writeln!(
+            output,
+            "Start with tmt install, then reload your agent's skills."
+        )?;
+        writeln!(
+            output,
+            "Providers: {}. Use install all or install --dir <skills-root>.",
+            Provider::ALL.map(Provider::as_str).join(", ")
+        )?;
+        writeln!(
+            output,
+            "Installation is non-interactive and does not install agent applications.\n"
+        )?;
+        writeln!(
+            output,
+            "  tmt name alice             Bind this pane temporarily; add -s to save it.\n  tmt add %14 reviewer       Bind another pane by stable ID.\n  tmt ls                     Show lifetime and verified presence.\n  tmt talk reviewer 'Review this patch' --timeout 300 --json\n  tmt talk reviewer 'Run the tests' --detach --json\n  tmt result <request-id> --json\n  tmt x ackall --identity coordinator\n  tmt config show --json\n"
+        )?;
+        writeln!(
+            output,
+            "Talk waits for tmt reply, not terminal output. Use exactly the supplied\nrequest ID and receipt with reply --message, --file or --stdin. Submit the\ncomplete result before showing a brief truthful user summary. Timeout ends\nonly the observer; preserve the request ID and do not automatically resend.\n"
+        )?;
+        writeln!(
+            output,
+            "Outside tmux, use an existing --identity for attributed talk or x.\nCreate saved identities with tmt identity create <name>. X reads never ack;\na later final reopens attention. Recipients still need a live tmux pane.\n"
+        )?;
+        writeln!(
+            output,
+            "Read tmt learn --skill for complete current safety and usage guidance.\nUse tmt help for options. Native network upgrade is not available yet."
+        )?;
+    }
+    Ok(0)
+}

--- a/rust/crates/tmt-cli/src/init_command.rs
+++ b/rust/crates/tmt-cli/src/init_command.rs
@@ -1,0 +1,27 @@
+//! Workspace-local configuration initialization.
+
+use crate::{invocation::OutputMode, output::Failure};
+use serde_json::json;
+use std::io::{self, Write};
+use tmt_adapters::config::{ConfigFiles, ConfigPaths};
+
+fn run() -> Result<std::path::PathBuf, Failure> {
+    let paths = ConfigPaths::discover()?;
+    let local_config = paths.local_config.clone();
+    ConfigFiles { paths }.initialize_local()?;
+    Ok(local_config)
+}
+
+pub fn execute(mode: OutputMode) -> io::Result<u8> {
+    let created = match run() {
+        Ok(path) => path,
+        Err(error) => return error.publish(mode),
+    };
+    let mut output = io::stdout().lock();
+    if mode.json {
+        writeln!(output, "{}", json!({"created": created}))?;
+    } else {
+        writeln!(output, "Created {}", created.display())?;
+    }
+    Ok(0)
+}

--- a/rust/crates/tmt-cli/src/install_command.rs
+++ b/rust/crates/tmt-cli/src/install_command.rs
@@ -1,0 +1,90 @@
+//! Native skill installation composition; filesystem policy stays in adapters.
+
+use crate::{invocation::OutputMode, output::Failure};
+use serde_json::{Value, json};
+use std::{
+    error::Error,
+    io::{self, Write},
+    path::Path,
+};
+use tmt_adapters::{
+    config::ConfigPaths,
+    skill_installation::{self, InstallReport, InstalledSkill, ProviderEnvironment},
+};
+
+fn failure(error: impl Error + 'static) -> Failure {
+    Failure::new("ERROR", error.to_string(), 1).caused_by(error)
+}
+
+fn document(item: &InstalledSkill) -> Value {
+    let mut value = json!({"target": item.target, "changed": item.changed});
+    if let Some(agent) = item.agent {
+        value["agent"] = agent.as_str().into();
+    }
+    if let Some(backup) = &item.backup {
+        value["backup"] = json!(backup);
+    }
+    if !item.legacy_backups.is_empty() {
+        value["legacyBackups"] = json!(item.legacy_backups);
+    }
+    value
+}
+
+fn run(
+    provider: Option<&str>,
+    directory: Option<&str>,
+    force: bool,
+) -> Result<InstallReport, Failure> {
+    let environment = ProviderEnvironment::capture().map_err(failure)?;
+    let paths = ConfigPaths::discover()?;
+    skill_installation::install(
+        &environment,
+        &paths.global_dir,
+        provider,
+        directory.map(Path::new),
+        force,
+    )
+    .map_err(failure)
+}
+
+pub fn execute(
+    provider: Option<String>,
+    directory: Option<String>,
+    force: bool,
+    mode: OutputMode,
+) -> io::Result<u8> {
+    let report = match run(provider.as_deref(), directory.as_deref(), force) {
+        Ok(report) => report,
+        Err(error) => return error.publish(mode),
+    };
+    let mut output = io::stdout().lock();
+    if mode.json {
+        let mut value =
+            json!({"installed": report.installed.iter().map(document).collect::<Vec<_>>()});
+        if !report.warnings.is_empty() {
+            value["warnings"] = json!(report.warnings);
+        }
+        writeln!(output, "{value}")?;
+    } else {
+        for item in &report.installed {
+            writeln!(
+                output,
+                "{} {} skill at {}",
+                if item.changed { "Installed" } else { "Current" },
+                item.agent.map_or("shared", |agent| agent.as_str()),
+                item.target.display()
+            )?;
+            for backup in item.backup.iter().chain(&item.legacy_backups) {
+                writeln!(output, "Recoverable backup: {}", backup.display())?;
+            }
+        }
+        for warning in &report.warnings {
+            writeln!(output, "Warning: {warning}")?;
+        }
+        writeln!(
+            output,
+            "Reload or restart your agent to use the current skill. Existing conversations can read tmt learn --skill."
+        )?;
+    }
+    Ok(0)
+}

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -5,13 +5,17 @@ mod config_command;
 mod diagnostics;
 mod exchange_command;
 mod grammar;
+mod guidance_command;
 mod identity_command;
 mod identity_context;
+mod init_command;
+mod install_command;
 mod invocation;
 mod output;
 mod parser;
 mod profile_command;
 mod response_command;
+mod skill_reminder;
 mod talk_command;
 mod target;
 
@@ -37,12 +41,13 @@ fn main() -> ExitCode {
 }
 
 fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
+    skill_reminder::emit(&parsed);
     let mut stdout = io::stdout().lock();
     match parsed.invocation {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, and x attention are available. Installation commands are not implemented yet. Use isolated test state only.\n"
+                "Native development preview: configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, x attention, init, learn, and skill installation are available. Native network upgrade is not implemented yet. Use isolated test state only.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -71,6 +76,22 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Config(request) => {
             drop(stdout);
             return config_command::execute(request, parsed.mode);
+        }
+        Invocation::Init => {
+            drop(stdout);
+            return init_command::execute(parsed.mode);
+        }
+        Invocation::Learn { skill } => {
+            drop(stdout);
+            return guidance_command::execute(skill);
+        }
+        Invocation::Install {
+            target,
+            directory,
+            force,
+        } => {
+            drop(stdout);
+            return install_command::execute(target, directory, force, parsed.mode);
         }
         Invocation::Identity(request) => {
             drop(stdout);
@@ -107,7 +128,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
             drop(stdout);
             return binding_command::execute(request, parsed.mode);
         }
-        _ => {
+        Invocation::Upgrade => {
             drop(stdout);
             return failure(
                 parsed.mode,

--- a/rust/crates/tmt-cli/src/skill_reminder.rs
+++ b/rust/crates/tmt-cli/src/skill_reminder.rs
@@ -1,0 +1,85 @@
+//! Best-effort human guidance, never part of command success or machine output.
+
+use crate::invocation::{Invocation, Parsed};
+use std::io::{self, IsTerminal, Write};
+use tmt_adapters::{
+    config::ConfigPaths,
+    skill_installation::{ProviderEnvironment, inspect_local_drift},
+};
+
+fn eligible(parsed: &Parsed, interactive: bool) -> bool {
+    interactive
+        && !parsed.mode.json
+        && !matches!(
+            parsed.invocation,
+            Invocation::Help
+                | Invocation::Version
+                | Invocation::Completion(_)
+                | Invocation::Init
+                | Invocation::Learn { .. }
+                | Invocation::Install { .. }
+                | Invocation::Upgrade
+        )
+}
+
+pub fn emit(parsed: &Parsed) {
+    if !eligible(
+        parsed,
+        io::stdin().is_terminal() && io::stderr().is_terminal(),
+    ) {
+        return;
+    }
+    let Ok(env) = ProviderEnvironment::capture() else {
+        return;
+    };
+    let Ok(paths) = ConfigPaths::discover() else {
+        return;
+    };
+    let Ok(drift) = inspect_local_drift(&env, &paths.global_dir) else {
+        return;
+    };
+    if let Some(first) = drift.first() {
+        let _ = writeln!(
+            io::stderr().lock(),
+            "Skill guidance needs inspection at {} ({} location(s)). Run tmt install for the intended provider; inspect conflicts before using --force. Reload the agent afterward.",
+            first.display(),
+            drift.len()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::invocation::OutputMode;
+
+    #[test]
+    fn machine_and_setup_commands_never_trigger_passive_inspection() {
+        let mut parsed = Parsed {
+            invocation: Invocation::Whoami,
+            mode: OutputMode::default(),
+        };
+        assert!(eligible(&parsed, true));
+        assert!(!eligible(&parsed, false));
+        parsed.mode.json = true;
+        assert!(!eligible(&parsed, true));
+        parsed.mode.json = false;
+        for invocation in [
+            Invocation::Help,
+            Invocation::Version,
+            Invocation::Completion(None),
+            Invocation::Init,
+            Invocation::Learn { skill: true },
+            Invocation::Learn { skill: false },
+            Invocation::Install {
+                target: None,
+                directory: None,
+                force: false,
+            },
+            Invocation::Upgrade,
+        ] {
+            parsed.invocation = invocation;
+            assert!(!eligible(&parsed, true));
+        }
+    }
+}

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -29,6 +29,7 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
             "subprocess",
             "nix",
             "signal-hook",
+            "sha2",
         ],
         "tmt-cli" => &[
             "tmt-core",

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod profile;
 pub mod request;
 pub mod retention;
 pub mod settings;
+pub mod skill_provider;
 
 #[cfg(test)]
 mod identity_tests;

--- a/rust/crates/tmt-core/src/skill_provider.rs
+++ b/rust/crates/tmt-core/src/skill_provider.rs
@@ -1,0 +1,70 @@
+//! Supported agent providers for the native installer boundary.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Provider {
+    Claude,
+    Codex,
+    Gemini,
+    Agy,
+    Pi,
+    Opencode,
+}
+
+impl Provider {
+    /// Stable provider order used by detection and `install all`.
+    pub const ALL: [Self; 6] = [
+        Self::Claude,
+        Self::Codex,
+        Self::Gemini,
+        Self::Agy,
+        Self::Pi,
+        Self::Opencode,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Gemini => "gemini",
+            Self::Agy => "agy",
+            Self::Pi => "pi",
+            Self::Opencode => "opencode",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|provider| provider.as_str().eq_ignore_ascii_case(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Provider;
+
+    #[test]
+    fn all_has_stable_install_order_and_names() {
+        assert_eq!(
+            Provider::ALL.map(Provider::as_str),
+            ["claude", "codex", "gemini", "agy", "pi", "opencode"]
+        );
+    }
+
+    #[test]
+    fn parse_is_case_insensitive_and_rejects_unknown_values() {
+        for (value, expected) in [
+            ("claude", Provider::Claude),
+            ("CODEX", Provider::Codex),
+            ("GeMiNi", Provider::Gemini),
+            ("agy", Provider::Agy),
+            ("PI", Provider::Pi),
+            ("OpenCode", Provider::Opencode),
+        ] {
+            assert_eq!(Provider::parse(value), Some(expected));
+        }
+        assert_eq!(Provider::parse(""), None);
+        assert_eq!(Provider::parse("all"), None);
+        assert_eq!(Provider::parse("unknown"), None);
+    }
+}

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -15,9 +15,14 @@ directory. Active presence also requires matching live tmux binding metadata.
 The instructions below describe the installed TypeScript runtime. The separate
 Rust executable is a development preview: use isolated test state only, never an
 existing user database (schema 9 is forward-only and TypeScript cannot reopen it).
-Its help explicitly identifies the native preview. It implements configuration
-and identity commands, not messaging, role/preamble, X, skill installation or
-upgrade; do not fall back to TypeScript on the same upgraded database.
+Its help explicitly identifies the native preview. It implements configuration,
+identity, talk/reply/result, check/read, role/preamble, X, initialization and
+skill viewing/installation. Native network upgrade is still a separate delivery
+gate; do not fall back to TypeScript on the same upgraded database. Native talk
+supplies a compact `v2_` receipt; use it unchanged. Native reply also accepts
+retained legacy receipts, but TypeScript cannot consume native receipts or
+schema 9. The common communication contracts below apply to both runtimes;
+the native-only lifetime and installation differences are called out explicitly.
 
 For an explicitly selected native preview, `name`, retained alias `this`, and
 `add <pane-target> <name>` default to temporary identities; `-s`/`--save` saves
@@ -510,3 +515,25 @@ Automatic drift reminders inspect known default paths, not custom folders.
 They do not reload an active agent, update provider-managed plugins, or track
 alpha release channels. Package upgrades and skill installation are separate
 from provider discovery.
+
+### Native preview installation differences
+
+The selected Rust executable embeds this exact skill; viewing and installation
+work after moving the binary, without Node or a checkout. Native installs link
+an immutable digest-addressed source under TMT's global directory
+(`skill-assets/<sha256>/tmux-team`). Re-run the intended `install` command after
+replacing a preview binary to refresh valid managed links. An edited current
+bundled source blocks installation even with force; inspect it before repair.
+Links to modified older sources are unmanaged conflicts: force can back up the
+link, never overwrite its source content. Old source
+directories remain available for recovery, not automatic cache deletion.
+
+`--force` backs up unmanaged target entries outside skill discovery in the
+sibling `.tmt-skill-backups` directory. If a later step fails, inspect the error's
+completed-target and recoverable-backup paths; installation across providers is
+not all-or-nothing. Custom target intents are recorded in `skill-installations.json`
+for future managed refresh, never as permission to overwrite their content.
+Native passive reminders cover known defaults only during interactive human
+commands; JSON and piped automation do not perform that scan. Neither installation
+nor a reminder reloads an active conversation. Native network `upgrade` remains
+unavailable until the separate distribution gate is complete.

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust:1.97.0-bookworm@sha256:8fa55b2f3ddf97471ab6a767bfa3f37e6bad0986ba823e75fea57e2a2a5c3073 AS native-tests
-WORKDIR /native
+WORKDIR /native/rust
 COPY rust/ ./
+COPY skills/ ../skills/
 RUN cargo build --locked --example tmux-probe \
   && cargo build --locked -p tmt-cli \
   && cargo test --locked --no-run -p tmt-adapters \

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -62,9 +62,9 @@ describe('native grammar preview process contract', () => {
       expect(help.stderr).toBe('');
       expect(help.stdout).toContain('Native development preview');
       expect(help.stdout).toContain(
-        'configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, and x attention are available'
+        'configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, x attention, init, learn, and skill installation are available'
       );
-      expect(help.stdout).toContain('Installation commands are not implemented yet.');
+      expect(help.stdout).toContain('Native network upgrade is not implemented yet.');
       expect(help.stdout).toContain('Manage identity records without probing tmux');
       expect(help.stdout).toContain('temporary unless saved');
       expect(help.stdout).toContain('rm');
@@ -75,16 +75,15 @@ describe('native grammar preview process contract', () => {
     });
   });
 
-  it('explicitly rejects effects for every recognized command family', async () => {
+  it('does not attempt a network upgrade in the native preview', async () => {
     await withSandbox(async (sandbox) => {
       const before = fileSnapshot(sandbox.root);
-      for (const args of [['init'], ['install', '--dir', sandbox.cwd]]) {
-        const result = await runCli(sandbox, [...args, '--json']);
-        expect(result.status, args.join(' ')).toBe(1);
-        expectError(result, 'NATIVE_NOT_IMPLEMENTED');
-        expect(fileSnapshot(sandbox.root)).toEqual(before);
-        expect(existsSync(sandbox.database)).toBe(false);
-      }
+      const result = await runCli(sandbox, ['upgrade']);
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('not implemented');
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect(existsSync(sandbox.database)).toBe(false);
     });
   });
 

--- a/test/native/installation.test.ts
+++ b/test/native/installation.test.ts
@@ -1,0 +1,336 @@
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { calibrateTmuxTripwire } from './tmux-tripwire.js';
+import {
+  expectError,
+  parseWholeStdout,
+  runCli,
+  type Sandbox,
+  withSandbox,
+} from '../../src/test-support/cli-process.js';
+
+if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
+
+type InstallItem = {
+  readonly agent?: string;
+  readonly target: string;
+  readonly changed: boolean;
+  readonly backup?: string;
+};
+
+type InstallDocument = {
+  readonly installed: InstallItem[];
+};
+
+const PROVIDERS = ['claude', 'codex', 'gemini', 'agy', 'pi', 'opencode'] as const;
+
+function canonicalSkill(): Buffer {
+  return readFileSync(
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../skills/tmux-team/SKILL.md')
+  );
+}
+
+function physicalFilePath(filePath: string): string {
+  return path.join(realpathSync(path.dirname(filePath)), path.basename(filePath));
+}
+
+function targetFor(sandbox: Sandbox, provider: (typeof PROVIDERS)[number]): string {
+  switch (provider) {
+    case 'claude':
+      return path.join(sandbox.home, '.claude', 'skills', 'tmux-team');
+    case 'agy':
+      return path.join(sandbox.home, '.gemini', 'config', 'skills', 'tmux-team');
+    case 'pi':
+      return path.join(sandbox.home, '.pi', 'agent', 'skills', 'tmux-team');
+    case 'codex':
+    case 'gemini':
+    case 'opencode':
+      return path.join(sandbox.home, '.agents', 'skills', 'tmux-team');
+  }
+}
+
+function assertSkillLink(target: string, expected: Buffer): string {
+  expect(lstatSync(target).isSymbolicLink()).toBe(true);
+  const source = realpathSync(target);
+  expect(readFileSync(path.join(source, 'SKILL.md'))).toEqual(expected);
+  expect(readFileSync(path.join(target, 'SKILL.md'))).toEqual(expected);
+  return source;
+}
+
+async function isolateExternalCommands(sandbox: Sandbox): Promise<{
+  readonly logPath: string;
+  readonly baseline: string;
+}> {
+  const logPath = await calibrateTmuxTripwire(sandbox);
+  // The native executable is selected by absolute path. Keep child PATH limited
+  // to the task-owned tripwire so provider/Node/Rust discovery cannot leak in.
+  sandbox.env.PATH = path.join(sandbox.root, 'task-owned-tripwire');
+  return { logPath, baseline: readFileSync(logPath, 'utf8') };
+}
+
+function assertNoExternalEffects(sandbox: Sandbox, logPath: string, baseline: string): void {
+  expect(readFileSync(logPath, 'utf8')).toBe(baseline);
+  expect(existsSync(sandbox.database)).toBe(false);
+}
+
+function installDocument(result: Awaited<ReturnType<typeof runCli>>): InstallDocument {
+  expect(result.status).toBe(0);
+  return parseWholeStdout(result) as unknown as InstallDocument;
+}
+
+describe('native installation process contract', () => {
+  it('runs a moved native binary from a path with spaces and prints exact canonical guidance', async () => {
+    await withSandbox(async (sandbox) => {
+      const movedDirectory = path.join(sandbox.root, "native build's files");
+      mkdirSync(movedDirectory);
+      const movedExecutable = path.join(movedDirectory, 'tmt preview');
+      copyFileSync(sandbox.cli.executable, movedExecutable);
+      chmodSync(movedExecutable, 0o755);
+      const moved = { ...sandbox, cli: { executable: movedExecutable, args: [] } };
+      const { logPath, baseline } = await isolateExternalCommands(sandbox);
+
+      const result = await runCli(moved, ['learn', '--skill']);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toBe(canonicalSkill().toString('utf8'));
+      expect(existsSync(sandbox.localConfig)).toBe(false);
+      expect(existsSync(sandbox.globalDir)).toBe(false);
+
+      const customRoot = path.join(sandbox.cwd, 'moved custom skills');
+      mkdirSync(customRoot);
+      const target = path.join(realpathSync(customRoot), 'tmux-team');
+      const installed = installDocument(
+        await runCli(moved, ['install', '--dir', 'moved custom skills', '--json'])
+      );
+      expect(installed).toEqual({ installed: [{ target, changed: true }] });
+      const source = assertSkillLink(target, canonicalSkill());
+      const assetsRoot = path.join(realpathSync(sandbox.globalDir), 'skill-assets');
+      expect(source.startsWith(`${assetsRoot}${path.sep}`)).toBe(true);
+      expect(
+        JSON.parse(readFileSync(path.join(sandbox.globalDir, 'skill-installations.json'), 'utf8'))
+      ).toEqual({
+        version: 1,
+        targets: [target],
+      });
+      assertNoExternalEffects(sandbox, logPath, baseline);
+    });
+  });
+
+  it('initializes the exact local file without storage, tmux, or global configuration', async () => {
+    await withSandbox(async (sandbox) => {
+      const { logPath, baseline } = await isolateExternalCommands(sandbox);
+      const result = await runCli(sandbox, ['init', '--json']);
+      expect(result.status).toBe(0);
+      expect(parseWholeStdout(result)).toEqual({ created: physicalFilePath(sandbox.localConfig) });
+      expect(readFileSync(sandbox.localConfig, 'utf8')).toBe('{}\n');
+      expect(existsSync(sandbox.globalDir)).toBe(false);
+      assertNoExternalEffects(sandbox, logPath, baseline);
+    });
+  });
+
+  it('refuses an existing malformed file, an ancestor file, and a broken link', async () => {
+    await withSandbox(async (sandbox) => {
+      const { logPath, baseline } = await isolateExternalCommands(sandbox);
+      const malformed = '{ user-owned malformed settings';
+      writeFileSync(sandbox.localConfig, malformed);
+      const existing = await runCli(sandbox, ['init', '--json']);
+      expect(existing.status).toBe(1);
+      expectError(existing, 'ERROR');
+      expect(readFileSync(sandbox.localConfig, 'utf8')).toBe(malformed);
+
+      const ancestor = sandbox.localConfig;
+      const nested = path.join(sandbox.cwd, 'child', 'nested');
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(ancestor, '{}\n');
+      const nestedSandbox = {
+        ...sandbox,
+        cwd: nested,
+        localConfig: ancestor,
+      };
+      const ancestorResult = await runCli(nestedSandbox, ['init', '--json']);
+      expect(ancestorResult.status).toBe(1);
+      expectError(ancestorResult, 'ERROR');
+      expect(readFileSync(ancestor, 'utf8')).toBe('{}\n');
+      expect(existsSync(path.join(nested, 'tmux-team.json'))).toBe(false);
+
+      // Re-select the ordinary local path and replace it with a dangling link.
+      // create_new must reject the link itself, without following or deleting it.
+      const missing = path.join(sandbox.root, 'missing-settings.json');
+      unlinkSync(sandbox.localConfig);
+      symlinkSync(missing, sandbox.localConfig);
+      const linkResult = await runCli(sandbox, ['init', '--json']);
+      expect(linkResult.status).toBe(1);
+      expectError(linkResult, 'ERROR');
+      expect(readlinkSync(sandbox.localConfig)).toBe(missing);
+      expect(existsSync(missing)).toBe(false);
+      assertNoExternalEffects(sandbox, logPath, baseline);
+    });
+  });
+
+  it('has exactly one successful concurrent init and leaves the winning bytes intact', async () => {
+    await withSandbox(async (sandbox) => {
+      const { logPath, baseline } = await isolateExternalCommands(sandbox);
+      const results = await Promise.all(
+        Array.from({ length: 8 }, () => runCli(sandbox, ['init', '--json']))
+      );
+      expect(results.filter((result) => result.status === 0)).toHaveLength(1);
+      expect(results.filter((result) => result.status === 1)).toHaveLength(7);
+      for (const result of results) {
+        if (result.status === 1) expectError(result, 'ERROR');
+        else
+          expect(parseWholeStdout(result)).toEqual({
+            created: physicalFilePath(sandbox.localConfig),
+          });
+      }
+      expect(readFileSync(sandbox.localConfig, 'utf8')).toBe('{}\n');
+      assertNoExternalEffects(sandbox, logPath, baseline);
+    });
+  });
+
+  it.each(PROVIDERS)(
+    'installs explicit %s at its canonical target and repeats as a no-op',
+    async (provider) => {
+      await withSandbox(async (sandbox) => {
+        const expected = canonicalSkill();
+        const { logPath, baseline } = await isolateExternalCommands(sandbox);
+        mkdirSync(sandbox.globalDir, { recursive: true });
+        writeFileSync(sandbox.globalConfig, '{ malformed global config');
+        writeFileSync(sandbox.localConfig, '{ malformed local config');
+        const target = targetFor(sandbox, provider);
+
+        const first = installDocument(await runCli(sandbox, ['install', provider, '--json']));
+        expect(first).toEqual({ installed: [{ agent: provider, target, changed: true }] });
+        const source = assertSkillLink(target, expected);
+        const second = installDocument(await runCli(sandbox, ['install', provider, '--json']));
+        expect(second).toEqual({ installed: [{ agent: provider, target, changed: false }] });
+        expect(assertSkillLink(target, expected)).toBe(source);
+        assertNoExternalEffects(sandbox, logPath, baseline);
+      });
+    }
+  );
+
+  it('installs all providers in stable order with shared targets and repeat no-op', async () => {
+    await withSandbox(async (sandbox) => {
+      const expected = canonicalSkill();
+      const { logPath, baseline } = await isolateExternalCommands(sandbox);
+      mkdirSync(sandbox.globalDir, { recursive: true });
+      writeFileSync(sandbox.globalConfig, '{ malformed global config');
+      writeFileSync(sandbox.localConfig, '{ malformed local config');
+      const targets = Object.fromEntries(
+        PROVIDERS.map((provider) => [provider, targetFor(sandbox, provider)])
+      );
+      const first = installDocument(await runCli(sandbox, ['install', 'all', '--json']));
+      expect(first).toEqual({
+        installed: PROVIDERS.map((agent, index) => ({
+          agent,
+          target: targets[agent],
+          changed: [true, true, false, true, true, false][index],
+        })),
+      });
+      for (const target of new Set(Object.values(targets))) assertSkillLink(target, expected);
+      const second = installDocument(await runCli(sandbox, ['install', 'all', '--json']));
+      expect(second.installed.map((item) => item.changed)).toEqual(PROVIDERS.map(() => false));
+      assertNoExternalEffects(sandbox, logPath, baseline);
+    });
+  });
+
+  it('uses the neutral target when no provider is detected', async () => {
+    await withSandbox(async (sandbox) => {
+      const expected = canonicalSkill();
+      const { logPath, baseline } = await isolateExternalCommands(sandbox);
+      writeFileSync(sandbox.localConfig, '{ malformed local config');
+      const target = path.join(sandbox.home, '.agents', 'skills', 'tmux-team');
+      const first = installDocument(await runCli(sandbox, ['install', '--json']));
+      expect(first).toEqual({ installed: [{ target, changed: true }] });
+      assertSkillLink(target, expected);
+      const second = installDocument(await runCli(sandbox, ['install', '--json']));
+      expect(second).toEqual({ installed: [{ target, changed: false }] });
+      assertNoExternalEffects(sandbox, logPath, baseline);
+    });
+  });
+
+  it('isolates custom installation roots and preserves unrelated siblings', async () => {
+    await withSandbox(async (sandbox) => {
+      const expected = canonicalSkill();
+      const { logPath, baseline } = await isolateExternalCommands(sandbox);
+      const customRoot = path.join(sandbox.cwd, 'custom skills');
+      mkdirSync(customRoot);
+      writeFileSync(path.join(customRoot, 'unrelated.txt'), 'keep this sibling');
+      writeFileSync(sandbox.localConfig, '{ malformed local config');
+      const target = path.join(realpathSync(customRoot), 'tmux-team');
+      const first = installDocument(
+        await runCli(sandbox, ['install', '--dir', 'custom skills', '--json'])
+      );
+      expect(first).toEqual({ installed: [{ target, changed: true }] });
+      assertSkillLink(target, expected);
+      const second = installDocument(
+        await runCli(sandbox, ['install', '--dir', 'custom skills', '--json'])
+      );
+      expect(second).toEqual({ installed: [{ target, changed: false }] });
+      expect(readFileSync(path.join(customRoot, 'unrelated.txt'), 'utf8')).toBe(
+        'keep this sibling'
+      );
+      assertNoExternalEffects(sandbox, logPath, baseline);
+    });
+  });
+
+  it('reports unmanaged conflicts and creates a recoverable JSON backup with force', async () => {
+    await withSandbox(async (sandbox) => {
+      const { logPath, baseline } = await isolateExternalCommands(sandbox);
+      const target = targetFor(sandbox, 'claude');
+      mkdirSync(target, { recursive: true });
+      writeFileSync(path.join(target, 'user-owned.md'), 'keep this content');
+      const refused = await runCli(sandbox, ['install', 'claude', '--json']);
+      expect(refused.status).toBe(1);
+      expectError(refused, 'ERROR');
+      expect(readFileSync(path.join(target, 'user-owned.md'), 'utf8')).toBe('keep this content');
+
+      const forced = installDocument(
+        await runCli(sandbox, ['install', 'claude', '--force', '--json'])
+      );
+      const item = forced.installed[0];
+      expect(item).toMatchObject({ agent: 'claude', target, changed: true });
+      expect(item.backup).toEqual(expect.any(String));
+      const backup = item.backup as string;
+      expect(backup).toContain(path.join(sandbox.home, '.claude', '.tmt-skill-backups'));
+      expect(readFileSync(path.join(backup, 'user-owned.md'), 'utf8')).toBe('keep this content');
+      assertSkillLink(target, canonicalSkill());
+      assertNoExternalEffects(sandbox, logPath, baseline);
+    });
+  });
+
+  it('rejects unknown providers and --dir conflicts before filesystem effects', async () => {
+    await withSandbox(async (sandbox) => {
+      const { logPath, baseline } = await isolateExternalCommands(sandbox);
+      const custom = path.join(sandbox.cwd, 'custom skills');
+      for (const args of [
+        ['install', 'unknown-provider', '--json'],
+        ['install', 'claude', '--dir', 'custom skills', '--json'],
+        ['install', 'all', '--dir', 'custom skills', '--json'],
+        ['install', '--dir', '', '--json'],
+      ]) {
+        const result = await runCli(sandbox, args);
+        expect(result.status, args.join(' ')).toBe(1);
+        expectError(result, 'USAGE_ERROR');
+      }
+      expect(existsSync(custom)).toBe(false);
+      expect(existsSync(sandbox.globalDir)).toBe(false);
+      expect(existsSync(sandbox.database)).toBe(false);
+      assertNoExternalEffects(sandbox, logPath, baseline);
+    });
+  });
+});


### PR DESCRIPTION
## Scope

- Issue: Closes #133; prerequisite for #82/#135, under #93.
- Complete native `init`, exact embedded `learn --skill`, short native guide and non-interactive provider/custom skill installation.
- Keep the TypeScript runtime installed until the explicit cutover gate. No network upgrade, public release, global install, user database or host tmux changes.

## Architecture and review

- Core owns one native provider inventory; grammar/completion and adapters consume it. Adapter ownership separates environment/targets, immutable assets, bounded intents, filesystem publication/locking and read-only drift inspection. CLI modules compose and present results. No Node execution bridge or second canonical skill content.
- Reused ConfigPaths/normalization, existing ConfigError mapping, bounded file reads, pinned sha2 already in the runtime graph, existing nix file locks and common output/process test boundaries. The sha2 change adds only an adapter dependency edge, not a new crate/version. Existing TypeScript installer/selection/drift callers were reviewed as the frozen reference.
- Local init uses exclusive creation and owned-partial-file cleanup. Managed source digest/inventory evidence is local ownership, not remote authentication. Preserve modified sources; force permits recoverable target backups only. Versioned target intents precede links, but never authorize future overwrite. Partial failures report completed targets and backups. There is no multi-provider transaction or power-loss rollback claim; old sources/abandoned stages are preserved.
- Passive reminders inspect only deduplicated known provider/legacy paths for interactive non-JSON human commands. They skip machine/setup invocations and never scan custom intents, executables, SQLite or the network.
- Primary reviewer: Codex. Personally reviewed all changed files, dispatch/parser/config paths, provider and source ownership, all delegated tests, failure/publication paths, native process harness and Docker build/runtime boundary. Delegated findings were not accepted as architectural decisions.
- Findings corrected: duplicate ConfigError mapping and provider constructor/executable strings; neutral CODEX_HOME detection; weak registry/string-count and symlink-preservation assertions; old-source fixture lexical/physical path mismatch; owned-stage cleanup placement; lock error classification; digest-directory symlink substitution; current-vs-old modified-source documentation; missing canonical skill input in Docker's clean Rust build stage. Added real backup/intent/partial-success failure evidence with injection only at link publication. The moved-binary test now actually installs, not just prints guidance.
- Reviewed commit: `8bd51fd9592ddc13f50ea4b322765b6ecb44e5a7`.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge.

Commands and results:

- `cargo test --workspace --locked` and `cargo +1.88.0 test --workspace --locked`: 294 tests each (210 adapter, 30 CLI, 19 architecture, 45 core), passed.
- `cargo build --workspace --examples --bins --locked`, strict `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo fmt --all --check`: passed.
- Architecture calibration: temporarily added a real core filesystem reference; workspace guard failed specifically with `tmt-core/skill_provider.rs: non-pure core reference std::fs::File`. Removed it exactly; all 19 guard tests passed. No calibration change is committed.
- `pnpm check`: passed; `pnpm test:run`: 1,102 tests / 70 files, coverage 95.66% statements and 89.47% branches, passed.
- `pnpm test:native` with explicit native CLI and storage-probe descriptors: 96 tests / 11 files, passed. The new suite includes 15 process scenarios with isolated HOME/config/PATH, calibrated tmux tripwire and moved native installation without Node/Rust.
- Canonical skill semantic review and skill-creator `quick_validate.py`: passed (missing PyYAML supplied only in a disposable virtual environment).
- Shared native-selected CI contract subsets: parser 8 passed / 14 intentionally unselected; config 6 passed / 4 intentionally unselected. Unselected TS-reference scenarios are not claimed as native parity.
- CI run 34197399779: all 11 jobs passed on reviewed head `8bd51fd9592ddc13f50ea4b322765b6ecb44e5a7`, including Native Rust contracts, Code quality, Unit tests, Docker E2E, all six packed reference-platform jobs and the matrix gate.
- `pnpm test:e2e`, two final-source local Docker runs: each 210 adapter tests plus 159 E2E tests passed (34 files; one existing optional performance test skipped), 300.26s and 325.22s. An earlier clean-build attempt exposed the missing compile-time skill COPY; fixed rather than treating host-only success as packaging evidence. A further intermediate pass also succeeded before the final modified-source test/doc refinement; only the two final-source runs are counted for acceptance.

## Project lifecycle

- Updated ARCHITECTURE, DEVELOPMENT, RUST-REWRITE and canonical installed guidance. README retains truthful installed-TypeScript instructions; public curl/native availability remains gated by #82/#135 and publication authority.
- GitHub #133 contains design, state/failure contracts and reminder/JSON refinements. #135 records the next artifact prerequisite; installation is not declared complete by this slice.
- Branch `feat/133-native-install`; worktree `/Users/benhsieh/dev/tmt-133-native-install`. Keep until reviewed-head CI, authorized merge, recorded delivery and safe cleanup.
