### PR TITLE
feat(native): add managed offline installation

### DIFF
--- a/.agents/skills/tmt-release/SKILL.md
+++ b/.agents/skills/tmt-release/SKILL.md
@@ -29,6 +29,12 @@ Use this skill for release-line maintenance, v4 compatibility fixes, v5 promotio
   Verify the installed application's schema and behavior, not only driver loading
   or manifest equality. Keep broken-artifact failure and cleanup evidence; do not
   seed schema through checkout test helpers or ship test-only sources.
+- For native binary publication changes, also follow DEVELOPMENT's offline
+  installer lifecycle procedure using actual separately versioned archives.
+  Keep ownership anchored in the installation prefix, not application-state
+  selectors; verify old executable preservation, pin policy, partial command-link
+  finalization and unchanged data. The internal preview entrypoint is not a
+  public bootstrap or permission to replace a user/package-manager installation.
 - Promotion requires passing Code quality, Unit tests, and Docker E2E checks.
 - Tags, GitHub Releases, npm publishing, and npm dist-tags are separate operations that require explicit authorization; this skill never assumes permission for them.
 - Update user-facing installation or channel documentation whenever a version change would make it inaccurate.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1445,10 +1445,58 @@ SQLite profile checks with an empty runtime PATH and isolated state. The existin
 npm packed matrix remains a distinct transitional TypeScript gate.
 
 Unsigned checksums detect corruption, not origin compromise. Native binary
-bootstrap, manager receipts, atomic update and authenticated public release
+bootstrap, public network update and authenticated public release
 provenance remain #82 gates. These developer archives do not change installed
 entrypoints or authorize publication. Candidate targets require actual matching
 target execution before they become supported release platforms.
+
+## Managed native installation boundary
+
+Under #138, the hidden `__native-install` entrypoint composes the offline
+`tmt-adapters::native_install` owner. It does not discover application settings,
+open SQLite, inspect tmux or install skills. The public `install` command still
+installs agent guidance. Public network upgrade remains unavailable in preview.
+
+`tmt-core::native_install` owns channel and forward-only version/pin policy using
+semver precedence. Stable accepts stable versions; alpha accepts the alpha
+prerelease family. Preserved pins block a different candidate, explicit pin or
+unpin does not authorize downgrades, and build metadata alone cannot replace an
+equal-precedence version. Adapters independently reject changed archive evidence
+at the same version, even when version policy would otherwise return a no-op.
+
+The artifact adapter consumes cargo-dist metadata and verifies bounded no-follow
+regular inputs, SHA-256 and exactly four runtime files. Maintained tar/flate2
+libraries decode a bounded in-memory snapshot; archive paths never become
+filesystem extraction targets. The native runtime and independent JavaScript
+packaging verifier are separate implementation/verification boundaries, not
+two runtime installation services.
+
+Ownership belongs to the canonical explicit installation prefix, never
+`TMUX_TEAM_HOME` or XDG application state. Immutable
+`lib/tmux-team/releases/<UUID>` directories contain payloads and a versioned
+receipt with prefix, release ID, version/channel/pin, target, archive digest and
+individual file digests. `current` is a relative `releases/<UUID>` link;
+`bin/tmt` and `bin/tmux-team` use `../lib/tmux-team/current/tmt`. Receipt content
+alone is not replacement authority: validate the layout, exact release inventory,
+regular files, permissions, digests and command links. Refuse unknown manager or
+manual command entries rather than adding force-overwrite behavior.
+
+The native owner holds a stable nonblocking regular-file lock, stages and syncs
+the release and receipt, revalidates expected current ownership, then atomically
+replaces only `current`. First-install command links are separately finalized;
+post-activation failures explicitly report partial completion, retaining the
+complete active release for retry. Previous releases and unknown abandoned
+entries are not pruned. Binary recovery does not downgrade SQLite schemas.
+The CLI reuses the interrupt guard; adapter checkpoints permit cancellation and
+failure injection before activation. Hard termination can leave an unactivated
+release, but never requires deleting the previous executable.
+
+`bounded_file` shares acquisition with an explicit no-follow variant; `file_lock`
+shares only stable advisory-lock mechanics and `content_digest` shares SHA-256
+encoding. Skill-specific assets, registry, backup and path policy remain in
+`skill_installation`; the binary installer does not reuse that registry as proof
+of binary ownership. HTTPS acquisition must call this same native owner rather
+than introducing a second shell publication mechanism.
 
 ## Maintenance contract
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -637,6 +637,55 @@ unexpected paths, duplicates, bounds and cleanup; never accept any arbitrary
 process error as proof of the intended check. Inspect exact manifest and archive
 bytes from the final source before running the reviewed CI candidate.
 
+## Offline native installer preview
+
+The internal entrypoint consumes a local cargo-dist archive and manifest. It is
+not advertised by help/completion and does not change `tmt install` skill syntax.
+Use a task-owned prefix and matching host archive, never an existing user install:
+
+```sh
+native_prefix=$(mktemp -d)
+rust/target/debug/tmt __native-install \
+  --archive target/distrib/tmt-cli-aarch64-apple-darwin.tar.gz \
+  --manifest "$native_manifest" --prefix "$native_prefix" --channel alpha --json
+"$native_prefix/bin/tmt" --version
+```
+
+`--pin` pins the selected candidate, `--unpin` clears an existing pin, and omission
+preserves its state. Neither authorizes a downgrade. Repeated exact artifacts are
+no-ops after ownership validation; metadata-only changes activate a new receipt
+with the same payload. Receipts record local-archive provenance, not authenticated
+public release provenance. Keep application state isolated separately when running
+identity/profile commands; installing the executable must not open a database.
+
+Native adapter tests cover bounded archive acquisition and publication failures;
+native process contracts use the existing executable selector and sandbox. Test
+current/receipt tampering, manager collisions, pin changes, interrupted staging,
+lock contention, missing command-link repair and retained previous releases.
+Assert surviving bytes and cleanup, not merely a failed exit. Synthetic filesystem
+fixtures are not proof of runnable release artifacts: retain separate actual
+cargo-dist archive execution and target/linkage/notice evidence. Run the shared
+skill-installation regressions when changing shared file locks or content digests.
+
+For actual old-to-new acceptance, build two separately versioned cargo-dist
+archives in task-owned source copies. Do not alter the repository release version
+or publish fixtures merely to test updates. The newer archive must contain the
+offline installer; the older artifact must run its real reported version. Verify
+each archive's notices/linkage with the artifact verifier above, then run:
+
+```sh
+node scripts/verify-native-installation.mjs \
+  --previous-archive "$previous_archive" --previous-manifest "$previous_manifest" \
+  --archive "$next_archive" --manifest "$next_manifest" \
+  --target aarch64-apple-darwin --skill skills/tmux-team/SKILL.md
+```
+
+This reuses the bounded packed-command runner and independent archive verifier.
+It checks exact old/new versions with no runtime PATH, pinned rejection, explicit
+unpin advancement, a retained executable, no-op and downgrade rejection, exact
+embedded skill and unchanged SQLite bytes during installation. Its temporary
+prefix/application state is always invocation-owned and removed afterward.
+
 ## Testing Strategy
 
 We prefer structured, deterministic assertions in tests. Human-facing formatting is validated sparingly; most tests assert on structured output or file contents.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -667,7 +667,13 @@ large executable buffers must use exact `Buffer.equals`
 checks rather than structural object matchers: enumerating every byte can exhaust
 the test runner's heap on debug binaries. Verify the comparator detects a changed
 byte; do not replace byte equality with a size-only assertion or raise CI memory
-limits to hide assertion overhead. Synthetic filesystem
+limits to hide assertion overhead. Installation cases also use an explicit
+15-second subprocess budget for debug
+archive hashing/decompression and durable publication, distinct from the ordinary
+CLI's five-second test budget and each scenario's 60-second cap. Keep ordinary
+command and production timeout policies unchanged; validate installation budgets
+under constrained local resources rather than treating CI as a timing probe.
+Synthetic filesystem
 fixtures are not proof of runnable release artifacts: retain separate actual
 cargo-dist archive execution and target/linkage/notice evidence. Run the shared
 skill-installation regressions when changing shared file locks or content digests.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -662,7 +662,12 @@ Native adapter tests cover bounded archive acquisition and publication failures;
 native process contracts use the existing executable selector and sandbox. Test
 current/receipt tampering, manager collisions, pin changes, interrupted staging,
 lock contention, missing command-link repair and retained previous releases.
-Assert surviving bytes and cleanup, not merely a failed exit. Synthetic filesystem
+Assert surviving bytes and cleanup, not merely a failed exit. Tests comparing
+large executable buffers must use exact `Buffer.equals`
+checks rather than structural object matchers: enumerating every byte can exhaust
+the test runner's heap on debug binaries. Verify the comparator detects a changed
+byte; do not replace byte equality with a size-only assertion or raise CI memory
+limits to hide assertion overhead. Synthetic filesystem
 fixtures are not proof of runnable release artifacts: retain separate actual
 cargo-dist archive execution and target/linkage/notice evidence. Run the shared
 skill-installation regressions when changing shared file locks or content digests.

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -526,6 +526,12 @@ static musl. Per-target cargo-about notices, bounded archive inventory/extractio
 system/static linkage checks and isolated executable/skill/SQLite verification
 are separate from the transitional npm package matrix. See DEVELOPMENT's native
 Rust release archive procedure. Actual matching-platform execution remains a
-release gate; the target list is not itself a support claim. Bootstrap, binary
-ownership receipts, atomic updates, public provenance and installed-runtime
-cutover remain #82/#93 work, not capabilities supplied by an archive generator.
+release gate; the target list is not itself a support claim.
+
+Offline installer prerequisite #138 owns prefix-anchored receipts, version/pin
+policy and single-pointer release activation. Its internal entrypoint accepts
+local archives without application-state discovery. See ARCHITECTURE's managed
+native installation boundary for ownership and partial-finalization semantics.
+HTTPS bootstrap, public upgrade/update, skill refresh composition, authenticated
+public provenance and installed-runtime cutover remain #82/#93 work, not
+capabilities supplied by the archive generator or offline installer alone.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +19,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -102,6 +114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,7 +165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -160,10 +181,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "futures-core"
@@ -381,12 +424,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -446,12 +499,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "libsqlite3-sys",
@@ -463,6 +525,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -546,6 +614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,12 +712,15 @@ name = "tmt-adapters"
 version = "5.0.0-alpha.1"
 dependencies = [
  "base64",
+ "flate2",
  "nix",
  "rusqlite",
+ "semver",
  "serde_json",
  "sha2",
  "signal-hook",
  "subprocess",
+ "tar",
  "tmt-core",
  "uuid",
 ]
@@ -657,6 +744,7 @@ dependencies = [
  "icu_casemap",
  "icu_locale_core",
  "icu_normalizer",
+ "semver",
  "sha2",
  "uuid",
 ]
@@ -771,12 +859,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "writeable"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 repository = "https://github.com/wkh237/tmux-team"
 
 [workspace.dependencies]
+semver = "=1.0.28"
+tar = { version = "=0.4.46", default-features = false }
+flate2 = { version = "=1.1.10", default-features = false, features = ["rust_backend"] }
 tmt-core = { path = "crates/tmt-core" }
 tmt-adapters = { path = "crates/tmt-adapters" }
 clap = { version = "=4.6.6", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions", "string"] }

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -13,6 +13,9 @@ serde_json.workspace = true
 base64.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 sha2.workspace = true
+semver.workspace = true
+tar.workspace = true
+flate2.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 subprocess.workspace = true

--- a/rust/crates/tmt-adapters/src/bounded_file.rs
+++ b/rust/crates/tmt-adapters/src/bounded_file.rs
@@ -33,10 +33,19 @@ impl Error for FileReadError {
 }
 
 pub fn read(path: &Path, maximum: usize) -> Result<Vec<u8>, FileReadError> {
+    read_with_flags(path, maximum, OFlag::O_NONBLOCK)
+}
+
+/// Read a regular file without following a symlink at the selected path.
+pub fn read_no_follow(path: &Path, maximum: usize) -> Result<Vec<u8>, FileReadError> {
+    read_with_flags(path, maximum, OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK)
+}
+
+fn read_with_flags(path: &Path, maximum: usize, flags: OFlag) -> Result<Vec<u8>, FileReadError> {
     let bound = maximum.checked_add(1).ok_or(FileReadError::TooLarge)?;
     let file = OpenOptions::new()
         .read(true)
-        .custom_flags(OFlag::O_NONBLOCK.bits())
+        .custom_flags(flags.bits())
         .open(path)
         .map_err(FileReadError::Io)?;
     if !file.metadata().map_err(FileReadError::Io)?.is_file() {
@@ -54,3 +63,6 @@ pub fn read(path: &Path, maximum: usize) -> Result<Vec<u8>, FileReadError> {
     }
     Ok(bytes)
 }
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-adapters/src/bounded_file/tests.rs
+++ b/rust/crates/tmt-adapters/src/bounded_file/tests.rs
@@ -1,0 +1,124 @@
+use super::*;
+use crate::test_support::TestDirectory;
+use nix::{sys::stat::Mode, unistd::mkfifo};
+use std::{
+    env, fs,
+    os::unix::fs::symlink,
+    process::{Child, Command, ExitStatus, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+const FIFO_FIXTURE_TEST: &str = "bounded_file::tests::fifo_fixture";
+const FIFO_FIXTURE_PATH: &str = "TMT_BOUNDED_FILE_FIFO";
+const FIFO_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[test]
+fn bounded_reads_accept_regular_files_and_reject_oversized_content() {
+    let directory = TestDirectory::new();
+    let file = directory.path.join("body");
+    fs::write(&file, b"body").unwrap();
+
+    assert_eq!(read(&file, 4).unwrap(), b"body");
+    assert_eq!(read_no_follow(&file, 4).unwrap(), b"body");
+    assert!(matches!(read(&file, 3), Err(FileReadError::TooLarge)));
+    assert!(matches!(
+        read_no_follow(&file, 3),
+        Err(FileReadError::TooLarge)
+    ));
+}
+
+#[test]
+fn no_follow_rejects_symlinks_while_read_continues_to_follow_them() {
+    let directory = TestDirectory::new();
+    let target = directory.path.join("target");
+    let link = directory.path.join("link");
+    fs::write(&target, b"target bytes").unwrap();
+    symlink(&target, &link).unwrap();
+
+    assert_eq!(read(&link, 64).unwrap(), b"target bytes");
+    assert!(matches!(
+        read_no_follow(&link, 64),
+        Err(FileReadError::Io(_))
+    ));
+    assert_eq!(fs::read(&target).unwrap(), b"target bytes");
+    assert_eq!(fs::read_link(&link).unwrap(), target);
+}
+
+#[test]
+fn no_follow_rejects_directories_without_waiting() {
+    let directory = TestDirectory::new();
+    assert!(matches!(
+        read_no_follow(&directory.path, 64),
+        Err(FileReadError::Io(_))
+    ));
+
+    let fifo = directory.path.join("fifo");
+    mkfifo(&fifo, Mode::S_IRUSR | Mode::S_IWUSR).unwrap();
+    let mut fixture = FifoFixture::start(&fifo);
+    let status = wait_for_exit(&mut fixture.child, FIFO_EXIT_TIMEOUT);
+    assert!(
+        status.success(),
+        "FIFO fixture rejected input unsuccessfully: {status}"
+    );
+}
+
+struct FifoFixture {
+    child: Child,
+}
+
+impl FifoFixture {
+    fn start(path: &std::path::Path) -> Self {
+        let executable = env::current_exe().expect("locate bounded-file test binary");
+        let child = Command::new(executable)
+            .args([
+                "--exact",
+                FIFO_FIXTURE_TEST,
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(FIFO_FIXTURE_PATH, path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn task-owned FIFO fixture");
+        Self { child }
+    }
+}
+
+impl Drop for FifoFixture {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn wait_for_exit(child: &mut Child, timeout: Duration) -> ExitStatus {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("inspect FIFO fixture status") {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let status = child.wait().expect("reap timed-out FIFO fixture");
+            panic!("FIFO fixture did not exit before deadline: {status}");
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[test]
+fn fifo_fixture() {
+    let Some(path) = env::var_os(FIFO_FIXTURE_PATH) else {
+        return;
+    };
+    let path = std::path::PathBuf::from(path);
+    assert!(matches!(
+        read_no_follow(&path, 64),
+        Err(FileReadError::Io(_))
+    ));
+}

--- a/rust/crates/tmt-adapters/src/content_digest.rs
+++ b/rust/crates/tmt-adapters/src/content_digest.rs
@@ -1,0 +1,10 @@
+//! Stable lowercase SHA-256 encoding for file-integrity evidence.
+
+use sha2::{Digest, Sha256};
+
+pub(crate) fn sha256(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}

--- a/rust/crates/tmt-adapters/src/file_lock.rs
+++ b/rust/crates/tmt-adapters/src/file_lock.rs
@@ -1,0 +1,30 @@
+//! Stable, regular-file advisory locks shared by independent publication owners.
+
+use nix::fcntl::{Flock, FlockArg, OFlag};
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    os::unix::fs::OpenOptionsExt,
+    path::Path,
+};
+
+pub(crate) fn exclusive(path: &Path) -> io::Result<Flock<File>> {
+    // Never unlink: replacing the inode would split concurrent lock domains.
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags((OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK).bits())
+        .open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(io::Error::other("Publication lock is not a regular file."));
+    }
+    Flock::lock(file, FlockArg::LockExclusiveNonblock).map_err(|(_, error)| {
+        io::Error::new(
+            io::Error::from_raw_os_error(error as i32).kind(),
+            format!("Cannot acquire publication lock; another installer may be running: {error}"),
+        )
+    })
+}

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -3,9 +3,14 @@
 #[cfg(unix)]
 pub mod bounded_file;
 pub mod config;
+mod content_digest;
+#[cfg(unix)]
+mod file_lock;
 #[cfg(unix)]
 pub mod interrupt;
 mod json_document;
+#[cfg(unix)]
+pub mod native_install;
 #[cfg(unix)]
 pub mod process;
 pub mod reply_receipt;

--- a/rust/crates/tmt-adapters/src/native_install/artifact.rs
+++ b/rust/crates/tmt-adapters/src/native_install/artifact.rs
@@ -1,0 +1,182 @@
+//! Cargo-dist metadata and bounded, allowlisted archive acquisition.
+//!
+//! Never use generic archive unpacking: archive paths are not filesystem targets.
+
+use super::invalid;
+use crate::bounded_file;
+pub(super) use crate::content_digest::sha256 as digest;
+use flate2::read::MultiGzDecoder;
+use semver::Version;
+use serde_json::Value;
+use std::{
+    collections::BTreeMap,
+    io::{self, Read},
+    path::Path,
+};
+
+const COMPRESSED_LIMIT: usize = 64 * 1024 * 1024;
+const EXPANDED_LIMIT: usize = 128 * 1024 * 1024;
+pub(super) const FILES: [&str; 4] = [
+    "tmt",
+    "LICENSE",
+    "NATIVE-INSTALL.md",
+    "THIRD-PARTY-NOTICES.txt",
+];
+
+#[derive(Debug)]
+pub(super) struct Artifact {
+    pub name: String,
+    pub version: Version,
+    pub target: String,
+    pub sha256: String,
+    pub files: BTreeMap<String, Vec<u8>>,
+}
+
+impl Artifact {
+    pub fn file_hashes(&self) -> BTreeMap<String, String> {
+        self.files
+            .iter()
+            .map(|(name, bytes)| (name.clone(), digest(bytes)))
+            .collect()
+    }
+}
+
+pub(super) fn acquire(manifest: &Path, archive: &Path, target: &str) -> io::Result<Artifact> {
+    let bytes =
+        bounded_file::read_no_follow(manifest, 4 * 1024 * 1024).map_err(io::Error::other)?;
+    let manifest: Value = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
+    let name = archive
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| invalid("Native archive requires an ASCII filename."))?;
+    let root = name
+        .strip_suffix(".tar.gz")
+        .filter(|root| {
+            root.as_bytes()
+                .first()
+                .is_some_and(u8::is_ascii_alphanumeric)
+                && root
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"._-".contains(&b))
+        })
+        .ok_or_else(|| invalid("Invalid native archive filename."))?;
+    let metadata = &manifest["artifacts"][name];
+    if metadata["kind"] != "executable-zip"
+        || metadata["name"] != name
+        || metadata["target_triples"] != serde_json::json!([target])
+    {
+        return Err(invalid("Native archive metadata or target does not match."));
+    }
+    let sha256 = metadata["checksums"]["sha256"]
+        .as_str()
+        .filter(|hash| {
+            hash.len() == 64
+                && hash
+                    .bytes()
+                    .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        })
+        .ok_or_else(|| invalid("Native archive requires a SHA-256 checksum."))?;
+    let mut inventory = metadata["assets"]
+        .as_array()
+        .ok_or_else(|| invalid("Native archive asset inventory is missing."))?
+        .iter()
+        .map(|asset| {
+            asset["path"]
+                .as_str()
+                .ok_or_else(|| invalid("Invalid archive asset path."))
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    inventory.sort_unstable();
+    let mut required = FILES;
+    required.sort_unstable();
+    if inventory != required {
+        return Err(invalid("Unexpected native archive asset inventory."));
+    }
+    let releases = manifest["releases"]
+        .as_array()
+        .ok_or_else(|| invalid("Native manifest releases are missing."))?
+        .iter()
+        .filter(|release| {
+            release["artifacts"]
+                .as_array()
+                .is_some_and(|assets| assets.iter().any(|asset| asset == name))
+        })
+        .collect::<Vec<_>>();
+    if releases.len() != 1 || releases[0]["app_name"] != "tmt-cli" {
+        return Err(invalid(
+            "Native archive must belong to exactly one TMT release.",
+        ));
+    }
+    let version = releases[0]["app_version"]
+        .as_str()
+        .ok_or_else(|| invalid("Native release version is missing."))?
+        .parse()
+        .map_err(|_| invalid("Native release version is invalid."))?;
+    let compressed =
+        bounded_file::read_no_follow(archive, COMPRESSED_LIMIT).map_err(io::Error::other)?;
+    if digest(&compressed) != sha256 {
+        return Err(invalid("Native archive checksum mismatch."));
+    }
+    let files = decode(&compressed, root)?;
+    Ok(Artifact {
+        name: name.into(),
+        version,
+        target: target.into(),
+        sha256: sha256.into(),
+        files,
+    })
+}
+
+fn decode(compressed: &[u8], root: &str) -> io::Result<BTreeMap<String, Vec<u8>>> {
+    let mut expanded = Vec::new();
+    MultiGzDecoder::new(compressed)
+        .take((EXPANDED_LIMIT + 1) as u64)
+        .read_to_end(&mut expanded)?;
+    if expanded.len() > EXPANDED_LIMIT {
+        return Err(invalid("Native archive expansion exceeds its bound."));
+    }
+    let mut archive = tar::Archive::new(expanded.as_slice());
+    let mut files = BTreeMap::new();
+    let mut directory_seen = false;
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path_bytes().into_owned();
+        let path = std::str::from_utf8(&path)
+            .map_err(|_| invalid("Native archive path must be ASCII."))?;
+        if path == format!("{root}/") && entry.header().entry_type().is_dir() {
+            if entry.header().mode()? & 0o7000 != 0 || entry.size() != 0 {
+                return Err(invalid("Native archive directory metadata is invalid."));
+            }
+            if directory_seen {
+                return Err(invalid("Duplicate native archive directory."));
+            }
+            directory_seen = true;
+            continue;
+        }
+        let name = path
+            .strip_prefix(root)
+            .and_then(|p| p.strip_prefix('/'))
+            .filter(|name| FILES.contains(name))
+            .ok_or_else(|| invalid("Unexpected native archive path."))?;
+        let mode = entry.header().mode()?;
+        if !entry.header().entry_type().is_file()
+            || mode & 0o7000 != 0
+            || entry.size() == 0
+            || (name == "tmt" && mode & 0o111 == 0)
+        {
+            return Err(invalid(
+                "Native archive requires nonempty regular files with safe permissions.",
+            ));
+        }
+        if files.contains_key(name) {
+            return Err(invalid("Duplicate native archive file."));
+        }
+        let mut contents = Vec::new();
+        entry.read_to_end(&mut contents)?;
+        files.insert(name.into(), contents);
+    }
+    if files.len() != FILES.len() {
+        return Err(invalid("Native archive is missing required files."));
+    }
+    Ok(files)
+}

--- a/rust/crates/tmt-adapters/src/native_install/artifact_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/artifact_tests.rs
@@ -1,0 +1,404 @@
+use super::artifact::{self, FILES};
+use crate::test_support::TestDirectory;
+use flate2::{Compression, write::GzEncoder};
+use serde_json::json;
+use std::{
+    collections::BTreeMap,
+    fs::{self, OpenOptions},
+    io::{self, Read},
+    path::PathBuf,
+};
+use tar::{Builder, EntryType, Header};
+
+const TARGET: &str = "aarch64-apple-darwin";
+
+enum Entry {
+    File {
+        path: String,
+        bytes: Vec<u8>,
+        mode: u32,
+    },
+    AdversarialFile {
+        path: String,
+        bytes: Vec<u8>,
+        mode: u32,
+    },
+    Symlink {
+        path: String,
+        target: String,
+    },
+}
+
+struct Fixture {
+    directory: TestDirectory,
+    manifest: PathBuf,
+    archive: PathBuf,
+    name: String,
+}
+
+fn valid_entries(root: &str) -> Vec<Entry> {
+    vec![
+        Entry::File {
+            path: format!("{root}/tmt"),
+            bytes: b"native executable\n".to_vec(),
+            mode: 0o755,
+        },
+        Entry::File {
+            path: format!("{root}/LICENSE"),
+            bytes: b"MIT\n".to_vec(),
+            mode: 0o644,
+        },
+        Entry::File {
+            path: format!("{root}/NATIVE-INSTALL.md"),
+            bytes: "Native install\n".as_bytes().to_vec(),
+            mode: 0o644,
+        },
+        Entry::File {
+            path: format!("{root}/THIRD-PARTY-NOTICES.txt"),
+            bytes: b"Third-party notices\n".to_vec(),
+            mode: 0o644,
+        },
+    ]
+}
+
+fn append_entry(builder: &mut Builder<GzEncoder<Vec<u8>>>, entry: Entry) {
+    match entry {
+        Entry::File { path, bytes, mode } => {
+            let mut header = Header::new_gnu();
+            header.set_path(path).unwrap();
+            header.set_entry_type(EntryType::Regular);
+            header.set_mode(mode);
+            header.set_size(bytes.len() as u64);
+            header.set_cksum();
+            builder.append(&header, bytes.as_slice()).unwrap();
+        }
+        Entry::AdversarialFile { path, bytes, mode } => {
+            let mut header = Header::new_gnu();
+            header.set_path("safe-placeholder").unwrap();
+            header.set_entry_type(EntryType::Regular);
+            header.set_mode(mode);
+            header.set_size(bytes.len() as u64);
+            assert!(path.is_ascii() && path.len() <= 100);
+            // Bypass tar::Header::set_path only to create a valid checksum-bearing archive with
+            // a traversal name; production decode must reject it before any extraction.
+            let raw = header.as_mut_bytes();
+            raw[..100].fill(0);
+            raw[..path.len()].copy_from_slice(path.as_bytes());
+            header.set_cksum();
+            builder.append(&header, bytes.as_slice()).unwrap();
+        }
+        Entry::Symlink { path, target } => {
+            let mut header = Header::new_gnu();
+            header.set_path(path).unwrap();
+            header.set_entry_type(EntryType::Symlink);
+            header.set_mode(0o777);
+            header.set_size(0);
+            header.set_link_name(target).unwrap();
+            header.set_cksum();
+            builder.append(&header, &[][..]).unwrap();
+        }
+    }
+}
+
+fn gzip_tar(entries: Vec<Entry>) -> Vec<u8> {
+    let encoder = GzEncoder::new(Vec::new(), Compression::default());
+    let mut builder = Builder::new(encoder);
+    for entry in entries {
+        append_entry(&mut builder, entry);
+    }
+    builder.finish().unwrap();
+    builder.into_inner().unwrap().finish().unwrap()
+}
+
+fn fixture(entries: Vec<Entry>) -> Fixture {
+    let directory = TestDirectory::new();
+    let name = "tmux-team-1.2.3-aarch64-apple-darwin.tar.gz".to_owned();
+    let archive = directory.path.join(&name);
+    let manifest = directory.path.join("manifest.json");
+    let compressed = gzip_tar(entries);
+    let checksum = artifact::digest(&compressed);
+    fs::write(&archive, compressed).unwrap();
+    fs::write(
+        &manifest,
+        serde_json::to_vec(&json!({
+            "artifacts": {
+                name.clone(): {
+                    "kind": "executable-zip",
+                    "name": name.clone(),
+                    "target_triples": [TARGET],
+                    "checksums": {"sha256": checksum},
+                    "assets": FILES.iter().map(|path| json!({"path": path})).collect::<Vec<_>>(),
+                }
+            },
+            "releases": [{
+                "app_name": "tmt-cli",
+                "app_version": "1.2.3",
+                "artifacts": [name.clone()]
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    Fixture {
+        directory,
+        manifest,
+        archive,
+        name,
+    }
+}
+
+fn replace_archive(fixture: &Fixture, compressed: &[u8]) {
+    fs::write(&fixture.archive, compressed).unwrap();
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&fixture.manifest).unwrap()).unwrap();
+    manifest["artifacts"][fixture.name.clone()]["checksums"]["sha256"] =
+        json!(artifact::digest(compressed));
+    fs::write(&fixture.manifest, serde_json::to_vec(&manifest).unwrap()).unwrap();
+}
+
+fn file_map(entries: &[(&str, &[u8])]) -> BTreeMap<String, Vec<u8>> {
+    entries
+        .iter()
+        .map(|(name, bytes)| ((*name).to_owned(), bytes.to_vec()))
+        .collect()
+}
+
+fn root_entries(directory: &TestDirectory) -> Vec<String> {
+    let mut entries = fs::read_dir(&directory.path)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_str().unwrap().to_owned())
+        .collect::<Vec<_>>();
+    entries.sort();
+    entries
+}
+
+fn assert_only_inputs_remain(fixture: &Fixture) {
+    let mut expected = vec![fixture.name.clone(), "manifest.json".to_owned()];
+    expected.sort();
+    assert_eq!(root_entries(&fixture.directory), expected);
+}
+
+#[test]
+fn acquire_returns_exact_metadata_and_payload_without_extracting_files() {
+    let fixture = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let artifact = artifact::acquire(&fixture.manifest, &fixture.archive, TARGET).unwrap();
+    assert_eq!(artifact.name, fixture.name);
+    assert_eq!(artifact.version, semver::Version::new(1, 2, 3));
+    assert_eq!(artifact.target, TARGET);
+    assert_eq!(artifact.sha256.len(), 64);
+    assert_eq!(
+        artifact.files,
+        file_map(&[
+            ("tmt", b"native executable\n"),
+            ("LICENSE", b"MIT\n"),
+            ("NATIVE-INSTALL.md", b"Native install\n"),
+            ("THIRD-PARTY-NOTICES.txt", b"Third-party notices\n"),
+        ])
+    );
+    assert_only_inputs_remain(&fixture);
+}
+
+#[test]
+fn corrupt_checksum_and_wrong_target_are_rejected_before_archive_processing() {
+    let checksum_fixture = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&checksum_fixture.manifest).unwrap()).unwrap();
+    let name = checksum_fixture.name.clone();
+    manifest["artifacts"][name]["checksums"]["sha256"] = json!("0".repeat(64));
+    fs::write(
+        &checksum_fixture.manifest,
+        serde_json::to_vec(&manifest).unwrap(),
+    )
+    .unwrap();
+    let error = artifact::acquire(
+        &checksum_fixture.manifest,
+        &checksum_fixture.archive,
+        TARGET,
+    )
+    .unwrap_err();
+    assert_eq!(error.to_string(), "Native archive checksum mismatch.");
+    assert_only_inputs_remain(&checksum_fixture);
+
+    let target_fixture = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let error = artifact::acquire(
+        &target_fixture.manifest,
+        &target_fixture.archive,
+        "x86_64-unknown-linux-musl",
+    )
+    .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native archive metadata or target does not match."
+    );
+    assert_only_inputs_remain(&target_fixture);
+}
+
+#[test]
+fn duplicate_and_missing_required_entries_are_rejected() {
+    let root = "tmux-team-1.2.3-aarch64-apple-darwin";
+    let mut duplicate = valid_entries(root);
+    duplicate.push(Entry::File {
+        path: format!("{root}/tmt"),
+        bytes: b"duplicate\n".to_vec(),
+        mode: 0o755,
+    });
+    let duplicate_fixture = fixture(duplicate);
+    let error = artifact::acquire(
+        &duplicate_fixture.manifest,
+        &duplicate_fixture.archive,
+        TARGET,
+    )
+    .unwrap_err();
+    assert_eq!(error.to_string(), "Duplicate native archive file.");
+    assert_only_inputs_remain(&duplicate_fixture);
+
+    let mut missing = valid_entries(root);
+    missing
+        .retain(|entry| !matches!(entry, Entry::File { path, .. } if path.ends_with("/LICENSE")));
+    let missing_fixture = fixture(missing);
+    let error =
+        artifact::acquire(&missing_fixture.manifest, &missing_fixture.archive, TARGET).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native archive is missing required files."
+    );
+    assert_only_inputs_remain(&missing_fixture);
+}
+
+#[test]
+fn symlink_path_traversal_and_special_permissions_are_rejected() {
+    let root = "tmux-team-1.2.3-aarch64-apple-darwin";
+    let mut symlink = valid_entries(root);
+    symlink[0] = Entry::Symlink {
+        path: format!("{root}/tmt"),
+        target: "outside".to_owned(),
+    };
+    let symlink_fixture = fixture(symlink);
+    let error =
+        artifact::acquire(&symlink_fixture.manifest, &symlink_fixture.archive, TARGET).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native archive requires nonempty regular files with safe permissions."
+    );
+    assert_only_inputs_remain(&symlink_fixture);
+
+    let traversal = vec![Entry::AdversarialFile {
+        path: format!("{root}/../escape"),
+        bytes: b"escape\n".to_vec(),
+        mode: 0o644,
+    }];
+    let traversal_fixture = fixture(traversal);
+    let error = artifact::acquire(
+        &traversal_fixture.manifest,
+        &traversal_fixture.archive,
+        TARGET,
+    )
+    .unwrap_err();
+    assert_eq!(error.to_string(), "Unexpected native archive path.");
+    assert_only_inputs_remain(&traversal_fixture);
+
+    let mut special = valid_entries(root);
+    special[0] = Entry::File {
+        path: format!("{root}/tmt"),
+        bytes: b"native executable\n".to_vec(),
+        mode: 0o4755,
+    };
+    let special_fixture = fixture(special);
+    let error =
+        artifact::acquire(&special_fixture.manifest, &special_fixture.archive, TARGET).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native archive requires nonempty regular files with safe permissions."
+    );
+    assert_only_inputs_remain(&special_fixture);
+}
+
+#[test]
+fn rejects_empty_and_non_executable_required_files() {
+    let root = "tmux-team-1.2.3-aarch64-apple-darwin";
+    let mut empty = valid_entries(root);
+    empty[0] = Entry::File {
+        path: format!("{root}/tmt"),
+        bytes: Vec::new(),
+        mode: 0o755,
+    };
+    let empty_fixture = fixture(empty);
+    let error =
+        artifact::acquire(&empty_fixture.manifest, &empty_fixture.archive, TARGET).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native archive requires nonempty regular files with safe permissions."
+    );
+    assert_only_inputs_remain(&empty_fixture);
+
+    let mut non_executable = valid_entries(root);
+    non_executable[0] = Entry::File {
+        path: format!("{root}/tmt"),
+        bytes: b"native executable\n".to_vec(),
+        mode: 0o644,
+    };
+    let non_executable_fixture = fixture(non_executable);
+    let error = artifact::acquire(
+        &non_executable_fixture.manifest,
+        &non_executable_fixture.archive,
+        TARGET,
+    )
+    .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native archive requires nonempty regular files with safe permissions."
+    );
+    assert_only_inputs_remain(&non_executable_fixture);
+}
+
+#[test]
+fn rejects_truncated_archive_after_checksum_verification() {
+    let fixture = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let mut truncated = fs::read(&fixture.archive).unwrap();
+    truncated.truncate(truncated.len() - 8);
+    replace_archive(&fixture, &truncated);
+    let error = artifact::acquire(&fixture.manifest, &fixture.archive, TARGET).unwrap_err();
+    assert_eq!(error.to_string(), "unexpected end of file");
+    assert_only_inputs_remain(&fixture);
+}
+
+#[test]
+fn rejects_compressed_archive_above_the_bound_before_checksum() {
+    let fixture = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    OpenOptions::new()
+        .write(true)
+        .open(&fixture.archive)
+        .unwrap()
+        .set_len((64 * 1024 * 1024 + 1) as u64)
+        .unwrap();
+    let error = artifact::acquire(&fixture.manifest, &fixture.archive, TARGET).unwrap_err();
+    assert_eq!(error.to_string(), "File exceeds the input bound.");
+    assert_only_inputs_remain(&fixture);
+}
+
+#[test]
+fn rejects_expanded_archive_above_the_bound_before_tar_parsing() {
+    let fixture = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    let mut source = io::repeat(0).take((128 * 1024 * 1024 + 1) as u64);
+    io::copy(&mut source, &mut encoder).unwrap();
+    let compressed = encoder.finish().unwrap();
+    assert!(compressed.len() < 64 * 1024 * 1024);
+    replace_archive(&fixture, &compressed);
+    let error = artifact::acquire(&fixture.manifest, &fixture.archive, TARGET).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native archive expansion exceeds its bound."
+    );
+    assert_only_inputs_remain(&fixture);
+}
+
+#[test]
+fn malformed_manifest_is_rejected_without_touching_archive_or_extracting() {
+    let fixture = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let original_archive = fs::read(&fixture.archive).unwrap();
+    fs::write(&fixture.manifest, b"{ malformed").unwrap();
+    assert!(artifact::acquire(&fixture.manifest, &fixture.archive, TARGET).is_err());
+    assert_eq!(fs::read(&fixture.archive).unwrap(), original_archive);
+    assert_only_inputs_remain(&fixture);
+}

--- a/rust/crates/tmt-adapters/src/native_install/interrupt_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/interrupt_tests.rs
@@ -1,0 +1,232 @@
+use super::{
+    publication::Layout,
+    receipt::Receipt,
+    test_support::{artifact, state},
+};
+use crate::{interrupt::Interrupt, test_support::TestDirectory};
+use nix::{
+    sys::signal::{Signal, kill},
+    unistd::Pid,
+};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+    process::{Child, Command, ExitStatus, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+const FIXTURE_TEST: &str = "native_install::interrupt_tests::subprocess_fixture";
+const FIXTURE_ROOT: &str = "TMT_NATIVE_INSTALL_INTERRUPT_ROOT";
+const FIXTURE_READY: &str = "TMT_NATIVE_INSTALL_INTERRUPT_READY";
+const FIXTURE_EVENT: &str = "TMT_NATIVE_INSTALL_INTERRUPT_EVENT";
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(2);
+const EXIT_TIMEOUT: Duration = Duration::from_secs(4);
+
+struct Fixture {
+    _directory: TestDirectory,
+    ready: PathBuf,
+    event: PathBuf,
+    child: Child,
+}
+
+impl Fixture {
+    fn start() -> Self {
+        let directory = TestDirectory::new();
+        let ready = directory.path.join("ready");
+        let event = directory.path.join("event");
+        let executable = env::current_exe().expect("locate native-install test binary");
+        let child = Command::new(executable)
+            .args(["--exact", FIXTURE_TEST, "--nocapture", "--test-threads=1"])
+            .env(FIXTURE_ROOT, &directory.path)
+            .env(FIXTURE_READY, &ready)
+            .env(FIXTURE_EVENT, &event)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn task-owned native-install interrupt fixture");
+        Self {
+            _directory: directory,
+            ready,
+            event,
+            child,
+        }
+    }
+
+    fn wait_for_content(&mut self, path: &Path, expected: &str, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if fs::read_to_string(path).ok().as_deref() == Some(expected) {
+                return;
+            }
+            if let Some(status) = self
+                .child
+                .try_wait()
+                .expect("inspect native-install interrupt fixture")
+            {
+                panic!(
+                    "native-install interrupt fixture exited before {}: {status}",
+                    path.display()
+                );
+            }
+            assert!(
+                Instant::now() < deadline,
+                "native-install interrupt fixture did not publish {expected:?}"
+            );
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+
+    fn wait_for_exit(&mut self, timeout: Duration) -> ExitStatus {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = self
+                .child
+                .try_wait()
+                .expect("inspect native-install interrupt fixture")
+            {
+                return status;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "native-install interrupt fixture did not exit"
+            );
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn fixture_pid(fixture: &Fixture) -> Pid {
+    Pid::from_raw(i32::try_from(fixture.child.id()).expect("fixture PID fits in pid_t"))
+}
+
+#[test]
+fn sigint_cleans_staged_native_publication_and_allows_retry() {
+    let mut fixture = Fixture::start();
+    fixture.wait_for_content(&fixture.ready.clone(), "staged", STARTUP_TIMEOUT);
+    kill(fixture_pid(&fixture), Signal::SIGINT).expect("signal task-owned fixture child");
+
+    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    assert!(
+        status.success(),
+        "native-install interrupt fixture failed: {status}"
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.event).unwrap(),
+        "interrupted-clean-retry"
+    );
+}
+
+#[test]
+fn subprocess_fixture() {
+    let Some(root) = env::var_os(FIXTURE_ROOT) else {
+        return;
+    };
+    let root = PathBuf::from(root);
+    let ready = PathBuf::from(env::var_os(FIXTURE_READY).expect("fixture readiness path"));
+    let event = PathBuf::from(env::var_os(FIXTURE_EVENT).expect("fixture event path"));
+    let prefix = root.join("prefix");
+    let layout = Layout::open(&prefix).expect("open task-owned native-install layout");
+    let first_artifact = artifact("1.2.3", b"old synthetic tmt payload\n");
+    let first_receipt = Receipt::new(&first_artifact, state("1.2.3", None));
+    let mut initial_checkpoint = || Ok(());
+    layout
+        .publish(
+            &first_artifact,
+            &first_receipt,
+            None,
+            &mut initial_checkpoint,
+        )
+        .expect("publish initial synthetic release");
+
+    let next_artifact = artifact("1.2.4", b"next synthetic tmt payload\n");
+    let next_receipt = Receipt::new(&next_artifact, state("1.2.4", None));
+    let next_release = layout
+        .root
+        .join("releases")
+        .join(next_receipt.id.to_string());
+    let next_pointer = layout.root.join(format!(".current-{}", next_receipt.id));
+    let old_target =
+        fs::read_link(layout.root.join("current")).expect("read initial current pointer");
+    let old_payload = fs::read(layout.root.join(&old_target).join("tmt"))
+        .expect("read initial synthetic payload");
+
+    let interrupt = Interrupt::install().expect("install task-owned interrupt guard");
+    let lock = crate::file_lock::exclusive(&layout.root.join("install.lock"))
+        .expect("acquire native-install lock");
+    let mut calls = 0;
+    let mut checkpoint = || {
+        if calls == 1 {
+            assert!(
+                next_release.is_dir(),
+                "publication checkpoint must observe its staged release"
+            );
+            fs::write(&ready, b"staged").expect("publish staged readiness");
+            interrupt
+                .wait_until(Instant::now() + Duration::from_secs(3))
+                .expect("wait for SIGINT in publication checkpoint");
+            if !interrupt.is_interrupted() {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "publication interrupt was not delivered",
+                ));
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "publication interrupted by SIGINT",
+            ));
+        }
+        calls += 1;
+        Ok(())
+    };
+    let error = layout
+        .publish(
+            &next_artifact,
+            &next_receipt,
+            Some(first_receipt.id),
+            &mut checkpoint,
+        )
+        .expect_err("SIGINT must stop publication before activation");
+    assert_eq!(error.kind(), io::ErrorKind::Interrupted);
+    drop(lock);
+    drop(interrupt);
+
+    assert_eq!(
+        fs::read_link(layout.root.join("current")).unwrap(),
+        old_target
+    );
+    assert_eq!(
+        fs::read(layout.root.join(&old_target).join("tmt")).unwrap(),
+        old_payload
+    );
+    assert!(fs::symlink_metadata(next_release).is_err());
+    assert!(fs::symlink_metadata(next_pointer).is_err());
+
+    let retry_lock = crate::file_lock::exclusive(&layout.root.join("install.lock"))
+        .expect("publication lock must be released after interruption");
+    let mut retry_checkpoint = || Ok(());
+    layout
+        .publish(
+            &next_artifact,
+            &next_receipt,
+            Some(first_receipt.id),
+            &mut retry_checkpoint,
+        )
+        .expect("retry publication after SIGINT");
+    drop(retry_lock);
+    assert_eq!(
+        fs::read_link(layout.root.join("current")).unwrap(),
+        PathBuf::from(format!("releases/{}", next_receipt.id))
+    );
+    fs::write(&event, b"interrupted-clean-retry").expect("publish fixture result");
+}

--- a/rust/crates/tmt-adapters/src/native_install/mod.rs
+++ b/rust/crates/tmt-adapters/src/native_install/mod.rs
@@ -1,0 +1,91 @@
+//! Verified native release acquisition and managed publication, without app state.
+
+mod artifact;
+#[cfg(test)]
+mod artifact_tests;
+#[cfg(test)]
+mod interrupt_tests;
+mod publication;
+#[cfg(test)]
+mod publication_tests;
+mod receipt;
+#[cfg(test)]
+mod test_support;
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+use tmt_core::native_install::{Channel, PinAction, plan_version};
+
+#[derive(Debug)]
+pub struct InstallReport {
+    pub executable: PathBuf,
+    pub version: String,
+    pub changed: bool,
+}
+
+/// Offline installation. Application data and provider skills are separate owners.
+pub struct InstallRequest<'a> {
+    pub archive: &'a Path,
+    pub manifest: &'a Path,
+    pub prefix: &'a Path,
+    pub target: &'a str,
+    pub channel: Channel,
+    pub pin: PinAction,
+}
+
+/// The caller owns cancellation. Checkpoints never run inside atomic activation.
+pub fn install(
+    request: InstallRequest<'_>,
+    mut checkpoint: impl FnMut() -> io::Result<()>,
+) -> io::Result<InstallReport> {
+    checkpoint()?;
+    let artifact = artifact::acquire(request.manifest, request.archive, request.target)?;
+    plan_version(None, &artifact.version, request.channel, request.pin)
+        .map_err(io::Error::other)?;
+    checkpoint()?;
+    let layout = publication::Layout::open(request.prefix)?;
+    let _lock = crate::file_lock::exclusive(&layout.root.join("install.lock"))?;
+    let current = layout.current()?;
+    layout.check_links(current.is_some())?;
+    let plan = plan_version(
+        current.as_ref().map(|receipt| &receipt.state),
+        &artifact.version,
+        request.channel,
+        request.pin,
+    )
+    .map_err(io::Error::other)?;
+    if let Some(current) = &current
+        && (current.target != artifact.target
+            || (current.state.version == artifact.version
+                && (current.archive_sha256 != artifact.sha256
+                    || current.archive_name != artifact.name
+                    || current.file_hashes != artifact.file_hashes())))
+    {
+        return Err(invalid(
+            "Installed target or equal-version artifact integrity does not match.",
+        ));
+    }
+    if plan.changed {
+        let receipt = receipt::Receipt::new(&artifact, plan.state);
+        layout.publish(
+            &artifact,
+            &receipt,
+            current.as_ref().map(|receipt| receipt.id),
+            &mut checkpoint,
+        )?;
+    } else {
+        checkpoint()?;
+        layout.ensure_links()?;
+    }
+    Ok(InstallReport {
+        executable: layout.prefix.join("bin/tmt"),
+        version: artifact.version.to_string(),
+        changed: plan.changed,
+    })
+}
+
+fn invalid(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/rust/crates/tmt-adapters/src/native_install/publication.rs
+++ b/rust/crates/tmt-adapters/src/native_install/publication.rs
@@ -1,0 +1,242 @@
+//! One durable release directory and one atomic activation pointer.
+
+use super::{
+    artifact::{Artifact, FILES},
+    invalid,
+    receipt::Receipt,
+};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{self, Write},
+    os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt, symlink},
+    path::{Path, PathBuf},
+};
+use uuid::Uuid;
+
+pub(super) struct Layout {
+    pub prefix: PathBuf,
+    pub root: PathBuf,
+}
+
+fn directory(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
+        Ok(_) => Err(invalid(
+            "Native installation directory is occupied by another entry.",
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            fs::DirBuilder::new().mode(0o700).create(path)?;
+            if let Some(parent) = path.parent() {
+                File::open(parent)?.sync_all()?;
+            }
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+impl Layout {
+    pub fn open(prefix: &Path) -> io::Result<Self> {
+        if prefix.as_os_str().is_empty() {
+            return Err(invalid("Installation prefix must not be empty."));
+        }
+        // Preserve the leaf entry: only ancestors may be symlink aliases.
+        // Components also remove a trailing separator that could make lstat
+        // follow a symlink supplied as the installation prefix.
+        let requested: PathBuf = std::env::current_dir()?.join(prefix).components().collect();
+        if let Some(parent) = requested.parent() {
+            create_prefix_ancestors(parent)?;
+        }
+        directory(&requested)?;
+        let prefix = fs::canonicalize(&requested)?;
+        directory(&prefix.join("lib"))?;
+        directory(&prefix.join("bin"))?;
+        let root = prefix.join("lib/tmux-team");
+        directory(&root)?;
+        directory(&root.join("releases"))?;
+        Ok(Self { prefix, root })
+    }
+
+    pub fn current(&self) -> io::Result<Option<Receipt>> {
+        let pointer = self.root.join("current");
+        let target = match fs::read_link(&pointer) {
+            Ok(target) => target,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let id = target
+            .to_str()
+            .and_then(|target| target.strip_prefix("releases/"))
+            .and_then(|id| Uuid::parse_str(id).ok())
+            .filter(|id| target == Path::new(&format!("releases/{id}")))
+            .ok_or_else(|| invalid("Native current pointer is not an owned release."))?;
+        let release = self.root.join(&target);
+        if !fs::symlink_metadata(&release)?.file_type().is_dir() {
+            return Err(invalid("Native current release is not a real directory."));
+        }
+        Receipt::read(&release, &self.prefix, id).map(Some)
+    }
+
+    pub fn check_links(&self, has_current: bool) -> io::Result<()> {
+        for name in ["tmt", "tmux-team"] {
+            let path = self.prefix.join("bin").join(name);
+            match fs::symlink_metadata(&path) {
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+                Ok(metadata)
+                    if has_current
+                        && metadata.file_type().is_symlink()
+                        && fs::read_link(&path)? == Path::new("../lib/tmux-team/current/tmt") => {}
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        format!(
+                            "Refusing to replace {}. Remove it using its original package manager or choose another prefix.",
+                            path.display()
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn ensure_links(&self) -> io::Result<()> {
+        self.check_links(true)?;
+        for name in ["tmt", "tmux-team"] {
+            let path = self.prefix.join("bin").join(name);
+            match symlink("../lib/tmux-team/current/tmt", &path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    self.check_links(true)?
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        File::open(self.prefix.join("bin"))?.sync_all()
+    }
+
+    pub fn publish(
+        &self,
+        artifact: &Artifact,
+        receipt: &Receipt,
+        expected_current: Option<Uuid>,
+        checkpoint: &mut impl FnMut() -> io::Result<()>,
+    ) -> io::Result<()> {
+        self.publish_with_finalization(artifact, receipt, expected_current, checkpoint, || {
+            self.ensure_links()
+        })
+    }
+
+    pub(super) fn publish_with_finalization(
+        &self,
+        artifact: &Artifact,
+        receipt: &Receipt,
+        expected_current: Option<Uuid>,
+        checkpoint: &mut impl FnMut() -> io::Result<()>,
+        finalize: impl FnOnce() -> io::Result<()>,
+    ) -> io::Result<()> {
+        checkpoint()?;
+        let release = self.root.join("releases").join(receipt.id.to_string());
+        fs::DirBuilder::new().mode(0o700).create(&release)?;
+        let pointer = self.root.join(format!(".current-{}", receipt.id));
+        let mut pointer_created = false;
+        let mut activated = false;
+        let result = (|| {
+            for name in FILES {
+                checkpoint()?;
+                write(
+                    &release.join(name),
+                    &artifact.files[name],
+                    if name == "tmt" { 0o755 } else { 0o644 },
+                )?;
+            }
+            write(
+                &release.join("receipt.json"),
+                &receipt.encode(&self.prefix)?,
+                0o600,
+            )?;
+            checkpoint()?;
+            File::open(&release)?.sync_all()?;
+            File::open(self.root.join("releases"))?.sync_all()?;
+            symlink(format!("releases/{}", receipt.id), &pointer)?;
+            pointer_created = true;
+            checkpoint()?;
+            if self.current()?.map(|receipt| receipt.id) != expected_current {
+                return Err(invalid(
+                    "Native current release changed during installation.",
+                ));
+            }
+            self.check_links(expected_current.is_some())?;
+            fs::rename(&pointer, self.root.join("current"))?;
+            activated = true;
+            File::open(&self.root)?.sync_all()?;
+            finalize()
+        })();
+        if !activated {
+            // A UUID name is not proof that this invocation created an entry.
+            let pointer_cleanup = if pointer_created {
+                fs::remove_file(&pointer)
+            } else {
+                Ok(())
+            };
+            let release_cleanup = fs::remove_dir_all(&release);
+            if let Err(cleanup) = pointer_cleanup.and(release_cleanup) {
+                return Err(io::Error::new(
+                    result
+                        .as_ref()
+                        .err()
+                        .map_or(cleanup.kind(), io::Error::kind),
+                    format!(
+                        "{}; owned staging cleanup failed: {cleanup}",
+                        result.as_ref().err().map_or_else(
+                            || "Native installation failed".into(),
+                            ToString::to_string
+                        )
+                    ),
+                ));
+            }
+        }
+        result.map_err(|error| {
+            if activated {
+                io::Error::new(error.kind(), format!("Release activated, but installation finalization failed; retry to repair command links: {error}"))
+            } else { error }
+        })
+    }
+}
+
+/// Prefix ancestors may be aliases; managed leaf entries may not. Track only
+/// missing ancestors so their directory links can be synced after creation.
+fn create_prefix_ancestors(parent: &Path) -> io::Result<()> {
+    let mut missing = Vec::new();
+    let mut cursor = parent;
+    loop {
+        match fs::symlink_metadata(cursor) {
+            Ok(_) => break,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                missing.push(cursor);
+                cursor = cursor.parent().ok_or(error)?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    fs::create_dir_all(parent)?;
+    for directory in missing {
+        File::open(directory)?.sync_all()?;
+        if let Some(parent) = directory.parent() {
+            File::open(parent)?.sync_all()?;
+        }
+    }
+    Ok(())
+}
+
+fn write(path: &Path, bytes: &[u8], mode: u32) -> io::Result<()> {
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(mode)
+        .open(path)?;
+    file.write_all(bytes)?;
+    file.set_permissions(fs::Permissions::from_mode(mode))?;
+    file.sync_all()
+}

--- a/rust/crates/tmt-adapters/src/native_install/publication_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/publication_tests.rs
@@ -1,0 +1,534 @@
+use super::{
+    artifact::{self, FILES},
+    publication::Layout,
+    receipt::Receipt,
+    test_support::{
+        VERSION, artifact as synthetic_artifact, checkpoint_count, publish, published_layout, state,
+    },
+};
+use crate::test_support::TestDirectory;
+use semver::Version;
+use std::{
+    collections::BTreeMap,
+    fs, io,
+    os::unix::fs::symlink,
+    path::{Path, PathBuf},
+};
+
+fn current_target(layout: &Layout) -> PathBuf {
+    fs::read_link(layout.root.join("current")).unwrap()
+}
+
+fn assert_managed_links(layout: &Layout) {
+    for name in ["tmt", "tmux-team"] {
+        assert_eq!(
+            fs::read_link(layout.prefix.join("bin").join(name)).unwrap(),
+            Path::new("../lib/tmux-team/current/tmt")
+        );
+    }
+}
+
+#[test]
+fn first_publish_writes_receipt_hashes_and_repeat_links_are_stable() {
+    let (_directory, layout, receipt) = published_layout();
+    let target = current_target(&layout);
+    let current = layout.current().unwrap().unwrap();
+
+    assert_eq!(current.id, receipt.id);
+    assert_eq!(current.file_hashes, receipt.file_hashes);
+    assert_eq!(
+        current.file_hashes["tmt"],
+        artifact::digest(b"synthetic tmt payload\n")
+    );
+    assert_eq!(target, PathBuf::from(format!("releases/{}", receipt.id)));
+    assert_managed_links(&layout);
+
+    layout.ensure_links().unwrap();
+    assert_eq!(current_target(&layout), target);
+    assert_managed_links(&layout);
+}
+
+#[test]
+fn corrupted_installed_payload_is_rejected_without_changing_current() {
+    let (_directory, layout, receipt) = published_layout();
+    let target = current_target(&layout);
+    let release = layout.root.join(&target);
+    fs::write(release.join("tmt"), b"modified executable\n").unwrap();
+
+    let error = match layout.current() {
+        Ok(_) => panic!("corrupted payload must be rejected"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error.to_string(),
+        "Installed release file has changed; refusing replacement."
+    );
+    assert_eq!(current_target(&layout), target);
+    assert_eq!(
+        fs::read_link(layout.prefix.join("bin/tmt")).unwrap(),
+        Path::new("../lib/tmux-team/current/tmt")
+    );
+    assert_eq!(target, PathBuf::from(format!("releases/{}", receipt.id)));
+}
+
+#[test]
+fn invalid_current_pointer_is_rejected_without_mutating_releases() {
+    let (_directory, layout, receipt) = published_layout();
+    let pointer = layout.root.join("current");
+    fs::remove_file(&pointer).unwrap();
+    symlink("releases/not-a-uuid", &pointer).unwrap();
+
+    let error = match layout.current() {
+        Ok(_) => panic!("invalid current pointer must be rejected"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error.to_string(),
+        "Native current pointer is not an owned release."
+    );
+    assert_eq!(
+        fs::read_link(&pointer).unwrap(),
+        Path::new("releases/not-a-uuid")
+    );
+    assert!(
+        layout
+            .root
+            .join(format!("releases/{}", receipt.id))
+            .is_dir()
+    );
+    assert_eq!(
+        fs::read(layout.root.join(format!("releases/{}/tmt", receipt.id))).unwrap(),
+        b"synthetic tmt payload\n"
+    );
+}
+
+#[test]
+fn failed_receipt_validation_keeps_old_current_and_release_bytes() {
+    let (_directory, layout, receipt) = published_layout();
+    let target = current_target(&layout);
+    let release = layout.root.join(&target);
+    fs::write(release.join("receipt.json"), b"{}\n").unwrap();
+
+    assert!(layout.current().is_err());
+    assert_eq!(current_target(&layout), target);
+    assert_eq!(
+        fs::read(release.join("tmt")).unwrap(),
+        b"synthetic tmt payload\n"
+    );
+    assert!(
+        layout
+            .root
+            .join(format!("releases/{}", receipt.id))
+            .is_dir()
+    );
+}
+
+#[test]
+fn unmanaged_files_and_package_manager_links_are_preserved() {
+    for symlinked in [false, true] {
+        let directory = TestDirectory::new();
+        let layout = Layout::open(&directory.path.join("prefix")).unwrap();
+        let target = layout.prefix.join("bin/tmt");
+        if symlinked {
+            symlink("/opt/package-manager/bin/tmt", &target).unwrap();
+        } else {
+            fs::write(&target, b"package manager executable\n").unwrap();
+        }
+
+        assert!(layout.check_links(false).is_err());
+        if symlinked {
+            assert_eq!(
+                fs::read_link(&target).unwrap(),
+                Path::new("/opt/package-manager/bin/tmt")
+            );
+        } else {
+            assert_eq!(fs::read(&target).unwrap(), b"package manager executable\n");
+        }
+    }
+}
+
+#[test]
+fn pin_metadata_publication_changes_receipt_and_pointer_retaining_previous_release() {
+    let (_directory, layout, first) = published_layout();
+    let first_target = current_target(&layout);
+    let artifact = synthetic_artifact(VERSION, b"synthetic tmt payload\n");
+    let pinned = Receipt::new(&artifact, state(VERSION, Some(VERSION)));
+
+    publish(&layout, &artifact, &pinned);
+    let second_target = current_target(&layout);
+    let current = layout.current().unwrap().unwrap();
+
+    assert_ne!(second_target, first_target);
+    assert_eq!(current.id, pinned.id);
+    assert_eq!(
+        current.state.pinned_version,
+        Some(Version::parse(VERSION).unwrap())
+    );
+    assert!(layout.root.join(&first_target).is_dir());
+    assert!(layout.root.join(&second_target).is_dir());
+    assert_ne!(
+        fs::read(layout.root.join(&first_target).join("receipt.json")).unwrap(),
+        fs::read(layout.root.join(&second_target).join("receipt.json")).unwrap()
+    );
+    assert_eq!(
+        Receipt::read(&layout.root.join(&first_target), &layout.prefix, first.id)
+            .unwrap()
+            .state
+            .pinned_version,
+        None
+    );
+}
+
+#[test]
+fn preactivation_checkpoint_failures_cleanup_owned_state_and_preserve_current() {
+    // Publication checkpoints occur before staging, once per required file,
+    // after the receipt and release sync, and after staging the activation link.
+    for failure_at in 0..checkpoint_count() {
+        let (_directory, layout, first) = published_layout();
+        let old_target = current_target(&layout);
+        let old_release = layout.root.join(&old_target);
+        let old_files = FILES
+            .iter()
+            .map(|name| {
+                (
+                    (*name).to_owned(),
+                    fs::read(old_release.join(name)).unwrap(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let old_receipt = fs::read(old_release.join("receipt.json")).unwrap();
+
+        let next_artifact = synthetic_artifact("1.2.4", b"next synthetic tmt payload\n");
+        let next_receipt = Receipt::new(&next_artifact, state("1.2.4", None));
+        let next_release = layout
+            .root
+            .join("releases")
+            .join(next_receipt.id.to_string());
+        let next_pointer = layout.root.join(format!(".current-{}", next_receipt.id));
+        let mut calls = 0;
+        let mut checkpoint = || {
+            let call = calls;
+            calls += 1;
+            if call == failure_at {
+                Err(io::Error::other("injected checkpoint"))
+            } else {
+                Ok(())
+            }
+        };
+
+        let error = layout
+            .publish(
+                &next_artifact,
+                &next_receipt,
+                Some(first.id),
+                &mut checkpoint,
+            )
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "injected checkpoint",
+            "checkpoint {failure_at}"
+        );
+        assert_eq!(
+            current_target(&layout),
+            old_target,
+            "checkpoint {failure_at}"
+        );
+        let current = layout.current().unwrap().unwrap();
+        assert_eq!(current.id, first.id, "checkpoint {failure_at}");
+        assert_eq!(
+            fs::read(old_release.join("receipt.json")).unwrap(),
+            old_receipt,
+            "checkpoint {failure_at}"
+        );
+        for (name, bytes) in &old_files {
+            assert_eq!(
+                fs::read(old_release.join(name)).unwrap(),
+                *bytes,
+                "checkpoint {failure_at}"
+            );
+        }
+        assert!(
+            fs::symlink_metadata(next_release).is_err(),
+            "checkpoint {failure_at}"
+        );
+        assert!(
+            fs::symlink_metadata(next_pointer).is_err(),
+            "checkpoint {failure_at}"
+        );
+    }
+}
+
+#[test]
+fn current_change_at_activation_checkpoint_preserves_unexpected_release() {
+    let (_directory, layout, first) = published_layout();
+    let old_target = current_target(&layout);
+    let foreign_artifact = synthetic_artifact("1.2.2", b"unexpected tmt payload\n");
+    let foreign_receipt = Receipt::new(&foreign_artifact, state("1.2.2", None));
+    publish(&layout, &foreign_artifact, &foreign_receipt);
+    let foreign_target = current_target(&layout);
+    assert_ne!(foreign_target, old_target);
+    fs::remove_file(layout.root.join("current")).unwrap();
+    symlink(&old_target, layout.root.join("current")).unwrap();
+
+    let next_artifact = synthetic_artifact("1.2.4", b"next synthetic tmt payload\n");
+    let next_receipt = Receipt::new(&next_artifact, state("1.2.4", None));
+    let next_release = layout
+        .root
+        .join("releases")
+        .join(next_receipt.id.to_string());
+    let next_pointer = layout.root.join(format!(".current-{}", next_receipt.id));
+    let last_checkpoint = checkpoint_count() - 1;
+    let mut calls = 0;
+    let mut checkpoint = || {
+        if calls == last_checkpoint {
+            fs::remove_file(layout.root.join("current")).unwrap();
+            symlink(&foreign_target, layout.root.join("current")).unwrap();
+        }
+        calls += 1;
+        Ok(())
+    };
+
+    let error = layout
+        .publish(
+            &next_artifact,
+            &next_receipt,
+            Some(first.id),
+            &mut checkpoint,
+        )
+        .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native current release changed during installation."
+    );
+    assert_eq!(current_target(&layout), foreign_target);
+    assert_eq!(layout.current().unwrap().unwrap().id, foreign_receipt.id);
+    assert!(fs::symlink_metadata(next_release).is_err());
+    assert!(fs::symlink_metadata(next_pointer).is_err());
+    assert_managed_links(&layout);
+}
+
+#[test]
+fn command_link_change_at_activation_checkpoint_is_preserved() {
+    let (_directory, layout, first) = published_layout();
+    let old_target = current_target(&layout);
+    let command = layout.prefix.join("bin/tmt");
+    let next_artifact = synthetic_artifact("1.2.4", b"next synthetic tmt payload\n");
+    let next_receipt = Receipt::new(&next_artifact, state("1.2.4", None));
+    let next_release = layout
+        .root
+        .join("releases")
+        .join(next_receipt.id.to_string());
+    let next_pointer = layout.root.join(format!(".current-{}", next_receipt.id));
+    let last_checkpoint = checkpoint_count() - 1;
+    let mut calls = 0;
+    let mut checkpoint = || {
+        if calls == last_checkpoint {
+            fs::remove_file(&command).unwrap();
+            fs::write(&command, b"unexpected manager command\n").unwrap();
+        }
+        calls += 1;
+        Ok(())
+    };
+
+    let error = layout
+        .publish(
+            &next_artifact,
+            &next_receipt,
+            Some(first.id),
+            &mut checkpoint,
+        )
+        .unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+    assert_eq!(current_target(&layout), old_target);
+    assert_eq!(fs::read(&command).unwrap(), b"unexpected manager command\n");
+    assert!(fs::symlink_metadata(next_release).is_err());
+    assert!(fs::symlink_metadata(next_pointer).is_err());
+}
+
+#[test]
+fn prefix_leaf_symlink_with_trailing_separator_is_rejected_without_following_it() {
+    let directory = TestDirectory::new();
+    let destination = directory.path.join("destination");
+    let prefix = directory.path.join("prefix");
+    fs::create_dir(&destination).unwrap();
+    symlink(&destination, &prefix).unwrap();
+    let requested = PathBuf::from(format!("{}/", prefix.display()));
+
+    let error = match Layout::open(&requested) {
+        Ok(_) => panic!("prefix leaf symlink must be rejected"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(fs::read_link(&prefix).unwrap(), destination);
+    assert!(fs::symlink_metadata(destination.join("lib")).is_err());
+    assert!(fs::symlink_metadata(destination.join("bin")).is_err());
+    assert!(fs::symlink_metadata(prefix.join("lib")).is_err());
+    assert!(fs::symlink_metadata(prefix.join("bin")).is_err());
+}
+
+#[test]
+fn ancestor_symlink_is_canonicalized_while_leaf_is_created() {
+    let directory = TestDirectory::new();
+    let destination = directory.path.join("destination");
+    let alias = directory.path.join("alias");
+    fs::create_dir(&destination).unwrap();
+    symlink(&destination, &alias).unwrap();
+    let requested = alias.join("nested");
+
+    let layout = Layout::open(&requested).unwrap();
+    assert_eq!(
+        layout.prefix,
+        fs::canonicalize(destination.join("nested")).unwrap()
+    );
+    assert!(layout.prefix.is_dir());
+    assert!(layout.prefix.join("lib").is_dir());
+    assert!(layout.prefix.join("bin").is_dir());
+    assert_eq!(fs::read_link(&alias).unwrap(), destination);
+}
+
+#[test]
+fn preexisting_activation_pointer_file_or_directory_is_preserved() {
+    for directory_collision in [false, true] {
+        let (_directory, layout, first) = published_layout();
+        let old_target = current_target(&layout);
+        let old_release = layout.root.join(&old_target);
+        let old_receipt = fs::read(old_release.join("receipt.json")).unwrap();
+        let next_artifact = synthetic_artifact("1.2.4", b"next synthetic tmt payload\n");
+        let next_receipt = Receipt::new(&next_artifact, state("1.2.4", None));
+        let pointer = layout.root.join(format!(".current-{}", next_receipt.id));
+        let next_release = layout
+            .root
+            .join("releases")
+            .join(next_receipt.id.to_string());
+
+        if directory_collision {
+            fs::create_dir(&pointer).unwrap();
+            fs::write(pointer.join("sentinel"), b"preserve directory").unwrap();
+        } else {
+            fs::write(&pointer, b"preserve regular file").unwrap();
+        }
+
+        let mut checkpoint = || Ok(());
+        let error = layout
+            .publish(
+                &next_artifact,
+                &next_receipt,
+                Some(first.id),
+                &mut checkpoint,
+            )
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(current_target(&layout), old_target);
+        assert_eq!(layout.current().unwrap().unwrap().id, first.id);
+        assert_eq!(
+            fs::read(old_release.join("receipt.json")).unwrap(),
+            old_receipt
+        );
+        assert!(fs::symlink_metadata(next_release).is_err());
+        if directory_collision {
+            assert!(pointer.is_dir());
+            assert_eq!(
+                fs::read(pointer.join("sentinel")).unwrap(),
+                b"preserve directory"
+            );
+        } else {
+            assert_eq!(fs::read(&pointer).unwrap(), b"preserve regular file");
+        }
+        assert_managed_links(&layout);
+    }
+}
+
+#[test]
+fn publication_lock_contention_preserves_one_stable_lock_file() {
+    let directory = TestDirectory::new();
+    let lock = directory.path.join("install.lock");
+    let first = crate::file_lock::exclusive(&lock).unwrap();
+    assert!(lock.is_file());
+    assert!(crate::file_lock::exclusive(&lock).is_err());
+    drop(first);
+
+    let second = crate::file_lock::exclusive(&lock).unwrap();
+    assert!(lock.is_file());
+    drop(second);
+    assert!(lock.is_file());
+}
+
+#[test]
+fn missing_command_links_are_repaired_without_replacing_the_release() {
+    let (_directory, layout, receipt) = published_layout();
+    let pointer = current_target(&layout);
+    fs::remove_file(layout.prefix.join("bin/tmt")).unwrap();
+    fs::remove_file(layout.prefix.join("bin/tmux-team")).unwrap();
+    layout.check_links(true).unwrap();
+    layout.ensure_links().unwrap();
+    assert_managed_links(&layout);
+    assert_eq!(current_target(&layout), pointer);
+    assert_eq!(layout.current().unwrap().unwrap().id, receipt.id);
+}
+
+#[test]
+fn finalization_failure_reports_activation_and_retry_repairs_first_install() {
+    let directory = TestDirectory::new();
+    let layout = Layout::open(&directory.path.join("prefix")).unwrap();
+    let artifact = synthetic_artifact(VERSION, b"complete staged payload");
+    let receipt = Receipt::new(&artifact, state(VERSION, None));
+    let error = layout
+        .publish_with_finalization(&artifact, &receipt, None, &mut || Ok(()), || {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "injected command-link failure",
+            ))
+        })
+        .unwrap_err();
+    assert!(error.to_string().contains("Release activated"));
+    assert!(error.to_string().contains("injected command-link failure"));
+    assert_eq!(layout.current().unwrap().unwrap().id, receipt.id);
+    assert!(!layout.prefix.join("bin/tmt").exists());
+    assert_eq!(
+        fs::read(layout.root.join("current/tmt")).unwrap(),
+        b"complete staged payload"
+    );
+    layout.ensure_links().unwrap();
+    assert_managed_links(&layout);
+    assert_eq!(layout.current().unwrap().unwrap().id, receipt.id);
+}
+
+#[test]
+fn receipt_symlinks_extra_files_and_nonexecutable_payloads_are_not_ownership() {
+    use std::os::unix::fs::PermissionsExt;
+    for defect in [
+        "receipt-link",
+        "extra-file",
+        "not-executable",
+        "relocated-prefix",
+    ] {
+        let (_directory, layout, receipt) = published_layout();
+        let pointer = current_target(&layout);
+        let release = layout.root.join(&pointer);
+        let original = fs::read(release.join("tmt")).unwrap();
+        match defect {
+            "receipt-link" => {
+                let external = layout.prefix.join("external-receipt.json");
+                fs::rename(release.join("receipt.json"), &external).unwrap();
+                symlink(&external, release.join("receipt.json")).unwrap();
+            }
+            "extra-file" => fs::write(release.join("unexpected"), b"preserve me").unwrap(),
+            "not-executable" => {
+                fs::set_permissions(release.join("tmt"), fs::Permissions::from_mode(0o644)).unwrap()
+            }
+            "relocated-prefix" => {
+                fs::write(
+                    release.join("receipt.json"),
+                    receipt.encode(Path::new("/another-prefix")).unwrap(),
+                )
+                .unwrap();
+            }
+            _ => unreachable!(),
+        }
+        assert!(layout.current().is_err(), "{defect}");
+        assert_eq!(current_target(&layout), pointer, "{defect}");
+        assert_eq!(fs::read(release.join("tmt")).unwrap(), original, "{defect}");
+        assert!(release.exists());
+    }
+}

--- a/rust/crates/tmt-adapters/src/native_install/receipt.rs
+++ b/rust/crates/tmt-adapters/src/native_install/receipt.rs
@@ -1,0 +1,147 @@
+//! Installation evidence is rooted in a release directory, not application config.
+
+use super::{
+    artifact::{Artifact, FILES, digest},
+    invalid,
+};
+use crate::bounded_file;
+use serde_json::{Value, json};
+use std::{collections::BTreeMap, fs, io, os::unix::fs::PermissionsExt, path::Path};
+use tmt_core::native_install::{Channel, InstalledVersion};
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub(super) struct Receipt {
+    pub id: Uuid,
+    pub state: InstalledVersion,
+    pub archive_name: String,
+    pub archive_sha256: String,
+    pub target: String,
+    pub file_hashes: BTreeMap<String, String>,
+}
+
+impl Receipt {
+    pub fn new(artifact: &Artifact, state: InstalledVersion) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            state,
+            archive_name: artifact.name.clone(),
+            archive_sha256: artifact.sha256.clone(),
+            target: artifact.target.clone(),
+            file_hashes: artifact.file_hashes(),
+        }
+    }
+
+    pub fn encode(&self, prefix: &Path) -> io::Result<Vec<u8>> {
+        let prefix = prefix
+            .to_str()
+            .ok_or_else(|| invalid("Installation prefix must be UTF-8."))?;
+        serde_json::to_vec_pretty(&json!({
+            "schema_version": 1, "release_id": self.id.to_string(), "prefix": prefix,
+            "version": self.state.version.to_string(), "channel": self.state.channel.as_str(),
+            "pinned_version": self.state.pinned_version.as_ref().map(ToString::to_string),
+            "archive": self.archive_name, "archive_sha256": self.archive_sha256,
+            "target": self.target, "file_sha256": self.file_hashes,
+            "source": "local-archive"
+        }))
+        .map_err(io::Error::other)
+    }
+
+    pub fn read(directory: &Path, prefix: &Path, id: Uuid) -> io::Result<Self> {
+        let mut inventory = fs::read_dir(directory)?
+            .take(FILES.len() + 2)
+            .map(|entry| entry.map(|entry| entry.file_name()))
+            .collect::<io::Result<Vec<_>>>()?;
+        inventory.sort();
+        let mut expected = FILES
+            .into_iter()
+            .chain(["receipt.json"])
+            .map(std::ffi::OsString::from)
+            .collect::<Vec<_>>();
+        expected.sort();
+        if inventory != expected {
+            return Err(invalid("Installed release inventory has changed."));
+        }
+        let bytes = bounded_file::read_no_follow(&directory.join("receipt.json"), 16 * 1024)
+            .map_err(io::Error::other)?;
+        let value: Value = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
+        let text = |key: &str| {
+            value[key]
+                .as_str()
+                .ok_or_else(|| invalid("Invalid native installation receipt."))
+        };
+        if value["schema_version"] != 1
+            || text("release_id")? != id.to_string()
+            || Some(text("prefix")?) != prefix.to_str()
+            || text("source")? != "local-archive"
+        {
+            return Err(invalid(
+                "Native receipt ownership does not match its installation.",
+            ));
+        }
+        if value.get("pinned_version").is_none()
+            || text("archive_sha256")?.len() != 64
+            || !text("archive_sha256")?
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        {
+            return Err(invalid("Native receipt digest or pin metadata is invalid."));
+        }
+        let state = InstalledVersion {
+            version: text("version")?
+                .parse()
+                .map_err(|_| invalid("Invalid installed version."))?,
+            channel: Channel::parse(text("channel")?)
+                .ok_or_else(|| invalid("Invalid installed channel."))?,
+            pinned_version: match &value["pinned_version"] {
+                Value::Null => None,
+                Value::String(version) => Some(
+                    version
+                        .parse()
+                        .map_err(|_| invalid("Invalid installed pin."))?,
+                ),
+                _ => return Err(invalid("Invalid installed pin.")),
+            },
+        };
+        state.validate().map_err(io::Error::other)?;
+        let hashes = value["file_sha256"]
+            .as_object()
+            .ok_or_else(|| invalid("Missing installed file digests."))?;
+        if hashes.len() != FILES.len() {
+            return Err(invalid("Unexpected installed file digest inventory."));
+        }
+        let mut file_hashes = BTreeMap::new();
+        for name in FILES {
+            let metadata = fs::symlink_metadata(directory.join(name))?;
+            let mode = metadata.permissions().mode();
+            if !metadata.file_type().is_file()
+                || mode & 0o7000 != 0
+                || (name == "tmt" && mode & 0o111 == 0)
+            {
+                return Err(invalid(
+                    "Installed release file type or permissions have changed.",
+                ));
+            }
+            let expected = hashes
+                .get(name)
+                .and_then(Value::as_str)
+                .ok_or_else(|| invalid("Missing installed file digest."))?;
+            let bytes = bounded_file::read_no_follow(&directory.join(name), 128 * 1024 * 1024)
+                .map_err(io::Error::other)?;
+            if digest(&bytes) != expected {
+                return Err(invalid(
+                    "Installed release file has changed; refusing replacement.",
+                ));
+            }
+            file_hashes.insert(name.into(), expected.into());
+        }
+        Ok(Self {
+            id,
+            state,
+            archive_name: text("archive")?.into(),
+            archive_sha256: text("archive_sha256")?.into(),
+            target: text("target")?.into(),
+            file_hashes,
+        })
+    }
+}

--- a/rust/crates/tmt-adapters/src/native_install/test_support.rs
+++ b/rust/crates/tmt-adapters/src/native_install/test_support.rs
@@ -1,0 +1,72 @@
+use super::{
+    artifact::{self, Artifact, FILES},
+    publication::Layout,
+    receipt::Receipt,
+};
+use crate::test_support::TestDirectory;
+use semver::Version;
+use std::collections::BTreeMap;
+use tmt_core::native_install::{Channel, InstalledVersion};
+
+const TARGET: &str = "aarch64-apple-darwin";
+pub(super) const VERSION: &str = "1.2.3";
+
+pub(super) fn artifact(version: &str, payload: &[u8]) -> Artifact {
+    let mut files = BTreeMap::new();
+    files.insert("tmt".to_owned(), payload.to_vec());
+    files.insert("LICENSE".to_owned(), b"MIT\n".to_vec());
+    files.insert("NATIVE-INSTALL.md".to_owned(), b"Native install\n".to_vec());
+    files.insert(
+        "THIRD-PARTY-NOTICES.txt".to_owned(),
+        b"Third-party notices\n".to_vec(),
+    );
+    assert_eq!(files.len(), FILES.len());
+    Artifact {
+        name: format!("tmux-team-{version}-{TARGET}.tar.gz"),
+        version: Version::parse(version).unwrap(),
+        target: TARGET.to_owned(),
+        sha256: artifact::digest(b"synthetic archive"),
+        files,
+    }
+}
+
+pub(super) fn state(version: &str, pinned: Option<&str>) -> InstalledVersion {
+    InstalledVersion {
+        version: Version::parse(version).unwrap(),
+        channel: Channel::Stable,
+        pinned_version: pinned.map(|value| Version::parse(value).unwrap()),
+    }
+}
+
+pub(super) fn published_layout() -> (TestDirectory, Layout, Receipt) {
+    let directory = TestDirectory::new();
+    let layout = Layout::open(&directory.path.join("prefix")).unwrap();
+    let artifact = artifact(VERSION, b"synthetic tmt payload\n");
+    let receipt = Receipt::new(&artifact, state(VERSION, None));
+    publish(&layout, &artifact, &receipt);
+    (directory, layout, receipt)
+}
+
+pub(super) fn publish(layout: &Layout, artifact: &Artifact, receipt: &Receipt) {
+    let mut checkpoint = || Ok(());
+    let expected_current = layout.current().unwrap().map(|current| current.id);
+    layout
+        .publish(artifact, receipt, expected_current, &mut checkpoint)
+        .unwrap();
+}
+
+pub(super) fn checkpoint_count() -> usize {
+    let directory = TestDirectory::new();
+    let layout = Layout::open(&directory.path.join("probe-prefix")).unwrap();
+    let artifact = artifact(VERSION, b"checkpoint probe\n");
+    let receipt = Receipt::new(&artifact, state(VERSION, None));
+    let mut calls = 0;
+    let mut checkpoint = || {
+        calls += 1;
+        Ok(())
+    };
+    layout
+        .publish(&artifact, &receipt, None, &mut checkpoint)
+        .unwrap();
+    calls
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/assets.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/assets.rs
@@ -1,7 +1,7 @@
 //! One embedded authored source, materialized without a checkout dependency.
 
 use crate::bounded_file;
-use sha2::{Digest, Sha256};
+use crate::content_digest::sha256 as digest;
 use std::{
     fs,
     io::{self, Write},
@@ -10,13 +10,6 @@ use std::{
 use uuid::Uuid;
 
 pub(super) const SKILL: &[u8] = include_bytes!("../../../../../skills/tmux-team/SKILL.md");
-
-fn digest(bytes: &[u8]) -> String {
-    Sha256::digest(bytes)
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect()
-}
 
 fn invalid(path: &Path) -> io::Error {
     io::Error::new(

--- a/rust/crates/tmt-adapters/src/skill_installation/files.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/files.rs
@@ -1,7 +1,7 @@
 //! Installer-local file publication and path guards. No command execution.
 
 use crate::config::normalize;
-use nix::fcntl::{Flock, FlockArg, OFlag};
+use nix::fcntl::Flock;
 use std::{
     fs::{self, File, OpenOptions},
     io::{self, Write},
@@ -12,22 +12,11 @@ use uuid::Uuid;
 
 pub(super) fn lock(global: &Path) -> io::Result<Flock<File>> {
     fs::create_dir_all(global)?;
-    // Keep this entry stable: unlinking it would split concurrent lock domains.
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .mode(0o600)
-        .custom_flags((OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK).bits())
-        .open(global.join("skill-install.lock"))?;
-    if !file.metadata()?.is_file() {
-        return Err(io::Error::other(
-            "Skill installation lock is not a regular file.",
-        ));
-    }
-    Flock::lock(file, FlockArg::LockExclusiveNonblock).map_err(|(_, error)| {
-        io::Error::new(io::Error::from_raw_os_error(error as i32).kind(), format!("Cannot acquire the skill installation lock; another installer may be running: {error}"))
+    crate::file_lock::exclusive(&global.join("skill-install.lock")).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("Cannot acquire the skill installation lock: {error}"),
+        )
     })
 }
 

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -190,6 +190,16 @@ pub fn grammar() -> Command {
         )
         .subcommand(general("completion", "Generate shell completion").arg(operand("shell", false)))
         .subcommand(general("upgrade", "Upgrade the CLI and refresh skills"))
+        .subcommand(
+            general("__native-install", "Internal offline native installation")
+                .hide(true)
+                .arg(Arg::new("archive").long("archive").required(true))
+                .arg(Arg::new("manifest").long("manifest").required(true))
+                .arg(Arg::new("prefix").long("prefix").required(true))
+                .arg(Arg::new("channel").long("channel").required(true).value_parser(["stable", "alpha"]))
+                .arg(Arg::new("pin").long("pin").action(ArgAction::SetTrue).conflicts_with("unpin"))
+                .arg(Arg::new("unpin").long("unpin").action(ArgAction::SetTrue)),
+        )
         .subcommand(with_options(
             general("learn", "Read agent guidance"),
             &["skill"],

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -56,6 +56,13 @@ pub enum Invocation {
         force: bool,
     },
     Upgrade,
+    NativeInstall {
+        archive: String,
+        manifest: String,
+        prefix: String,
+        channel: tmt_core::native_install::Channel,
+        pin: tmt_core::native_install::PinAction,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -11,6 +11,7 @@ mod identity_context;
 mod init_command;
 mod install_command;
 mod invocation;
+mod native_install_command;
 mod output;
 mod parser;
 mod profile_command;
@@ -134,6 +135,23 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
                 parsed.mode,
                 "NATIVE_NOT_IMPLEMENTED",
                 "This command is not implemented by the native development preview. No effects were performed; use the installed TypeScript CLI until native cutover.",
+            );
+        }
+        Invocation::NativeInstall {
+            archive,
+            manifest,
+            prefix,
+            channel,
+            pin,
+        } => {
+            drop(stdout);
+            return native_install_command::execute(
+                &archive,
+                &manifest,
+                &prefix,
+                channel,
+                pin,
+                parsed.mode,
             );
         }
     }

--- a/rust/crates/tmt-cli/src/native_install_command.rs
+++ b/rust/crates/tmt-cli/src/native_install_command.rs
@@ -1,0 +1,91 @@
+//! Internal offline installer composition; no config discovery or skill mutation.
+
+use crate::{invocation::OutputMode, output::Failure};
+use std::{
+    io::{self, Write},
+    path::Path,
+};
+use tmt_core::native_install::{Channel, PinAction};
+
+pub fn execute(
+    archive: &str,
+    manifest: &str,
+    prefix: &str,
+    channel: Channel,
+    pin: PinAction,
+    mode: OutputMode,
+) -> io::Result<u8> {
+    let target = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => "aarch64-apple-darwin",
+        ("macos", "x86_64") => "x86_64-apple-darwin",
+        ("linux", "aarch64") => "aarch64-unknown-linux-musl",
+        ("linux", "x86_64") => "x86_64-unknown-linux-musl",
+        _ => {
+            return Failure::new(
+                "NATIVE_INSTALL_UNSUPPORTED",
+                "No native artifact is supported for this platform.",
+                1,
+            )
+            .publish(mode);
+        }
+    };
+    let interrupt = match tmt_adapters::interrupt::Interrupt::install() {
+        Ok(interrupt) => interrupt,
+        Err(error) => {
+            return Failure::new("NATIVE_INSTALL_FAILED", error.to_string(), 1)
+                .caused_by(error)
+                .publish(mode);
+        }
+    };
+    let request = tmt_adapters::native_install::InstallRequest {
+        archive: Path::new(archive),
+        manifest: Path::new(manifest),
+        prefix: Path::new(prefix),
+        target,
+        channel,
+        pin,
+    };
+    let report = match tmt_adapters::native_install::install(request, || {
+        if interrupt.is_interrupted() {
+            Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "Native installation interrupted before activation.",
+            ))
+        } else {
+            Ok(())
+        }
+    }) {
+        Ok(report) => report,
+        Err(error) => {
+            let exit = if error.kind() == io::ErrorKind::Interrupted {
+                130
+            } else {
+                1
+            };
+            return Failure::new("NATIVE_INSTALL_FAILED", error.to_string(), exit)
+                .caused_by(error)
+                .publish(mode);
+        }
+    };
+    let mut stdout = io::stdout().lock();
+    if mode.json {
+        writeln!(
+            stdout,
+            "{}",
+            serde_json::json!({"executable": report.executable, "version": report.version, "changed": report.changed})
+        )?;
+    } else {
+        writeln!(
+            stdout,
+            "{} tmt {} at {}",
+            if report.changed {
+                "Installed"
+            } else {
+                "Current"
+            },
+            report.version,
+            report.executable.display()
+        )?;
+    }
+    Ok(0)
+}

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -145,6 +145,20 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
         ["whoami"] => Invocation::Whoami,
         ["unbind"] => Invocation::Unbind,
         ["upgrade"] => Invocation::Upgrade,
+        ["__native-install"] => Invocation::NativeInstall {
+            archive: required(m, "archive"),
+            manifest: required(m, "manifest"),
+            prefix: required(m, "prefix"),
+            channel: tmt_core::native_install::Channel::parse(&required(m, "channel"))
+                .expect("channel was validated by grammar"),
+            pin: if flag(m, "pin") {
+                tmt_core::native_install::PinAction::PinCandidate
+            } else if flag(m, "unpin") {
+                tmt_core::native_install::PinAction::Clear
+            } else {
+                tmt_core::native_install::PinAction::Preserve
+            },
+        },
         ["list"] => Invocation::List {
             target: text(m, "target"),
         },

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -10,6 +10,50 @@ fn args(values: &[&str]) -> Vec<OsString> {
 }
 
 #[test]
+fn internal_native_install_requires_explicit_inputs_and_typed_pin_policy() {
+    use tmt_core::native_install::{Channel, PinAction};
+    let input = [
+        "__native-install",
+        "--archive",
+        "archive.tar.gz",
+        "--manifest",
+        "manifest.json",
+        "--prefix",
+        "/prefix with spaces",
+        "--channel",
+        "alpha",
+        "--json",
+    ];
+    let parsed = parsed(&input);
+    assert!(parsed.mode.json);
+    assert_eq!(
+        parsed.invocation,
+        Invocation::NativeInstall {
+            archive: "archive.tar.gz".into(),
+            manifest: "manifest.json".into(),
+            prefix: "/prefix with spaces".into(),
+            channel: Channel::Alpha,
+            pin: PinAction::Preserve,
+        }
+    );
+    for pin in ["--pin", "--unpin"] {
+        let mut args = input.to_vec();
+        args.push(pin);
+        let result = super::parse(&self::args(&args)).unwrap();
+        assert!(
+            matches!(result.invocation, Invocation::NativeInstall { pin: actual, .. }
+            if actual == if pin == "--pin" { PinAction::PinCandidate } else { PinAction::Clear })
+        );
+    }
+    let mut conflict = input.to_vec();
+    conflict.extend(["--pin", "--unpin"]);
+    assert_eq!(parse_error(&conflict).code, "USAGE_ERROR");
+    assert_eq!(parse_error(&["__native-install"]).code, "USAGE_ERROR");
+    let help = crate::grammar::public_grammar(&crate::grammar::grammar(), true);
+    assert!(help.find_subcommand("__native-install").is_none());
+}
+
+#[test]
 fn negative_config_values_reach_setting_validation_without_accepting_unknown_flags() {
     let invocation = parsed(&["config", "set", "preambleEvery", "-1", "--json"]);
     assert_eq!(

--- a/rust/crates/tmt-cli/src/skill_reminder.rs
+++ b/rust/crates/tmt-cli/src/skill_reminder.rs
@@ -19,6 +19,7 @@ fn eligible(parsed: &Parsed, interactive: bool) -> bool {
                 | Invocation::Learn { .. }
                 | Invocation::Install { .. }
                 | Invocation::Upgrade
+                | Invocation::NativeInstall { .. }
         )
 }
 
@@ -77,6 +78,13 @@ mod tests {
                 force: false,
             },
             Invocation::Upgrade,
+            Invocation::NativeInstall {
+                archive: "archive.tar.gz".into(),
+                manifest: "manifest.json".into(),
+                prefix: "/explicit-prefix".into(),
+                channel: tmt_core::native_install::Channel::Alpha,
+                pin: tmt_core::native_install::PinAction::Preserve,
+            },
         ] {
             parsed.invocation = invocation;
             assert!(!eligible(&parsed, true));

--- a/rust/crates/tmt-cli/tests/architecture/cases.rs
+++ b/rust/crates/tmt-cli/tests/architecture/cases.rs
@@ -370,6 +370,7 @@ fn dependency_policy_handles_normal_build_target_renamed_and_dev_entries() {
             vec![
                 dependency("uuid", "normal", None, None),
                 dependency("sha2", "normal", None, None),
+                dependency("semver", "normal", None, None),
                 dependency("serde_json", "dev", None, None)
             ],
         )),

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -14,6 +14,7 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
     let name = package["name"].as_str().expect("Cargo package name");
     let allowed: &[&str] = match name {
         "tmt-core" => &[
+            "semver",
             "uuid",
             "icu_casemap",
             "icu_normalizer",
@@ -21,6 +22,9 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
             "sha2",
         ],
         "tmt-adapters" => &[
+            "semver",
+            "tar",
+            "flate2",
             "tmt-core",
             "rusqlite",
             "serde_json",

--- a/rust/crates/tmt-core/Cargo.toml
+++ b/rust/crates/tmt-core/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+semver.workspace = true
 uuid.workspace = true
 icu_normalizer.workspace = true
 icu_casemap.workspace = true

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod exact_text;
 pub mod identity;
 pub mod limits;
 pub mod names;
+pub mod native_install;
 pub mod profile;
 pub mod request;
 pub mod retention;

--- a/rust/crates/tmt-core/src/native_install.rs
+++ b/rust/crates/tmt-core/src/native_install.rs
@@ -1,0 +1,140 @@
+//! Pure release-channel and version policy; no filesystem or transport effects.
+
+use semver::Version;
+use std::{cmp::Ordering, error::Error, fmt};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    Stable,
+    Alpha,
+}
+
+impl Channel {
+    pub const ALL: [Self; 2] = [Self::Stable, Self::Alpha];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Stable => "stable",
+            Self::Alpha => "alpha",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|channel| channel.as_str().eq_ignore_ascii_case(value))
+    }
+
+    pub fn accepts(self, version: &Version) -> bool {
+        match self {
+            Self::Stable => version.pre.is_empty(),
+            Self::Alpha => version.pre.as_str().split('.').next() == Some("alpha"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledVersion {
+    pub version: Version,
+    pub channel: Channel,
+    pub pinned_version: Option<Version>,
+}
+
+impl InstalledVersion {
+    pub fn validate(&self) -> Result<(), VersionError> {
+        if !self.channel.accepts(&self.version)
+            || self
+                .pinned_version
+                .as_ref()
+                .is_some_and(|pinned| pinned != &self.version)
+        {
+            return Err(VersionError::InvalidCurrentState);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinAction {
+    Preserve,
+    PinCandidate,
+    Clear,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionPlan {
+    pub state: InstalledVersion,
+    pub changed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionError {
+    InvalidCurrentState,
+    WrongChannel,
+    Pinned,
+    Downgrade,
+    EqualPrecedenceChange,
+}
+
+impl fmt::Display for VersionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidCurrentState => "Installed version, channel and pin disagree.",
+            Self::WrongChannel => "The selected version does not belong to the selected channel.",
+            Self::Pinned => "The installation is pinned; explicitly select a version or unpin it.",
+            Self::Downgrade => "Native installation does not permit a version downgrade.",
+            Self::EqualPrecedenceChange => {
+                "Build metadata alone cannot select a different installed release."
+            }
+        })
+    }
+}
+impl Error for VersionError {}
+
+/// Filesystem ownership and equal-version artifact integrity are separate
+/// adapter checks. A version no-op never authorizes ignoring those checks.
+pub fn plan_version(
+    current: Option<&InstalledVersion>,
+    candidate: &Version,
+    channel: Channel,
+    pin: PinAction,
+) -> Result<VersionPlan, VersionError> {
+    if let Some(current) = current {
+        current.validate()?;
+    }
+    if !channel.accepts(candidate) {
+        return Err(VersionError::WrongChannel);
+    }
+    let pinned_version = match pin {
+        PinAction::PinCandidate => Some(candidate.clone()),
+        PinAction::Clear => None,
+        PinAction::Preserve => current.and_then(|state| state.pinned_version.clone()),
+    };
+    if pinned_version
+        .as_ref()
+        .is_some_and(|pinned| pinned != candidate)
+    {
+        return Err(VersionError::Pinned);
+    }
+    if let Some(current) = current {
+        match candidate.cmp_precedence(&current.version) {
+            Ordering::Less => return Err(VersionError::Downgrade),
+            Ordering::Equal if candidate != &current.version => {
+                return Err(VersionError::EqualPrecedenceChange);
+            }
+            Ordering::Equal | Ordering::Greater => {}
+        }
+    }
+    let state = InstalledVersion {
+        version: candidate.clone(),
+        channel,
+        pinned_version,
+    };
+    Ok(VersionPlan {
+        changed: current != Some(&state),
+        state,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-core/src/native_install/tests.rs
+++ b/rust/crates/tmt-core/src/native_install/tests.rs
@@ -1,0 +1,246 @@
+use semver::Version;
+
+use super::*;
+
+fn version(value: &str) -> Version {
+    Version::parse(value).expect("test version must be valid")
+}
+
+fn installed(value: &str, channel: Channel, pinned: Option<&str>) -> InstalledVersion {
+    InstalledVersion {
+        version: version(value),
+        channel,
+        pinned_version: pinned.map(version),
+    }
+}
+
+#[test]
+fn first_install_and_explicit_pin_advancement_preserve_exact_state() {
+    let candidate = version("5.0.0-alpha.10");
+    for pin in [
+        PinAction::Preserve,
+        PinAction::Clear,
+        PinAction::PinCandidate,
+    ] {
+        let plan = plan_version(None, &candidate, Channel::Alpha, pin).unwrap();
+        assert!(plan.changed);
+        assert_eq!(plan.state.version, candidate);
+        assert_eq!(plan.state.channel, Channel::Alpha);
+        assert_eq!(
+            plan.state.pinned_version,
+            (pin == PinAction::PinCandidate).then(|| candidate.clone())
+        );
+    }
+    let current = installed("5.0.0-alpha.2", Channel::Alpha, Some("5.0.0-alpha.2"));
+    for pin in [PinAction::Clear, PinAction::PinCandidate] {
+        let plan = plan_version(Some(&current), &candidate, Channel::Alpha, pin).unwrap();
+        assert!(plan.changed);
+        assert_eq!(plan.state.version, candidate);
+        assert_eq!(
+            plan.state.pinned_version,
+            (pin == PinAction::PinCandidate).then(|| candidate.clone())
+        );
+    }
+}
+
+#[test]
+fn channel_names_and_version_families_are_explicit() {
+    assert_eq!(Channel::ALL, [Channel::Stable, Channel::Alpha]);
+    assert_eq!(Channel::Stable.as_str(), "stable");
+    assert_eq!(Channel::Alpha.as_str(), "alpha");
+    assert_eq!(Channel::parse("STABLE"), Some(Channel::Stable));
+    assert_eq!(Channel::parse("Alpha"), Some(Channel::Alpha));
+    assert_eq!(Channel::parse("beta"), None);
+    assert_eq!(Channel::parse(" stable"), None);
+
+    assert!(Channel::Stable.accepts(&version("1.2.3")));
+    assert!(!Channel::Stable.accepts(&version("1.2.3-alpha.1")));
+    assert!(!Channel::Stable.accepts(&version("1.2.3-beta.1")));
+    assert!(Channel::Alpha.accepts(&version("1.2.3-alpha.1")));
+    assert!(Channel::Alpha.accepts(&version("1.2.3-alpha.10")));
+    assert!(!Channel::Alpha.accepts(&version("1.2.3")));
+    assert!(!Channel::Alpha.accepts(&version("1.2.3-beta.1")));
+
+    assert_eq!(
+        plan_version(
+            None,
+            &version("1.2.3-alpha.1"),
+            Channel::Stable,
+            PinAction::Preserve,
+        ),
+        Err(VersionError::WrongChannel)
+    );
+    assert_eq!(
+        plan_version(None, &version("1.2.3"), Channel::Alpha, PinAction::Preserve,),
+        Err(VersionError::WrongChannel)
+    );
+}
+
+#[test]
+fn alpha_prerelease_numeric_order_is_semantic() {
+    let current = installed("5.0.0-alpha.2", Channel::Alpha, None);
+    let candidate = version("5.0.0-alpha.10");
+
+    assert_eq!(
+        candidate.cmp_precedence(&current.version),
+        Ordering::Greater
+    );
+    assert_eq!(
+        plan_version(
+            Some(&current),
+            &candidate,
+            Channel::Alpha,
+            PinAction::Preserve,
+        ),
+        Ok(VersionPlan {
+            state: installed("5.0.0-alpha.10", Channel::Alpha, None),
+            changed: true,
+        })
+    );
+}
+
+#[test]
+fn downgrade_is_rejected_even_when_pin_action_is_explicit() {
+    let current = installed("1.2.0", Channel::Stable, None);
+    let candidate = version("1.1.9");
+
+    for pin in [PinAction::PinCandidate, PinAction::Clear] {
+        assert_eq!(
+            plan_version(Some(&current), &candidate, Channel::Stable, pin),
+            Err(VersionError::Downgrade),
+            "pin action {pin:?} must not permit a downgrade",
+        );
+    }
+}
+
+#[test]
+fn preserved_pin_rejects_a_different_candidate() {
+    let current = installed("5.0.0-alpha.2", Channel::Alpha, Some("5.0.0-alpha.2"));
+    let candidate = version("5.0.0-alpha.3");
+
+    assert_eq!(
+        plan_version(
+            Some(&current),
+            &candidate,
+            Channel::Alpha,
+            PinAction::Preserve,
+        ),
+        Err(VersionError::Pinned)
+    );
+}
+
+#[test]
+fn same_version_pin_changes_metadata_but_preserve_is_a_noop() {
+    let candidate = version("1.2.3");
+    let unpinned = installed("1.2.3", Channel::Stable, None);
+    let pinned = installed("1.2.3", Channel::Stable, Some("1.2.3"));
+
+    assert_eq!(
+        plan_version(
+            Some(&unpinned),
+            &candidate,
+            Channel::Stable,
+            PinAction::PinCandidate,
+        ),
+        Ok(VersionPlan {
+            state: pinned.clone(),
+            changed: true,
+        })
+    );
+    assert_eq!(
+        plan_version(
+            Some(&unpinned),
+            &candidate,
+            Channel::Stable,
+            PinAction::Preserve,
+        ),
+        Ok(VersionPlan {
+            state: unpinned.clone(),
+            changed: false,
+        })
+    );
+    assert_eq!(
+        plan_version(Some(&pinned), &candidate, Channel::Stable, PinAction::Clear,),
+        Ok(VersionPlan {
+            state: unpinned,
+            changed: true,
+        })
+    );
+    assert_eq!(
+        plan_version(
+            Some(&pinned),
+            &candidate,
+            Channel::Stable,
+            PinAction::Preserve,
+        ),
+        Ok(VersionPlan {
+            state: pinned,
+            changed: false,
+        })
+    );
+}
+
+#[test]
+fn invalid_current_channel_or_pin_state_fails_before_candidate_policy() {
+    let invalid_channel = installed("5.0.0-alpha.1", Channel::Stable, None);
+    assert_eq!(
+        plan_version(
+            Some(&invalid_channel),
+            &version("5.0.0"),
+            Channel::Stable,
+            PinAction::Clear,
+        ),
+        Err(VersionError::InvalidCurrentState)
+    );
+
+    let invalid_pin = installed("5.0.0", Channel::Stable, Some("5.0.1"));
+    assert_eq!(
+        plan_version(
+            Some(&invalid_pin),
+            &version("5.1.0"),
+            Channel::Stable,
+            PinAction::Clear,
+        ),
+        Err(VersionError::InvalidCurrentState)
+    );
+}
+
+#[test]
+fn build_metadata_only_change_is_rejected_by_precedence() {
+    let current = installed("1.2.3+build.1", Channel::Stable, None);
+    let candidate = version("1.2.3+build.2");
+
+    assert_eq!(
+        candidate.cmp_precedence(&current.version),
+        Ordering::Equal,
+        "build metadata must not affect release precedence",
+    );
+    assert_eq!(
+        plan_version(
+            Some(&current),
+            &candidate,
+            Channel::Stable,
+            PinAction::Preserve,
+        ),
+        Err(VersionError::EqualPrecedenceChange)
+    );
+}
+
+#[test]
+fn explicit_unpinned_alpha_to_stable_forward_transition_is_allowed() {
+    let current = installed("5.0.0-alpha.2", Channel::Alpha, None);
+    let candidate = version("5.0.0");
+
+    assert_eq!(
+        plan_version(
+            Some(&current),
+            &candidate,
+            Channel::Stable,
+            PinAction::Preserve,
+        ),
+        Ok(VersionPlan {
+            state: installed("5.0.0", Channel::Stable, None),
+            changed: true,
+        })
+    );
+}

--- a/scripts/verify-native-installation.mjs
+++ b/scripts/verify-native-installation.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+import { selectNativeArtifact, withNativeArtifact } from './native-artifact-policy.mjs';
+import { runPackedCommand } from './packed-command.mjs';
+
+const { values } = parseArgs({
+  options: Object.fromEntries(
+    ['archive', 'manifest', 'previous-archive', 'previous-manifest', 'target', 'skill'].map(
+      (name) => [name, { type: 'string' }]
+    )
+  ),
+});
+for (const name of [
+  'archive',
+  'manifest',
+  'previous-archive',
+  'previous-manifest',
+  'target',
+  'skill',
+]) {
+  assert(values[name], `--${name} is required`);
+}
+const current = selectNativeArtifact(values.manifest, values.archive, values.target);
+const previous = selectNativeArtifact(
+  values['previous-manifest'],
+  values['previous-archive'],
+  values.target
+);
+assert.notEqual(
+  previous.version,
+  current.version,
+  'Use actual separately versioned release artifacts'
+);
+const architecture = { arm64: 'aarch64', x64: 'x86_64' }[process.arch];
+const platform = { darwin: 'apple-darwin', linux: 'unknown-linux-musl' }[process.platform];
+assert(architecture && platform, 'Unsupported verification host');
+assert.equal(values.target, `${architecture}-${platform}`, 'Use matching-host artifacts');
+
+await withNativeArtifact(values.archive, current, async (source) => {
+  await withNativeArtifact(values['previous-archive'], previous, async (oldSource) => {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "tmt managed install's ")));
+    try {
+      const prefix = path.join(root, 'prefix with spaces');
+      const state = path.join(root, 'separate application state');
+      const env = { HOME: root, TMUX_TEAM_HOME: state, PATH: '', LANG: 'C', TMPDIR: root };
+      const options = { cwd: root, env };
+      const installer = path.join(source, 'tmt');
+      assert.equal(runPackedCommand(installer, ['--version'], options).trim(), current.version);
+      assert.equal(
+        runPackedCommand(path.join(oldSource, 'tmt'), ['--version'], options).trim(),
+        previous.version
+      );
+      const managed = path.join(prefix, 'bin/tmt');
+      const pointer = path.join(prefix, 'lib/tmux-team/current');
+      const run = (args) => runPackedCommand(managed, args, options);
+      const install = (archive, manifest, flags = [], expectedStatus = 0) =>
+        JSON.parse(
+          runPackedCommand(
+            installer,
+            [
+              '__native-install',
+              '--archive',
+              path.resolve(archive),
+              '--manifest',
+              path.resolve(manifest),
+              '--prefix',
+              prefix,
+              '--channel',
+              'alpha',
+              ...flags,
+              '--json',
+            ],
+            { ...options, expectedStatus }
+          )
+        );
+      const initial = install(values['previous-archive'], values['previous-manifest'], ['--pin']);
+      assert.equal(initial.changed, true);
+      assert.equal(run(['--version']).trim(), previous.version);
+      assert(
+        !fs.existsSync(state),
+        'Binary installation must not discover or create application state'
+      );
+      const originalPointer = fs.readlinkSync(pointer);
+      const identity = JSON.parse(
+        run(['identity', 'create', 'installation-proof', '--json'])
+      ).identity;
+      const database = path.join(state, 'tmux-team.db');
+      const originalDatabase = fs.readFileSync(database);
+
+      const blocked = install(values.archive, values.manifest, [], 1);
+      assert.equal(blocked.error.code, 'NATIVE_INSTALL_FAILED');
+      assert.match(blocked.error.message, /pinned/);
+      assert.equal(fs.readlinkSync(pointer), originalPointer);
+      assert.deepEqual(fs.readFileSync(database), originalDatabase);
+
+      const upgraded = install(values.archive, values.manifest, ['--unpin']);
+      assert.equal(upgraded.changed, true);
+      assert.notEqual(fs.readlinkSync(pointer), originalPointer);
+      assert.equal(run(['--version']).trim(), current.version);
+      assert.equal(run(['learn', '--skill']), fs.readFileSync(values.skill, 'utf8'));
+      assert.deepEqual(
+        fs.readFileSync(database),
+        originalDatabase,
+        'Installation must not migrate or write SQLite'
+      );
+      assert.deepEqual(
+        JSON.parse(run(['identity', 'show', 'installation-proof', '--json'])).identity,
+        identity
+      );
+      const oldExecutable = path.join(prefix, 'lib/tmux-team', originalPointer, 'tmt');
+      assert.equal(
+        runPackedCommand(oldExecutable, ['--version'], options).trim(),
+        previous.version
+      );
+
+      const activePointer = fs.readlinkSync(pointer);
+      assert.equal(install(values.archive, values.manifest).changed, false);
+      const downgrade = install(
+        values['previous-archive'],
+        values['previous-manifest'],
+        ['--pin'],
+        1
+      );
+      assert.match(downgrade.error.message, /downgrade/);
+      assert.equal(fs.readlinkSync(pointer), activePointer);
+      assert.equal(run(['--version']).trim(), current.version);
+      assert.equal(fs.readdirSync(path.join(prefix, 'lib/tmux-team/releases')).length, 2);
+      console.log(
+        `Managed native lifecycle verified: ${previous.version} -> ${current.version} (${values.target})`
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/native/artifact.Dockerfile
+++ b/test/native/artifact.Dockerfile
@@ -21,7 +21,7 @@ RUN npm install --global pnpm@10.33.0
 WORKDIR /verification
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --ignore-scripts
-COPY scripts/native-artifact-policy.mjs scripts/verify-native-artifact.mjs scripts/packed-command.mjs scripts/
+COPY scripts/native-artifact-policy.mjs scripts/verify-native-artifact.mjs scripts/verify-native-installation.mjs scripts/packed-command.mjs scripts/
 COPY skills/tmux-team/SKILL.md expected-skill.md
 COPY --from=build /workspace/native-manifest.json ./
 COPY --from=build /workspace/rust/target/native-notices/THIRD-PARTY-NOTICES.txt expected-notices.txt

--- a/test/native/native-installation.test.ts
+++ b/test/native/native-installation.test.ts
@@ -215,7 +215,9 @@ describe('native installation process contract', () => {
         expect(second).toEqual({ ...first, changed: false });
         expect(third).toEqual({ ...first, changed: false });
         expect(readlinkSync(currentPointer(prefix))).toBe(pointer);
-        expect(readFileSync(path.join(prefix, 'lib', 'tmux-team', pointer, 'tmt'))).toEqual(before);
+        expect(
+          readFileSync(path.join(prefix, 'lib', 'tmux-team', pointer, 'tmt')).equals(before)
+        ).toBe(true);
         expect(releaseIds(prefix)).toHaveLength(1);
         expect(existsSync(firstHome)).toBe(false);
         expect(existsSync(secondHome)).toBe(false);
@@ -248,8 +250,10 @@ describe('native installation process contract', () => {
           pinned_version: fixture.version,
         });
         expect(
-          readFileSync(path.join(prefix, 'lib', 'tmux-team', 'releases', originalId, 'tmt'))
-        ).toEqual(originalBytes);
+          readFileSync(path.join(prefix, 'lib', 'tmux-team', 'releases', originalId, 'tmt')).equals(
+            originalBytes
+          )
+        ).toBe(true);
 
         const unpinned = await install(sandbox, fixture, prefix, ['--unpin']);
         const unpinnedId = currentReleaseId(prefix);
@@ -262,8 +266,10 @@ describe('native installation process contract', () => {
         });
         expect(releaseIds(prefix)).toEqual([originalId, pinnedId, unpinnedId].sort());
         expect(
-          readFileSync(path.join(prefix, 'lib', 'tmux-team', 'releases', originalId, 'tmt'))
-        ).toEqual(originalBytes);
+          readFileSync(path.join(prefix, 'lib', 'tmux-team', 'releases', originalId, 'tmt')).equals(
+            originalBytes
+          )
+        ).toBe(true);
         expect(existsSync(sandbox.database)).toBe(false);
       });
     }
@@ -316,9 +322,11 @@ describe('native installation process contract', () => {
           'Installed target or equal-version artifact integrity does not match.'
         );
         expect(readlinkSync(currentPointer(prefix))).toBe(pointer);
-        expect(readFileSync(path.join(prefix, 'lib', 'tmux-team', pointer, 'tmt'))).toEqual(
-          originalExecutable
-        );
+        expect(
+          readFileSync(path.join(prefix, 'lib', 'tmux-team', pointer, 'tmt')).equals(
+            originalExecutable
+          )
+        ).toBe(true);
         expect(readFileSync(receiptPath(prefix))).toEqual(forgedReceiptBytes);
         expect(receipt(prefix).file_sha256).toEqual(originalReceipt.file_sha256);
         expect(existsSync(sandbox.database)).toBe(false);
@@ -375,9 +383,11 @@ describe('native installation process contract', () => {
         expect(tampered.status).toBe(1);
         expectError(tampered, 'NATIVE_INSTALL_FAILED');
         expect(readlinkSync(currentPointer(ownedPrefix))).toBe(pointer);
-        expect(readFileSync(path.join(ownedPrefix, 'lib', 'tmux-team', pointer, 'tmt'))).toEqual(
-          executable
-        );
+        expect(
+          readFileSync(path.join(ownedPrefix, 'lib', 'tmux-team', pointer, 'tmt')).equals(
+            executable
+          )
+        ).toBe(true);
         expect(existsSync(sandbox.database)).toBe(false);
       });
     }

--- a/test/native/native-installation.test.ts
+++ b/test/native/native-installation.test.ts
@@ -1,0 +1,401 @@
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import * as tar from 'tar';
+import {
+  expectError,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+  type Sandbox,
+} from '../../src/test-support/cli-process.js';
+
+if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
+
+const REQUIRED_FILES = ['tmt', 'LICENSE', 'NATIVE-INSTALL.md', 'THIRD-PARTY-NOTICES.txt'];
+
+type InstallResult = {
+  readonly executable: string;
+  readonly version: string;
+  readonly changed: boolean;
+};
+
+type ArtifactFixture = {
+  readonly archive: string;
+  readonly manifest: string;
+  readonly version: string;
+  readonly target: string;
+};
+
+function nativeTarget(): string {
+  const architecture =
+    process.arch === 'arm64' ? 'aarch64' : process.arch === 'x64' ? 'x86_64' : null;
+  const platform =
+    process.platform === 'darwin'
+      ? 'apple-darwin'
+      : process.platform === 'linux'
+        ? 'unknown-linux-musl'
+        : null;
+  if (architecture === null || platform === null)
+    throw new Error(`Unsupported native test target: ${process.arch}-${process.platform}`);
+  return `${architecture}-${platform}`;
+}
+
+async function createArtifact(
+  sandbox: Sandbox,
+  version: string,
+  executableSuffix: Uint8Array = new Uint8Array()
+): Promise<ArtifactFixture> {
+  const target = nativeTarget();
+  const name = `tmux-team-${version}-${target}.tar.gz`;
+  const fixtureRoot = path.join(sandbox.root, 'native archive inputs with spaces');
+  const tree = path.join(fixtureRoot, 'tree');
+  const root = path.join(tree, name.slice(0, -'.tar.gz'.length));
+  const archive = path.join(fixtureRoot, name);
+  const manifest = path.join(fixtureRoot, 'manifest.json');
+  mkdirSync(root, { recursive: true });
+  copyFileSync(sandbox.cli.executable, path.join(root, 'tmt'));
+  const executable = path.join(root, 'tmt');
+  chmodSync(executable, 0o755);
+  if (executableSuffix.byteLength > 0)
+    writeFileSync(executable, Buffer.concat([readFileSync(executable), executableSuffix]));
+  writeFileSync(path.join(root, 'LICENSE'), 'MIT\n');
+  writeFileSync(path.join(root, 'NATIVE-INSTALL.md'), 'Native local installation fixture.\n');
+  writeFileSync(path.join(root, 'THIRD-PARTY-NOTICES.txt'), 'Synthetic test notice fixture.\n');
+  await tar.c({ cwd: tree, file: archive, gzip: true }, [path.basename(root)]);
+  const checksum = createHash('sha256').update(readFileSync(archive)).digest('hex');
+  writeFileSync(
+    manifest,
+    `${JSON.stringify({
+      artifacts: {
+        [name]: {
+          kind: 'executable-zip',
+          name,
+          target_triples: [target],
+          checksums: { sha256: checksum },
+          assets: REQUIRED_FILES.map((file) => ({ path: file })),
+        },
+      },
+      releases: [{ app_name: 'tmt-cli', app_version: version, artifacts: [name] }],
+    })}\n`
+  );
+  return { archive, manifest, version, target };
+}
+
+function installPrefix(sandbox: Sandbox): string {
+  return path.join(sandbox.root, 'native install prefix with spaces');
+}
+
+async function install(
+  sandbox: Sandbox,
+  fixture: ArtifactFixture,
+  prefix: string,
+  flags: readonly string[] = [],
+  tmuxTeamHome?: string
+): Promise<InstallResult> {
+  const selected =
+    tmuxTeamHome === undefined
+      ? sandbox
+      : {
+          ...sandbox,
+          cli: {
+            executable: '/usr/bin/env',
+            args: [`TMUX_TEAM_HOME=${tmuxTeamHome}`, sandbox.cli.executable, ...sandbox.cli.args],
+          },
+        };
+  const result = await runCli(selected, [
+    '__native-install',
+    '--archive',
+    fixture.archive,
+    '--manifest',
+    fixture.manifest,
+    '--prefix',
+    prefix,
+    '--channel',
+    'alpha',
+    ...flags,
+    '--json',
+  ]);
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe('');
+  return parseWholeStdout(result) as unknown as InstallResult;
+}
+
+function currentPointer(prefix: string): string {
+  return path.join(prefix, 'lib', 'tmux-team', 'current');
+}
+
+function receiptPath(prefix: string): string {
+  return path.join(currentPointer(prefix), 'receipt.json');
+}
+
+function currentReleaseId(prefix: string): string {
+  return readlinkSync(currentPointer(prefix)).replace(/^releases\//, '');
+}
+
+function releaseIds(prefix: string): string[] {
+  return readdirSync(path.join(prefix, 'lib', 'tmux-team', 'releases')).sort();
+}
+
+function receipt(prefix: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(receiptPath(prefix), 'utf8')) as Record<string, unknown>;
+}
+
+function artifactChecksum(fixture: ArtifactFixture): string {
+  const manifest = JSON.parse(readFileSync(fixture.manifest, 'utf8')) as {
+    artifacts: Record<string, { checksums: { sha256: string } }>;
+  };
+  return manifest.artifacts[path.basename(fixture.archive)].checksums.sha256;
+}
+
+describe('native installation process contract', () => {
+  it(
+    'installs a real copied native executable from spaced paths and runs it with an empty PATH',
+    { timeout: 60_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const versionResult = await runCli(sandbox, ['--version']);
+        expect(versionResult.status).toBe(0);
+        expect(versionResult.stderr).toBe('');
+        const version = versionResult.stdout.trim();
+        expect(version).toMatch(/^\d+\.\d+\.\d+-alpha(?:\.[0-9A-Za-z-]+)?$/);
+        const fixture = await createArtifact(sandbox, version);
+        const prefix = installPrefix(sandbox);
+        const installed = await install(sandbox, fixture, prefix);
+        expect(installed).toEqual({
+          executable: path.join(realpathSync(prefix), 'bin', 'tmt'),
+          version,
+          changed: true,
+        });
+        expect(readlinkSync(installed.executable)).toBe('../lib/tmux-team/current/tmt');
+        expect(existsSync(sandbox.database)).toBe(false);
+
+        sandbox.env.PATH = '';
+        const moved = await runCli(
+          { ...sandbox, cli: { executable: installed.executable, args: [] } },
+          ['--version']
+        );
+        expect(moved.status).toBe(0);
+        expect(moved.stdout).toBe(`${version}\n`);
+        expect(moved.stderr).toBe('');
+        expect(existsSync(sandbox.database)).toBe(false);
+      });
+    }
+  );
+
+  it(
+    'repeats as a no-op while application-state selectors change',
+    { timeout: 60_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const versionResult = await runCli(sandbox, ['--version']);
+        const fixture = await createArtifact(sandbox, versionResult.stdout.trim());
+        const prefix = installPrefix(sandbox);
+        const first = await install(sandbox, fixture, prefix);
+        const pointer = readlinkSync(currentPointer(prefix));
+        const before = readFileSync(path.join(prefix, 'lib', 'tmux-team', pointer, 'tmt'));
+
+        const firstHome = path.join(sandbox.root, 'unrelated tmux state one');
+        const second = await install(sandbox, fixture, prefix, [], firstHome);
+        const secondHome = path.join(sandbox.root, 'unrelated tmux state two');
+        const third = await install(sandbox, fixture, prefix, [], secondHome);
+
+        expect(first.changed).toBe(true);
+        expect(second).toEqual({ ...first, changed: false });
+        expect(third).toEqual({ ...first, changed: false });
+        expect(readlinkSync(currentPointer(prefix))).toBe(pointer);
+        expect(readFileSync(path.join(prefix, 'lib', 'tmux-team', pointer, 'tmt'))).toEqual(before);
+        expect(releaseIds(prefix)).toHaveLength(1);
+        expect(existsSync(firstHome)).toBe(false);
+        expect(existsSync(secondHome)).toBe(false);
+        expect(existsSync(sandbox.database)).toBe(false);
+      });
+    }
+  );
+
+  it(
+    'records pin and unpin transitions while retaining the old release bytes',
+    { timeout: 60_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const versionResult = await runCli(sandbox, ['--version']);
+        const fixture = await createArtifact(sandbox, versionResult.stdout.trim());
+        const prefix = installPrefix(sandbox);
+        await install(sandbox, fixture, prefix);
+        const originalId = currentReleaseId(prefix);
+        const originalBytes = readFileSync(
+          path.join(prefix, 'lib', 'tmux-team', 'releases', originalId, 'tmt')
+        );
+
+        const pinned = await install(sandbox, fixture, prefix, ['--pin']);
+        const pinnedId = currentReleaseId(prefix);
+        expect(pinned.changed).toBe(true);
+        expect(pinnedId).not.toBe(originalId);
+        expect(receipt(prefix)).toMatchObject({
+          version: fixture.version,
+          channel: 'alpha',
+          pinned_version: fixture.version,
+        });
+        expect(
+          readFileSync(path.join(prefix, 'lib', 'tmux-team', 'releases', originalId, 'tmt'))
+        ).toEqual(originalBytes);
+
+        const unpinned = await install(sandbox, fixture, prefix, ['--unpin']);
+        const unpinnedId = currentReleaseId(prefix);
+        expect(unpinned.changed).toBe(true);
+        expect(unpinnedId).not.toBe(pinnedId);
+        expect(receipt(prefix)).toMatchObject({
+          version: fixture.version,
+          channel: 'alpha',
+          pinned_version: null,
+        });
+        expect(releaseIds(prefix)).toEqual([originalId, pinnedId, unpinnedId].sort());
+        expect(
+          readFileSync(path.join(prefix, 'lib', 'tmux-team', 'releases', originalId, 'tmt'))
+        ).toEqual(originalBytes);
+        expect(existsSync(sandbox.database)).toBe(false);
+      });
+    }
+  );
+
+  it(
+    'rejects an equal-version artifact with changed file bytes even when its archive digest is forged into the receipt',
+    { timeout: 60_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const versionResult = await runCli(sandbox, ['--version']);
+        const version = versionResult.stdout.trim();
+        const originalFixture = await createArtifact(sandbox, version);
+        const prefix = installPrefix(sandbox);
+        await install(sandbox, originalFixture, prefix);
+        const pointer = readlinkSync(currentPointer(prefix));
+        const originalExecutable = readFileSync(
+          path.join(prefix, 'lib', 'tmux-team', pointer, 'tmt')
+        );
+        const originalReceipt = receipt(prefix);
+        const candidate = await createArtifact(
+          sandbox,
+          version,
+          Buffer.from('\nintentionally different candidate bytes\n')
+        );
+        const forgedReceipt = {
+          ...originalReceipt,
+          archive_sha256: artifactChecksum(candidate),
+        };
+        const forgedReceiptBytes = Buffer.from(`${JSON.stringify(forgedReceipt)}\n`);
+        writeFileSync(receiptPath(prefix), forgedReceiptBytes);
+
+        // This candidate is intentionally never executed; it only tests equal-version file integrity.
+        const result = await runCli(sandbox, [
+          '__native-install',
+          '--archive',
+          candidate.archive,
+          '--manifest',
+          candidate.manifest,
+          '--prefix',
+          prefix,
+          '--channel',
+          'alpha',
+          '--json',
+        ]);
+        expect(result.status).toBe(1);
+        expectError(
+          result,
+          'NATIVE_INSTALL_FAILED',
+          'Installed target or equal-version artifact integrity does not match.'
+        );
+        expect(readlinkSync(currentPointer(prefix))).toBe(pointer);
+        expect(readFileSync(path.join(prefix, 'lib', 'tmux-team', pointer, 'tmt'))).toEqual(
+          originalExecutable
+        );
+        expect(readFileSync(receiptPath(prefix))).toEqual(forgedReceiptBytes);
+        expect(receipt(prefix).file_sha256).toEqual(originalReceipt.file_sha256);
+        expect(existsSync(sandbox.database)).toBe(false);
+      });
+    }
+  );
+
+  it(
+    'refuses unmanaged collisions and a tampered receipt without changing owned bytes or pointer',
+    { timeout: 60_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const versionResult = await runCli(sandbox, ['--version']);
+        const fixture = await createArtifact(sandbox, versionResult.stdout.trim());
+        const prefix = installPrefix(sandbox);
+        mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+        const collision = path.join(prefix, 'bin', 'tmt');
+        const collisionBytes = Buffer.from('user-owned command\n');
+        writeFileSync(collision, collisionBytes);
+        const collisionResult = await runCli(sandbox, [
+          '__native-install',
+          '--archive',
+          fixture.archive,
+          '--manifest',
+          fixture.manifest,
+          '--prefix',
+          prefix,
+          '--channel',
+          'alpha',
+          '--json',
+        ]);
+        expect(collisionResult.status).toBe(1);
+        expectError(collisionResult, 'NATIVE_INSTALL_FAILED');
+        expect(readFileSync(collision)).toEqual(collisionBytes);
+        expect(existsSync(currentPointer(prefix))).toBe(false);
+
+        const ownedPrefix = path.join(sandbox.root, 'owned prefix');
+        await install(sandbox, fixture, ownedPrefix);
+        const pointer = readlinkSync(currentPointer(ownedPrefix));
+        const executable = readFileSync(path.join(ownedPrefix, 'lib', 'tmux-team', pointer, 'tmt'));
+        writeFileSync(receiptPath(ownedPrefix), '{ malformed receipt');
+        const tampered = await runCli(sandbox, [
+          '__native-install',
+          '--archive',
+          fixture.archive,
+          '--manifest',
+          fixture.manifest,
+          '--prefix',
+          ownedPrefix,
+          '--channel',
+          'alpha',
+          '--json',
+        ]);
+        expect(tampered.status).toBe(1);
+        expectError(tampered, 'NATIVE_INSTALL_FAILED');
+        expect(readlinkSync(currentPointer(ownedPrefix))).toBe(pointer);
+        expect(readFileSync(path.join(ownedPrefix, 'lib', 'tmux-team', pointer, 'tmt'))).toEqual(
+          executable
+        );
+        expect(existsSync(sandbox.database)).toBe(false);
+      });
+    }
+  );
+
+  it('keeps the internal installer out of help and completion output', async () => {
+    await withSandbox(async (sandbox) => {
+      const help = await runCli(sandbox, ['help']);
+      expect(help.status).toBe(0);
+      expect(help.stdout).not.toContain('__native-install');
+      expect(help.stdout).not.toContain('--archive');
+      for (const shell of ['bash', 'zsh']) {
+        const completion = await runCli(sandbox, ['completion', shell]);
+        expect(completion.status).toBe(0);
+        expect(completion.stdout).not.toContain('__native-install');
+        expect(completion.stdout).not.toContain('--archive');
+      }
+      expect(existsSync(sandbox.database)).toBe(false);
+    });
+  });
+});

--- a/test/native/native-installation.test.ts
+++ b/test/native/native-installation.test.ts
@@ -24,6 +24,9 @@ import {
 if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
 
 const REQUIRED_FILES = ['tmt', 'LICENSE', 'NATIVE-INSTALL.md', 'THIRD-PARTY-NOTICES.txt'];
+// Debug payload hashing/decompression and fsync are installation work, not the
+// ordinary command-startup budget. Keep a separate finite process deadline.
+const INSTALL_PROCESS_BUDGET_MS = 15_000;
 
 type InstallResult = {
   readonly executable: string;
@@ -114,19 +117,23 @@ async function install(
             args: [`TMUX_TEAM_HOME=${tmuxTeamHome}`, sandbox.cli.executable, ...sandbox.cli.args],
           },
         };
-  const result = await runCli(selected, [
-    '__native-install',
-    '--archive',
-    fixture.archive,
-    '--manifest',
-    fixture.manifest,
-    '--prefix',
-    prefix,
-    '--channel',
-    'alpha',
-    ...flags,
-    '--json',
-  ]);
+  const result = await runCli(
+    selected,
+    [
+      '__native-install',
+      '--archive',
+      fixture.archive,
+      '--manifest',
+      fixture.manifest,
+      '--prefix',
+      prefix,
+      '--channel',
+      'alpha',
+      ...flags,
+      '--json',
+    ],
+    { deadlineMs: INSTALL_PROCESS_BUDGET_MS }
+  );
   expect(result.status).toBe(0);
   expect(result.stderr).toBe('');
   return parseWholeStdout(result) as unknown as InstallResult;
@@ -303,18 +310,22 @@ describe('native installation process contract', () => {
         writeFileSync(receiptPath(prefix), forgedReceiptBytes);
 
         // This candidate is intentionally never executed; it only tests equal-version file integrity.
-        const result = await runCli(sandbox, [
-          '__native-install',
-          '--archive',
-          candidate.archive,
-          '--manifest',
-          candidate.manifest,
-          '--prefix',
-          prefix,
-          '--channel',
-          'alpha',
-          '--json',
-        ]);
+        const result = await runCli(
+          sandbox,
+          [
+            '__native-install',
+            '--archive',
+            candidate.archive,
+            '--manifest',
+            candidate.manifest,
+            '--prefix',
+            prefix,
+            '--channel',
+            'alpha',
+            '--json',
+          ],
+          { deadlineMs: INSTALL_PROCESS_BUDGET_MS }
+        );
         expect(result.status).toBe(1);
         expectError(
           result,
@@ -346,18 +357,22 @@ describe('native installation process contract', () => {
         const collision = path.join(prefix, 'bin', 'tmt');
         const collisionBytes = Buffer.from('user-owned command\n');
         writeFileSync(collision, collisionBytes);
-        const collisionResult = await runCli(sandbox, [
-          '__native-install',
-          '--archive',
-          fixture.archive,
-          '--manifest',
-          fixture.manifest,
-          '--prefix',
-          prefix,
-          '--channel',
-          'alpha',
-          '--json',
-        ]);
+        const collisionResult = await runCli(
+          sandbox,
+          [
+            '__native-install',
+            '--archive',
+            fixture.archive,
+            '--manifest',
+            fixture.manifest,
+            '--prefix',
+            prefix,
+            '--channel',
+            'alpha',
+            '--json',
+          ],
+          { deadlineMs: INSTALL_PROCESS_BUDGET_MS }
+        );
         expect(collisionResult.status).toBe(1);
         expectError(collisionResult, 'NATIVE_INSTALL_FAILED');
         expect(readFileSync(collision)).toEqual(collisionBytes);
@@ -368,18 +383,22 @@ describe('native installation process contract', () => {
         const pointer = readlinkSync(currentPointer(ownedPrefix));
         const executable = readFileSync(path.join(ownedPrefix, 'lib', 'tmux-team', pointer, 'tmt'));
         writeFileSync(receiptPath(ownedPrefix), '{ malformed receipt');
-        const tampered = await runCli(sandbox, [
-          '__native-install',
-          '--archive',
-          fixture.archive,
-          '--manifest',
-          fixture.manifest,
-          '--prefix',
-          ownedPrefix,
-          '--channel',
-          'alpha',
-          '--json',
-        ]);
+        const tampered = await runCli(
+          sandbox,
+          [
+            '__native-install',
+            '--archive',
+            fixture.archive,
+            '--manifest',
+            fixture.manifest,
+            '--prefix',
+            ownedPrefix,
+            '--channel',
+            'alpha',
+            '--json',
+          ],
+          { deadlineMs: INSTALL_PROCESS_BUDGET_MS }
+        );
         expect(tampered.status).toBe(1);
         expectError(tampered, 'NATIVE_INSTALL_FAILED');
         expect(readlinkSync(currentPointer(ownedPrefix))).toBe(pointer);


### PR DESCRIPTION
## Scope

- Closes #138; bounded installation prerequisite under #82 and #93.
- Add the single offline native installation owner, hidden `__native-install` composition, prefix-anchored receipts and atomic release activation. `tmt install` remains skill installation; public network upgrade and the installed TypeScript entrypoint are unchanged.
- Own Rust version policy, artifact acquisition, managed filesystem publication, narrow shared file primitives, native/process regression tests and maintained architecture/developer/release guidance. Most added lines are adverse-state fixtures and assertions, not another runtime framework.

## Architecture and review

- Pure `tmt-core::native_install` owns semantic channel/version/pin policy. The adapter consumes cargo-dist metadata through pinned semver/tar/flate2 libraries, bounds inputs, verifies checksums/inventory and never uses generic archive paths as extraction destinations.
- One immutable release contains payloads and its receipt. A single relative `current` pointer activates both; command-link finalization has explicit partial-failure and retry semantics. No SQLite/config/tmux discovery or provider installation occurs in the offline owner.
- Reused `bounded_file` via a no-follow variant, extracted only stable lock mechanics and SHA-256 encoding from skill installation, and retained skill-specific registry/backup/path policy. Native tests share synthetic release fixtures and the existing process/Docker harnesses. No CI job or threshold was added or weakened.
- Primary reviewer: Codex. Personally reviewed every changed file and relevant grammar/parser/output, interrupt, bounded-file, skill-publication, archive-verifier, dependency-policy and test-harness callers. Independent review supplemented, not replaced, this review.
- Reviewed commit: `ed1d93294b4848db53ccad41ff4aa989f48b3aab` (including both CI-diagnosed test-harness corrections, reviewed with their callers and regression evidence).
- Findings corrected before submission: leaf-prefix symlink following; equal-version artifact checks trusting only receipt archive metadata; deleting an unowned colliding activation filename; skill lock diagnostic context; unsynced newly created directory links; a FIFO regression that could hang before its timing assertion; a traversal fixture rejected by the fixture builder; a process test whose ambient state override was removed by the shared runner. Each has causal regression coverage or an explicitly inspected filesystem correction.
- Accepted semantics: prefix ancestors use ordinary filesystem `..`/symlink resolution rather than rewriting paths lexically; this can create an explicitly requested missing ancestor. `changed` describes release/receipt activation; a retry may repair missing owned command links without activating another release. Hard termination may leave an unactivated directory; unknown/old releases are not pruned. Checksums and local-archive receipts are not authenticated public provenance.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] All 11 CI checks passed on reviewed head `ed1d93294b4848db53ccad41ff4aa989f48b3aab` in run 34213928041 before authorized merge.

Commands and results:

- `cargo fmt --manifest-path rust/Cargo.toml --all --check`: passed.
- `cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings`: passed.
- `cargo test --manifest-path rust/Cargo.toml --locked --workspace`: 241 adapter, 31 CLI, 19 architecture and 54 core tests passed (345 total), including actual child-process SIGINT cleanup/retry and archive expansion bounds.
- `cargo +1.88.0 build --manifest-path rust/Cargo.toml --locked --workspace`: passed with a separate task-owned MSRV target directory.
- `pnpm check`: type checks, lint and formatting gates passed.
- `pnpm test:run`: 1,131 tests in 72 files and existing coverage thresholds passed.
- `pnpm test:native` with the absolute native CLI/storage-probe descriptors: 102 tests in 12 files passed (31.66 seconds on the final source).
- Existing CI-selected shared parser/config contracts with the native descriptor: 8 parser and 6 config cases passed; unrelated cases intentionally unselected.
- Two final-source Docker lifecycle passes: each passed 241 adapter tests and 159 real-tmux/mock-agent E2E tests across 34 E2E files, with the existing optional performance skip (305.29 and 307.59 seconds). Earlier passes are not substituted for these.
- The second CI candidate exceeded the ordinary five-second child-process bound while installing a large Linux debug binary. Reproduced that exact failure at 0.25 CPU / 256 MiB JS heap / 1 GiB container memory. All six installer cases passed under the same caps with a dedicated 15-second installer child budget (106.69 seconds total). Ordinary CLI calls retain five seconds; case and CI limits are unchanged. The distinction and exact-byte assertion rule are maintained in DEVELOPMENT. Final `pnpm check` also passed. Neither failed candidate was blindly rerun.
- First CI candidate failed in Node/Vitest heap exhaustion while structurally comparing debug executable Buffers. Reproduced the old matcher under a 128 MiB JS heap / 512 MiB isolated container cap. Exact `Buffer.equals` passes with the same cap and detects a changed final byte; no assertion weakening or CI limit increase. All six actual native installer process cases then passed with the Docker-built Linux executable and pinned Node 22 under a 256 MiB JS heap / 1 GiB cap (23.91 seconds). No blind CI rerun.
- `verify-native-artifact.mjs` and `verify-native-installation.mjs`: actual macOS arm64 and Linux arm64 static-musl cargo-dist artifacts passed linkage/notices/embedded-skill/SQLite verification and actual `5.0.0-alpha.1 -> 5.0.0-alpha.2` fixture installation. Tested pin rejection, explicit unpin upgrade, no-op, downgrade rejection, retained runnable old binary and unchanged database bytes. Linux ran in a network-isolated container. Fixture versions were changed only in task-owned temporary source copies; no repository version or public release changed.
- Release skill validator passed in a task-owned temporary environment.

## Project lifecycle

- Updated ARCHITECTURE, DEVELOPMENT, RUST-REWRITE and the repository release skill. The installed skill deliberately does not advertise an internal preview entrypoint.
- GitHub #138 records scope, contracts, review findings and local progress. Remaining HTTPS bootstrap/public upgrade, managed skill refresh, full matching-host distribution matrix, provenance and runtime cutover stay under #82/#93.
- Branch `feat/138-native-install`; worktree `/Users/benhsieh/dev/tmt-138-native-install`. Keep until exact-head required CI and authorized merge, then verify clean/pushed state and remove it.
- No public release, npm operation, signing credential, global user installation, user database or host tmux modification.

Co-authored-by: Codex <codex@openai.com>
