### PR TITLE
Build and verify native release archives and dependency notices

### DIFF
--- a/.agents/skills/tmt-release/SKILL.md
+++ b/.agents/skills/tmt-release/SKILL.md
@@ -20,6 +20,11 @@ Use this skill for release-line maintenance, v4 compatibility fixes, v5 promotio
 
 ## Promotion and prerelease checks
 
+- For Rust archives, follow DEVELOPMENT's native Rust release archive procedure.
+  Keep cargo-dist's manifest as the artifact metadata owner; independently verify
+  bounded extraction, notices, linkage, skill installation and persisted state.
+  The npm packed matrix does not establish Rust target support. Do not enable a
+  generated installer or publication workflow merely to obtain local archives.
 - Follow DEVELOPMENT's packed native-install verification for artifact changes.
   Verify the installed application's schema and behavior, not only driver loading
   or manifest equality. Keep broken-artifact failure and cleanup evidence; do not

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ node_modules
 coverage
 dist
 rust/target
+target/distrib
 .DS_Store
 *.log
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .tmux-team-id
 coverage/
 rust/target/
+target/distrib/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1419,6 +1419,37 @@ a gap is resolved; do not leave a permanent exception or label a proposal as shi
 | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | Memory and an offline recipient inbox remain future capabilities, not installed APIs. | [TMT-15](https://linear.app/tigerpig-dev/issue/TMT-15), [TMT-16](https://linear.app/tigerpig-dev/issue/TMT-16) |
 
+## Native release artifact boundary
+
+Under #135, `dist-workspace.toml` selects cargo-dist's archive-only generator:
+its manifest owns release versions, target triples, archive names and checksums.
+Generated shell installers, axoupdater and publication workflows are disabled.
+The optimized CLI embeds the canonical skill and contains no Node runtime or
+checkout dependency. `rust/about.toml` and `rust/about.hbs` generate resolved
+runtime dependency notices; developer tools are not native runtime dependencies.
+The archive carries the executable, first-party license, third-party notices
+and preview installation guidance only.
+
+`scripts/build-native-artifact.sh` composes pinned developer tools from the Rust
+workspace so the toolchain file applies. `native-cargo.sh` adds the missing
+locked build/metadata policy without duplicating an existing locked/frozen flag.
+It is a packaging adapter, not a second application subprocess owner.
+
+The independent `native-artifact-policy.mjs` consumes the generator manifest,
+checks SHA-256, bounds compressed and expanded input, rejects links and all
+unexpected archive paths, and extracts only into a private owned directory.
+Pinned developer-only `tar` handles the archive format; TMT does not implement
+another tar parser. `verify-native-artifact.mjs` reuses the bounded packed-command
+runner for linkage, version, exact skill installation and cross-process native
+SQLite profile checks with an empty runtime PATH and isolated state. The existing
+npm packed matrix remains a distinct transitional TypeScript gate.
+
+Unsigned checksums detect corruption, not origin compromise. Native binary
+bootstrap, manager receipts, atomic update and authenticated public release
+provenance remain #82 gates. These developer archives do not change installed
+entrypoints or authorize publication. Candidate targets require actual matching
+target execution before they become supported release platforms.
+
 ## Maintenance contract
 
 The implementer updates this map; the primary reviewer is accountable for its

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -587,6 +587,56 @@ arm64 capacity is unavailable for a pull request, the release gate must run
 the same command on a native arm64 runner; emulation does not satisfy this
 matrix.
 
+## Native Rust release archives
+
+This is separate from the transitional npm packed matrix above. #135 adds
+archive generation and isolated runtime verification, not a public installer.
+The target inventory and artifact metadata live in `dist-workspace.toml` and
+the generated cargo-dist manifest, not another TMT release catalog.
+
+Install the pinned developer tools into a chosen tool directory (not needed by
+end users): cargo-dist 0.32.0 with `cargo install --locked`, and cargo-about
+0.9.2 with `cargo install --locked --features cli`. Put their binaries on PATH.
+Fetch the locked workspace dependencies before the offline notice step.
+Build targets sequentially in one checkout, or use separate worktrees: the
+generator's distribution directory and generated notice input are per-checkout.
+
+```sh
+# Choose a target from dist-workspace.toml that matches the verification host.
+native_manifest=$(mktemp)
+MACOSX_DEPLOYMENT_TARGET=11.0 scripts/build-native-artifact.sh aarch64-apple-darwin > "$native_manifest"
+node scripts/verify-native-artifact.mjs \
+  --manifest "$native_manifest" \
+  --archive target/distrib/tmt-cli-aarch64-apple-darwin.tar.gz \
+  --target aarch64-apple-darwin --skill skills/tmux-team/SKILL.md \
+  --notices rust/target/native-notices/THIRD-PARTY-NOTICES.txt --license LICENSE
+```
+
+Review the generated `rust/target/native-notices/THIRD-PARTY-NOTICES.txt` against
+the locked, archive-target-filtered runtime graph, including Unicode copyrights;
+the verifier compares the archived notices and license with these selected
+inputs and rejects placeholder attribution. A successful generator
+is not legal certification. Keep the complete notice text with redistributed
+binaries. The verifier bounds inputs (64 MiB compressed, 128 MiB expanded),
+requires exactly the four runtime files, and removes its private staging after
+success or failure. It runs the extracted executable with no Node/Rust/tmux on
+PATH and verifies native SQLite persistence through public commands. macOS
+requires system `otool`; Linux requires `readelf` for static-musl linkage checks.
+
+`test/native/artifact.Dockerfile` provides a local matching-architecture Linux
+musl build and verifier. Set `TARGET_TRIPLE` from the selected generator target,
+give the image a task-owned name, then run it with `--rm --init --network none`
+and `--archive artifacts/<manifest archive name> --target <target>`. Remove that
+owned image after verification. Emulated execution and cross-compilation alone
+do not satisfy native target acceptance. This optional image is not the tmux
+E2E harness or a publication workflow.
+
+Negative archive tests use real tar fixtures and causal guard assertions.
+Exercise checksum corruption, truncation, missing executable/notices, links,
+unexpected paths, duplicates, bounds and cleanup; never accept any arbitrary
+process error as proof of the intended check. Inspect exact manifest and archive
+bytes from the final source before running the reviewed CI candidate.
+
 ## Testing Strategy
 
 We prefer structured, deterministic assertions in tests. Human-facing formatting is validated sparingly; most tests assert on structured output or file contents.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Ben Hsieh and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NATIVE-INSTALL.md
+++ b/NATIVE-INSTALL.md
@@ -1,0 +1,38 @@
+# TMT native artifact preview
+
+This archive contains a standalone Rust development preview, not a published
+replacement for the npm runtime. It needs no Node.js, Rust toolchain or source
+checkout to run. tmux is still required for pane operations.
+
+Use isolated test state until native cutover. Native schema 9 is forward-only:
+the TypeScript runtime cannot reopen it. Replacing a binary is not a database
+downgrade. Do not run this preview against an existing user database.
+
+After extracting a verified archive into a chosen test directory:
+
+```sh
+tmt_preview_root=$(mktemp -d)
+./tmt --version
+TMUX_TEAM_HOME="$tmt_preview_root" ./tmt learn --skill
+TMUX_TEAM_HOME="$tmt_preview_root" ./tmt install --dir "$tmt_preview_root/skills" --json
+```
+
+Skill installation is non-interactive and does not install agent applications.
+This example deliberately keeps its managed files in the temporary preview root.
+Choose a directory your provider discovers and reload its skills. Retain the
+included LICENSE and THIRD-PARTY-NOTICES.txt with redistributed binaries.
+
+Native shell bootstrap, managed binary receipts and network `upgrade` are not
+available yet. Do not overwrite an npm, pnpm, Homebrew or manual installation.
+The selected executable's help is the capability authority; the shared alpha
+version number alone does not distinguish native and TypeScript runtimes.
+
+The distribution manifest supplies archive names, target triples and SHA-256
+checksums. Checksums detect corruption, not compromise of the download origin.
+No local test artifact is authenticated by a published GitHub attestation.
+Public immutable-release provenance and verification instructions remain a
+separate release gate; do not describe locally generated checksums as signatures.
+
+Target candidates are macOS x64/arm64 (deployment target 11.0) and Linux x64/arm64
+with a static musl runtime. Actual target execution and linkage must pass before
+release support is claimed; cross-compilation alone is not acceptance evidence.

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -518,3 +518,14 @@ Unresolved release decisions owned by #82 include minimum macOS/glibc versions,
 musl artifacts, signing/provenance, atomic upgrade/rollback, PATH/manager ownership,
 skill relocation and clean install without Node. Do not promise native support
 based on a developer's successful macOS build alone.
+
+Native archive prerequisite #135 selects cargo-dist for archive/manifest
+generation only, with generated installers and publishing disabled. The selected
+candidates are macOS arm64/x64 with deployment target 11.0 and Linux arm64/x64
+static musl. Per-target cargo-about notices, bounded archive inventory/extraction,
+system/static linkage checks and isolated executable/skill/SQLite verification
+are separate from the transitional npm package matrix. See DEVELOPMENT's native
+Rust release archive procedure. Actual matching-platform execution remains a
+release gate; the target list is not itself a support claim. Bootstrap, binary
+ownership receipts, atomic updates, public provenance and installed-runtime
+cutover remain #82/#93 work, not capabilities supplied by an archive generator.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = ["cargo:rust"]
+
+[dist]
+cargo-dist-version = "0.32.0"
+# Artifact generation only. Publishing and the native updater have separate gates.
+ci = []
+installers = []
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
+unix-archive = ".tar.gz"
+checksum = "sha256"
+source-tarball = false
+auto-includes = false
+include = ["LICENSE", "NATIVE-INSTALL.md", "rust/target/native-notices/THIRD-PARTY-NOTICES.txt"]

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@vitest/coverage-v8": "^1.6.1",
     "oxlint": "^1.34.0",
     "prettier": "^3.7.4",
+    "tar": "7.5.22",
     "typescript": "^5.3.0",
     "vitest": "^1.2.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       prettier:
         specifier: ^3.7.4
         version: 3.7.4
+      tar:
+        specifier: 7.5.22
+        version: 7.5.22
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -360,6 +363,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
@@ -615,6 +622,10 @@ packages:
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
@@ -756,6 +767,14 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
@@ -888,6 +907,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
+
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -996,6 +1019,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
@@ -1169,6 +1196,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.2':
     optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@istanbuljs/schema@0.1.3': {}
 
@@ -1377,6 +1408,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  chownr@3.0.0: {}
+
   commander@15.0.0: {}
 
   concat-map@0.0.1: {}
@@ -1563,6 +1596,12 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mlly@1.8.0:
     dependencies:
       acorn: 8.15.0
@@ -1697,6 +1736,14 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -1795,5 +1842,7 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
+
+  yallist@5.0.0: {}
 
   yocto-queue@1.2.2: {}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 rust-version = "1.88"
 license = "MIT"
 publish = false
+repository = "https://github.com/wkh237/tmux-team"
 
 [workspace.dependencies]
 tmt-core = { path = "crates/tmt-core" }
@@ -32,3 +33,6 @@ unsafe_code = "forbid"
 [profile.release]
 lto = "thin"
 strip = "debuginfo"
+
+[profile.dist]
+inherits = "release"

--- a/rust/about.hbs
+++ b/rust/about.hbs
@@ -1,0 +1,19 @@
+TMT native runtime third-party notices
+
+Generated from the locked runtime dependency graph using cargo-about.
+Build-only and development-only dependencies are excluded. Dependencies are
+filtered to this archive's target triple, not the packaging host.
+The TMT project's own license is supplied separately in LICENSE.
+
+{{#each licenses}}
+===============================================================================
+{{name}} ({{id}})
+
+Used by:
+{{#each used_by}}
+- {{crate.name}} {{crate.version}}
+{{/each}}
+
+{{{text}}}
+
+{{/each}}

--- a/rust/about.toml
+++ b/rust/about.toml
@@ -1,0 +1,5 @@
+# Generate runtime dependency notices, not developer/build-tool inventories.
+accepted = ["MIT", "Apache-2.0", "Unicode-3.0"]
+ignore-dev-dependencies = true
+ignore-build-dependencies = true
+private = { ignore = true }

--- a/rust/crates/tmt-cli/Cargo.toml
+++ b/rust/crates/tmt-cli/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
+repository.workspace = true
+
+[package.metadata.dist]
+dist = true
 
 [[bin]]
 name = "tmt"

--- a/scripts/build-native-artifact.sh
+++ b/scripts/build-native-artifact.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  printf '%s\n' 'Usage: scripts/build-native-artifact.sh <cargo-dist target>' >&2
+  exit 2
+fi
+target=$1
+repo=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+cd "$repo/rust"
+# Resolve the repository toolchain before cargo-dist discovers the generic root
+# workspace. Source archives/containers need not contain Git metadata.
+selected_toolchain=$(rustup show active-toolchain)
+RUSTUP_TOOLCHAIN=${selected_toolchain%% *}
+export RUSTUP_TOOLCHAIN
+
+# Developer tools only; do not silently install tools or change release settings.
+test "$(cargo-about --version)" = 'cargo-about 0.9.2' || {
+  printf '%s\n' 'Native packaging requires cargo-about 0.9.2.' >&2
+  exit 2
+}
+TMT_NATIVE_REAL_CARGO=${TMT_NATIVE_REAL_CARGO:-$(command -v cargo)}
+export TMT_NATIVE_REAL_CARGO
+CARGO="$repo/scripts/native-cargo.sh"
+export CARGO
+# cargo-dist checks its own version against dist-workspace.toml.
+cd "$repo"
+dist generate --check --target "$target"
+cd "$repo/rust"
+mkdir -p target/native-notices
+cargo-about generate --manifest-path crates/tmt-cli/Cargo.toml \
+  --config about.toml --target "$target" --locked --offline --fail about.hbs \
+  --output-file target/native-notices/THIRD-PARTY-NOTICES.txt
+
+# Keep diagnostics on stderr and cargo-dist's authoritative manifest on stdout.
+# Callers save stdout alongside the archives, then run the independent verifier.
+cd "$repo"
+dist build --artifacts local --target "$target" --output-format=json --no-local-paths

--- a/scripts/native-artifact-policy.mjs
+++ b/scripts/native-artifact-policy.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { gunzipSync } from 'node:zlib';
+import * as tar from 'tar';
+
+const requiredFiles = ['tmt', 'LICENSE', 'NATIVE-INSTALL.md', 'THIRD-PARTY-NOTICES.txt'];
+const compressedLimit = 64 * 1024 * 1024;
+const expandedLimit = 128 * 1024 * 1024;
+
+function archiveRootName(name) {
+  assert(/^[a-zA-Z0-9][a-zA-Z0-9._-]*\.tar\.gz$/.test(name), 'Invalid native archive name');
+  return name.slice(0, -'.tar.gz'.length);
+}
+
+function readBoundedFile(file, limit) {
+  const descriptor = fs.openSync(
+    file,
+    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK
+  );
+  try {
+    const stat = fs.fstatSync(descriptor);
+    assert(stat.isFile() && stat.size <= limit, 'Artifact input must be a bounded regular file');
+    const bytes = Buffer.alloc(stat.size + 1);
+    let length = 0;
+    while (length < bytes.length) {
+      const count = fs.readSync(descriptor, bytes, length, bytes.length - length, null);
+      if (!count) break;
+      length += count;
+    }
+    assert.equal(length, stat.size, 'Artifact input changed while reading');
+    return bytes.subarray(0, length);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+/** Consume cargo-dist metadata; do not maintain a second checksum/version catalog. */
+export function selectNativeArtifact(manifestFile, archiveFile, target) {
+  const manifest = JSON.parse(readBoundedFile(manifestFile, 4 * 1024 * 1024));
+  const name = path.basename(archiveFile);
+  archiveRootName(name);
+  const artifact = manifest.artifacts?.[name];
+  assert.equal(artifact?.kind, 'executable-zip', 'Manifest is missing the native archive');
+  assert.equal(artifact.name, name, 'Manifest archive name mismatch');
+  assert.deepEqual(artifact.target_triples, [target], 'Manifest target mismatch');
+  assert(/^[a-f0-9]{64}$/.test(artifact.checksums?.sha256), 'Manifest requires SHA-256');
+  const releases = manifest.releases?.filter((release) => release.artifacts.includes(name));
+  assert.equal(releases?.length, 1, 'Archive must belong to exactly one release');
+  const version = releases[0].app_version;
+  assert(typeof version === 'string' && version.length > 0, 'Manifest requires a version');
+  assert.deepEqual(
+    artifact.assets.map((asset) => asset.path).sort(),
+    [...requiredFiles].sort(),
+    'Manifest must describe exactly the native runtime files'
+  );
+  return { name, version, target, sha256: artifact.checksums.sha256 };
+}
+
+/** Extract only verified regular files into an owned directory and always remove it. */
+export async function withNativeArtifact(archiveFile, metadata, inspect) {
+  const rootName = archiveRootName(metadata.name);
+  const compressed = readBoundedFile(archiveFile, compressedLimit);
+  assert.equal(
+    createHash('sha256').update(compressed).digest('hex'),
+    metadata.sha256,
+    'Native archive checksum mismatch'
+  );
+  // Bound the whole stream, including metadata and padding, before tar parsing.
+  const expanded = gunzipSync(compressed, { maxOutputLength: expandedLimit });
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt native archive '));
+  try {
+    const snapshot = path.join(staging, 'snapshot.tar');
+    fs.writeFileSync(snapshot, expanded, { flag: 'wx', mode: 0o600 });
+    const expected = new Set(requiredFiles.map((name) => `${rootName}/${name}`));
+    const seen = new Set();
+    tar.t({
+      file: snapshot,
+      sync: true,
+      strict: true,
+      onReadEntry(entry) {
+        assert(!seen.has(entry.path), `Duplicate native archive entry: ${entry.path}`);
+        seen.add(entry.path);
+        if (entry.path === `${rootName}/` && entry.type === 'Directory') return;
+        assert(expected.has(entry.path), `Unexpected native archive entry: ${entry.path}`);
+        assert.equal(entry.type, 'File', `Native archive entry must be regular: ${entry.path}`);
+        assert.equal(entry.mode & 0o7000, 0, 'Native archive must not set special permission bits');
+        assert(entry.size > 0, `Empty native archive entry: ${entry.path}`);
+        if (entry.path.endsWith('/tmt')) {
+          assert(entry.mode & 0o111, 'Native executable lacks execute permission');
+        }
+      },
+    });
+    for (const entry of expected) assert(seen.has(entry), `Missing native archive entry: ${entry}`);
+    const extracted = path.join(staging, 'extracted');
+    fs.mkdirSync(extracted);
+    tar.x({ file: snapshot, cwd: extracted, sync: true, strict: true, preserveOwner: false });
+    return await inspect(path.join(extracted, rootName));
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+}

--- a/scripts/native-cargo.sh
+++ b/scripts/native-cargo.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+real_cargo=${TMT_NATIVE_REAL_CARGO:-}
+if [ -z "$real_cargo" ]; then
+  printf '%s\n' 'TMT_NATIVE_REAL_CARGO must be an absolute executable path.' >&2
+  exit 2
+fi
+
+case "$real_cargo" in
+  /*) ;;
+  *)
+    printf '%s\n' 'TMT_NATIVE_REAL_CARGO must be an absolute executable path.' >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -x "$real_cargo" ]; then
+  printf '%s\n' "TMT_NATIVE_REAL_CARGO is not executable: $real_cargo" >&2
+  exit 2
+fi
+
+for argument in "$@"; do
+  if [ "$argument" = '--locked' ] || [ "$argument" = '--frozen' ]; then
+    exec "$real_cargo" "$@"
+  fi
+done
+
+case "${1:-}" in
+  build|metadata)
+    exec "$real_cargo" "$@" --locked
+    ;;
+  *)
+    exec "$real_cargo" "$@"
+    ;;
+esac

--- a/scripts/verify-native-artifact.mjs
+++ b/scripts/verify-native-artifact.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+import { selectNativeArtifact, withNativeArtifact } from './native-artifact-policy.mjs';
+import { runPackedCommand } from './packed-command.mjs';
+
+const { values } = parseArgs({
+  options: {
+    manifest: { type: 'string' },
+    archive: { type: 'string' },
+    target: { type: 'string' },
+    skill: { type: 'string' },
+    notices: { type: 'string' },
+    license: { type: 'string' },
+  },
+});
+for (const name of ['manifest', 'archive', 'target', 'skill', 'notices', 'license']) {
+  assert(values[name], `--${name} is required`);
+}
+const metadata = selectNativeArtifact(values.manifest, values.archive, values.target);
+const architecture =
+  process.arch === 'arm64' ? 'aarch64' : process.arch === 'x64' ? 'x86_64' : null;
+const platform = process.platform === 'darwin' ? 'apple-darwin' : 'unknown-linux-musl';
+assert(
+  ['darwin', 'linux'].includes(process.platform) && architecture,
+  'Unsupported verification host'
+);
+assert.equal(
+  values.target,
+  `${architecture}-${platform}`,
+  'Artifact requires a matching native host'
+);
+const skill = fs.readFileSync(values.skill, 'utf8');
+const notices = fs.readFileSync(values.notices, 'utf8');
+assert(
+  !/<year>|<copyright holders>/.test(notices),
+  'Dependency notices contain placeholder attribution'
+);
+
+await withNativeArtifact(values.archive, metadata, async (artifactRoot) => {
+  assert.equal(
+    fs.readFileSync(path.join(artifactRoot, 'THIRD-PARTY-NOTICES.txt'), 'utf8'),
+    notices,
+    'Native archive notices differ from the generated inventory'
+  );
+  assert.deepEqual(
+    fs.readFileSync(path.join(artifactRoot, 'LICENSE')),
+    fs.readFileSync(values.license),
+    'Native archive license differs from the selected source'
+  );
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "tmt installed proof's ")));
+  try {
+    const home = path.join(root, 'home');
+    const cwd = path.join(root, 'outside checkout');
+    const xdg = path.join(root, 'config');
+    const emptyPath = path.join(root, 'empty-path');
+    for (const directory of [home, cwd, emptyPath]) fs.mkdirSync(directory);
+    // An allowlist avoids ambient provider, tmux, loader and runtime overrides.
+    const env = { HOME: home, XDG_CONFIG_HOME: xdg, PATH: emptyPath, LANG: 'C', TMPDIR: root };
+    const executable = path.join(artifactRoot, 'tmt');
+    // Inspection tools belong to the verifier, never the executable's PATH.
+    if (process.platform === 'darwin') {
+      const libraries = runPackedCommand('/usr/bin/otool', ['-L', executable], { cwd, env });
+      const dependencies = libraries.trim().split('\n').slice(1);
+      assert(dependencies.length > 0, 'Mach-O dependency inventory is empty');
+      for (const dependency of dependencies) {
+        assert(
+          /^\s+(\/usr\/lib\/|\/System\/Library\/Frameworks\/)/.test(dependency),
+          `Native archive requires a non-system library: ${dependency}`
+        );
+      }
+    } else {
+      const headers = runPackedCommand('/usr/bin/readelf', ['--program-headers', executable], {
+        cwd,
+        env,
+      });
+      assert(!/\bINTERP\b/.test(headers), 'Musl archive must not require a dynamic interpreter');
+      const dynamic = runPackedCommand('/usr/bin/readelf', ['--dynamic', executable], { cwd, env });
+      assert(!/\(NEEDED\)/.test(dynamic), 'Musl archive must not require shared libraries');
+    }
+    const run = (args) => runPackedCommand(executable, args, { cwd, env });
+    const json = (args) => JSON.parse(run([...args, '--json']));
+    assert.equal(run(['--version']).trim(), metadata.version, 'Native archive version mismatch');
+    assert.equal(run(['learn', '--skill']), skill, 'Native archive embedded skill mismatch');
+    const customRoot = path.join(cwd, 'custom skills');
+    fs.mkdirSync(customRoot);
+    const target = path.join(fs.realpathSync(customRoot), 'tmux-team');
+    assert.deepEqual(json(['install', '--dir', customRoot]), {
+      installed: [{ target, changed: true }],
+    });
+    assert(fs.lstatSync(target).isSymbolicLink(), 'Installed skill must be a managed link');
+    assert.equal(fs.readFileSync(path.join(target, 'SKILL.md'), 'utf8'), skill);
+    const globalRoot = path.join(xdg, 'tmux-team');
+    const managedAssets = path.join(fs.realpathSync(globalRoot), 'skill-assets');
+    assert(
+      fs.realpathSync(target).startsWith(`${managedAssets}${path.sep}`),
+      'Installed skill must use the isolated managed asset store'
+    );
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(path.join(globalRoot, 'skill-installations.json'))),
+      {
+        version: 1,
+        targets: [target],
+      }
+    );
+    const database = path.join(globalRoot, 'tmux-team.db');
+    assert(!fs.existsSync(database), 'Skill installation must not initialize SQLite');
+    const created = json(['identity', 'create', 'artifact-proof']);
+    assert.equal(created.created, true);
+    assert.equal(created.identity.name, 'artifact-proof');
+    assert.equal(created.identity.lifetime, 'saved');
+    const shown = json(['identity', 'show', 'artifact-proof']);
+    assert.deepEqual(shown.identity, created.identity);
+    const profile = json([
+      'role',
+      '--identity',
+      'artifact-proof',
+      'set',
+      'Persisted by native archive',
+    ]);
+    assert.equal(profile.role.content, 'Persisted by native archive');
+    assert.deepEqual(json(['role', '--identity', 'artifact-proof', 'show']), profile);
+    const descriptor = fs.openSync(database, 'r');
+    try {
+      const header = Buffer.alloc(16);
+      assert.equal(fs.readSync(descriptor, header, 0, 16, 0), 16);
+      assert.equal(header.toString(), 'SQLite format 3\0');
+    } finally {
+      fs.closeSync(descriptor);
+    }
+    console.log(
+      `Verified native archive ${metadata.name}: linkage, version, skill, managed install, SQLite persistence`
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/native-artifact-policy.test.ts
+++ b/src/native-artifact-policy.test.ts
@@ -1,0 +1,481 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createGzip } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import * as tar from 'tar';
+import { runCli, withSandbox, type Sandbox } from './test-support/cli-process.js';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { selectNativeArtifact, withNativeArtifact } = (await import(
+  pathToFileURL(path.join(repositoryRoot, 'scripts', 'native-artifact-policy.mjs')).href
+)) as unknown as {
+  selectNativeArtifact: (
+    manifestFile: string,
+    archiveFile: string,
+    target: string
+  ) => NativeArtifact;
+  withNativeArtifact: <T>(
+    archiveFile: string,
+    metadata: NativeArtifact,
+    inspect: (root: string) => Promise<T> | T
+  ) => Promise<T>;
+};
+
+const REQUIRED_FILES = ['tmt', 'LICENSE', 'NATIVE-INSTALL.md', 'THIRD-PARTY-NOTICES.txt'];
+const TARGET = 'aarch64-apple-darwin';
+const VERSION = '5.0.0-alpha.1';
+
+interface NativeArtifact {
+  readonly name: string;
+  readonly version: string;
+  readonly target: string;
+  readonly sha256: string;
+}
+
+interface ArchiveOptions {
+  readonly duplicate?: string;
+  readonly executable?: boolean;
+  readonly extra?: string;
+  readonly link?: 'hard' | 'symlink';
+  readonly omit?: string;
+  readonly specialPermissions?: boolean;
+  readonly traversal?: boolean;
+}
+
+interface ArchiveFixture {
+  readonly archiveFile: string;
+  readonly manifestFile: string;
+  readonly manifest: Record<string, unknown>;
+  readonly metadata: NativeArtifact;
+}
+
+function archiveName(target = TARGET): string {
+  return `tmux-team-${VERSION}-${target}.tar.gz`;
+}
+
+async function createArchiveFixture(
+  sandbox: Sandbox,
+  options: ArchiveOptions = {}
+): Promise<ArchiveFixture> {
+  const name = archiveName();
+  const rootName = name.slice(0, -'.tar.gz'.length);
+  const fixtureRoot = fs.mkdtempSync(path.join(sandbox.root, 'archive-fixture-'));
+  const tree = path.join(fixtureRoot, 'archive tree');
+  const root = path.join(tree, rootName);
+  const archiveFile = path.join(fixtureRoot, name);
+  const manifestFile = path.join(fixtureRoot, 'manifest.json');
+  fs.mkdirSync(root, { recursive: true });
+
+  for (const file of REQUIRED_FILES) {
+    if (file === options.omit) continue;
+    const target = path.join(root, file);
+    fs.writeFileSync(target, `${file} fixture\n`, { mode: file === 'tmt' ? 0o755 : 0o644 });
+  }
+  if (options.executable === false) fs.chmodSync(path.join(root, 'tmt'), 0o644);
+  if (options.specialPermissions) fs.chmodSync(path.join(root, 'tmt'), 0o4755);
+  if (options.extra !== undefined) {
+    fs.writeFileSync(path.join(root, options.extra), 'unexpected test fixture\n');
+  }
+  if (options.link === 'symlink') {
+    fs.unlinkSync(path.join(root, 'LICENSE'));
+    fs.symlinkSync('../../outside', path.join(root, 'LICENSE'));
+  } else if (options.link === 'hard') {
+    fs.unlinkSync(path.join(root, 'LICENSE'));
+    fs.linkSync(path.join(root, 'tmt'), path.join(root, 'LICENSE'));
+  }
+
+  const entries = [rootName];
+  const tarOptions = {
+    cwd: tree,
+    file: archiveFile,
+    gzip: true,
+    portable: options.specialPermissions !== true,
+  };
+  if (options.traversal) {
+    fs.writeFileSync(path.join(fixtureRoot, 'escape'), 'traversal fixture\n');
+    entries.push('../escape');
+    Object.assign(tarOptions, { preservePaths: true });
+  }
+  if (options.specialPermissions) {
+    Object.assign(tarOptions, {
+      onWriteEntry(entry: { path: string; stat: { mode: number } }) {
+        if (entry.path === `${rootName}/tmt`) entry.stat.mode = 0o4755;
+      },
+    });
+  }
+  if (options.duplicate !== undefined) entries.push(path.join(rootName, options.duplicate));
+  await tar.c(tarOptions, entries);
+  const sha256 = createHash('sha256').update(fs.readFileSync(archiveFile)).digest('hex');
+  const manifest = {
+    artifacts: {
+      [name]: {
+        kind: 'executable-zip',
+        name,
+        target_triples: [TARGET],
+        checksums: { sha256 },
+        assets: REQUIRED_FILES.map((file) => ({ path: file })),
+      },
+    },
+    releases: [{ app_version: VERSION, artifacts: [name] }],
+  };
+  fs.writeFileSync(manifestFile, `${JSON.stringify(manifest)}\n`);
+  return {
+    archiveFile,
+    manifestFile,
+    manifest,
+    metadata: selectNativeArtifact(manifestFile, archiveFile, TARGET),
+  };
+}
+
+function withArtifactMetadata(sha256: string): NativeArtifact {
+  return {
+    name: archiveName(),
+    version: VERSION,
+    target: TARGET,
+    sha256,
+  };
+}
+
+describe('native artifact policy', () => {
+  it.each([
+    ['notices', 'stale notices', 'Native archive notices differ from the generated inventory'],
+    ['license', 'stale license', 'Native archive license differs from the selected source'],
+    ['notices', 'Copyright (c) <year>', 'Dependency notices contain placeholder attribution'],
+  ])('fails the verifier process for invalid %s evidence', async (changed, content, diagnostic) => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox);
+      const architecture = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
+      const platform = process.platform === 'darwin' ? 'apple-darwin' : 'unknown-linux-musl';
+      const target = `${architecture}-${platform}`;
+      const artifact = (fixture.manifest.artifacts as Record<string, Record<string, unknown>>)[
+        archiveName()
+      ];
+      artifact.target_triples = [target];
+      fs.writeFileSync(fixture.manifestFile, JSON.stringify(fixture.manifest));
+      const notices = path.join(sandbox.root, 'selected-notices.txt');
+      const license = path.join(sandbox.root, 'selected-license.txt');
+      fs.writeFileSync(
+        notices,
+        changed === 'notices' ? content : 'THIRD-PARTY-NOTICES.txt fixture\n'
+      );
+      fs.writeFileSync(license, changed === 'license' ? content : 'LICENSE fixture\n');
+      const result = await runCli(
+        {
+          ...sandbox,
+          cli: {
+            executable: process.execPath,
+            args: [path.join(repositoryRoot, 'scripts/verify-native-artifact.mjs')],
+          },
+        },
+        [
+          '--manifest',
+          fixture.manifestFile,
+          '--archive',
+          fixture.archiveFile,
+          '--target',
+          target,
+          '--skill',
+          license,
+          '--notices',
+          notices,
+          '--license',
+          license,
+        ]
+      );
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain(diagnostic);
+    });
+  });
+
+  it('rejects a manifest target mismatch and a missing checksum', async () => {
+    await withSandbox(async (sandbox) => {
+      const targetFixture = await createArchiveFixture(sandbox);
+      const mismatched = structuredClone(targetFixture.manifest) as Record<string, unknown>;
+      const artifact = (mismatched.artifacts as Record<string, Record<string, unknown>>)[
+        archiveName()
+      ];
+      artifact.target_triples = ['x86_64-unknown-linux-musl'];
+      fs.writeFileSync(targetFixture.manifestFile, JSON.stringify(mismatched));
+      expect(() =>
+        selectNativeArtifact(targetFixture.manifestFile, targetFixture.archiveFile, TARGET)
+      ).toThrow('Manifest target mismatch');
+
+      const checksumFixture = await createArchiveFixture(sandbox);
+      const missingChecksum = structuredClone(checksumFixture.manifest) as Record<string, unknown>;
+      const missingArtifact = (
+        missingChecksum.artifacts as Record<string, Record<string, unknown>>
+      )[archiveName()];
+      missingArtifact.checksums = {};
+      fs.writeFileSync(checksumFixture.manifestFile, JSON.stringify(missingChecksum));
+      expect(() =>
+        selectNativeArtifact(checksumFixture.manifestFile, checksumFixture.archiveFile, TARGET)
+      ).toThrow('Manifest requires SHA-256');
+    });
+  });
+
+  it('rejects malformed asset inventories and release membership', async () => {
+    await withSandbox(async (sandbox) => {
+      const assetFixture = await createArchiveFixture(sandbox);
+      const malformedAssets = structuredClone(assetFixture.manifest) as Record<string, unknown>;
+      const assetArtifact = (malformedAssets.artifacts as Record<string, Record<string, unknown>>)[
+        archiveName()
+      ];
+      assetArtifact.assets = [{ path: 'tmt' }];
+      fs.writeFileSync(assetFixture.manifestFile, JSON.stringify(malformedAssets));
+      expect(() =>
+        selectNativeArtifact(assetFixture.manifestFile, assetFixture.archiveFile, TARGET)
+      ).toThrow('Manifest must describe exactly the native runtime files');
+
+      const releaseFixture = await createArchiveFixture(sandbox);
+      const missingRelease = structuredClone(releaseFixture.manifest) as Record<string, unknown>;
+      missingRelease.releases = [];
+      fs.writeFileSync(releaseFixture.manifestFile, JSON.stringify(missingRelease));
+      expect(() =>
+        selectNativeArtifact(releaseFixture.manifestFile, releaseFixture.archiveFile, TARGET)
+      ).toThrow('Archive must belong to exactly one release');
+    });
+  });
+
+  it('accepts four regular files, returns the inspector value, and cleans staging', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox);
+      const sentinel = path.join(sandbox.root, 'unrelated sentinel.txt');
+      fs.writeFileSync(sentinel, 'preserve me\n');
+      let extracted: string | undefined;
+
+      const result = await withNativeArtifact(fixture.archiveFile, fixture.metadata, (root) => {
+        extracted = root;
+        expect(fs.readdirSync(root).sort()).toEqual([...REQUIRED_FILES].sort());
+        expect(fs.readFileSync(path.join(root, 'LICENSE'), 'utf8')).toBe('LICENSE fixture\n');
+        expect(fs.statSync(path.join(root, 'tmt')).mode & 0o111).not.toBe(0);
+        expect(fs.readFileSync(sentinel, 'utf8')).toBe('preserve me\n');
+        return 'inspected';
+      });
+
+      expect(result).toBe('inspected');
+      expect(extracted).toBeDefined();
+      expect(fs.existsSync(extracted as string)).toBe(false);
+      expect(fs.readFileSync(sentinel, 'utf8')).toBe('preserve me\n');
+    });
+  });
+
+  it('rejects an archive checksum mismatch before invoking the callback', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox);
+      const original = fs.readFileSync(fixture.archiveFile);
+      let called = false;
+      const metadata = { ...fixture.metadata, sha256: '0'.repeat(64) };
+
+      await expect(
+        withNativeArtifact(fixture.archiveFile, metadata, () => {
+          called = true;
+        })
+      ).rejects.toThrow('Native archive checksum mismatch');
+      expect(called).toBe(false);
+      expect(fs.readFileSync(fixture.archiveFile)).toEqual(original);
+    });
+  });
+
+  it('rejects an invalid metadata archive name before reading the archive', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox);
+      const original = fs.readFileSync(fixture.archiveFile);
+      let called = false;
+
+      await expect(
+        withNativeArtifact(fixture.archiveFile, { ...fixture.metadata, name: '...tar.gz' }, () => {
+          called = true;
+        })
+      ).rejects.toThrow('Invalid native archive name');
+      expect(called).toBe(false);
+      expect(fs.readFileSync(fixture.archiveFile)).toEqual(original);
+    });
+  });
+
+  it('rejects oversized compressed input before allocating its contents', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox);
+      const descriptor = fs.openSync(fixture.archiveFile, 'r+');
+      try {
+        fs.ftruncateSync(descriptor, 64 * 1024 * 1024 + 1);
+      } finally {
+        fs.closeSync(descriptor);
+      }
+      let called = false;
+
+      await expect(
+        withNativeArtifact(fixture.archiveFile, fixture.metadata, () => {
+          called = true;
+        })
+      ).rejects.toThrow('Artifact input must be a bounded regular file');
+      expect(called).toBe(false);
+    });
+  });
+
+  it('rejects a truncated gzip after recomputing its checksum', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox);
+      const compressed = fs.readFileSync(fixture.archiveFile);
+      const truncated = compressed.subarray(0, compressed.length - 8);
+      fs.writeFileSync(fixture.archiveFile, truncated);
+      const metadata = withArtifactMetadata(createHash('sha256').update(truncated).digest('hex'));
+
+      await expect(
+        withNativeArtifact(fixture.archiveFile, metadata, () => undefined)
+      ).rejects.toThrow(/unexpected end/i);
+    });
+  });
+
+  it('rejects missing notices and a non-executable runtime', async () => {
+    await withSandbox(async (sandbox) => {
+      const missingNotice = await createArchiveFixture(sandbox, {
+        omit: 'THIRD-PARTY-NOTICES.txt',
+      });
+      await expect(
+        withNativeArtifact(missingNotice.archiveFile, missingNotice.metadata, () => undefined)
+      ).rejects.toThrow(
+        'Missing native archive entry: tmux-team-5.0.0-alpha.1-aarch64-apple-darwin/THIRD-PARTY-NOTICES.txt'
+      );
+
+      const missingExecutable = await createArchiveFixture(sandbox, { omit: 'tmt' });
+      await expect(
+        withNativeArtifact(
+          missingExecutable.archiveFile,
+          missingExecutable.metadata,
+          () => undefined
+        )
+      ).rejects.toThrow(
+        'Missing native archive entry: tmux-team-5.0.0-alpha.1-aarch64-apple-darwin/tmt'
+      );
+
+      const nonExecutable = await createArchiveFixture(sandbox, { executable: false });
+      await expect(
+        withNativeArtifact(nonExecutable.archiveFile, nonExecutable.metadata, () => undefined)
+      ).rejects.toThrow('Native executable lacks execute permission');
+    });
+  });
+
+  it('rejects special permission bits on an otherwise executable runtime', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox, { specialPermissions: true });
+
+      await expect(
+        withNativeArtifact(fixture.archiveFile, fixture.metadata, () => undefined)
+      ).rejects.toThrow('Native archive must not set special permission bits');
+    });
+  });
+
+  it('rejects a FIFO input through the bounded process helper', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox);
+      const fifo = path.join(sandbox.root, 'native archive fifo');
+      const mkfifoSandbox = { ...sandbox, cli: { executable: '/usr/bin/mkfifo', args: [] } };
+      const created = await runCli(mkfifoSandbox, [fifo]);
+      expect(created.status).toBe(0);
+      expect(created.signal).toBeNull();
+      expect(created.stderr).toBe('');
+      expect(fs.statSync(fifo).isFIFO()).toBe(true);
+      // Put the subject, not just FIFO creation, behind the process deadline:
+      // regressing to a blocking open must fail rather than hang the test runner.
+      const moduleUrl = pathToFileURL(
+        path.join(repositoryRoot, 'scripts/native-artifact-policy.mjs')
+      ).href;
+      const probe = `import { withNativeArtifact } from ${JSON.stringify(moduleUrl)};
+await withNativeArtifact(process.argv[1], JSON.parse(process.argv[2]), () => console.log('unexpected extraction'));`;
+      const result = await runCli(
+        {
+          ...sandbox,
+          cli: { executable: process.execPath, args: ['--input-type=module', '--eval', probe] },
+        },
+        [fifo, JSON.stringify(fixture.metadata)]
+      );
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Artifact input must be a bounded regular file');
+    });
+  });
+
+  it(
+    'rejects expanded gzip input over the bound without allocating a giant test buffer',
+    { timeout: 5_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const fixture = await createArchiveFixture(sandbox);
+        const chunk = Buffer.alloc(256 * 1024, 0x61);
+        const source = Readable.from(
+          (async function* repeatedChunks() {
+            for (let index = 0; index < 513; index += 1) yield chunk;
+          })()
+        );
+        await pipeline(source, createGzip(), fs.createWriteStream(fixture.archiveFile));
+        const compressed = fs.readFileSync(fixture.archiveFile);
+        const metadata = withArtifactMetadata(
+          createHash('sha256').update(compressed).digest('hex')
+        );
+
+        await expect(
+          withNativeArtifact(fixture.archiveFile, metadata, () => undefined)
+        ).rejects.toThrow(/larger than 134217728 bytes/i);
+      });
+    }
+  );
+
+  it('rejects unexpected test files and duplicate entries', async () => {
+    await withSandbox(async (sandbox) => {
+      const unexpected = await createArchiveFixture(sandbox, { extra: 'native.test.ts' });
+      await expect(
+        withNativeArtifact(unexpected.archiveFile, unexpected.metadata, () => undefined)
+      ).rejects.toThrow('Unexpected native archive entry');
+
+      const duplicate = await createArchiveFixture(sandbox, { duplicate: 'LICENSE' });
+      await expect(
+        withNativeArtifact(duplicate.archiveFile, duplicate.metadata, () => undefined)
+      ).rejects.toThrow('Duplicate native archive entry');
+    });
+  });
+
+  it('rejects a regular path traversal entry before extraction', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox, { traversal: true });
+      await expect(
+        withNativeArtifact(fixture.archiveFile, fixture.metadata, () => undefined)
+      ).rejects.toThrow('Unexpected native archive entry: ../escape');
+    });
+  });
+
+  it.each(['symlink', 'hard'] as const)(
+    'rejects %s entries, including traversal links',
+    async (link) => {
+      await withSandbox(async (sandbox) => {
+        const fixture = await createArchiveFixture(sandbox, { link });
+        await expect(
+          withNativeArtifact(fixture.archiveFile, fixture.metadata, () => undefined)
+        ).rejects.toThrow('Native archive entry must be regular');
+      });
+    }
+  );
+
+  it('cleans staging after callback failure without removing an unrelated sentinel', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createArchiveFixture(sandbox);
+      const sentinel = path.join(sandbox.root, 'unrelated sentinel.txt');
+      fs.writeFileSync(sentinel, 'preserve me\n');
+      let extracted: string | undefined;
+
+      await expect(
+        withNativeArtifact(fixture.archiveFile, fixture.metadata, (root) => {
+          extracted = root;
+          throw new Error('inspection failed');
+        })
+      ).rejects.toThrow('inspection failed');
+      expect(extracted).toBeDefined();
+      expect(fs.existsSync(extracted as string)).toBe(false);
+      expect(fs.readFileSync(sentinel, 'utf8')).toBe('preserve me\n');
+    });
+  });
+});

--- a/src/native-cargo.test.ts
+++ b/src/native-cargo.test.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { runCli, withSandbox, type Sandbox } from './test-support/cli-process.js';
+
+const wrapper = fileURLToPath(new URL('../scripts/native-cargo.sh', import.meta.url));
+
+interface FakeCargo {
+  readonly argsFile: string;
+  readonly executable: string;
+}
+
+function runWrapper(sandbox: Sandbox, args: string[]) {
+  return runCli({ ...sandbox, cli: { executable: wrapper, args: [] } }, args);
+}
+
+function createFakeCargo(sandbox: Sandbox, exitCode = 0): FakeCargo {
+  const recorder = path.join(sandbox.root, 'fake cargo recorder "quoted".mjs');
+  const executable = path.join(sandbox.root, 'fake cargo "quoted"');
+  const argsFile = path.join(sandbox.root, 'fake cargo args.json');
+  fs.writeFileSync(
+    recorder,
+    `import { writeFileSync } from 'node:fs';
+writeFileSync(process.env.TMT_NATIVE_ARGS_FILE, JSON.stringify(process.argv.slice(2)));
+process.exit(Number(process.env.TMT_TEST_STATUS));
+`
+  );
+  fs.writeFileSync(executable, '#!/bin/sh\nexec "$TMT_TEST_NODE" "$TMT_TEST_RECORDER" "$@"\n', {
+    mode: 0o755,
+  });
+  sandbox.env.TMT_TEST_NODE = process.execPath;
+  sandbox.env.TMT_TEST_RECORDER = recorder;
+  sandbox.env.TMT_NATIVE_ARGS_FILE = argsFile;
+  sandbox.env.TMT_TEST_STATUS = String(exitCode);
+  return { argsFile, executable };
+}
+
+function recordedArgs(argsFile: string): string[] {
+  return JSON.parse(fs.readFileSync(argsFile, 'utf8')) as string[];
+}
+
+describe('native cargo wrapper', () => {
+  it('is executable and forwards build and metadata arguments before adding locked', async () => {
+    expect(fs.existsSync(wrapper)).toBe(true);
+    expect(fs.statSync(wrapper).mode & 0o111).not.toBe(0);
+
+    for (const command of ['build', 'metadata']) {
+      await withSandbox(async (sandbox) => {
+        const fake = createFakeCargo(sandbox);
+        const args = [command, '--target', 'target with spaces', '--features', 'quote"value'];
+        sandbox.env.TMT_NATIVE_REAL_CARGO = fake.executable;
+
+        const result = await runWrapper(sandbox, args);
+
+        expect(result.status).toBe(0);
+        expect(result.signal).toBeNull();
+        expect(result.stderr).toBe('');
+        expect(recordedArgs(fake.argsFile)).toEqual([...args, '--locked']);
+      });
+    }
+  });
+
+  it.each([
+    ['-vV'],
+    ['--version'],
+    ['check', '--locked'],
+    ['metadata', '--locked'],
+    ['build', '--frozen'],
+  ])('leaves non-build cargo invocation %j unchanged', async (...args: string[]) => {
+    await withSandbox(async (sandbox) => {
+      const fake = createFakeCargo(sandbox);
+      sandbox.env.TMT_NATIVE_REAL_CARGO = fake.executable;
+
+      const result = await runWrapper(sandbox, args);
+
+      expect(result.status).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(result.stderr).toBe('');
+      expect(recordedArgs(fake.argsFile)).toEqual(args);
+    });
+  });
+
+  it('propagates the real cargo exit status without changing its arguments', async () => {
+    await withSandbox(async (sandbox) => {
+      const fake = createFakeCargo(sandbox, 17);
+      const args = ['-vV'];
+      sandbox.env.TMT_NATIVE_REAL_CARGO = fake.executable;
+
+      const result = await runWrapper(sandbox, args);
+
+      expect(result.status).toBe(17);
+      expect(result.signal).toBeNull();
+      expect(result.stderr).toBe('');
+      expect(recordedArgs(fake.argsFile)).toEqual(args);
+    });
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['relative', 'cargo'],
+  ])('rejects %s real cargo configuration without fallback', async (_label, realCargo) => {
+    await withSandbox(async (sandbox) => {
+      delete sandbox.env.TMT_NATIVE_REAL_CARGO;
+      if (realCargo !== undefined) sandbox.env.TMT_NATIVE_REAL_CARGO = realCargo;
+
+      const result = await runWrapper(sandbox, []);
+
+      expect(result.status).toBe(2);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('TMT_NATIVE_REAL_CARGO must be an absolute executable path.');
+    });
+  });
+
+  it('rejects an absolute non-executable cargo target', async () => {
+    await withSandbox(async (sandbox) => {
+      const target = path.join(sandbox.root, 'cargo target with spaces');
+      fs.writeFileSync(target, 'not executable\n', { mode: 0o644 });
+      sandbox.env.TMT_NATIVE_REAL_CARGO = target;
+
+      const result = await runWrapper(sandbox, []);
+
+      expect(result.status).toBe(2);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain(`TMT_NATIVE_REAL_CARGO is not executable: ${target}`);
+    });
+  });
+});

--- a/test/native/artifact.Dockerfile
+++ b/test/native/artifact.Dockerfile
@@ -1,0 +1,31 @@
+# Local native-architecture artifact proof. Not a publishing workflow.
+FROM rust:1.97.0-bookworm@sha256:8fa55b2f3ddf97471ab6a767bfa3f37e6bad0986ba823e75fea57e2a2a5c3073 AS build
+RUN apt-get update && apt-get install --no-install-recommends -y musl-tools \
+  && rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-dist --version 0.32.0 --locked \
+  && cargo install cargo-about --version 0.9.2 --locked --features cli
+ARG TARGET_TRIPLE
+RUN test -n "$TARGET_TRIPLE" && rustup target add "$TARGET_TRIPLE"
+WORKDIR /workspace
+COPY rust/ rust/
+COPY skills/ skills/
+COPY scripts/native-cargo.sh scripts/build-native-artifact.sh scripts/
+COPY dist-workspace.toml LICENSE NATIVE-INSTALL.md ./
+RUN cd rust && cargo fetch --locked
+RUN scripts/build-native-artifact.sh "$TARGET_TRIPLE" > native-manifest.json
+
+FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
+RUN apt-get update && apt-get install --no-install-recommends -y binutils \
+  && rm -rf /var/lib/apt/lists/*
+RUN npm install --global pnpm@10.33.0
+WORKDIR /verification
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --ignore-scripts
+COPY scripts/native-artifact-policy.mjs scripts/verify-native-artifact.mjs scripts/packed-command.mjs scripts/
+COPY skills/tmux-team/SKILL.md expected-skill.md
+COPY --from=build /workspace/native-manifest.json ./
+COPY --from=build /workspace/rust/target/native-notices/THIRD-PARTY-NOTICES.txt expected-notices.txt
+COPY LICENSE expected-license.txt
+COPY --from=build /workspace/target/distrib/ artifacts/
+# Pass archive and target explicitly from the generator's target selection.
+ENTRYPOINT ["node", "scripts/verify-native-artifact.mjs", "--manifest", "native-manifest.json", "--skill", "expected-skill.md", "--notices", "expected-notices.txt", "--license", "expected-license.txt"]

--- a/test/native/binding.test.ts
+++ b/test/native/binding.test.ts
@@ -1,6 +1,5 @@
 import Database from 'better-sqlite3';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { calibrateTmuxTripwire } from './tmux-tripwire.js';
 import {


### PR DESCRIPTION
## Scope

- Closes #135; artifact prerequisite for #82 and #93. Native managed installation continues in #138.
- Build optimized cargo-dist archives and target-filtered cargo-about notices; independently verify archive safety and actual native operation outside the checkout.
- This does not publish artifacts, change installed entrypoints, install globally, enable a generated shell installer or implement native self-update.

## Architecture and review

- `dist-workspace.toml` and cargo-dist's generated manifest own targets, version, archive layout and checksums. The pinned generator is used for archives only; CI/installers are disabled. There is no second release catalog or updater.
- The build wrapper resolves the repository Rust toolchain before generic-root discovery, works without Git metadata, and enforces locked Cargo build/metadata calls. `cargo-about` is pinned with its required CLI feature and filters notices to the selected archive target.
- The developer-only pinned `tar` parser handles format decoding. Independent verification bounds compressed/expanded input, verifies SHA-256, rejects unsafe names/paths/links/duplicates/permissions, and owns private extraction cleanup. The existing packed-command runner supplies bounded subprocess/descendant cleanup.
- The actual archive verifier checks system/static linkage, version, exact embedded skill, isolated managed skill source/link/registry, and native SQLite identity/role persistence across processes with an empty runtime PATH. It compares notices/LICENSE against selected fresh inputs and rejects placeholder attribution. The old npm matrix remains a separate TypeScript gate.
- Primary reviewer: Codex. Reviewed every changed file plus relevant config/skill publication, packed process/policy helpers, native profile/install contracts, Docker/CI boundaries and dependency manifests. Bounded delegated test/inventory findings were reviewed and refined, not accepted by test count alone.
- Findings corrected: duplicated `--locked`; missing cargo-about CLI feature; no-Git workspace discovery; inherited malformed test fixtures; dot-only archive roots; special permission bits; FIFO blocking before validation; and target-irrelevant placeholder notice attribution. FIFO regression execution itself is behind the shared process deadline. Also removed one existing unused native-test import found by quality checks.
- Notice audit: all four configured targets resolve the same 66 external runtime entries. ICU4X and unicode-ident copyright text is retained; no missing external package name or placeholder attribution was found after filtering. This is reviewed evidence, not legal certification.
- Reviewed commit: `4b40ee4c86661734d0b27a6c2372de050496094c`.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and final lifecycle results are recorded below.
- [x] CI was checked on the current commit before authorized merge.

Local commands/results:

- CI run `34202137595`, attempt 1: all 11 required checks succeeded on reviewed head `4b40ee4c86661734d0b27a6c2372de050496094c` before merge; no rerun or bypass.

- `cargo test --locked`: 294 passed (210 adapter, 30 CLI, 19 architecture, 45 core).
- `cargo fmt --all --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo +1.88.0 build --locked`, native debug/storage-probe builds: passed.
- `pnpm check`: passed with zero warnings/errors; `git diff --check`: passed.
- `pnpm test:run`: 1,131 tests in 72 files passed; existing coverage gates passed.
- `pnpm test:native`, selecting absolute native CLI/storage-probe descriptors: 96 tests in 11 files passed.
- `pnpm exec vitest run src/native-artifact-policy.test.ts src/native-cargo.test.ts`: 29 focused tests passed. Includes real malformed tar fixtures, compressed/expanded bounds, FIFO, process-level stale/placeholder notices, and cleanup/preservation assertions.
- Native-selected shared CI parser/config subsets: 8 and 6 passed respectively; other cases are intentionally unselected by the existing CI filters.
- `MACOSX_DEPLOYMENT_TARGET=11.0 scripts/build-native-artifact.sh aarch64-apple-darwin` followed by `node scripts/verify-native-artifact.mjs` with the generated manifest/archive and canonical skill/notices/LICENSE: passed on native macOS arm64. Runtime PATH has no Node/Rust/tmux; only system libraries required.
- `docker build -f test/native/artifact.Dockerfile --build-arg TARGET_TRIPLE=aarch64-unknown-linux-musl ...` followed by the task-owned image under `docker run --rm --init --network none`: passed on native Linux arm64. No ELF interpreter or shared-library dependency; real skill and SQLite persistence passed.
- Two final-source `pnpm test:e2e` lifecycle passes: both passed (each 210 adapter + 159 E2E, 34 files, one existing optional performance skip; 307.72 s and 318.37 s). An earlier intermediate pass also succeeded and is not substituted for the final-source pair.
- `pnpm audit --json`: main and candidate have identical advisory IDs (6 moderate, 13 high, 1 critical), zero added by the new parser dependency. Existing Node developer/test-toolchain findings are tracked in #137; no unrelated toolchain upgrade is hidden in this PR.

## Project lifecycle

- Updated ARCHITECTURE, DEVELOPMENT, RUST-REWRITE, release skill and archive-specific preview instructions. Application skill content is unchanged because this PR adds no installed public command.
- Scope/refinement and CI-cost decision recorded in #135. Existing required CI topology is retained; no four-platform tool compilation matrix is added to every PR. Native x64 execution/full distribution readiness remain #82 gates, not claims inferred from the npm matrix.
- Branch `feat/135-native-artifacts`, dedicated issue worktree. Cleanup occurs only after authorized exact-head CI merge and safe delivery recording.
- Remaining: #138 managed receipts/activation, then HTTPS bootstrap/update integration, full target readiness and runtime cutover. Public release/tag/npm publishing and credentials still require separate authorization.
