### PR TITLE
feat(native): refresh recorded managed skills with partial reports

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -825,6 +825,22 @@ Explicit install and future #82 update own custom-target refresh. `init` separat
 reuses ConfigPaths and exclusive local file creation; it creates no other state.
 Neither this boundary nor tests imply native release publication or network upgrade.
 
+Under #141, `skill_installation::refresh` reads only bounded recorded intents,
+then re-reads under the existing installer lock. Missing/empty intent is a
+no-effects no-op. It reuses source ownership, path guards and link publication;
+missing targets stay deleted and modified/unmanaged targets are preserved as
+conflicts. Independent targets can complete despite conflicts; operational
+failure preserves the completed report. No force backups, legacy migration,
+provider detection or second registry is involved. Install and refresh share
+one explicit lock-release/error-composition helper.
+
+The hidden `__native-refresh-skills` command is a new-executable composition
+boundary for the future updater: only the activated executable has the new
+embedded skill. It uses existing path discovery without reading configuration
+contents, opening SQLite or probing tmux. Its one JSON document retains
+refreshed/skipped/conflicted paths on failure; the shared output owner formats
+the error envelope. This is not yet public network-update integration.
+
 ## Current module map
 
 | Location                                                                                                                                                                   | Responsibility and integration points                                                                                                                                   |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -527,6 +527,15 @@ PATH scan belongs on ordinary commands. Run the full native process suite and
 two Docker lifecycle passes when changing publication/cleanup. These tests do
 not establish remote release availability or native binary update acceptance.
 
+The internal `__native-refresh-skills --json` entrypoint (#141) must be invoked
+from the new executable during future update composition. Adapter tests use
+distinct old digest-owned bytes, not identical source copies, and verify exact
+new bytes, preserved conflicts, missing-target skips, lock contention and
+partial publication/retry. Native process tests check the one-document partial
+report and no config-content/SQLite/tmux effects. Refresh must not detect new
+providers, recreate deleted targets or treat recorded intent as overwrite
+permission. Run the shared install regressions and both Docker lifecycle passes.
+
 ## Packed native-install verification
 
 The packed native-install check verifies release artifacts. It installs the actual

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -532,6 +532,9 @@ Offline installer prerequisite #138 owns prefix-anchored receipts, version/pin
 policy and single-pointer release activation. Its internal entrypoint accepts
 local archives without application-state discovery. See ARCHITECTURE's managed
 native installation boundary for ownership and partial-finalization semantics.
-HTTPS bootstrap, public upgrade/update, skill refresh composition, authenticated
+Managed skill refresh prerequisite #141 supplies an internal new-executable
+entrypoint over the existing skill owner, preserving modified and missing
+integrations with partial-effect reporting. It is not wired to public updates yet.
+HTTPS bootstrap, public upgrade/update composition, authenticated
 public provenance and installed-runtime cutover remain #82/#93 work, not
 capabilities supplied by the archive generator or offline installer alone.

--- a/rust/crates/tmt-adapters/src/skill_installation/files.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/files.rs
@@ -20,6 +20,28 @@ pub(super) fn lock(global: &Path) -> io::Result<Flock<File>> {
     })
 }
 
+pub(super) fn with_lock<T>(
+    global: &Path,
+    operation: impl FnOnce() -> io::Result<T>,
+) -> io::Result<T> {
+    let lock = lock(global)?;
+    let pending = operation();
+    let released = lock.unlock().map_err(|(guard, error)| {
+        drop(guard);
+        io::Error::other(format!(
+            "Could not release skill installation lock: {error}"
+        ))
+    });
+    match (pending, released) {
+        (Err(primary), Err(cleanup)) => Err(io::Error::other(format!("{primary}; {cleanup}"))),
+        (Err(error), _) | (_, Err(error)) => Err(error),
+        (Ok(value), Ok(file)) => {
+            drop(file);
+            Ok(value)
+        }
+    }
+}
+
 /// Resolve existing ancestors while retaining a nonexistent suffix. Lexical
 /// normalization alone cannot detect source overlap through symlink aliases.
 pub(super) fn resolved(path: &Path) -> io::Result<PathBuf> {

--- a/rust/crates/tmt-adapters/src/skill_installation/mod.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/mod.rs
@@ -4,7 +4,11 @@ mod assets;
 mod drift;
 mod files;
 mod providers;
+mod refresh;
 mod registry;
+pub use refresh::{RefreshFailure, RefreshReport, RefreshedSkill, refresh};
+#[cfg(test)]
+mod refresh_tests;
 pub use drift::inspect_local_drift;
 pub use providers::ProviderEnvironment;
 #[cfg(test)]
@@ -152,8 +156,7 @@ fn install_with_publisher(
         for (_, target) in &targets {
             files::safe_target(assets.root(), target)?;
         }
-        let lock = files::lock(&global)?;
-        let operation = (|| {
+        files::with_lock(&global, || {
             registry::read(&global)?;
             let source = assets.materialize()?;
             registry::remember(&global, targets.iter().map(|(_, target)| target.clone()))?;
@@ -202,18 +205,7 @@ fn install_with_publisher(
                 }
             }
             Ok(())
-        })();
-        let released = lock.unlock().map_err(|(guard, error)| {
-            drop(guard);
-            io::Error::other(format!(
-                "Could not release skill installation lock: {error}"
-            ))
-        });
-        match (operation, released) {
-            (Err(primary), Err(cleanup)) => Err(io::Error::other(format!("{primary}; {cleanup}"))),
-            (Err(error), _) | (_, Err(error)) => Err(error),
-            _ => Ok(()),
-        }
+        })
     })();
     match pending {
         Ok(()) => Ok(report),

--- a/rust/crates/tmt-adapters/src/skill_installation/refresh.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/refresh.rs
@@ -1,0 +1,102 @@
+//! Refresh existing managed links, never install new integrations from intent.
+
+use super::{assets::SkillAssets, files, managed_link, registry};
+use std::{
+    collections::BTreeSet,
+    error::Error,
+    fmt, io,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug)]
+pub struct RefreshedSkill {
+    pub target: PathBuf,
+    pub changed: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct RefreshReport {
+    pub refreshed: Vec<RefreshedSkill>,
+    pub skipped: Vec<PathBuf>,
+    pub conflicts: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+pub struct RefreshFailure {
+    cause: io::Error,
+    pub report: RefreshReport,
+}
+
+impl fmt::Display for RefreshFailure {
+    fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(output, "Skill refresh failed: {}", self.cause)
+    }
+}
+
+impl Error for RefreshFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.cause)
+    }
+}
+
+/// Invoke from the new active executable so materialization uses its embedded
+/// skill, not the old updater process's bytes. No provider detection occurs.
+pub fn refresh(global: &Path) -> Result<RefreshReport, RefreshFailure> {
+    refresh_with_publisher(global, files::link)
+}
+
+pub(super) fn refresh_with_publisher(
+    global: &Path,
+    mut publish: impl FnMut(&Path, &Path) -> io::Result<()>,
+) -> Result<RefreshReport, RefreshFailure> {
+    let mut report = RefreshReport::default();
+    let pending = (|| {
+        let global = files::resolved(global)?;
+        // A never-installed user must not gain application state just by updating
+        // a binary. This read is observational; nonempty intent is re-read locked.
+        if registry::read(&global)?.is_empty() {
+            return Ok(());
+        }
+        files::with_lock(&global, || {
+            let targets = registry::read(&global)?;
+            let assets = SkillAssets::new(&global);
+            let mut locations = BTreeSet::new();
+            let mut source = None;
+            for target in targets {
+                let location = files::entry_location(&target)?;
+                if !locations.insert(location) {
+                    continue;
+                }
+                if !files::exists(&target)? {
+                    report.skipped.push(target);
+                    continue;
+                }
+                let Some(prior) = managed_link(&target, &assets)? else {
+                    report.conflicts.push(target);
+                    continue;
+                };
+                files::safe_target(assets.root(), &target)?;
+                let current = match &source {
+                    Some(source) => source,
+                    None => source.insert(assets.materialize()?),
+                };
+                let changed = prior != *current;
+                if changed {
+                    publish(&target, current)?;
+                }
+                report.refreshed.push(RefreshedSkill { target, changed });
+            }
+            if report.conflicts.is_empty() {
+                Ok(())
+            } else {
+                Err(io::Error::other(
+                    "Unmanaged or modified skill targets were preserved; inspect the conflicts before reinstalling.",
+                ))
+            }
+        })
+    })();
+    match pending {
+        Ok(()) => Ok(report),
+        Err(cause) => Err(RefreshFailure { cause, report }),
+    }
+}

--- a/rust/crates/tmt-adapters/src/skill_installation/refresh_tests.rs
+++ b/rust/crates/tmt-adapters/src/skill_installation/refresh_tests.rs
@@ -1,0 +1,362 @@
+use super::{bundled_skill, files, refresh, registry};
+use crate::{content_digest::sha256, test_support::TestDirectory};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+fn fixture() -> (TestDirectory, PathBuf) {
+    let directory = TestDirectory::new();
+    let global = directory.path.join("global");
+    (directory, global)
+}
+
+fn old_source(global: &Path, bytes: &[u8]) -> PathBuf {
+    let root = files::resolved(global).unwrap().join("skill-assets");
+    let source = root.join(sha256(bytes)).join("tmux-team");
+    fs::create_dir_all(&source).unwrap();
+    fs::write(source.join("SKILL.md"), bytes).unwrap();
+    source
+}
+
+fn managed_target(target: &Path, source: &Path) {
+    fs::create_dir_all(target.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(source, target).unwrap();
+}
+
+fn remember(global: &Path, targets: impl IntoIterator<Item = PathBuf>) {
+    registry::remember(global, targets).unwrap();
+}
+
+fn target_paths(root: &Path) -> [PathBuf; 3] {
+    [
+        root.join("home/.claude/skills/tmux-team"),
+        root.join("home/.agents/skills/tmux-team"),
+        root.join("workspace/custom/tmux-team"),
+    ]
+}
+
+fn assert_current(target: &Path) {
+    let source = fs::read_link(target).unwrap();
+    assert_eq!(fs::read(source.join("SKILL.md")).unwrap(), bundled_skill());
+}
+
+#[test]
+fn refreshes_old_owned_source_and_repeat_is_an_exact_byte_noop() {
+    let (directory, global) = fixture();
+    let old = b"old canonical skill\n";
+    let source = old_source(&global, old);
+    let target = directory.path.join("home/.claude/skills/tmux-team");
+    managed_target(&target, &source);
+    remember(&global, [target.clone()]);
+    let manifest_before = fs::read(global.join("skill-installations.json")).unwrap();
+
+    let first = refresh(&global).unwrap();
+    assert_eq!(first.skipped, Vec::<PathBuf>::new());
+    assert_eq!(first.conflicts, Vec::<PathBuf>::new());
+    assert_eq!(first.refreshed.len(), 1);
+    assert_eq!(first.refreshed[0].target, target);
+    assert!(first.refreshed[0].changed);
+    assert_current(&target);
+    assert_ne!(old.as_slice(), bundled_skill());
+    assert_eq!(fs::read(source.join("SKILL.md")).unwrap(), old);
+    assert!(
+        !directory
+            .path
+            .join("home/.claude/.tmt-skill-backups")
+            .exists()
+    );
+
+    let second = refresh(&global).unwrap();
+    assert_eq!(second.refreshed.len(), 1);
+    assert!(!second.refreshed[0].changed);
+    assert_eq!(second.skipped, Vec::<PathBuf>::new());
+    assert_eq!(second.conflicts, Vec::<PathBuf>::new());
+    assert_eq!(
+        fs::read(global.join("skill-installations.json")).unwrap(),
+        manifest_before
+    );
+    assert_current(&target);
+}
+
+#[test]
+fn refreshes_multiple_provider_and_custom_targets_without_discovery() {
+    let (directory, global) = fixture();
+    let old = b"old provider skill\n";
+    let source = old_source(&global, old);
+    let targets = target_paths(&directory.path);
+    for target in &targets {
+        managed_target(target, &source);
+    }
+    remember(&global, targets.iter().cloned());
+
+    let report = refresh(&global).unwrap();
+    assert_eq!(report.refreshed.len(), targets.len());
+    assert!(report.refreshed.iter().all(|item| item.changed));
+    for target in targets {
+        assert_current(&target);
+    }
+}
+
+#[test]
+fn missing_or_empty_registry_does_not_create_filesystem_state() {
+    let (directory, missing_global) = fixture();
+    assert!(!missing_global.exists());
+    let missing = refresh(&missing_global).unwrap();
+    assert!(missing.refreshed.is_empty());
+    assert!(missing.skipped.is_empty());
+    assert!(missing.conflicts.is_empty());
+    assert!(!missing_global.exists());
+
+    let empty_global = directory.path.join("empty-global");
+    fs::create_dir(&empty_global).unwrap();
+    let manifest = empty_global.join("skill-installations.json");
+    fs::write(&manifest, br#"{"version":1,"targets":[]}"#).unwrap();
+    let before = fs::read_dir(&empty_global)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect::<Vec<_>>();
+
+    let empty = refresh(&empty_global).unwrap();
+    assert!(empty.refreshed.is_empty());
+    assert!(empty.skipped.is_empty());
+    assert!(empty.conflicts.is_empty());
+    assert_eq!(
+        fs::read_dir(&empty_global)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>(),
+        before
+    );
+    assert_eq!(
+        fs::read(&manifest).unwrap(),
+        br#"{"version":1,"targets":[]}"#
+    );
+    assert!(!empty_global.join("skill-assets").exists());
+    assert!(!empty_global.join("skill-install.lock").exists());
+}
+
+#[test]
+fn missing_recorded_target_is_skipped_without_resurrection() {
+    let (_directory, global) = fixture();
+    let target = global
+        .parent()
+        .unwrap()
+        .join("deleted/.agents/skills/tmux-team");
+    remember(&global, [target.clone()]);
+
+    let report = refresh(&global).unwrap();
+    assert!(report.refreshed.is_empty());
+    assert_eq!(report.skipped, vec![target.clone()]);
+    assert!(report.conflicts.is_empty());
+    assert!(!target.exists());
+    assert!(!global.join("skill-assets").exists());
+}
+
+#[test]
+fn conflicts_are_preserved_while_independent_targets_refresh() {
+    let (directory, global) = fixture();
+    let old = b"old canonical skill\n";
+    let modified_source = old_source(&global, old);
+    fs::write(modified_source.join("SKILL.md"), b"user-modified source\n").unwrap();
+    let modified_target = directory.path.join("home/.claude/skills/tmux-team");
+    managed_target(&modified_target, &modified_source);
+    let unmanaged_target = directory.path.join("home/.agents/skills/tmux-team");
+    fs::create_dir_all(unmanaged_target.parent().unwrap()).unwrap();
+    fs::write(&unmanaged_target, b"user-owned target\n").unwrap();
+    let good_target = directory.path.join("workspace/custom/tmux-team");
+    let good_source = old_source(&global, b"another old skill\n");
+    managed_target(&good_target, &good_source);
+    remember(
+        &global,
+        [
+            modified_target.clone(),
+            unmanaged_target.clone(),
+            good_target.clone(),
+        ],
+    );
+
+    let failure = refresh(&global).unwrap_err();
+    assert_eq!(failure.report.refreshed.len(), 1);
+    assert_eq!(failure.report.refreshed[0].target, good_target);
+    assert!(failure.report.refreshed[0].changed);
+    assert_eq!(
+        failure.report.conflicts,
+        vec![unmanaged_target.clone(), modified_target.clone()]
+    );
+    assert!(failure.report.skipped.is_empty());
+    assert_current(&good_target);
+    assert_eq!(
+        fs::read(modified_source.join("SKILL.md")).unwrap(),
+        b"user-modified source\n"
+    );
+    assert_eq!(fs::read(&unmanaged_target).unwrap(), b"user-owned target\n");
+    assert!(
+        !directory
+            .path
+            .join("home/.claude/.tmt-skill-backups")
+            .exists()
+    );
+}
+
+#[test]
+fn duplicate_registry_intents_publish_once() {
+    let (directory, global) = fixture();
+    let old = b"old canonical skill\n";
+    let source = old_source(&global, old);
+    let target = directory.path.join("home/.claude/skills/tmux-team");
+    managed_target(&target, &source);
+    let manifest = global.join("skill-installations.json");
+    fs::create_dir_all(&global).unwrap();
+    fs::write(
+        &manifest,
+        serde_json::to_vec(&serde_json::json!({
+            "version": 1,
+            "targets": [target.to_str().unwrap(), target.to_str().unwrap()]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let mut publications = 0;
+    let report = super::refresh::refresh_with_publisher(&global, |actual, source| {
+        publications += 1;
+        files::link(actual, source)
+    })
+    .unwrap();
+    assert_eq!(publications, 1);
+    assert_eq!(report.refreshed.len(), 1);
+    assert_current(&target);
+}
+
+#[test]
+fn invalid_or_symlink_registry_is_rejected_without_mutation() {
+    let (directory, global) = fixture();
+    fs::create_dir_all(&global).unwrap();
+    let manifest = global.join("skill-installations.json");
+    let invalid = br#"{"version":2,"targets":[]}"#;
+    fs::write(&manifest, invalid).unwrap();
+    let failure = refresh(&global).unwrap_err();
+    assert!(
+        failure
+            .to_string()
+            .contains("Invalid or oversized skill installation manifest")
+    );
+    assert!(failure.report.refreshed.is_empty());
+    assert_eq!(fs::read(&manifest).unwrap(), invalid);
+    assert!(!global.join("skill-install.lock").exists());
+    assert!(!global.join("skill-assets").exists());
+
+    fs::remove_file(&manifest).unwrap();
+    let external = directory.path.join("external.json");
+    let external_bytes = br#"{"version":1,"targets":[]}"#;
+    fs::write(&external, external_bytes).unwrap();
+    std::os::unix::fs::symlink(&external, &manifest).unwrap();
+    let failure = refresh(&global).unwrap_err();
+    assert!(
+        failure
+            .to_string()
+            .contains("Invalid or oversized skill installation manifest")
+    );
+    assert!(failure.report.refreshed.is_empty());
+    assert_eq!(fs::read_link(&manifest).unwrap(), external);
+    assert_eq!(fs::read(&external).unwrap(), external_bytes);
+    assert!(!global.join("skill-install.lock").exists());
+    assert!(!global.join("skill-assets").exists());
+}
+
+#[test]
+fn held_lock_rejects_refresh_without_materializing_assets() {
+    let (directory, global) = fixture();
+    let target = directory.path.join("home/.claude/skills/tmux-team");
+    remember(&global, [target.clone()]);
+    let lock = files::lock(&global).unwrap();
+
+    let failure = refresh(&global).unwrap_err();
+    assert!(failure.report.refreshed.is_empty());
+    assert!(failure.report.skipped.is_empty());
+    assert!(failure.report.conflicts.is_empty());
+    assert!(failure.to_string().contains("Cannot acquire"));
+    assert!(!target.exists());
+    assert!(!global.join("skill-assets").exists());
+    drop(lock);
+}
+
+#[test]
+fn later_publication_failure_preserves_prior_bytes_and_retry_reuses_owner() {
+    let (directory, global) = fixture();
+    let old = b"old canonical skill\n";
+    let source = old_source(&global, old);
+    let first = directory.path.join("home/.claude/skills/first/tmux-team");
+    let second = directory.path.join("home/.agents/skills/second/tmux-team");
+    managed_target(&first, &source);
+    managed_target(&second, &source);
+    remember(&global, [first.clone(), second.clone()]);
+
+    let mut publications = 0;
+    let failure = super::refresh::refresh_with_publisher(&global, |target, source| {
+        publications += 1;
+        if publications == 2 {
+            return Err(io::Error::other("injected second publication failure"));
+        }
+        files::link(target, source)
+    })
+    .unwrap_err();
+    assert_eq!(publications, 2);
+    assert!(
+        failure
+            .to_string()
+            .contains("injected second publication failure")
+    );
+    assert_eq!(failure.report.refreshed.len(), 1);
+    assert_eq!(failure.report.refreshed[0].target, second);
+    assert_current(&second);
+    assert_eq!(fs::read_link(&first).unwrap(), source);
+    assert_eq!(fs::read(source.join("SKILL.md")).unwrap(), old);
+
+    let retry = refresh(&global).unwrap();
+    assert_eq!(retry.refreshed.len(), 2);
+    assert!(
+        !retry
+            .refreshed
+            .iter()
+            .find(|item| item.target == second)
+            .unwrap()
+            .changed
+    );
+    assert!(
+        retry
+            .refreshed
+            .iter()
+            .find(|item| item.target == first)
+            .unwrap()
+            .changed
+    );
+    assert_current(&first);
+    assert_current(&second);
+}
+
+#[test]
+fn alias_intents_share_one_observed_target_without_rewriting_the_registry() {
+    let (directory, global) = fixture();
+    let source = old_source(&global, b"old alias fixture\n");
+    let parent = directory.path.join("actual-skills");
+    let target = parent.join("tmux-team");
+    managed_target(&target, &source);
+    let alias = directory.path.join("alias-skills");
+    std::os::unix::fs::symlink(&parent, &alias).unwrap();
+    remember(&global, [target.clone(), alias.join("tmux-team")]);
+    let registry_before = fs::read(global.join("skill-installations.json")).unwrap();
+    let mut publications = 0;
+    let report = super::refresh::refresh_with_publisher(&global, |target, source| {
+        publications += 1;
+        files::link(target, source)
+    })
+    .unwrap();
+    assert_eq!(publications, 1);
+    assert_eq!(report.refreshed.len(), 1);
+    assert_current(&target);
+    assert_eq!(
+        fs::read(global.join("skill-installations.json")).unwrap(),
+        registry_before
+    );
+}

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -190,6 +190,7 @@ pub fn grammar() -> Command {
         )
         .subcommand(general("completion", "Generate shell completion").arg(operand("shell", false)))
         .subcommand(general("upgrade", "Upgrade the CLI and refresh skills"))
+        .subcommand(general("__native-refresh-skills", "Internal managed skill refresh").hide(true))
         .subcommand(
             general("__native-install", "Internal offline native installation")
                 .hide(true)

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -56,6 +56,7 @@ pub enum Invocation {
         force: bool,
     },
     Upgrade,
+    NativeRefreshSkills,
     NativeInstall {
         archive: String,
         manifest: String,

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -16,6 +16,7 @@ mod output;
 mod parser;
 mod profile_command;
 mod response_command;
+mod skill_refresh_command;
 mod skill_reminder;
 mod talk_command;
 mod target;
@@ -136,6 +137,10 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
                 "NATIVE_NOT_IMPLEMENTED",
                 "This command is not implemented by the native development preview. No effects were performed; use the installed TypeScript CLI until native cutover.",
             );
+        }
+        Invocation::NativeRefreshSkills => {
+            drop(stdout);
+            return skill_refresh_command::execute(parsed.mode);
         }
         Invocation::NativeInstall {
             archive,

--- a/rust/crates/tmt-cli/src/output.rs
+++ b/rust/crates/tmt-cli/src/output.rs
@@ -91,32 +91,38 @@ impl Failure {
         self
     }
 
+    /// Feature reports may attach their own bounded partial-effect projection;
+    /// this remains the sole shared error-envelope formatter.
+    pub fn document(&self) -> serde_json::Value {
+        let mut document =
+            serde_json::json!({"error": {"code": self.code, "message": self.message}});
+        if let Some(suggestion) = &self.suggestion {
+            document["error"]["suggestion"] = suggestion.clone().into();
+        }
+        if let Some(request) = &self.request {
+            let (request_id, status) = request.as_ref();
+            document["requestId"] = request_id.clone().into();
+            if let Some(status) = status {
+                document["status"] = (*status).into();
+            }
+        }
+        if let Some(target) = &self.target {
+            document["target"] = target.target.clone().into();
+            document["pane"] = target.pane.clone().into();
+            if let Some((name, canonical_name)) = &target.identity {
+                document["identity"] =
+                    serde_json::json!({"name": name, "canonicalName": canonical_name});
+            }
+        }
+        if let Some(stage) = self.stage {
+            document["error"]["stage"] = stage.into();
+        }
+        document
+    }
+
     pub fn publish(&self, mode: OutputMode) -> io::Result<u8> {
         if mode.json {
-            let mut document =
-                serde_json::json!({"error": {"code": self.code, "message": self.message}});
-            if let Some(suggestion) = &self.suggestion {
-                document["error"]["suggestion"] = suggestion.clone().into();
-            }
-            if let Some(request) = &self.request {
-                let (request_id, status) = request.as_ref();
-                document["requestId"] = request_id.clone().into();
-                if let Some(status) = status {
-                    document["status"] = (*status).into();
-                }
-            }
-            if let Some(target) = &self.target {
-                document["target"] = target.target.clone().into();
-                document["pane"] = target.pane.clone().into();
-                if let Some((name, canonical_name)) = &target.identity {
-                    document["identity"] =
-                        serde_json::json!({"name": name, "canonicalName": canonical_name});
-                }
-            }
-            if let Some(stage) = self.stage {
-                document["error"]["stage"] = stage.into();
-            }
-            writeln!(io::stdout().lock(), "{document}")?;
+            writeln!(io::stdout().lock(), "{}", self.document())?;
         } else {
             writeln!(io::stderr().lock(), "{}", self.message)?;
             if let Some(suggestion) = &self.suggestion {

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -145,6 +145,7 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
         ["whoami"] => Invocation::Whoami,
         ["unbind"] => Invocation::Unbind,
         ["upgrade"] => Invocation::Upgrade,
+        ["__native-refresh-skills"] => Invocation::NativeRefreshSkills,
         ["__native-install"] => Invocation::NativeInstall {
             archive: required(m, "archive"),
             manifest: required(m, "manifest"),

--- a/rust/crates/tmt-cli/src/skill_refresh_command.rs
+++ b/rust/crates/tmt-cli/src/skill_refresh_command.rs
@@ -1,0 +1,68 @@
+//! New-executable composition for the native updater's managed-skill phase.
+
+use crate::{invocation::OutputMode, output::Failure};
+use serde_json::{Value, json};
+use std::io::{self, Write};
+use tmt_adapters::{
+    config::ConfigPaths,
+    skill_installation::{self, RefreshReport},
+};
+
+fn document(report: &RefreshReport) -> Value {
+    json!({
+        "refreshed": report.refreshed.iter().map(|item| json!({"target": item.target, "changed": item.changed})).collect::<Vec<_>>(),
+        "skipped": report.skipped,
+        "conflicts": report.conflicts,
+    })
+}
+
+pub fn execute(mode: OutputMode) -> io::Result<u8> {
+    let paths = match ConfigPaths::discover() {
+        Ok(paths) => paths,
+        Err(error) => return Failure::from(error).publish(mode),
+    };
+    let (report, failure) = match skill_installation::refresh(&paths.global_dir) {
+        Ok(report) => (report, None),
+        Err(error) => {
+            let failure = Failure::new("SKILL_REFRESH_FAILED", error.to_string(), 1);
+            (error.report, Some(failure))
+        }
+    };
+    if mode.json {
+        let mut value = document(&report);
+        if let Some(failure) = &failure {
+            value["error"] = failure.document()["error"].clone();
+        }
+        writeln!(io::stdout().lock(), "{value}")?;
+    } else {
+        let mut output = io::stdout().lock();
+        for item in &report.refreshed {
+            writeln!(
+                output,
+                "{} skill at {}",
+                if item.changed { "Refreshed" } else { "Current" },
+                item.target.display()
+            )?;
+        }
+        for target in &report.skipped {
+            writeln!(output, "Skipped missing skill at {}", target.display())?;
+        }
+        for target in &report.conflicts {
+            writeln!(
+                output,
+                "Preserved conflicting skill at {}",
+                target.display()
+            )?;
+        }
+        if !report.refreshed.is_empty() {
+            writeln!(
+                output,
+                "Reload or restart your agent to use the current skill. Existing conversations can read tmt learn --skill."
+            )?;
+        }
+        if let Some(failure) = &failure {
+            failure.publish(mode)?;
+        }
+    }
+    Ok(if failure.is_some() { 1 } else { 0 })
+}

--- a/rust/crates/tmt-cli/src/skill_refresh_command.rs
+++ b/rust/crates/tmt-cli/src/skill_refresh_command.rs
@@ -17,16 +17,17 @@ fn document(report: &RefreshReport) -> Value {
 }
 
 pub fn execute(mode: OutputMode) -> io::Result<u8> {
-    let paths = match ConfigPaths::discover() {
-        Ok(paths) => paths,
-        Err(error) => return Failure::from(error).publish(mode),
-    };
-    let (report, failure) = match skill_installation::refresh(&paths.global_dir) {
-        Ok(report) => (report, None),
-        Err(error) => {
-            let failure = Failure::new("SKILL_REFRESH_FAILED", error.to_string(), 1);
-            (error.report, Some(failure))
-        }
+    let (report, failure) = match ConfigPaths::discover() {
+        Err(error) => (RefreshReport::default(), Some(Failure::from(error))),
+        Ok(paths) => match skill_installation::refresh(&paths.global_dir) {
+            Ok(report) => (report, None),
+            Err(mut error) => {
+                let report = std::mem::take(&mut error.report);
+                let failure =
+                    Failure::new("SKILL_REFRESH_FAILED", error.to_string(), 1).caused_by(error);
+                (report, Some(failure))
+            }
+        },
     };
     if mode.json {
         let mut value = document(&report);

--- a/rust/crates/tmt-cli/src/skill_reminder.rs
+++ b/rust/crates/tmt-cli/src/skill_reminder.rs
@@ -20,6 +20,7 @@ fn eligible(parsed: &Parsed, interactive: bool) -> bool {
                 | Invocation::Install { .. }
                 | Invocation::Upgrade
                 | Invocation::NativeInstall { .. }
+                | Invocation::NativeRefreshSkills
         )
 }
 
@@ -78,6 +79,7 @@ mod tests {
                 force: false,
             },
             Invocation::Upgrade,
+            Invocation::NativeRefreshSkills,
             Invocation::NativeInstall {
                 archive: "archive.tar.gz".into(),
                 manifest: "manifest.json".into(),

--- a/test/native/skill-refresh.test.ts
+++ b/test/native/skill-refresh.test.ts
@@ -1,0 +1,113 @@
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  expectError,
+  parseWholeStdout,
+  runCli,
+  withSandbox,
+} from '../../src/test-support/cli-process.js';
+import { calibrateTmuxTripwire } from './tmux-tripwire.js';
+
+if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
+
+describe('native managed skill refresh', () => {
+  it('keeps a never-installed home unchanged and hides internal grammar', async () => {
+    await withSandbox(async (sandbox) => {
+      const tripwire = await calibrateTmuxTripwire(sandbox);
+      const baseline = readFileSync(tripwire);
+      const result = await runCli(sandbox, ['__native-refresh-skills', '--json']);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(parseWholeStdout(result)).toEqual({ refreshed: [], skipped: [], conflicts: [] });
+      for (const args of [[], ['completion', 'bash'], ['completion', 'zsh']]) {
+        const help = await runCli(sandbox, args);
+        expect(help.status).toBe(0);
+        expect(help.stdout).not.toContain('__native-refresh-skills');
+      }
+      for (const args of [['--force'], ['--dir', 'new-skills'], ['claude']]) {
+        const rejected = await runCli(sandbox, ['__native-refresh-skills', ...args, '--json']);
+        expect(rejected.status).toBe(1);
+        expectError(rejected, 'USAGE_ERROR');
+      }
+      expect(existsSync(sandbox.globalDir)).toBe(false);
+      expect(existsSync(sandbox.database)).toBe(false);
+      expect(readFileSync(tripwire)).toEqual(baseline);
+    });
+  });
+
+  it('refreshes distinct old bytes, preserves conflicts, and reports a truthful retry', async () => {
+    await withSandbox(async (sandbox) => {
+      const tripwire = await calibrateTmuxTripwire(sandbox);
+      const baseline = readFileSync(tripwire);
+      const current = await runCli(sandbox, ['learn', '--skill']);
+      expect(current.status).toBe(0);
+      const old = Buffer.from(
+        '---\nname: tmux-team\ndescription: Old fixture guidance.\n---\nOld version instructions.\n'
+      );
+      expect(current.stdout).not.toBe(old.toString());
+      mkdirSync(sandbox.globalDir, { recursive: true });
+      const global = realpathSync(sandbox.globalDir);
+      const oldSource = path.join(
+        global,
+        'skill-assets',
+        createHash('sha256').update(old).digest('hex'),
+        'tmux-team'
+      );
+      mkdirSync(oldSource, { recursive: true });
+      writeFileSync(path.join(oldSource, 'SKILL.md'), old);
+      const targets = ['a-conflict', 'b-custom skills', 'c-deleted'].map((name) =>
+        path.join(sandbox.cwd, name, 'tmux-team')
+      );
+      for (const target of targets.slice(0, 2))
+        mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(targets[0], 'user-owned content');
+      symlinkSync(oldSource, targets[1]);
+      const registry = path.join(global, 'skill-installations.json');
+      const intents = JSON.stringify({ version: 1, targets });
+      writeFileSync(registry, intents);
+      writeFileSync(sandbox.globalConfig, '{ malformed configuration must not be loaded');
+      writeFileSync(sandbox.localConfig, '{ malformed local configuration');
+
+      const result = await runCli(sandbox, ['__native-refresh-skills', '--json']);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe('');
+      expectError(result, 'SKILL_REFRESH_FAILED');
+      expect(parseWholeStdout(result)).toMatchObject({
+        refreshed: [{ target: targets[1], changed: true }],
+        skipped: [targets[2]],
+        conflicts: [targets[0]],
+      });
+      expect(readFileSync(path.join(targets[1], 'SKILL.md'), 'utf8')).toBe(current.stdout);
+      expect(readlinkSync(targets[1])).not.toBe(oldSource);
+      expect(readFileSync(path.join(oldSource, 'SKILL.md'))).toEqual(old);
+      expect(readFileSync(targets[0], 'utf8')).toBe('user-owned content');
+      expect(existsSync(targets[2])).toBe(false);
+      expect(readFileSync(registry, 'utf8')).toBe(intents);
+
+      unlinkSync(targets[0]);
+      const retry = await runCli(sandbox, ['__native-refresh-skills', '--json']);
+      expect(retry.status).toBe(0);
+      expect(parseWholeStdout(retry)).toEqual({
+        refreshed: [{ target: targets[1], changed: false }],
+        skipped: [targets[0], targets[2]],
+        conflicts: [],
+      });
+      const human = await runCli(sandbox, ['__native-refresh-skills']);
+      expect(human.status).toBe(0);
+      expect(human.stdout).toContain('Reload or restart your agent');
+      expect(existsSync(sandbox.database)).toBe(false);
+      expect(readFileSync(tripwire)).toEqual(baseline);
+    });
+  });
+});


### PR DESCRIPTION
## Scope

- Closes #141; managed-skill prerequisite under #82/#93, following #138.
- Add hidden `__native-refresh-skills` for a future updater's newly active executable. Only already recorded managed targets are refreshed; this does not discover providers or enable public network updates.
- Own the skill-refresh orchestration, narrow lock reuse, structured partial CLI report and representative adapter/process tests.

## Architecture and review

- One skill owner continues to govern embedded assets, source integrity, path validation, publication and registry intent. `files::with_lock` extracts the existing lock lifecycle for installation and refresh; there is no new registry or force-overwrite path.
- Missing or empty registry returns without creating state. Recorded aliases are deduplicated by entry location. Missing integrations stay missing; unmanaged or modified targets are preserved and reported as conflicts while independent valid targets can refresh. I/O failures retain their cause and earlier partial effects.
- The CLI discovers state location only, not config contents, SQLite or tmux. JSON is a single report with refreshed/skipped/conflicts and the shared error envelope on failure. `Failure::document` is extracted from the existing formatter, not another error schema.
- Primary reviewer: Codex. Personally read every changed file and relevant parser/grammar/main/reminder, assets, registry, path, file publication, output and test-harness callers. Reviewed delegated tests as evidence, not automatic acceptance.
- Findings resolved: a test recreated its old-source fixture while asserting preservation; it now reads the original bytes. Added real alias-deduplication coverage and retained causal I/O errors and empty discovery-failure reports. No claim that matching bytes alone proves the update protocol.
- Reviewed commit: `d6e761557b442e4d8110373720a7ec36ae027b26`. `git range-diff` confirms both commits are unchanged after rebasing onto merged #138; only the parent's already-reviewed installer child budget differs from the prior verified base.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] All 11 CI checks passed on reviewed head `d6e761557b442e4d8110373720a7ec36ae027b26` (run 34215169994) before authorized merge.

Commands and results:

- `cargo fmt --manifest-path rust/Cargo.toml --all --check`: passed.
- `cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings`: passed.
- `cargo test --manifest-path rust/Cargo.toml --locked --workspace`: 355 tests passed (251 adapter, 31 CLI, 19 architecture, 54 core).
- `cargo +1.88.0 build --manifest-path rust/Cargo.toml --locked --workspace`: passed with a task-owned target directory.
- `cargo build --manifest-path rust/Cargo.toml --locked --workspace --examples`: passed.
- `pnpm check`: passed.
- `pnpm test:run`: 1,131 tests in 72 files and coverage gates passed. An initial local run under simultaneous Docker/native/MSRV work hit the existing one-second cargo-wrapper fixture bound; the unchanged focused 10 tests and the full suite passed after that concurrent load ended. No CI run was used to investigate it.
- `pnpm test:native` with absolute native CLI/storage-probe descriptors: 104 tests in 13 files passed on the rebased reviewed head (32.62 seconds), including the inherited installer-specific child budget.
- Two final-runtime Docker lifecycle passes: each passed 251 adapter tests and 159 real-tmux/mock-agent E2E tests across 34 files, with the existing optional performance skip (299.07 and 299.93 seconds). The earlier pre-refinement pass is not substituted for these.
- Representative tests prove distinct old/new embedded skill sources, exact preserved conflicting bytes, no missing-target resurrection, duplicate entry aliases, partial errors/retry, malformed unused config isolation, calibrated tmux non-use, no database creation and explicit agent reload guidance.

## Project lifecycle

- ARCHITECTURE, DEVELOPMENT and RUST-REWRITE describe the new owner and internal contract. Installed end-user guidance intentionally does not advertise a hidden preview operation.
- GitHub #141 records the bounded scope. Public native updates (#142), bootstrap, matching-target distribution, authenticated publication and runtime cutover remain separate #82/#93 work.
- Branch `feat/141-managed-skill-refresh`; dedicated worktree `/Users/benhsieh/dev/tmt-141-managed-skill-refresh`. Keep until exact-head green and authorized merge, then safely clean up.
- No public release, package operation, global user installation, user database or host tmux mutation.

Co-authored-by: Codex <codex@openai.com>
