### PR TITLE
feat(native): add verified upgrades and managed skill refresh

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -700,7 +700,8 @@ It must not throw exit control flow across an event callback. Neither timeout
 nor interruption cancels recipient work or alters recorded delivery certainty.
 
 Text-only help/version/completion/learn reject JSON mode with `JSON_UNSUPPORTED`
-before effects; upgrade retains its JSON rejection. No new text-command schemas
+before effects; the TypeScript upgrade retains its JSON rejection while native
+upgrade has the structured contract described below. No new text-command schemas
 or grammar are introduced. Runtime boot failures before application loading and
 unwritable output streams are outside the one-document guarantee.
 
@@ -1471,7 +1472,7 @@ target execution before they become supported release platforms.
 Under #138, the hidden `__native-install` entrypoint composes the offline
 `tmt-adapters::native_install` owner. It does not discover application settings,
 open SQLite, inspect tmux or install skills. The public `install` command still
-installs agent guidance. Public network upgrade remains unavailable in preview.
+installs agent guidance. #142 composes the same owner for public native updates.
 
 `tmt-core::native_install` owns channel and forward-only version/pin policy using
 semver precedence. Stable accepts stable versions; alpha accepts the alpha
@@ -1513,6 +1514,53 @@ encoding. Skill-specific assets, registry, backup and path policy remain in
 `skill_installation`; the binary installer does not reuse that registry as proof
 of binary ownership. HTTPS acquisition must call this same native owner rather
 than introducing a second shell publication mechanism.
+
+### Native HTTPS update composition
+
+`upgrade` and its `update` alias accept an optional retained channel, exact
+`--to` pin or `--unpin`. Core resolves that intent before discovery. A pinned
+ordinary invocation validates ownership/integrity and returns without network
+or skill writes. The actual executing file must match the active immutable
+release, not a retained old executable or another command found through PATH.
+This read-only inspection does not create directories or discover app settings.
+
+`release_http` is the sole synchronous HTTPS transport, using pinned ureq with
+rustls and the platform certificate verifier. Native trusted corporate roots and
+the library's proxy environment apply; there is no insecure switch, arbitrary
+origin override, async runtime or curl subprocess. Only canonical GitHub/API and
+GitHub asset origins are allowed, including redirects. Three redirects, bounded
+headers/bodies and a shared 60-second network deadline constrain acquisition.
+OS resolver/CA work is subject to platform behavior; this is not a guarantee
+that arbitrary blocking system calls can be forcibly cancelled.
+
+`native_install::release` owns canonical repository discovery: at most three
+100-entry pages, channel-scoped semantic maximum or exact version, a non-draft
+immutable release, and unique uploaded assets with GitHub size/SHA-256 metadata.
+The cargo-dist manifest remains the target/version/inventory authority. Both API
+and manifest digests are checked before publication. Receipt provenance records
+canonical repository/release ID and manifest digest; local archives remain
+explicitly local. This trusts authenticated HTTPS and the canonical origin,
+not independent client-side attestation verification or a compromised origin.
+
+Downloads happen outside the publication lock. Invocation-owned staging has
+explicit cleanup; the observed release UUID is checked under the existing lock
+before activation, including same-version pin changes. Typed partial activation
+evidence survives finalization or staging cleanup failures. No second publisher,
+pin registry, SQLite owner, provider discovery or automatic release pruning is
+introduced.
+
+The CLI runs the newly activated immutable executable's hidden managed-skill
+refresh via the existing bounded Unix process runner. Skill refresh is permitted
+only after revalidating current release ownership while holding
+the installation lock for that bounded child. This prevents an earlier updater
+from publishing old skill bytes after a later binary activation. Lock order is
+installation then skill publication, never network under either lock. Only fully observed
+nonzero exits retain bounded output in `CommandError`; formatting never exposes
+that output. The skill command owns its JSON protocol validator. The updater
+preserves valid partial reports and returns failure without claiming binary
+rollback when skill refresh fails. Timeouts, malformed reports and oversized
+output are failures, not successful updates. Shell bootstrap, public publication
+and installed-runtime cutover are separate delivery gates.
 
 ## Maintenance contract
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,9 @@ storage-only `identity create/show/list` under #113, and pane identity
 `reply`/`result` under #122, diagnostic `check`/`read` under #125, and
 `role`/`preamble` under #127, durable `talk` under #129, X attention under #131,
 and `init`/`learn`/managed skill installation under #133.
-Native network `upgrade` still explicitly fails.
+Native `upgrade`/`update` under #142 compose verified HTTPS acquisition, the
+offline publication owner and new-executable managed-skill refresh. Public
+release availability and installed-runtime cutover remain separate gates.
 The #118 request/final service is the shared transactional foundation;
 public reply/result composition is supplied by #122 and talk by #129. Its real SQLite
 tests run in ordinary adapter Cargo tests and therefore in the existing Docker
@@ -647,6 +649,56 @@ process error as proof of the intended check. Inspect exact manifest and archive
 bytes from the final source before running the reviewed CI candidate.
 
 ## Offline native installer preview
+
+### Native update verification
+
+`tmt upgrade [--channel stable|alpha] [--to <version> | --unpin] [--json]`
+and `tmt update` share one grammar and implementation. Use task-owned managed
+prefixes, never a user's installed command or app data. The invoking executable
+must be the active release; an unmanaged checkout binary fails before networking.
+Production has no test endpoint or TLS bypass. API fixtures inject only the
+adapter's acquisition boundary; actual local TLS fixtures use test-only trust.
+Test old/new real release archives separately from synthetic tar fixtures, with
+different embedded skills, to prove the newly active executable supplies refresh.
+
+Check pinned no-network behavior, explicit pin/unpin, unchanged release identity,
+preserved old bytes, missing/mutable release rejection, dual digest checks,
+same-version integrity and concurrent pin fencing. Cancellation and finalization
+tests must inspect active receipts and surviving executables, not only exit codes.
+After activation, skill failures retain a partial report and nonzero status;
+malformed/nonzero/oversized/timed-out child output is never a success. The existing
+process runner retains bounded output only for completed nonzero exits and never
+prints it implicitly. Verify both byte preservation and task-owned cleanup.
+
+The synchronous HTTPS dependency is pinned ureq 3.4.0 (MIT/Apache-2.0, upstream
+MSRV 1.85), selected without an async runtime or curl fallback. The lockfile and
+workspace MSRV 1.88 remain authoritative for the complete graph. rustls and
+platform-verifier use native trust and library proxy environment behavior.
+Runtime attribution includes ISC crypto and CDLA-Permissive-2.0 certificate data;
+generate target-filtered notices through cargo-about and retain complete texts.
+rcgen/rustls local-server fixtures are dev-only, not production endpoint options.
+
+The explicit actual-archive acceptance test requires separately versioned,
+matching-host cargo-dist artifacts with different embedded skills. It is ignored
+by ordinary tests, not counted as release proof until selected and passed:
+
+```sh
+TMT_UPGRADE_OLD_ARCHIVE=/absolute/old/archive.tar.gz \
+TMT_UPGRADE_OLD_MANIFEST=/absolute/old/manifest.json \
+TMT_UPGRADE_NEW_ARCHIVE=/absolute/new/archive.tar.gz \
+TMT_UPGRADE_NEW_MANIFEST=/absolute/new/manifest.json \
+TMT_UPGRADE_TARGET=aarch64-apple-darwin \
+cargo test --locked --manifest-path rust/Cargo.toml -p tmt-adapters \
+  cargo_dist_upgrade_refreshes_real_artifacts_and_preserves_conflicts -- --ignored
+```
+
+Require one selected passing test, not an empty filtered run. This test injects
+canonical acquisition responses but executes real old/new binaries, managed
+skill installation, partial hidden refresh and repair in scrubbed task-owned
+state. It does not claim to contact a public release or exercise the public CLI
+over a fake production endpoint. Run the independent artifact verifier too.
+
+### Offline composition
 
 The internal entrypoint consumes a local cargo-dist archive and manifest. It is
 not advertised by help/completion and does not change `tmt install` skill syntax.

--- a/NATIVE-INSTALL.md
+++ b/NATIVE-INSTALL.md
@@ -22,10 +22,24 @@ This example deliberately keeps its managed files in the temporary preview root.
 Choose a directory your provider discovers and reload its skills. Retain the
 included LICENSE and THIRD-PARTY-NOTICES.txt with redistributed binaries.
 
-Native shell bootstrap, managed binary receipts and network `upgrade` are not
-available yet. Do not overwrite an npm, pnpm, Homebrew or manual installation.
+Managed binary receipts and `upgrade`/`update` are implemented in the preview.
+Shell bootstrap and public native releases remain separate publication gates;
+do not assume a downloadable native release exists yet. Do not overwrite an
+npm, pnpm, Homebrew or manual installation.
 The selected executable's help is the capability authority; the shared alpha
 version number alone does not distinguish native and TypeScript runtimes.
+
+For a verified managed native installation, `tmt upgrade` retains its channel;
+`tmt upgrade --channel alpha` selects alpha, `--to 5.0.0-alpha.2` pins an exact
+version, and `--unpin` resumes channel updates. `tmt update` is the same command.
+Downgrades are rejected. An ordinary pinned invocation does not access the
+network. Use `--json` for a single structured result. The update refreshes only
+previously managed skills through the new binary; missing integrations stay
+missing and user modifications are preserved. Reload the agent after changes.
+A skill failure can occur after binary activation and is reported as partial
+completion, not rollback; resolve reported conflicts and repeat the original
+selection, including `--to <version>` when pinned. Ordinary pinned updates do
+not retry skill work.
 
 The distribution manifest supplies archive names, target triples and SHA-256
 checksums. Checksums detect corruption, not compromise of the download origin.

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -76,9 +76,10 @@ The preview implements help, version, Bash/Zsh completion and the existing
 identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109), plus storage-only
 `reply`/`result` (#122), diagnostic `check`/`read` (#125), role/preamble (#127), and
 durable `talk` (#129), identity-scoped `x list/show/ack/ackall` (#131), and
-`init`/`learn`/`install` (#133). Native network `upgrade` returns
-`NATIVE_NOT_IMPLEMENTED`, exit 1, before any settings,
-storage, tmux or input acquisition. Text-only commands reject JSON. Native
+`init`/`learn`/`install` (#133), and managed native `upgrade`/`update` (#142).
+Updates validate the executing installation before network and reuse the offline
+publisher; unmanaged package-manager executables are rejected without writes.
+Public release availability remains a separate gate. Text-only commands reject JSON. Native
 `name`/`this`/`add` create temporary bindings unless `-s`/`--save` promotes or
 creates a saved identity. `rm`/`remove` require explicit force for saved rows.
 
@@ -534,7 +535,8 @@ local archives without application-state discovery. See ARCHITECTURE's managed
 native installation boundary for ownership and partial-finalization semantics.
 Managed skill refresh prerequisite #141 supplies an internal new-executable
 entrypoint over the existing skill owner, preserving modified and missing
-integrations with partial-effect reporting. It is not wired to public updates yet.
-HTTPS bootstrap, public upgrade/update composition, authenticated
+integrations with partial-effect reporting. #142 wires it to native upgrade/update
+with bounded canonical HTTPS discovery and compare-before-activation fencing.
+HTTPS bootstrap, authenticated
 public provenance and installed-runtime cutover remain #82/#93 work, not
 capabilities supplied by the archive generator or offline installer alone.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -15,10 +15,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -46,6 +106,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -105,6 +171,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +222,32 @@ checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -234,6 +352,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -248,6 +377,22 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
@@ -384,6 +529,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +587,12 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -418,10 +618,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -446,10 +658,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -473,6 +750,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -499,12 +782,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rcgen"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -521,10 +831,143 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -620,6 +1063,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +1111,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -697,6 +1162,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,10 +1226,12 @@ dependencies = [
 name = "tmt-adapters"
 version = "5.0.0-alpha.1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "nix",
+ "rcgen",
  "rusqlite",
+ "rustls",
  "semver",
  "serde_json",
  "sha2",
@@ -722,6 +1239,7 @@ dependencies = [
  "subprocess",
  "tar",
  "tmt-core",
+ "ureq",
  "uuid",
 ]
 
@@ -762,6 +1280,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,7 +1332,7 @@ version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -783,6 +1342,22 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -830,6 +1405,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +1437,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -946,6 +1548,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1618,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 repository = "https://github.com/wkh237/tmux-team"
 
 [workspace.dependencies]
+ureq = { version = "=3.4.0", default-features = false, features = ["rustls", "platform-verifier"] }
+rustls = { version = "=0.23.44", default-features = false, features = ["std", "ring", "tls12"] }
+rcgen = { version = "=0.14.10", default-features = false, features = ["crypto", "ring"] }
 semver = "=1.0.28"
 tar = { version = "=0.4.46", default-features = false }
 flate2 = { version = "=1.1.10", default-features = false, features = ["rust_backend"] }

--- a/rust/about.toml
+++ b/rust/about.toml
@@ -1,5 +1,7 @@
 # Generate runtime dependency notices, not developer/build-tool inventories.
-accepted = ["MIT", "Apache-2.0", "Unicode-3.0"]
+# The HTTPS runtime adds ISC crypto code and CDLA-permissive root-certificate
+# data. Preserve their complete generated texts and copyright notices.
+accepted = ["MIT", "Apache-2.0", "Unicode-3.0", "ISC", "BSD-3-Clause", "CDLA-Permissive-2.0"]
 ignore-dev-dependencies = true
 ignore-build-dependencies = true
 private = { ignore = true }

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+ureq.workspace = true
 tmt-core.workspace = true
 rusqlite.workspace = true
 serde_json.workspace = true
@@ -23,6 +24,8 @@ nix.workspace = true
 signal-hook.workspace = true
 
 [target.'cfg(unix)'.dev-dependencies]
+rustls.workspace = true
+rcgen.workspace = true
 nix = { workspace = true, features = ["term"] }
 
 [lints]

--- a/rust/crates/tmt-adapters/src/content_digest.rs
+++ b/rust/crates/tmt-adapters/src/content_digest.rs
@@ -2,6 +2,13 @@
 
 use sha2::{Digest, Sha256};
 
+pub(crate) fn is_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
 pub(crate) fn sha256(bytes: &[u8]) -> String {
     Sha256::digest(bytes)
         .iter()

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -13,6 +13,8 @@ mod json_document;
 pub mod native_install;
 #[cfg(unix)]
 pub mod process;
+#[cfg(unix)]
+mod release_http;
 pub mod reply_receipt;
 pub mod request_runtime;
 #[cfg(unix)]

--- a/rust/crates/tmt-adapters/src/native_install/artifact.rs
+++ b/rust/crates/tmt-adapters/src/native_install/artifact.rs
@@ -14,7 +14,8 @@ use std::{
     path::Path,
 };
 
-const COMPRESSED_LIMIT: usize = 64 * 1024 * 1024;
+pub(super) const COMPRESSED_LIMIT: usize = 64 * 1024 * 1024;
+pub(super) const MANIFEST_LIMIT: usize = 4 * 1024 * 1024;
 const EXPANDED_LIMIT: usize = 128 * 1024 * 1024;
 pub(super) const FILES: [&str; 4] = [
     "tmt",
@@ -42,15 +43,55 @@ impl Artifact {
 }
 
 pub(super) fn acquire(manifest: &Path, archive: &Path, target: &str) -> io::Result<Artifact> {
-    let bytes =
-        bounded_file::read_no_follow(manifest, 4 * 1024 * 1024).map_err(io::Error::other)?;
+    let bytes = bounded_file::read_no_follow(manifest, MANIFEST_LIMIT).map_err(io::Error::other)?;
     let manifest: Value = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
     let name = archive
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| invalid("Native archive requires an ASCII filename."))?;
-    let root = name
-        .strip_suffix(".tar.gz")
+    let (version, sha256) = metadata(&manifest, name, target)?;
+    let compressed =
+        bounded_file::read_no_follow(archive, COMPRESSED_LIMIT).map_err(io::Error::other)?;
+    if digest(&compressed) != sha256 {
+        return Err(invalid("Native archive checksum mismatch."));
+    }
+    let files = decode(&compressed, archive_root(name)?)?;
+    Ok(Artifact {
+        name: name.into(),
+        version,
+        target: target.into(),
+        sha256,
+        files,
+    })
+}
+
+pub(super) fn select(manifest: &[u8], target: &str) -> io::Result<(String, Version)> {
+    if manifest.len() > MANIFEST_LIMIT {
+        return Err(invalid("Native manifest exceeds its bound."));
+    }
+    let manifest: Value = serde_json::from_slice(manifest).map_err(io::Error::other)?;
+    let matches = manifest["artifacts"]
+        .as_object()
+        .ok_or_else(|| invalid("Native manifest artifacts are missing."))?
+        .iter()
+        .filter(|(_, value)| {
+            value["kind"] == "executable-zip"
+                && value["target_triples"] == serde_json::json!([target])
+        })
+        .map(|(name, _)| name)
+        .collect::<Vec<_>>();
+    if matches.len() != 1 {
+        return Err(invalid(
+            "Native manifest must select exactly one target archive.",
+        ));
+    }
+    let name = matches[0];
+    let (version, _) = metadata(&manifest, name, target)?;
+    Ok((name.clone(), version))
+}
+
+fn archive_root(name: &str) -> io::Result<&str> {
+    name.strip_suffix(".tar.gz")
         .filter(|root| {
             root.as_bytes()
                 .first()
@@ -59,7 +100,11 @@ pub(super) fn acquire(manifest: &Path, archive: &Path, target: &str) -> io::Resu
                     .bytes()
                     .all(|b| b.is_ascii_alphanumeric() || b"._-".contains(&b))
         })
-        .ok_or_else(|| invalid("Invalid native archive filename."))?;
+        .ok_or_else(|| invalid("Invalid native archive filename."))
+}
+
+fn metadata(manifest: &Value, name: &str, target: &str) -> io::Result<(Version, String)> {
+    archive_root(name)?;
     let metadata = &manifest["artifacts"][name];
     if metadata["kind"] != "executable-zip"
         || metadata["name"] != name
@@ -69,12 +114,7 @@ pub(super) fn acquire(manifest: &Path, archive: &Path, target: &str) -> io::Resu
     }
     let sha256 = metadata["checksums"]["sha256"]
         .as_str()
-        .filter(|hash| {
-            hash.len() == 64
-                && hash
-                    .bytes()
-                    .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-        })
+        .filter(|hash| crate::content_digest::is_sha256(hash))
         .ok_or_else(|| invalid("Native archive requires a SHA-256 checksum."))?;
     let mut inventory = metadata["assets"]
         .as_array()
@@ -112,19 +152,7 @@ pub(super) fn acquire(manifest: &Path, archive: &Path, target: &str) -> io::Resu
         .ok_or_else(|| invalid("Native release version is missing."))?
         .parse()
         .map_err(|_| invalid("Native release version is invalid."))?;
-    let compressed =
-        bounded_file::read_no_follow(archive, COMPRESSED_LIMIT).map_err(io::Error::other)?;
-    if digest(&compressed) != sha256 {
-        return Err(invalid("Native archive checksum mismatch."));
-    }
-    let files = decode(&compressed, root)?;
-    Ok(Artifact {
-        name: name.into(),
-        version,
-        target: target.into(),
-        sha256: sha256.into(),
-        files,
-    })
+    Ok((version, sha256.into()))
 }
 
 fn decode(compressed: &[u8], root: &str) -> io::Result<BTreeMap<String, Vec<u8>>> {

--- a/rust/crates/tmt-adapters/src/native_install/managed.rs
+++ b/rust/crates/tmt-adapters/src/native_install/managed.rs
@@ -1,0 +1,66 @@
+//! Read-only ownership of the executing binary, independent of PATH/app state.
+
+use super::{invalid, publication::Layout};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+use tmt_core::native_install::InstalledVersion;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub struct ManagedInstallation {
+    pub executable: PathBuf,
+    pub active_executable: PathBuf,
+    pub state: InstalledVersion,
+    pub target: String,
+    pub(super) prefix: PathBuf,
+    pub(super) id: Uuid,
+}
+
+pub fn inspect(executable: &Path) -> io::Result<ManagedInstallation> {
+    let executable = fs::canonicalize(executable)?;
+    let prefix = executable.ancestors().nth(5).ok_or_else(unmanaged)?;
+    let layout = Layout::existing(prefix).map_err(|_| unmanaged())?;
+    let current = layout.current()?.ok_or_else(unmanaged)?;
+    let active = layout
+        .root
+        .join("releases")
+        .join(current.id.to_string())
+        .join("tmt");
+    if executable != active {
+        return Err(invalid(
+            "This executable is not the active managed release. Run the current native installation, or update using its original package manager.",
+        ));
+    }
+    layout.check_links(true)?;
+    Ok(ManagedInstallation {
+        executable: layout.prefix.join("bin/tmt"),
+        active_executable: active,
+        state: current.state,
+        target: current.target,
+        prefix: layout.prefix,
+        id: current.id,
+    })
+}
+
+/// Keep the selected release current while its bounded skill-refresh child
+/// runs. Lock order is installation then skills; acquisition never holds either.
+pub fn with_active_release<T>(executable: &Path, operation: impl FnOnce() -> T) -> io::Result<T> {
+    let observed = inspect(executable)?;
+    let layout = Layout::existing(&observed.prefix)?;
+    let _lock = crate::file_lock::exclusive(&layout.root.join("install.lock"))?;
+    if layout.current()?.map(|receipt| receipt.id) != Some(observed.id) {
+        return Err(invalid(
+            "The active release changed before skill refresh. Retry from the current native executable.",
+        ));
+    }
+    layout.check_links(true)?;
+    Ok(operation())
+}
+
+fn unmanaged() -> io::Error {
+    invalid(
+        "This executable is not a managed native installation. Use its original package manager (for example brew upgrade tmux-team), or install the official native release into a separate prefix. Do not overwrite npm/pnpm/brew files.",
+    )
+}

--- a/rust/crates/tmt-adapters/src/native_install/mod.rs
+++ b/rust/crates/tmt-adapters/src/native_install/mod.rs
@@ -1,6 +1,8 @@
 //! Verified native release acquisition and managed publication, without app state.
 
 mod artifact;
+mod managed;
+pub use managed::{ManagedInstallation, inspect, with_active_release};
 #[cfg(test)]
 mod artifact_tests;
 #[cfg(test)]
@@ -9,6 +11,9 @@ mod publication;
 #[cfg(test)]
 mod publication_tests;
 mod receipt;
+mod release;
+mod upgrade;
+pub use upgrade::{UpgradeFailure, UpgradeReport, UpgradeRequest, upgrade};
 #[cfg(test)]
 mod test_support;
 
@@ -18,11 +23,31 @@ use std::{
 };
 use tmt_core::native_install::{Channel, PinAction, plan_version};
 
-#[derive(Debug)]
+const OFFICIAL_REPOSITORY: &str = "wkh237/tmux-team";
+
+#[derive(Debug, Clone)]
 pub struct InstallReport {
     pub executable: PathBuf,
+    pub active_executable: PathBuf,
     pub version: String,
     pub changed: bool,
+}
+
+#[derive(Debug)]
+struct ActivatedInstallation {
+    report: InstallReport,
+    cause: io::Error,
+}
+
+impl std::fmt::Display for ActivatedInstallation {
+    fn fmt(&self, output: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.cause.fmt(output)
+    }
+}
+impl std::error::Error for ActivatedInstallation {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.cause)
+    }
 }
 
 /// Offline installation. Application data and provider skills are separate owners.
@@ -38,6 +63,15 @@ pub struct InstallRequest<'a> {
 /// The caller owns cancellation. Checkpoints never run inside atomic activation.
 pub fn install(
     request: InstallRequest<'_>,
+    checkpoint: impl FnMut() -> io::Result<()>,
+) -> io::Result<InstallReport> {
+    install_observed(request, None, None, checkpoint)
+}
+
+fn install_observed(
+    request: InstallRequest<'_>,
+    expected: Option<uuid::Uuid>,
+    provenance: Option<receipt::GitHubProvenance>,
     mut checkpoint: impl FnMut() -> io::Result<()>,
 ) -> io::Result<InstallReport> {
     checkpoint()?;
@@ -48,6 +82,13 @@ pub fn install(
     let layout = publication::Layout::open(request.prefix)?;
     let _lock = crate::file_lock::exclusive(&layout.root.join("install.lock"))?;
     let current = layout.current()?;
+    if let Some(expected) = expected
+        && current.as_ref().map(|receipt| receipt.id) != Some(expected)
+    {
+        return Err(invalid(
+            "The installed release or pin changed while downloading. Retry from the active executable.",
+        ));
+    }
     layout.check_links(current.is_some())?;
     let plan = plan_version(
         current.as_ref().map(|receipt| &receipt.state),
@@ -67,23 +108,70 @@ pub fn install(
             "Installed target or equal-version artifact integrity does not match.",
         ));
     }
-    if plan.changed {
-        let receipt = receipt::Receipt::new(&artifact, plan.state);
-        layout.publish(
+    let active_id = if plan.changed {
+        let mut receipt = receipt::Receipt::new(&artifact, plan.state);
+        receipt.provenance = provenance;
+        if let Err(error) = layout.publish(
             &artifact,
             &receipt,
             current.as_ref().map(|receipt| receipt.id),
             &mut checkpoint,
-        )?;
+        ) {
+            return Err(
+                if error
+                    .get_ref()
+                    .is_some_and(|cause| cause.is::<publication::ActivatedError>())
+                {
+                    io::Error::new(
+                        error.kind(),
+                        ActivatedInstallation {
+                            report: installed_report(
+                                &layout,
+                                &artifact.version.to_string(),
+                                receipt.id,
+                                true,
+                            ),
+                            cause: error,
+                        },
+                    )
+                } else {
+                    error
+                },
+            );
+        }
+        receipt.id
     } else {
         checkpoint()?;
         layout.ensure_links()?;
-    }
-    Ok(InstallReport {
+        current
+            .as_ref()
+            .expect("unchanged installation has a current receipt")
+            .id
+    };
+    Ok(installed_report(
+        &layout,
+        &artifact.version.to_string(),
+        active_id,
+        plan.changed,
+    ))
+}
+
+fn installed_report(
+    layout: &publication::Layout,
+    version: &str,
+    active_id: uuid::Uuid,
+    changed: bool,
+) -> InstallReport {
+    InstallReport {
         executable: layout.prefix.join("bin/tmt"),
-        version: artifact.version.to_string(),
-        changed: plan.changed,
-    })
+        active_executable: layout
+            .root
+            .join("releases")
+            .join(active_id.to_string())
+            .join("tmt"),
+        version: version.into(),
+        changed,
+    }
 }
 
 fn invalid(message: &str) -> io::Error {

--- a/rust/crates/tmt-adapters/src/native_install/publication.rs
+++ b/rust/crates/tmt-adapters/src/native_install/publication.rs
@@ -13,18 +13,37 @@ use std::{
 };
 use uuid::Uuid;
 
+#[derive(Debug)]
+pub(super) struct ActivatedError(io::Error);
+
+impl std::fmt::Display for ActivatedError {
+    fn fmt(&self, output: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            output,
+            "Release activated, but installation finalization failed; retry to repair command links: {}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for ActivatedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
 pub(super) struct Layout {
     pub prefix: PathBuf,
     pub root: PathBuf,
 }
 
-fn directory(path: &Path) -> io::Result<()> {
+fn directory(path: &Path, create: bool) -> io::Result<()> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
         Ok(_) => Err(invalid(
             "Native installation directory is occupied by another entry.",
         )),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+        Err(error) if create && error.kind() == io::ErrorKind::NotFound => {
             fs::DirBuilder::new().mode(0o700).create(path)?;
             if let Some(parent) = path.parent() {
                 File::open(parent)?.sync_all()?;
@@ -36,6 +55,21 @@ fn directory(path: &Path) -> io::Result<()> {
 }
 
 impl Layout {
+    pub fn existing(prefix: &Path) -> io::Result<Self> {
+        directory(prefix, false)?;
+        let prefix = fs::canonicalize(prefix)?;
+        let root = prefix.join("lib/tmux-team");
+        for path in [
+            prefix.join("lib"),
+            prefix.join("bin"),
+            root.clone(),
+            root.join("releases"),
+        ] {
+            directory(&path, false)?;
+        }
+        Ok(Self { prefix, root })
+    }
+
     pub fn open(prefix: &Path) -> io::Result<Self> {
         if prefix.as_os_str().is_empty() {
             return Err(invalid("Installation prefix must not be empty."));
@@ -47,13 +81,13 @@ impl Layout {
         if let Some(parent) = requested.parent() {
             create_prefix_ancestors(parent)?;
         }
-        directory(&requested)?;
+        directory(&requested, true)?;
         let prefix = fs::canonicalize(&requested)?;
-        directory(&prefix.join("lib"))?;
-        directory(&prefix.join("bin"))?;
+        directory(&prefix.join("lib"), true)?;
+        directory(&prefix.join("bin"), true)?;
         let root = prefix.join("lib/tmux-team");
-        directory(&root)?;
-        directory(&root.join("releases"))?;
+        directory(&root, true)?;
+        directory(&root.join("releases"), true)?;
         Ok(Self { prefix, root })
     }
 
@@ -199,8 +233,10 @@ impl Layout {
         }
         result.map_err(|error| {
             if activated {
-                io::Error::new(error.kind(), format!("Release activated, but installation finalization failed; retry to repair command links: {error}"))
-            } else { error }
+                io::Error::new(error.kind(), ActivatedError(error))
+            } else {
+                error
+            }
         })
     }
 }

--- a/rust/crates/tmt-adapters/src/native_install/receipt.rs
+++ b/rust/crates/tmt-adapters/src/native_install/receipt.rs
@@ -18,6 +18,13 @@ pub(super) struct Receipt {
     pub archive_sha256: String,
     pub target: String,
     pub file_hashes: BTreeMap<String, String>,
+    pub provenance: Option<GitHubProvenance>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct GitHubProvenance {
+    pub release_id: u64,
+    pub manifest_sha256: String,
 }
 
 impl Receipt {
@@ -29,6 +36,7 @@ impl Receipt {
             archive_sha256: artifact.sha256.clone(),
             target: artifact.target.clone(),
             file_hashes: artifact.file_hashes(),
+            provenance: None,
         }
     }
 
@@ -42,7 +50,10 @@ impl Receipt {
             "pinned_version": self.state.pinned_version.as_ref().map(ToString::to_string),
             "archive": self.archive_name, "archive_sha256": self.archive_sha256,
             "target": self.target, "file_sha256": self.file_hashes,
-            "source": "local-archive"
+            "source": self.provenance.as_ref().map_or_else(|| json!("local-archive"), |source| json!({
+                "kind": "github-release", "repository": super::OFFICIAL_REPOSITORY,
+                "release_id": source.release_id, "manifest_sha256": source.manifest_sha256,
+            }))
         }))
         .map_err(io::Error::other)
     }
@@ -73,17 +84,13 @@ impl Receipt {
         if value["schema_version"] != 1
             || text("release_id")? != id.to_string()
             || Some(text("prefix")?) != prefix.to_str()
-            || text("source")? != "local-archive"
         {
             return Err(invalid(
                 "Native receipt ownership does not match its installation.",
             ));
         }
         if value.get("pinned_version").is_none()
-            || text("archive_sha256")?.len() != 64
-            || !text("archive_sha256")?
-                .bytes()
-                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+            || !crate::content_digest::is_sha256(text("archive_sha256")?)
         {
             return Err(invalid("Native receipt digest or pin metadata is invalid."));
         }
@@ -104,6 +111,30 @@ impl Receipt {
             },
         };
         state.validate().map_err(io::Error::other)?;
+        let provenance = if value["source"] == "local-archive" {
+            None
+        } else {
+            let source = &value["source"];
+            if source.as_object().is_none_or(|fields| fields.len() != 4)
+                || source["kind"] != "github-release"
+                || source["repository"] != super::OFFICIAL_REPOSITORY
+            {
+                return Err(invalid("Invalid native release provenance."));
+            }
+            let release_id = source["release_id"]
+                .as_u64()
+                .filter(|id| *id > 0)
+                .ok_or_else(|| invalid("Invalid native release provenance."))?;
+            let manifest_sha256 = source["manifest_sha256"]
+                .as_str()
+                .filter(|hash| crate::content_digest::is_sha256(hash))
+                .ok_or_else(|| invalid("Invalid native release provenance."))?
+                .into();
+            Some(GitHubProvenance {
+                release_id,
+                manifest_sha256,
+            })
+        };
         let hashes = value["file_sha256"]
             .as_object()
             .ok_or_else(|| invalid("Missing installed file digests."))?;
@@ -142,6 +173,7 @@ impl Receipt {
             archive_sha256: text("archive_sha256")?.into(),
             target: text("target")?.into(),
             file_hashes,
+            provenance,
         })
     }
 }

--- a/rust/crates/tmt-adapters/src/native_install/release.rs
+++ b/rust/crates/tmt-adapters/src/native_install/release.rs
@@ -1,0 +1,220 @@
+//! Canonical GitHub release discovery, separate from cargo-dist archive policy.
+
+use super::{OFFICIAL_REPOSITORY, artifact, invalid, receipt::GitHubProvenance};
+use crate::content_digest::sha256;
+use semver::Version;
+use serde_json::Value;
+use std::{io, time::Instant};
+use tmt_core::native_install::{Channel, latest_in_channel};
+
+const METADATA_LIMIT: usize = 2 * 1024 * 1024;
+const MANIFEST_NAME: &str = "dist-manifest.json";
+
+pub(super) struct DownloadedRelease {
+    pub version: Version,
+    pub manifest: Vec<u8>,
+    pub archive: Vec<u8>,
+    pub archive_name: String,
+    pub provenance: GitHubProvenance,
+}
+
+pub(super) fn download(
+    channel: Channel,
+    exact: Option<&Version>,
+    target: &str,
+    deadline: Instant,
+    mut get: impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>>,
+) -> io::Result<DownloadedRelease> {
+    let endpoint = format!("https://api.github.com/repos/{OFFICIAL_REPOSITORY}/releases");
+    let document = if let Some(version) = exact {
+        json(&get(
+            &format!("{endpoint}/tags/v{version}"),
+            "application/vnd.github+json",
+            METADATA_LIMIT,
+            deadline,
+        )?)?
+    } else {
+        let mut releases = Vec::new();
+        for page in 1..=3 {
+            let document = json(&get(
+                &format!("{endpoint}?per_page=100&page={page}"),
+                "application/vnd.github+json",
+                METADATA_LIMIT,
+                deadline,
+            )?)?;
+            let entries = document
+                .as_array()
+                .ok_or_else(|| invalid("Invalid release discovery response."))?;
+            if entries.len() > 100 {
+                return Err(invalid("Release discovery exceeds its page bound."));
+            }
+            releases.extend(
+                entries
+                    .iter()
+                    .filter(|entry| entry["draft"] == false)
+                    .cloned(),
+            );
+            if entries.len() < 100 {
+                break;
+            }
+            if page == 3 {
+                return Err(invalid(
+                    "Release discovery exceeds its bound; select an exact version with --to.",
+                ));
+            }
+        }
+        let candidates = releases
+            .iter()
+            .filter_map(|release| version(release).ok().map(|version| (release, version)))
+            .collect::<Vec<_>>();
+        let versions = candidates
+            .iter()
+            .map(|(_, version)| version.clone())
+            .collect::<Vec<_>>();
+        let selected = latest_in_channel(&versions, channel)
+            .map_err(io::Error::other)?
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "No release is available in the selected native channel.",
+                )
+            })?;
+        candidates
+            .iter()
+            .find(|(_, version)| version == selected)
+            .expect("selected release exists")
+            .0
+            .clone()
+    };
+    let version = version(&document)?;
+    if !channel.accepts(&version) || exact.is_some_and(|expected| expected != &version) {
+        return Err(invalid(
+            "Release version does not match the selected channel or exact version.",
+        ));
+    }
+    if document["draft"] != false
+        || document["immutable"] != true
+        || document["prerelease"] != !version.pre.is_empty()
+    {
+        return Err(invalid(
+            "Native updates require a non-draft immutable release with matching channel metadata.",
+        ));
+    }
+    let release_id = document["id"]
+        .as_u64()
+        .filter(|id| *id > 0)
+        .ok_or_else(|| invalid("Invalid native release ID."))?;
+    let manifest_asset = asset(&document, MANIFEST_NAME, artifact::MANIFEST_LIMIT)?;
+    let manifest = fetch_asset(
+        &endpoint,
+        &manifest_asset,
+        artifact::MANIFEST_LIMIT,
+        deadline,
+        &mut get,
+    )?;
+    let (archive_name, manifest_version) = artifact::select(&manifest, target)?;
+    if manifest_version != version {
+        return Err(invalid(
+            "Release and cargo-dist manifest versions disagree.",
+        ));
+    }
+    let archive_asset = asset(&document, &archive_name, artifact::COMPRESSED_LIMIT)?;
+    let archive = fetch_asset(
+        &endpoint,
+        &archive_asset,
+        artifact::COMPRESSED_LIMIT,
+        deadline,
+        &mut get,
+    )?;
+    Ok(DownloadedRelease {
+        version,
+        archive_name,
+        archive,
+        manifest,
+        provenance: GitHubProvenance {
+            release_id,
+            manifest_sha256: manifest_asset.digest,
+        },
+    })
+}
+
+fn json(bytes: &[u8]) -> io::Result<Value> {
+    serde_json::from_slice(bytes).map_err(|_| invalid("Invalid release metadata JSON."))
+}
+
+fn version(release: &Value) -> io::Result<Version> {
+    release["tag_name"]
+        .as_str()
+        .and_then(|tag| tag.strip_prefix('v'))
+        .and_then(|version| version.parse().ok())
+        .ok_or_else(|| invalid("Release tag is not a canonical native version."))
+}
+
+struct Asset {
+    id: u64,
+    size: usize,
+    digest: String,
+}
+
+fn asset(release: &Value, name: &str, maximum: usize) -> io::Result<Asset> {
+    let entries = release["assets"]
+        .as_array()
+        .ok_or_else(|| invalid("Release assets are missing."))?;
+    let matches = entries
+        .iter()
+        .filter(|asset| asset["name"] == name)
+        .collect::<Vec<_>>();
+    if matches.len() != 1 {
+        return Err(invalid(
+            "Selected release does not contain exactly one required native asset.",
+        ));
+    }
+    let value = matches[0];
+    if value["state"] != "uploaded" {
+        return Err(invalid("Native release asset is not fully uploaded."));
+    }
+    let id = value["id"]
+        .as_u64()
+        .filter(|id| *id > 0)
+        .ok_or_else(|| invalid("Invalid native release asset ID."))?;
+    let size = value["size"]
+        .as_u64()
+        .filter(|size| *size > 0 && *size <= maximum as u64)
+        .ok_or_else(|| invalid("Native release asset exceeds its size bound."))?
+        as usize;
+    let digest = value["digest"]
+        .as_str()
+        .and_then(|digest| digest.strip_prefix("sha256:"))
+        .filter(|hash| crate::content_digest::is_sha256(hash))
+        .ok_or_else(|| invalid("Native release asset has no valid GitHub SHA-256 digest."))?
+        .into();
+    Ok(Asset { id, size, digest })
+}
+
+fn fetch_asset(
+    endpoint: &str,
+    asset: &Asset,
+    maximum: usize,
+    deadline: Instant,
+    get: &mut impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>>,
+) -> io::Result<Vec<u8>> {
+    let bytes = get(
+        &format!("{endpoint}/assets/{}", asset.id),
+        "application/octet-stream",
+        maximum,
+        deadline,
+    )?;
+    if bytes.len() != asset.size || sha256(&bytes) != asset.digest {
+        return Err(invalid(
+            "Downloaded asset does not match GitHub's recorded size and digest.",
+        ));
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+#[path = "release_tests.rs"]
+mod release_tests;
+
+#[cfg(test)]
+pub(super) use release_tests::valid_fixture;

--- a/rust/crates/tmt-adapters/src/native_install/release_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/release_tests.rs
@@ -1,0 +1,421 @@
+use super::{OFFICIAL_REPOSITORY, artifact, download};
+use crate::content_digest::sha256;
+use flate2::{Compression, write::GzEncoder};
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeMap,
+    io,
+    time::{Duration, Instant},
+};
+use tar::{Builder, EntryType, Header};
+use tmt_core::native_install::Channel;
+
+const TARGET: &str = "aarch64-apple-darwin";
+const MANIFEST_NAME: &str = "dist-manifest.json";
+
+#[derive(Debug)]
+struct Call {
+    url: String,
+    accept: String,
+    maximum: usize,
+}
+
+#[derive(Default)]
+struct HttpFixture {
+    responses: BTreeMap<String, Vec<u8>>,
+    calls: Vec<Call>,
+}
+
+impl HttpFixture {
+    fn response(&mut self, url: String, bytes: Vec<u8>) {
+        self.responses.insert(url, bytes);
+    }
+
+    fn page(&mut self, page: usize, releases: &[Value]) {
+        self.response(page_url(page), serde_json::to_vec(releases).unwrap());
+    }
+
+    fn exact(&mut self, version: &str, release: &Value) {
+        self.response(exact_url(version), serde_json::to_vec(release).unwrap());
+    }
+
+    fn assets(&mut self, release: &Value, manifest: &[u8], archive: &[u8]) {
+        for asset in release["assets"].as_array().unwrap() {
+            let id = asset["id"].as_u64().unwrap();
+            let bytes = match asset["name"].as_str().unwrap() {
+                MANIFEST_NAME => manifest,
+                _ => archive,
+            };
+            self.response(asset_url(id), bytes.to_vec());
+        }
+    }
+
+    fn get(
+        &mut self,
+        url: &str,
+        accept: &str,
+        maximum: usize,
+        _deadline: Instant,
+    ) -> io::Result<Vec<u8>> {
+        self.calls.push(Call {
+            url: url.into(),
+            accept: accept.into(),
+            maximum,
+        });
+        self.responses
+            .get(url)
+            .cloned()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "fixture response missing"))
+    }
+}
+
+fn endpoint() -> String {
+    format!("https://api.github.com/repos/{OFFICIAL_REPOSITORY}/releases")
+}
+
+fn page_url(page: usize) -> String {
+    format!("{}?per_page=100&page={page}", endpoint())
+}
+
+fn exact_url(version: &str) -> String {
+    format!("{}/tags/v{version}", endpoint())
+}
+
+fn asset_url(id: u64) -> String {
+    format!("{}/assets/{id}", endpoint())
+}
+
+fn deadline() -> Instant {
+    Instant::now() + Duration::from_secs(5)
+}
+
+fn call_download(
+    fixture: &mut HttpFixture,
+    channel: Channel,
+    exact: Option<&str>,
+    target: &str,
+) -> io::Result<super::DownloadedRelease> {
+    let exact = exact.map(|version| version.parse().unwrap());
+    download(
+        channel,
+        exact.as_ref(),
+        target,
+        deadline(),
+        |url, accept, maximum, deadline| fixture.get(url, accept, maximum, deadline),
+    )
+}
+
+fn append_file(builder: &mut Builder<GzEncoder<Vec<u8>>>, path: &str, bytes: &[u8], mode: u32) {
+    let mut header = Header::new_gnu();
+    header.set_path(path).unwrap();
+    header.set_entry_type(EntryType::Regular);
+    header.set_mode(mode);
+    header.set_size(bytes.len() as u64);
+    header.set_cksum();
+    builder.append(&header, bytes).unwrap();
+}
+
+fn archive(version: &str, target: &str) -> (String, Vec<u8>) {
+    let name = format!("tmux-team-{version}-{target}.tar.gz");
+    let root = name.strip_suffix(".tar.gz").unwrap();
+    let encoder = GzEncoder::new(Vec::new(), Compression::default());
+    let mut builder = Builder::new(encoder);
+    append_file(
+        &mut builder,
+        &format!("{root}/tmt"),
+        b"native executable\n",
+        0o755,
+    );
+    append_file(&mut builder, &format!("{root}/LICENSE"), b"MIT\n", 0o644);
+    append_file(
+        &mut builder,
+        &format!("{root}/NATIVE-INSTALL.md"),
+        b"Native install\n",
+        0o644,
+    );
+    append_file(
+        &mut builder,
+        &format!("{root}/THIRD-PARTY-NOTICES.txt"),
+        b"Third-party notices\n",
+        0o644,
+    );
+    builder.finish().unwrap();
+    (name, builder.into_inner().unwrap().finish().unwrap())
+}
+
+/// Shared real archive fixture for native-install orchestration tests.
+pub(in crate::native_install) fn valid_fixture(
+    version: &str,
+    target: &str,
+    release_id: u64,
+) -> (Value, Vec<u8>, Vec<u8>, String) {
+    let (archive_name, archive) = archive(version, target);
+    let manifest = serde_json::to_vec(&json!({
+        "artifacts": {
+            archive_name.clone(): {
+                "kind": "executable-zip",
+                "name": archive_name.clone(),
+                "target_triples": [target],
+                "checksums": {"sha256": sha256(&archive)},
+                "assets": artifact::FILES
+                    .iter()
+                    .map(|path| json!({"path": path}))
+                    .collect::<Vec<_>>(),
+            }
+        },
+        "releases": [{
+            "app_name": "tmt-cli",
+            "app_version": version,
+            "artifacts": [archive_name.clone()]
+        }]
+    }))
+    .unwrap();
+    let release = json!({
+        "id": release_id,
+        "tag_name": format!("v{version}"),
+        "draft": false,
+        "immutable": true,
+        "prerelease": version.contains('-'),
+        "assets": [
+            {
+                "id": release_id * 10 + 1,
+                "name": MANIFEST_NAME,
+                "state": "uploaded",
+                "size": manifest.len(),
+                "digest": format!("sha256:{}", sha256(&manifest)),
+            },
+            {
+                "id": release_id * 10 + 2,
+                "name": archive_name,
+                "state": "uploaded",
+                "size": archive.len(),
+                "digest": format!("sha256:{}", sha256(&archive)),
+            }
+        ]
+    });
+    (release, manifest, archive, archive_name)
+}
+
+fn register(fixture: &mut HttpFixture, release: &Value, manifest: &[u8], archive: &[u8]) {
+    fixture.assets(release, manifest, archive);
+}
+
+fn update_manifest_asset(release: &mut Value, manifest: &[u8]) {
+    let asset = release["assets"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|asset| asset["name"] == MANIFEST_NAME)
+        .unwrap();
+    asset["size"] = json!(manifest.len());
+    asset["digest"] = json!(format!("sha256:{}", sha256(manifest)));
+}
+
+#[test]
+fn selects_latest_stable_and_alpha_versions_and_uses_canonical_asset_urls() {
+    let (stable_old, _, _, _) = valid_fixture("1.2.3", TARGET, 101);
+    let (stable_new, stable_manifest, stable_archive, _) = valid_fixture("1.10.0", TARGET, 102);
+    let (alpha, alpha_manifest, alpha_archive, _) = valid_fixture("1.11.0-alpha.1", TARGET, 103);
+    let mut fixture = HttpFixture::default();
+    fixture.page(1, &[stable_old, stable_new.clone(), alpha.clone()]);
+    register(&mut fixture, &stable_new, &stable_manifest, &stable_archive);
+    register(&mut fixture, &alpha, &alpha_manifest, &alpha_archive);
+
+    let result = call_download(&mut fixture, Channel::Stable, None, TARGET).unwrap();
+    assert_eq!(result.version.to_string(), "1.10.0");
+    assert_eq!(
+        fixture
+            .calls
+            .iter()
+            .map(|call| call.url.as_str())
+            .collect::<Vec<_>>(),
+        vec![page_url(1), asset_url(1021), asset_url(1022)]
+    );
+    assert!(
+        fixture.calls[1..]
+            .iter()
+            .all(|call| call.accept == "application/octet-stream")
+    );
+    assert_eq!(fixture.calls[1].maximum, artifact::MANIFEST_LIMIT);
+
+    fixture.calls.clear();
+    let result = call_download(&mut fixture, Channel::Alpha, None, TARGET).unwrap();
+    assert_eq!(result.version.to_string(), "1.11.0-alpha.1");
+    assert_eq!(fixture.calls[1].url, asset_url(1031));
+    assert_eq!(fixture.calls[2].url, asset_url(1032));
+}
+
+#[test]
+fn exact_selection_uses_tag_api_and_numeric_asset_endpoints() {
+    let (release, manifest, archive, _) = valid_fixture("1.2.3", TARGET, 220);
+    let mut fixture = HttpFixture::default();
+    fixture.exact("1.2.3", &release);
+    register(&mut fixture, &release, &manifest, &archive);
+    call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).unwrap();
+    assert_eq!(fixture.calls[0].url, exact_url("1.2.3"));
+    assert_eq!(fixture.calls[1].url, asset_url(2201));
+    assert_eq!(fixture.calls[2].url, asset_url(2202));
+    assert!(
+        fixture
+            .calls
+            .iter()
+            .all(|call| !call.url.contains("/releases/download/"))
+    );
+}
+
+#[test]
+fn rejects_draft_mutable_and_mismatched_prerelease_metadata() {
+    let (base, _, _, _) = valid_fixture("1.2.3", TARGET, 230);
+    for (field, value) in [
+        ("draft", json!(true)),
+        ("immutable", json!(false)),
+        ("prerelease", json!(true)),
+    ] {
+        let mut release = base.clone();
+        release[field] = value;
+        let mut fixture = HttpFixture::default();
+        fixture.exact("1.2.3", &release);
+        assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).is_err());
+        assert_eq!(fixture.calls.len(), 1);
+    }
+    let (mut alpha, _, _, _) = valid_fixture("1.3.0-alpha.1", TARGET, 231);
+    alpha["prerelease"] = json!(false);
+    let mut fixture = HttpFixture::default();
+    fixture.exact("1.3.0-alpha.1", &alpha);
+    assert!(call_download(&mut fixture, Channel::Alpha, Some("1.3.0-alpha.1"), TARGET).is_err());
+}
+
+#[test]
+fn rejects_channel_and_exact_version_mismatches() {
+    let (alpha, _, _, _) = valid_fixture("1.3.0-alpha.1", TARGET, 240);
+    let mut fixture = HttpFixture::default();
+    fixture.exact("1.3.0-alpha.1", &alpha);
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.3.0-alpha.1"), TARGET).is_err());
+
+    let (release, _, _, _) = valid_fixture("1.2.3", TARGET, 241);
+    fixture.responses.clear();
+    fixture.calls.clear();
+    fixture.exact("1.2.4", &release);
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.4"), TARGET).is_err());
+}
+
+#[test]
+fn missing_release_is_not_reported_as_current_or_successful() {
+    let mut fixture = HttpFixture::default();
+    fixture.page(1, &[]);
+    let error = call_download(&mut fixture, Channel::Stable, None, TARGET)
+        .err()
+        .expect("empty discovery should fail");
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    assert_eq!(fixture.calls.len(), 1);
+}
+
+#[test]
+fn release_discovery_stops_at_its_three_page_bound() {
+    let mut fixture = HttpFixture::default();
+    for page in 1..=3 {
+        let releases = (0..100)
+            .map(|offset| {
+                json!({
+                    "id": page * 1000 + offset,
+                    "tag_name": format!("v1.{page}.{offset}"),
+                    "draft": false,
+                    "immutable": true,
+                    "prerelease": false,
+                })
+            })
+            .collect::<Vec<_>>();
+        fixture.page(page, &releases);
+    }
+    assert!(call_download(&mut fixture, Channel::Stable, None, TARGET).is_err());
+    assert_eq!(
+        fixture
+            .calls
+            .iter()
+            .map(|call| call.url.as_str())
+            .collect::<Vec<_>>(),
+        vec![page_url(1), page_url(2), page_url(3)]
+    );
+}
+
+#[test]
+fn malformed_release_metadata_is_rejected_before_asset_requests() {
+    let mut fixture = HttpFixture::default();
+    fixture.response(exact_url("1.2.3"), b"{".to_vec());
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).is_err());
+    assert_eq!(fixture.calls.len(), 1);
+    fixture.calls.clear();
+    fixture.response(exact_url("1.2.3"), b"[]".to_vec());
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).is_err());
+    assert_eq!(fixture.calls.len(), 1);
+}
+
+#[test]
+fn duplicate_and_missing_assets_are_rejected() {
+    let (mut release, _, _, _) = valid_fixture("1.2.3", TARGET, 250);
+    let duplicate = release["assets"][0].clone();
+    release["assets"].as_array_mut().unwrap().push(duplicate);
+    let mut fixture = HttpFixture::default();
+    fixture.exact("1.2.3", &release);
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).is_err());
+    assert_eq!(fixture.calls.len(), 1);
+
+    let (mut release, manifest, archive, _) = valid_fixture("1.2.3", TARGET, 251);
+    release["assets"] = json!([release["assets"][0].clone()]);
+    fixture.responses.clear();
+    fixture.calls.clear();
+    fixture.exact("1.2.3", &release);
+    fixture.response(asset_url(2511), manifest);
+    fixture.response(asset_url(2512), archive);
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).is_err());
+    assert_eq!(fixture.calls.len(), 2);
+}
+
+#[test]
+fn api_size_and_digest_mismatches_are_rejected() {
+    let (base, manifest, archive, _) = valid_fixture("1.2.3", TARGET, 260);
+    let mut release = base.clone();
+    release["assets"][1]["size"] = json!(archive.len() + 1);
+    let mut fixture = HttpFixture::default();
+    fixture.exact("1.2.3", &release);
+    register(&mut fixture, &release, &manifest, &archive);
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).is_err());
+
+    let mut release = base;
+    release["assets"][1]["digest"] = json!(format!("sha256:{}", "0".repeat(64)));
+    fixture.responses.clear();
+    fixture.calls.clear();
+    fixture.exact("1.2.3", &release);
+    register(&mut fixture, &release, &manifest, &archive);
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).is_err());
+}
+
+#[test]
+fn manifest_target_and_version_mismatches_are_rejected() {
+    let (mut release, mut manifest, _, archive_name) = valid_fixture("1.2.3", TARGET, 270);
+    manifest = serde_json::to_vec(&{
+        let mut value: Value = serde_json::from_slice(&manifest).unwrap();
+        value["artifacts"][archive_name.clone()]["target_triples"] =
+            json!(["x86_64-unknown-linux-gnu"]);
+        value
+    })
+    .unwrap();
+    update_manifest_asset(&mut release, &manifest);
+    let mut fixture = HttpFixture::default();
+    fixture.exact("1.2.3", &release);
+    fixture.response(asset_url(2701), manifest.clone());
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).is_err());
+    assert_eq!(fixture.calls.len(), 2);
+
+    let (mut release, mut manifest, _, _) = valid_fixture("1.2.3", TARGET, 271);
+    let mut value: Value = serde_json::from_slice(&manifest).unwrap();
+    value["releases"][0]["app_version"] = json!("1.2.4");
+    manifest = serde_json::to_vec(&value).unwrap();
+    update_manifest_asset(&mut release, &manifest);
+    fixture.responses.clear();
+    fixture.calls.clear();
+    fixture.exact("1.2.3", &release);
+    fixture.response(asset_url(2711), manifest);
+    assert!(call_download(&mut fixture, Channel::Stable, Some("1.2.3"), TARGET).is_err());
+    assert_eq!(fixture.calls.len(), 2);
+}

--- a/rust/crates/tmt-adapters/src/native_install/upgrade.rs
+++ b/rust/crates/tmt-adapters/src/native_install/upgrade.rs
@@ -1,0 +1,195 @@
+//! Public update orchestration. Network acquisition never holds the install lock.
+
+use super::{
+    ActivatedInstallation, InstallReport, InstallRequest, inspect, install_observed, release,
+};
+use std::{
+    fs,
+    io::{self, Write},
+    os::unix::fs::{DirBuilderExt, OpenOptionsExt},
+    path::Path,
+    time::{Duration, Instant},
+};
+use tmt_core::native_install::{
+    Channel, InstalledVersion, UpgradeSelection, plan_version, select_upgrade,
+};
+
+pub struct UpgradeRequest<'a> {
+    pub executable: &'a Path,
+    pub channel: Option<Channel>,
+    pub exact: Option<&'a str>,
+    pub unpin: bool,
+}
+
+#[derive(Debug)]
+pub struct UpgradeReport {
+    pub installation: InstallReport,
+    pub state: InstalledVersion,
+    pub skipped_pinned: bool,
+}
+
+#[derive(Debug)]
+pub struct UpgradeFailure {
+    /// Present only when this invocation activated a release before failing.
+    pub activated: Option<Box<UpgradeReport>>,
+    cause: io::Error,
+}
+
+impl std::fmt::Display for UpgradeFailure {
+    fn fmt(&self, output: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.cause.fmt(output)
+    }
+}
+impl std::error::Error for UpgradeFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.cause)
+    }
+}
+impl From<io::Error> for UpgradeFailure {
+    fn from(cause: io::Error) -> Self {
+        Self {
+            activated: None,
+            cause,
+        }
+    }
+}
+impl UpgradeFailure {
+    pub fn kind(&self) -> io::ErrorKind {
+        self.cause.kind()
+    }
+}
+
+pub fn upgrade(
+    request: UpgradeRequest<'_>,
+    checkpoint: impl FnMut() -> io::Result<()>,
+) -> Result<UpgradeReport, UpgradeFailure> {
+    let client = crate::release_http::Https::new();
+    upgrade_with(request, checkpoint, |url, accept, limit, deadline| {
+        client.get(url, accept, limit, deadline)
+    })
+}
+
+fn upgrade_with(
+    request: UpgradeRequest<'_>,
+    mut checkpoint: impl FnMut() -> io::Result<()>,
+    get: impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>>,
+) -> Result<UpgradeReport, UpgradeFailure> {
+    checkpoint()?;
+    let current = inspect(request.executable)?;
+    let selection = select_upgrade(
+        &current.state,
+        request.channel,
+        request.exact,
+        request.unpin,
+    )
+    .map_err(io::Error::other)?;
+    let UpgradeSelection::Fetch {
+        channel,
+        exact,
+        pin,
+    } = selection
+    else {
+        return Ok(UpgradeReport {
+            installation: InstallReport {
+                executable: current.executable,
+                active_executable: current.active_executable,
+                version: current.state.version.to_string(),
+                changed: false,
+            },
+            state: current.state,
+            skipped_pinned: true,
+        });
+    };
+    let downloaded = release::download(
+        channel,
+        exact.as_ref(),
+        &current.target,
+        Instant::now() + Duration::from_secs(60),
+        get,
+    )?;
+    let plan = plan_version(Some(&current.state), &downloaded.version, channel, pin)
+        .map_err(io::Error::other)?;
+    checkpoint()?;
+    // Only this successful create grants cleanup ownership. Never remove a
+    // colliding or abandoned staging directory from another invocation.
+    let stage = current
+        .prefix
+        .join("lib/tmux-team")
+        .join(format!(".download-{}", uuid::Uuid::new_v4()));
+    fs::DirBuilder::new().mode(0o700).create(&stage)?;
+    let archive = stage.join(&downloaded.archive_name);
+    let manifest = stage.join("dist-manifest.json");
+    let result = (|| {
+        for (path, bytes) in [
+            (&archive, &downloaded.archive),
+            (&manifest, &downloaded.manifest),
+        ] {
+            let mut file = fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .mode(0o600)
+                .open(path)?;
+            file.write_all(bytes)?;
+        }
+        install_observed(
+            InstallRequest {
+                archive: &archive,
+                manifest: &manifest,
+                prefix: &current.prefix,
+                target: &current.target,
+                channel,
+                pin,
+            },
+            Some(current.id),
+            Some(downloaded.provenance),
+            &mut checkpoint,
+        )
+    })();
+    let result = result
+        .map(|installation| UpgradeReport {
+            installation,
+            state: plan.state.clone(),
+            skipped_pinned: false,
+        })
+        .map_err(|cause: io::Error| {
+            let activated = cause
+                .get_ref()
+                .and_then(|error| error.downcast_ref::<ActivatedInstallation>())
+                .map(|error| {
+                    Box::new(UpgradeReport {
+                        installation: error.report.clone(),
+                        state: plan.state.clone(),
+                        skipped_pinned: false,
+                    })
+                });
+            UpgradeFailure { activated, cause }
+        });
+    match (result, fs::remove_dir_all(&stage)) {
+        (result, Ok(())) => result,
+        (Ok(report), Err(cleanup)) => Err(UpgradeFailure {
+            activated: report.installation.changed.then(|| Box::new(report)),
+            cause: io::Error::new(
+                cleanup.kind(),
+                format!("Native update staging cleanup failed: {cleanup}"),
+            ),
+        }),
+        (Err(mut failure), Err(cleanup)) => {
+            failure.cause = io::Error::new(
+                failure.cause.kind(),
+                format!(
+                    "{}; native update staging cleanup failed: {cleanup}",
+                    failure.cause
+                ),
+            );
+            Err(failure)
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "upgrade_tests.rs"]
+mod tests;
+
+#[cfg(test)]
+#[path = "upgrade_artifact_tests.rs"]
+mod artifact_tests;

--- a/rust/crates/tmt-adapters/src/native_install/upgrade_artifact_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/upgrade_artifact_tests.rs
@@ -1,0 +1,331 @@
+use super::*;
+use crate::{
+    content_digest::sha256,
+    native_install::{artifact, publication::Layout},
+    process::{
+        CommandError, CommandFailure, CommandOutput, CommandRequest, CommandRunner,
+        UnixCommandRunner,
+    },
+    test_support::TestDirectory,
+};
+use serde_json::{Value, json};
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    fs, io,
+    os::unix::fs::symlink,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+use tmt_core::native_install::{Channel, PinAction};
+
+const TASK_ROOT: &str = "TMT_UPGRADE_TASK";
+const RELEASE_ID: u64 = 9001;
+const OUTPUT_LIMIT: usize = 4 * 1024 * 1024;
+
+fn required_path(name: &str) -> PathBuf {
+    PathBuf::from(
+        env::var_os(name).unwrap_or_else(|| panic!("explicit acceptance test requires {name}")),
+    )
+}
+
+fn command_args(args: &[&str]) -> Vec<OsString> {
+    args.iter().map(OsString::from).collect()
+}
+
+fn assignment(name: &str, value: &Path) -> OsString {
+    let mut result = OsString::from(name);
+    result.push("=");
+    result.push(value.as_os_str());
+    result
+}
+
+fn run(executable: &Path, args: &[OsString], task: &Path) -> Result<CommandOutput, CommandError> {
+    let mut command = vec![
+        OsString::from("-i"),
+        assignment("HOME", task),
+        assignment("TMUX_TEAM_HOME", task),
+        OsString::from("PATH="),
+        OsString::from("LANG=C"),
+        executable.as_os_str().to_os_string(),
+    ];
+    command.extend(args.iter().cloned());
+    UnixCommandRunner.execute(CommandRequest {
+        program: OsStr::new("/usr/bin/env"),
+        args: &command,
+        input: &[],
+        deadline: Instant::now() + Duration::from_secs(20),
+        max_output_bytes: OUTPUT_LIMIT,
+    })
+}
+
+fn release_document(
+    version: &semver::Version,
+    archive_name: &str,
+    manifest: &[u8],
+    archive: &[u8],
+) -> Value {
+    json!({
+        "id": RELEASE_ID,
+        "tag_name": format!("v{version}"),
+        "draft": false,
+        "immutable": true,
+        "prerelease": !version.pre.is_empty(),
+        "assets": [
+            {
+                "id": RELEASE_ID * 10 + 1,
+                "name": "dist-manifest.json",
+                "state": "uploaded",
+                "size": manifest.len(),
+                "digest": format!("sha256:{}", sha256(manifest)),
+            },
+            {
+                "id": RELEASE_ID * 10 + 2,
+                "name": archive_name,
+                "state": "uploaded",
+                "size": archive.len(),
+                "digest": format!("sha256:{}", sha256(archive)),
+            }
+        ]
+    })
+}
+
+fn injected_release(
+    version: &semver::Version,
+    release: Value,
+    manifest: Vec<u8>,
+    archive: Vec<u8>,
+) -> impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>> {
+    let endpoint = "https://api.github.com/repos/wkh237/tmux-team/releases".to_owned();
+    let exact = format!("{endpoint}/tags/v{version}");
+    let manifest_url = format!("{endpoint}/assets/{}", RELEASE_ID * 10 + 1);
+    let archive_url = format!("{endpoint}/assets/{}", RELEASE_ID * 10 + 2);
+    let release_bytes = serde_json::to_vec(&release).unwrap();
+    move |url, accept, maximum, deadline| {
+        assert!(deadline > Instant::now());
+        let (bytes, expected_accept) = match url {
+            url if url == exact => (release_bytes.clone(), "application/vnd.github+json"),
+            url if url == manifest_url => (manifest.clone(), "application/octet-stream"),
+            url if url == archive_url => (archive.clone(), "application/octet-stream"),
+            _ => panic!("unexpected canonical release URL: {url}"),
+        };
+        assert_eq!(accept, expected_accept);
+        assert!(bytes.len() <= maximum);
+        Ok(bytes)
+    }
+}
+
+fn skill_target(root: &Path) -> PathBuf {
+    root.join("tmux-team")
+}
+
+fn report_contains(report: &Value, key: &str, path: &Path) -> bool {
+    report[key].as_array().is_some_and(|entries| {
+        entries.iter().any(|entry| {
+            let target = if key == "refreshed" {
+                entry["target"].as_str()
+            } else {
+                entry.as_str()
+            };
+            target == path.to_str()
+        })
+    })
+}
+
+#[test]
+#[ignore = "requires TMT_UPGRADE_* paths and real versioned matching-host binaries"]
+fn cargo_dist_upgrade_refreshes_real_artifacts_and_preserves_conflicts() {
+    let old_archive_path = required_path("TMT_UPGRADE_OLD_ARCHIVE");
+    let old_manifest_path = required_path("TMT_UPGRADE_OLD_MANIFEST");
+    let new_archive_path = required_path("TMT_UPGRADE_NEW_ARCHIVE");
+    let new_manifest_path = required_path("TMT_UPGRADE_NEW_MANIFEST");
+    let target = env::var("TMT_UPGRADE_TARGET")
+        .unwrap_or_else(|_| panic!("explicit acceptance test requires TMT_UPGRADE_TARGET"));
+    let directory = TestDirectory::new();
+    let task = directory.path.join(TASK_ROOT);
+    fs::create_dir(&task).unwrap();
+
+    let new_archive = fs::read(&new_archive_path).unwrap();
+    let new_manifest = fs::read(&new_manifest_path).unwrap();
+    let old_artifact = artifact::acquire(&old_manifest_path, &old_archive_path, &target).unwrap();
+    let new_artifact = artifact::acquire(&new_manifest_path, &new_archive_path, &target).unwrap();
+    assert!(new_artifact.version > old_artifact.version);
+    assert!(old_artifact.files["tmt"] != new_artifact.files["tmt"]);
+    let channel = if old_artifact.version.pre.is_empty() {
+        Channel::Stable
+    } else {
+        Channel::Alpha
+    };
+    assert!(channel.accepts(&new_artifact.version));
+
+    let prefix = directory.path.join("prefix");
+    let initial = install_observed(
+        InstallRequest {
+            archive: &old_archive_path,
+            manifest: &old_manifest_path,
+            prefix: &prefix,
+            target: &target,
+            channel,
+            pin: PinAction::Preserve,
+        },
+        None,
+        None,
+        || Ok(()),
+    )
+    .unwrap();
+    let old_executable = initial.active_executable.clone();
+    let old_version = run(&old_executable, &command_args(&["--version"]), &task)
+        .unwrap()
+        .stdout;
+    assert_eq!(
+        String::from_utf8(old_version).unwrap().trim(),
+        old_artifact.version.to_string()
+    );
+    let old_skill = run(&old_executable, &command_args(&["learn", "--skill"]), &task)
+        .unwrap()
+        .stdout;
+
+    let first_root = task.join("first-skills");
+    run(
+        &old_executable,
+        &[
+            OsString::from("install"),
+            OsString::from("--dir"),
+            first_root.as_os_str().to_os_string(),
+        ],
+        &task,
+    )
+    .unwrap();
+    let first_target = skill_target(&first_root);
+    assert_eq!(fs::read(first_target.join("SKILL.md")).unwrap(), old_skill);
+
+    let second_root = task.join("second-skills");
+    run(
+        &old_executable,
+        &[
+            OsString::from("install"),
+            OsString::from("--dir"),
+            second_root.as_os_str().to_os_string(),
+        ],
+        &task,
+    )
+    .unwrap();
+    let second_target = skill_target(&second_root);
+    let old_source = fs::read_link(&second_target).unwrap();
+    fs::remove_file(&second_target).unwrap();
+    fs::create_dir_all(second_target.parent().unwrap()).unwrap();
+    let mut conflict = old_skill.clone();
+    conflict.extend_from_slice(b"\nuser conflict\n");
+    fs::create_dir(&second_target).unwrap();
+    fs::write(second_target.join("SKILL.md"), &conflict).unwrap();
+
+    let release = release_document(
+        &new_artifact.version,
+        &new_artifact.name,
+        &new_manifest,
+        &new_archive,
+    );
+    let new_version = new_artifact.version.to_string();
+    let report = upgrade_with(
+        UpgradeRequest {
+            executable: &old_executable,
+            channel: Some(channel),
+            exact: Some(&new_version),
+            unpin: false,
+        },
+        || Ok(()),
+        injected_release(
+            &new_artifact.version,
+            release,
+            new_manifest.clone(),
+            new_archive,
+        ),
+    )
+    .unwrap();
+    assert!(report.installation.changed);
+    assert_eq!(report.state.version, new_artifact.version);
+    assert_eq!(report.installation.version, new_version);
+
+    let layout = Layout::existing(&prefix).unwrap();
+    let receipt = layout.current().unwrap().unwrap();
+    let provenance = receipt.provenance.as_ref().unwrap();
+    assert_eq!(provenance.release_id, RELEASE_ID);
+    assert_eq!(provenance.manifest_sha256, sha256(&new_manifest));
+    assert_eq!(receipt.target, target);
+    assert_eq!(receipt.state.version, new_artifact.version);
+    assert!(
+        fs::read_dir(prefix.join("lib/tmux-team"))
+            .unwrap()
+            .all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".download-"))
+    );
+    assert!(!task.join("tmux-team.db").exists());
+
+    let new_skill = run(
+        &report.installation.active_executable,
+        &command_args(&["learn", "--skill"]),
+        &task,
+    )
+    .unwrap()
+    .stdout;
+    assert_ne!(new_skill, old_skill);
+    assert_eq!(fs::read(first_target.join("SKILL.md")).unwrap(), old_skill);
+
+    let refresh = run(
+        &report.installation.active_executable,
+        &command_args(&["__native-refresh-skills", "--json"]),
+        &task,
+    )
+    .expect_err("modified managed target should produce a partial refresh failure");
+    assert!(matches!(
+        refresh.kind,
+        CommandFailure::Exit {
+            code: Some(1),
+            signal: None
+        }
+    ));
+    let refresh_document: Value = serde_json::from_slice(&refresh.output.unwrap().stdout).unwrap();
+    assert!(refresh_document["error"].is_object());
+    assert!(report_contains(
+        &refresh_document,
+        "refreshed",
+        &first_target
+    ));
+    assert!(report_contains(
+        &refresh_document,
+        "conflicts",
+        &second_target
+    ));
+    assert_eq!(fs::read(first_target.join("SKILL.md")).unwrap(), new_skill);
+    assert_eq!(fs::read(second_target.join("SKILL.md")).unwrap(), conflict);
+
+    let old_still_runs = run(&old_executable, &command_args(&["--version"]), &task)
+        .unwrap()
+        .stdout;
+    assert_eq!(
+        String::from_utf8(old_still_runs).unwrap().trim(),
+        old_artifact.version.to_string()
+    );
+
+    fs::remove_dir_all(&second_target).unwrap();
+    symlink(old_source, &second_target).unwrap();
+    let retry = run(
+        &report.installation.active_executable,
+        &command_args(&["__native-refresh-skills", "--json"]),
+        &task,
+    )
+    .unwrap();
+    let retry_document: Value = serde_json::from_slice(&retry.stdout).unwrap();
+    assert!(retry_document["error"].is_null());
+    assert!(report_contains(&retry_document, "refreshed", &first_target));
+    assert!(report_contains(
+        &retry_document,
+        "refreshed",
+        &second_target
+    ));
+    assert_eq!(fs::read(first_target.join("SKILL.md")).unwrap(), new_skill);
+    assert_eq!(fs::read(second_target.join("SKILL.md")).unwrap(), new_skill);
+}

--- a/rust/crates/tmt-adapters/src/native_install/upgrade_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/upgrade_tests.rs
@@ -1,0 +1,405 @@
+use super::*;
+use crate::native_install::{
+    receipt::Receipt,
+    test_support::{artifact, publish, published_layout, state},
+};
+
+fn release_download() -> impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>> {
+    let (release, manifest, archive, _) =
+        release::valid_fixture("1.2.4", "aarch64-apple-darwin", 42);
+    move |url, _, limit, deadline| {
+        assert!(deadline > Instant::now());
+        let bytes = if url.ends_with("/assets/421") {
+            manifest.clone()
+        } else if url.ends_with("/assets/422") {
+            archive.clone()
+        } else if url.ends_with("/tags/v1.2.4") {
+            serde_json::to_vec(&release).unwrap()
+        } else {
+            assert!(url.ends_with("?per_page=100&page=1"));
+            serde_json::to_vec(&vec![release.clone()]).unwrap()
+        };
+        assert!(bytes.len() <= limit);
+        Ok(bytes)
+    }
+}
+
+fn assert_no_downloads(root: &Path) {
+    assert!(!fs::read_dir(root).unwrap().any(|entry| {
+        entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".download-")
+    }));
+}
+
+#[test]
+fn skill_refresh_holds_the_existing_install_lock_and_refuses_stale_releases() {
+    let (_directory, layout, old) = published_layout();
+    let executable = layout
+        .root
+        .join("releases")
+        .join(old.id.to_string())
+        .join("tmt");
+    let mut ran = false;
+    crate::native_install::with_active_release(&executable, || {
+        ran = true;
+        assert!(crate::file_lock::exclusive(&layout.root.join("install.lock")).is_err());
+    })
+    .unwrap();
+    assert!(ran);
+    drop(crate::file_lock::exclusive(&layout.root.join("install.lock")).unwrap());
+    let next = artifact("1.2.4", b"next executable");
+    publish(&layout, &next, &Receipt::new(&next, state("1.2.4", None)));
+    let error = crate::native_install::with_active_release(&executable, || {
+        panic!("stale skill must not be published")
+    })
+    .unwrap_err();
+    assert!(error.to_string().contains("not the active managed release"));
+}
+
+#[test]
+fn finalization_failure_reports_the_active_release_and_retry_repairs_links() {
+    let (_directory, layout, old) = published_layout();
+    let executable = layout
+        .root
+        .join("releases")
+        .join(old.id.to_string())
+        .join("tmt");
+    let mut checkpoints = 0;
+    // Four orchestration checkpoints precede the existing publisher's sequence.
+    let last_checkpoint = crate::native_install::test_support::checkpoint_count() + 4;
+    let error = upgrade_with(
+        UpgradeRequest {
+            executable: &executable,
+            channel: None,
+            exact: None,
+            unpin: false,
+        },
+        || {
+            checkpoints += 1;
+            if checkpoints == last_checkpoint {
+                for name in ["tmt", "tmux-team"] {
+                    fs::remove_file(layout.prefix.join("bin").join(name))?;
+                }
+                fs::remove_dir(layout.prefix.join("bin"))?;
+            }
+            Ok(())
+        },
+        release_download(),
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("Release activated"));
+    let activated = error.activated.unwrap();
+    assert!(activated.installation.changed);
+    assert_eq!(activated.installation.version, "1.2.4");
+    assert_eq!(
+        fs::read(&activated.installation.active_executable).unwrap(),
+        b"native executable\n"
+    );
+    assert_eq!(fs::read(&executable).unwrap(), b"synthetic tmt payload\n");
+    assert_no_downloads(&layout.root);
+    fs::create_dir(layout.prefix.join("bin")).unwrap();
+    let retry = upgrade_with(
+        UpgradeRequest {
+            executable: &activated.installation.active_executable,
+            channel: None,
+            exact: None,
+            unpin: false,
+        },
+        || Ok(()),
+        release_download(),
+    )
+    .unwrap();
+    assert!(!retry.installation.changed);
+    assert_eq!(
+        fs::read(&retry.installation.executable).unwrap(),
+        b"native executable\n"
+    );
+    assert_no_downloads(&layout.root);
+}
+
+#[test]
+fn forged_remote_provenance_is_not_accepted_as_owned_receipt_metadata() {
+    let (_directory, layout, old) = published_layout();
+    let release = layout.root.join("releases").join(old.id.to_string());
+    let receipt_path = release.join("receipt.json");
+    let original: serde_json::Value =
+        serde_json::from_slice(&fs::read(&receipt_path).unwrap()).unwrap();
+    for source in [
+        serde_json::json!({"kind":"github-release", "repository":"attacker/other", "release_id":42, "manifest_sha256":"a".repeat(64)}),
+        serde_json::json!({"kind":"github-release", "repository":"wkh237/tmux-team", "release_id":0, "manifest_sha256":"a".repeat(64)}),
+        serde_json::json!({"kind":"github-release", "repository":"wkh237/tmux-team", "release_id":42, "manifest_sha256":"invalid"}),
+    ] {
+        let mut forged = original.clone();
+        forged["source"] = source;
+        fs::write(&receipt_path, serde_json::to_vec(&forged).unwrap()).unwrap();
+        let error = inspect(&release.join("tmt")).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid native release provenance")
+        );
+        assert_eq!(
+            fs::read(release.join("tmt")).unwrap(),
+            b"synthetic tmt payload\n"
+        );
+    }
+}
+
+#[test]
+fn verified_update_pins_noops_and_unpins_through_one_publisher() {
+    let (_directory, layout, old) = published_layout();
+    let old_executable = layout
+        .root
+        .join("releases")
+        .join(old.id.to_string())
+        .join("tmt");
+    let old_bytes = fs::read(&old_executable).unwrap();
+    let report = upgrade_with(
+        UpgradeRequest {
+            executable: &old_executable,
+            channel: None,
+            exact: Some("1.2.4"),
+            unpin: false,
+        },
+        || Ok(()),
+        release_download(),
+    )
+    .unwrap();
+    assert!(report.installation.changed);
+    assert!(!report.skipped_pinned);
+    assert_eq!(
+        report.state.pinned_version.as_ref().unwrap().to_string(),
+        "1.2.4"
+    );
+    assert_eq!(
+        fs::read(&report.installation.active_executable).unwrap(),
+        b"native executable\n"
+    );
+    assert_eq!(fs::read(&old_executable).unwrap(), old_bytes);
+    let receipt = layout.current().unwrap().unwrap();
+    assert_eq!(receipt.provenance.as_ref().unwrap().release_id, 42);
+    assert_eq!(
+        receipt.provenance.as_ref().unwrap().manifest_sha256.len(),
+        64
+    );
+    let active = report.installation.active_executable;
+    let current = fs::read_link(layout.root.join("current")).unwrap();
+    let noop = upgrade_with(
+        UpgradeRequest {
+            executable: &active,
+            channel: None,
+            exact: Some("1.2.4"),
+            unpin: false,
+        },
+        || Ok(()),
+        release_download(),
+    )
+    .unwrap();
+    assert!(!noop.installation.changed);
+    assert_eq!(fs::read_link(layout.root.join("current")).unwrap(), current);
+    let unpinned = upgrade_with(
+        UpgradeRequest {
+            executable: &active,
+            channel: None,
+            exact: None,
+            unpin: true,
+        },
+        || Ok(()),
+        release_download(),
+    )
+    .unwrap();
+    assert!(unpinned.installation.changed);
+    assert!(unpinned.state.pinned_version.is_none());
+    assert_ne!(fs::read_link(layout.root.join("current")).unwrap(), current);
+    assert_eq!(
+        fs::read(&unpinned.installation.active_executable).unwrap(),
+        fs::read(&active).unwrap()
+    );
+    assert_no_downloads(&layout.root);
+}
+
+#[test]
+fn a_pin_changed_during_download_cannot_be_overridden() {
+    let (_directory, layout, old) = published_layout();
+    let executable = layout
+        .root
+        .join("releases")
+        .join(old.id.to_string())
+        .join("tmt");
+    let mut fetch = release_download();
+    let mut switched = false;
+    let mut pinned_id = None;
+    let error = upgrade_with(
+        UpgradeRequest {
+            executable: &executable,
+            channel: None,
+            exact: None,
+            unpin: false,
+        },
+        || Ok(()),
+        |url, accept, limit, deadline| {
+            if !switched {
+                let candidate = artifact("1.2.3", b"synthetic tmt payload\n");
+                let receipt = Receipt::new(&candidate, state("1.2.3", Some("1.2.3")));
+                pinned_id = Some(receipt.id);
+                publish(&layout, &candidate, &receipt);
+                switched = true;
+            }
+            fetch(url, accept, limit, deadline)
+        },
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("pin changed while downloading"));
+    assert!(error.activated.is_none());
+    let current = layout.current().unwrap().unwrap();
+    assert_eq!(Some(current.id), pinned_id);
+    assert_eq!(current.state.pinned_version.unwrap().to_string(), "1.2.3");
+    assert_no_downloads(&layout.root);
+}
+
+#[test]
+fn cancellation_after_download_removes_only_owned_staging_and_preserves_old_release() {
+    for stop_at in [2, 3, 5] {
+        let (_directory, layout, old) = published_layout();
+        let executable = layout
+            .root
+            .join("releases")
+            .join(old.id.to_string())
+            .join("tmt");
+        let mut calls = 0;
+        let error = upgrade_with(
+            UpgradeRequest {
+                executable: &executable,
+                channel: None,
+                exact: None,
+                unpin: false,
+            },
+            || {
+                calls += 1;
+                if calls == stop_at {
+                    Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "fixture interrupted",
+                    ))
+                } else {
+                    Ok(())
+                }
+            },
+            release_download(),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Interrupted);
+        assert!(error.activated.is_none());
+        assert_eq!(layout.current().unwrap().unwrap().id, old.id);
+        assert_eq!(fs::read(&executable).unwrap(), b"synthetic tmt payload\n");
+        assert_no_downloads(&layout.root);
+        assert_eq!(
+            fs::read_dir(layout.root.join("releases")).unwrap().count(),
+            1
+        );
+    }
+}
+
+#[test]
+fn pinned_installation_is_verified_without_network_or_staging() {
+    let (_directory, layout, _) = published_layout();
+    let artifact = artifact("1.2.3", b"pinned executable");
+    let receipt = Receipt::new(&artifact, state("1.2.3", Some("1.2.3")));
+    publish(&layout, &artifact, &receipt);
+    let original = fs::read_link(layout.root.join("current")).unwrap();
+    let executable = layout.root.join(&original).join("tmt");
+    let report = upgrade_with(
+        UpgradeRequest {
+            executable: &executable,
+            channel: None,
+            exact: None,
+            unpin: false,
+        },
+        || Ok(()),
+        |_, _, _, _| panic!("pinned update must not access the network"),
+    )
+    .unwrap();
+    assert!(report.skipped_pinned);
+    assert!(!report.installation.changed);
+    assert_eq!(report.state.pinned_version.unwrap().to_string(), "1.2.3");
+    assert_eq!(
+        fs::read_link(layout.root.join("current")).unwrap(),
+        original
+    );
+    assert!(!fs::read_dir(&layout.root).unwrap().any(|entry| {
+        entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".download-")
+    }));
+}
+
+#[test]
+fn stale_executable_and_unowned_paths_fail_before_network() {
+    let (directory, layout, old) = published_layout();
+    let stale = layout
+        .root
+        .join("releases")
+        .join(old.id.to_string())
+        .join("tmt");
+    let next = artifact("1.2.4", b"new executable");
+    publish(&layout, &next, &Receipt::new(&next, state("1.2.4", None)));
+    let unmanaged = directory.path.join("unmanaged");
+    fs::write(&unmanaged, b"unmanaged executable").unwrap();
+    for executable in [&stale, &unmanaged] {
+        let error = upgrade_with(
+            UpgradeRequest {
+                executable,
+                channel: None,
+                exact: None,
+                unpin: false,
+            },
+            || Ok(()),
+            |_, _, _, _| panic!("unowned update must not access the network"),
+        )
+        .unwrap_err();
+        assert!(error.activated.is_none());
+        assert!(error.to_string().contains("package manager"));
+    }
+    assert_eq!(fs::read(&unmanaged).unwrap(), b"unmanaged executable");
+    assert_eq!(fs::read(&stale).unwrap(), b"synthetic tmt payload\n");
+}
+
+#[test]
+fn missing_release_preserves_active_files_without_staging() {
+    let (_directory, layout, _) = published_layout();
+    let original = fs::read_link(layout.root.join("current")).unwrap();
+    let executable = layout.root.join(&original).join("tmt");
+    let before = fs::read(&executable).unwrap();
+    let mut calls = 0;
+    let error = upgrade_with(
+        UpgradeRequest {
+            executable: &executable,
+            channel: None,
+            exact: None,
+            unpin: false,
+        },
+        || Ok(()),
+        |url, _, _, _| {
+            calls += 1;
+            assert_eq!(
+                url,
+                "https://api.github.com/repos/wkh237/tmux-team/releases?per_page=100&page=1"
+            );
+            Ok(b"[]".to_vec())
+        },
+    )
+    .unwrap_err();
+    assert_eq!(calls, 1);
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    assert!(error.activated.is_none());
+    assert_eq!(
+        fs::read_link(layout.root.join("current")).unwrap(),
+        original
+    );
+    assert_eq!(fs::read(&executable).unwrap(), before);
+}

--- a/rust/crates/tmt-adapters/src/process.rs
+++ b/rust/crates/tmt-adapters/src/process.rs
@@ -47,6 +47,9 @@ pub enum CommandFailure {
 pub struct CommandError {
     pub kind: CommandFailure,
     pub cleanup_error: Option<io::Error>,
+    /// Bounded output only for a fully observed nonzero exit. Never formatted
+    /// implicitly; callers must validate a protocol before exposing it.
+    pub output: Option<CommandOutput>,
     cause: Option<io::Error>,
 }
 
@@ -55,6 +58,7 @@ impl CommandError {
         Self {
             kind,
             cleanup_error: None,
+            output: None,
             cause: None,
         }
     }
@@ -166,10 +170,15 @@ fn communicate(
         .map_err(|cause| CommandError::io(CommandFailure::Io, cause))?
         .ok_or_else(|| CommandError::new(CommandFailure::Timeout))?;
     if !status.success() {
-        return Err(CommandError::new(CommandFailure::Exit {
+        let mut error = CommandError::new(CommandFailure::Exit {
             code: status.code(),
             signal: status.signal(),
-        }));
+        });
+        error.output = Some(CommandOutput {
+            stdout: stdout.bytes,
+            stderr: stderr.bytes,
+        });
+        return Err(error);
     }
     Ok(CommandOutput {
         stdout: stdout.bytes,

--- a/rust/crates/tmt-adapters/src/process_tests.rs
+++ b/rust/crates/tmt-adapters/src/process_tests.rs
@@ -19,6 +19,36 @@ const SHELL: &str = "/bin/sh";
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const CLEANUP_WAIT: Duration = Duration::from_secs(2);
 
+#[test]
+fn nonzero_exit_preserves_bounded_protocol_output_without_formatting_it() {
+    let args = shell_args(
+        "printf 'private stdout'; printf 'private stderr' >&2; exit 1",
+        &[],
+    );
+    let error =
+        execute_shell(&UnixCommandRunner, &args, &[], Duration::from_secs(2), 64).unwrap_err();
+    assert_eq!(
+        error.kind,
+        CommandFailure::Exit {
+            code: Some(1),
+            signal: None
+        }
+    );
+    assert!(!error.cleanup_failed());
+    assert!(!error.to_string().contains("private"));
+    let output = error.output.unwrap();
+    assert_eq!(output.stdout, b"private stdout");
+    assert_eq!(output.stderr, b"private stderr");
+
+    let error =
+        execute_shell(&UnixCommandRunner, &args, &[], Duration::from_secs(2), 3).unwrap_err();
+    assert_eq!(error.kind, CommandFailure::OutputLimit);
+    assert!(
+        error.output.is_none(),
+        "incomplete oversized output is not a protocol report"
+    );
+}
+
 fn shell_args(script: &'static str, extra: &[OsString]) -> Vec<OsString> {
     let mut args = vec![
         OsString::from("-c"),

--- a/rust/crates/tmt-adapters/src/release_http.rs
+++ b/rust/crates/tmt-adapters/src/release_http.rs
@@ -1,0 +1,253 @@
+//! Bounded HTTPS acquisition for the canonical native release service.
+
+use std::{
+    io,
+    time::{Duration, Instant},
+};
+
+use ureq::{
+    Agent,
+    http::{StatusCode, Uri},
+    tls::{RootCerts, TlsConfig},
+};
+
+const MAX_REDIRECTS: usize = 3;
+const MAX_RESPONSE_HEADER: usize = 64 * 1024;
+const USER_AGENT: &str = "tmt";
+
+const ALLOWED_HOSTS: &[&str] = &[
+    "api.github.com",
+    "github.com",
+    "release-assets.githubusercontent.com",
+    "objects.githubusercontent.com",
+];
+
+/// The bounded synchronous HTTPS client used by native release acquisition.
+pub(crate) struct Https {
+    agent: Agent,
+    #[cfg(test)]
+    allow_loopback: bool,
+}
+
+impl Https {
+    pub(crate) fn new() -> Self {
+        let config = Agent::config_builder()
+            .https_only(true)
+            .max_redirects(0)
+            .max_response_header_size(MAX_RESPONSE_HEADER)
+            .user_agent(USER_AGENT)
+            .tls_config(
+                TlsConfig::builder()
+                    .root_certs(RootCerts::PlatformVerifier)
+                    .build(),
+            )
+            .build();
+
+        Self {
+            agent: Agent::new_with_config(config),
+            #[cfg(test)]
+            allow_loopback: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_test_agent(agent: Agent) -> Self {
+        Self {
+            agent,
+            allow_loopback: true,
+        }
+    }
+
+    pub(crate) fn get(
+        &self,
+        url: &str,
+        accept: &str,
+        maximum: usize,
+        deadline: Instant,
+    ) -> io::Result<Vec<u8>> {
+        #[cfg(test)]
+        let mut current = validate_url_with_loopback(url, self.allow_loopback)?;
+        #[cfg(not(test))]
+        let mut current = validate_url(url)?;
+        let body_limit = bounded_body_limit(maximum)?;
+
+        for redirects in 0..=MAX_REDIRECTS {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(timeout_error)?;
+            if remaining == Duration::ZERO {
+                return Err(timeout_error());
+            }
+
+            let mut response = self
+                .agent
+                .get(current.clone())
+                .header("Accept", accept)
+                .config()
+                .timeout_global(Some(remaining))
+                .build()
+                .call()
+                .map_err(map_ureq_error)?;
+
+            let status = response.status();
+            if status.is_redirection() {
+                if redirects == MAX_REDIRECTS {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "too many HTTPS redirects",
+                    ));
+                }
+                let location = response
+                    .headers()
+                    .get("location")
+                    .ok_or_else(|| invalid_response("redirect has no location"))?
+                    .to_str()
+                    .map_err(|_| invalid_response("redirect location is invalid"))?;
+                #[cfg(test)]
+                let next = validate_url_with_loopback(location, self.allow_loopback);
+                #[cfg(not(test))]
+                let next = validate_url(location);
+                current =
+                    next.map_err(|_| invalid_response("redirect location is not approved"))?;
+                continue;
+            }
+
+            if status == StatusCode::NOT_FOUND {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "HTTPS resource was not found",
+                ));
+            }
+            if !status.is_success() {
+                return Err(invalid_response("unexpected HTTPS response status"));
+            }
+
+            if let Some(length) = response.headers().get("content-length") {
+                let length = length
+                    .to_str()
+                    .ok()
+                    .and_then(|value| value.parse::<u64>().ok())
+                    .ok_or_else(|| invalid_response("HTTPS response length is invalid"))?;
+                if length > maximum as u64 {
+                    return Err(invalid_response("HTTPS response exceeds its size limit"));
+                }
+            }
+
+            let bytes = response
+                .body_mut()
+                .with_config()
+                .limit(body_limit)
+                .read_to_vec()
+                .map_err(map_ureq_error)?;
+            if bytes.len() > maximum {
+                return Err(invalid_response("HTTPS response exceeds its size limit"));
+            }
+            return Ok(bytes);
+        }
+
+        unreachable!("redirect loop returns before exhausting its bounded range")
+    }
+}
+
+fn validate_url(value: &str) -> io::Result<Uri> {
+    validate_url_inner(value, false)
+}
+
+#[cfg(test)]
+fn validate_url_with_loopback(value: &str, allow_loopback: bool) -> io::Result<Uri> {
+    validate_url_inner(value, allow_loopback)
+}
+
+fn validate_url_inner(value: &str, allow_loopback: bool) -> io::Result<Uri> {
+    if value.contains('#') {
+        return Err(invalid_url());
+    }
+    let uri = value.parse::<Uri>().map_err(|_| invalid_url())?;
+    if uri.scheme_str() != Some("https") {
+        return Err(invalid_url());
+    }
+    let authority = uri.authority().ok_or_else(invalid_url)?;
+    if authority.as_str().contains('@') {
+        return Err(invalid_url());
+    }
+    let loopback = allow_loopback && matches!(uri.host(), Some("127.0.0.1" | "localhost"));
+    if !loopback && uri.port_u16().is_some_and(|port| port != 443) {
+        return Err(invalid_url());
+    }
+    let host = uri.host().ok_or_else(invalid_url)?;
+    if !loopback
+        && !ALLOWED_HOSTS
+            .iter()
+            .any(|allowed| host.eq_ignore_ascii_case(allowed))
+    {
+        return Err(invalid_url());
+    }
+    Ok(uri)
+}
+
+fn bounded_body_limit(maximum: usize) -> io::Result<u64> {
+    maximum
+        .checked_add(1)
+        .and_then(|limit| u64::try_from(limit).ok())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "response limit is too large"))
+}
+
+fn map_ureq_error(error: ureq::Error) -> io::Error {
+    match error {
+        ureq::Error::StatusCode(404) => {
+            io::Error::new(io::ErrorKind::NotFound, "HTTPS resource was not found")
+        }
+        ureq::Error::Timeout(_) => timeout_error(),
+        ureq::Error::Io(error) if error.kind() == io::ErrorKind::TimedOut => timeout_error(),
+        ureq::Error::BodyExceedsLimit(_) => {
+            invalid_response("HTTPS response exceeds its size limit")
+        }
+        _ => io::Error::other("HTTPS request failed"),
+    }
+}
+
+fn timeout_error() -> io::Error {
+    io::Error::new(io::ErrorKind::TimedOut, "HTTPS request timed out")
+}
+
+fn invalid_url() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, "HTTPS URL is not approved")
+}
+
+fn invalid_response(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_canonical_https_hosts() {
+        for host in ALLOWED_HOSTS {
+            assert!(validate_url(&format!("https://{host}/release")).is_ok());
+        }
+        assert!(validate_url("http://api.github.com/release").is_err());
+        assert!(validate_url("https://github.com:8443/release").is_err());
+        assert!(validate_url("https://github.com.evil.example/release").is_err());
+        assert!(validate_url("https://user@github.com/release").is_err());
+        assert!(validate_url("https://github.com/release#fragment").is_err());
+    }
+
+    #[test]
+    fn redirects_must_be_absolute_approved_https_urls() {
+        assert!(validate_url("/releases/latest").is_err());
+        assert!(validate_url("https://objects.githubusercontent.com/archive").is_ok());
+        assert!(validate_url("https://example.com/archive").is_err());
+    }
+
+    #[test]
+    fn body_limit_reserves_one_byte_for_oversize_detection() {
+        assert_eq!(bounded_body_limit(3).unwrap(), 4);
+        assert!(bounded_body_limit(usize::MAX).is_err());
+    }
+}
+
+#[cfg(test)]
+#[path = "release_http_tests.rs"]
+mod release_http_tests;

--- a/rust/crates/tmt-adapters/src/release_http_tests.rs
+++ b/rust/crates/tmt-adapters/src/release_http_tests.rs
@@ -1,0 +1,479 @@
+use std::{
+    io::{self, Read, Write},
+    net::{Shutdown, SocketAddr, TcpListener, TcpStream},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+        mpsc,
+    },
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+use rcgen::generate_simple_self_signed;
+use rustls::{
+    ServerConfig, ServerConnection, StreamOwned,
+    pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+};
+use ureq::{
+    Agent,
+    tls::{Certificate, RootCerts, TlsConfig},
+};
+
+use super::{Https, MAX_REDIRECTS, MAX_RESPONSE_HEADER, USER_AGENT};
+
+const SERVER_WAIT: Duration = Duration::from_secs(2);
+
+struct Response {
+    status: u16,
+    location: Option<String>,
+    body: Vec<u8>,
+    declared_length: Option<usize>,
+    emit_length: bool,
+    hold_body: bool,
+    header_delay: Duration,
+}
+
+impl Response {
+    fn ok(body: impl Into<Vec<u8>>) -> Self {
+        Self {
+            status: 200,
+            location: None,
+            body: body.into(),
+            declared_length: None,
+            emit_length: true,
+            hold_body: false,
+            header_delay: Duration::ZERO,
+        }
+    }
+
+    fn not_found() -> Self {
+        Self {
+            status: 404,
+            ..Self::ok("missing")
+        }
+    }
+
+    fn redirect(location: String) -> Self {
+        Self {
+            status: 302,
+            location: Some(location),
+            ..Self::ok(Vec::new())
+        }
+    }
+
+    fn truncated(declared_length: usize, body: impl Into<Vec<u8>>) -> Self {
+        Self {
+            declared_length: Some(declared_length),
+            ..Self::ok(body)
+        }
+    }
+
+    fn without_length(body: impl Into<Vec<u8>>) -> Self {
+        Self {
+            emit_length: false,
+            ..Self::ok(body)
+        }
+    }
+
+    fn held(declared_length: usize) -> Self {
+        Self {
+            declared_length: Some(declared_length),
+            hold_body: true,
+            ..Self::ok(Vec::new())
+        }
+    }
+
+    fn delayed_headers(mut self, delay: Duration) -> Self {
+        self.header_delay = delay;
+        self
+    }
+}
+
+struct TestServer {
+    address: SocketAddr,
+    release: Option<mpsc::Sender<()>>,
+    thread: Option<JoinHandle<io::Result<()>>>,
+    accepted: Option<Arc<AtomicUsize>>,
+}
+
+impl TestServer {
+    fn spawn(config: Arc<ServerConfig>, response: Response) -> Self {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind local TLS listener");
+        listener
+            .set_nonblocking(true)
+            .expect("set local listener nonblocking");
+        let address = listener.local_addr().expect("read local listener address");
+        let (release, released) = mpsc::channel();
+        let thread = thread::spawn(move || serve(listener, config, response, released));
+        Self {
+            address,
+            release: Some(release),
+            thread: Some(thread),
+            accepted: None,
+        }
+    }
+
+    fn spawn_redirect_loop(config: Arc<ServerConfig>) -> Self {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind local TLS listener");
+        listener
+            .set_nonblocking(true)
+            .expect("set local listener nonblocking");
+        let address = listener.local_addr().expect("read local listener address");
+        let (release, released) = mpsc::channel();
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let count = Arc::clone(&accepted);
+        let thread =
+            thread::spawn(move || serve_redirect_loop(listener, config, address, released, count));
+        Self {
+            address,
+            release: Some(release),
+            thread: Some(thread),
+            accepted: Some(accepted),
+        }
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("https://{}{}", self.address, path)
+    }
+
+    fn accepted(&self) -> usize {
+        self.accepted
+            .as_ref()
+            .map_or(0, |count| count.load(Ordering::SeqCst))
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(release) = self.release.take() {
+            let _ = release.send(());
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn serve(
+    listener: TcpListener,
+    config: Arc<ServerConfig>,
+    response: Response,
+    released: mpsc::Receiver<()>,
+) -> io::Result<()> {
+    let stream = accept(&listener, &released)?;
+    serve_connection(stream, config, response, &released)
+}
+
+fn serve_redirect_loop(
+    listener: TcpListener,
+    config: Arc<ServerConfig>,
+    address: SocketAddr,
+    released: mpsc::Receiver<()>,
+    accepted: Arc<AtomicUsize>,
+) -> io::Result<()> {
+    for _ in 0..=MAX_REDIRECTS {
+        let stream = accept(&listener, &released)?;
+        accepted.fetch_add(1, Ordering::SeqCst);
+        serve_connection(
+            stream,
+            Arc::clone(&config),
+            Response::redirect(format!("https://{address}/loop")),
+            &released,
+        )?;
+    }
+    if let Ok(stream) = accept(&listener, &released) {
+        accepted.fetch_add(1, Ordering::SeqCst);
+        drop(stream);
+    }
+    Ok(())
+}
+
+fn serve_connection(
+    stream: TcpStream,
+    config: Arc<ServerConfig>,
+    response: Response,
+    released: &mpsc::Receiver<()>,
+) -> io::Result<()> {
+    stream.set_nonblocking(false)?;
+    stream.set_read_timeout(Some(SERVER_WAIT))?;
+    stream.set_write_timeout(Some(SERVER_WAIT))?;
+    let connection = ServerConnection::new(config).map_err(io::Error::other)?;
+    let mut stream = StreamOwned::new(connection, stream);
+    read_request(&mut stream)?;
+    thread::sleep(response.header_delay);
+
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\n",
+        response.status,
+        reason(response.status)
+    )?;
+    if let Some(location) = &response.location {
+        write!(stream, "Location: {location}\r\n")?;
+    }
+    if response.emit_length {
+        let length = response.declared_length.unwrap_or(response.body.len());
+        write!(stream, "Content-Length: {length}\r\n")?;
+    }
+    write!(stream, "Connection: close\r\n\r\n")?;
+    stream.flush()?;
+
+    if response.hold_body {
+        let _ = released.recv_timeout(SERVER_WAIT);
+    } else {
+        stream.write_all(&response.body)?;
+        stream.flush()?;
+        let _ = stream.get_mut().shutdown(Shutdown::Write);
+    }
+    Ok(())
+}
+
+fn accept(listener: &TcpListener, released: &mpsc::Receiver<()>) -> io::Result<TcpStream> {
+    let deadline = Instant::now() + SERVER_WAIT;
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => return Ok(stream),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                if released.try_recv().is_ok() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "test server released",
+                    ));
+                }
+                if Instant::now() >= deadline {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "test server accept",
+                    ));
+                }
+                thread::yield_now();
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn read_request(stream: &mut impl Read) -> io::Result<()> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        let count = stream.read(&mut buffer)?;
+        if count == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "test request ended",
+            ));
+        }
+        request.extend_from_slice(&buffer[..count]);
+        if request.len() > 16 * 1024 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "test request too large",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        302 => "Found",
+        404 => "Not Found",
+        _ => "Status",
+    }
+}
+
+fn tls_material() -> (Arc<ServerConfig>, Vec<u8>) {
+    let certified = generate_simple_self_signed(vec!["127.0.0.1".to_owned()])
+        .expect("generate test TLS certificate");
+    let certificate = certified.cert.der().as_ref().to_vec();
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+        certified.signing_key.serialize_der(),
+    ));
+    let config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![CertificateDer::from(certificate.clone())], key)
+        .expect("build test TLS server config");
+    (Arc::new(config), certificate)
+}
+
+fn client(root: &[u8]) -> Https {
+    let roots = [Certificate::from_der(root).to_owned()];
+    let config = Agent::config_builder()
+        .https_only(true)
+        .max_redirects(0)
+        .max_response_header_size(MAX_RESPONSE_HEADER)
+        .user_agent(USER_AGENT)
+        .tls_config(
+            TlsConfig::builder()
+                .root_certs(RootCerts::new_with_certs(&roots))
+                .build(),
+        )
+        .build();
+    Https::with_test_agent(Agent::new_with_config(config))
+}
+
+#[test]
+fn valid_platform_like_task_trust_fetches_over_real_tls() {
+    let (config, certificate) = tls_material();
+    let server = TestServer::spawn(config, Response::ok("native"));
+    let bytes = client(&certificate)
+        .get(
+            &server.url("/release"),
+            "application/json",
+            64,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect("trusted TLS request");
+    assert_eq!(bytes, b"native");
+}
+
+#[test]
+fn wrong_task_trust_rejects_real_tls() {
+    let (config, _server_certificate) = tls_material();
+    let (_wrong_config, wrong_certificate) = tls_material();
+    let server = TestServer::spawn(config, Response::ok("secret"));
+    let error = client(&wrong_certificate)
+        .get(
+            &server.url("/release"),
+            "application/json",
+            64,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect_err("wrong TLS trust must fail");
+    assert_eq!(error.kind(), io::ErrorKind::Other);
+}
+
+#[test]
+fn http_and_unapproved_redirects_are_rejected_before_following() {
+    let production = Https::new();
+    let error = production
+        .get(
+            "http://api.github.com/releases",
+            "application/json",
+            64,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect_err("HTTP URL must be rejected");
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+
+    let (config, certificate) = tls_material();
+    let server = TestServer::spawn(
+        config,
+        Response::redirect("https://example.com/release".to_owned()),
+    );
+    let error = client(&certificate)
+        .get(
+            &server.url("/redirect"),
+            "application/json",
+            64,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect_err("unapproved redirect must be rejected");
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn oversized_body_is_rejected_before_unbounded_read() {
+    let (config, certificate) = tls_material();
+    let server = TestServer::spawn(config, Response::without_length(vec![b'x'; 5]));
+    let error = client(&certificate)
+        .get(
+            &server.url("/oversized"),
+            "application/octet-stream",
+            4,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect_err("oversized body must fail");
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn content_length_overflow_is_rejected_before_body_read() {
+    let (config, certificate) = tls_material();
+    let server = TestServer::spawn(config, Response::truncated(5, Vec::new()));
+    let error = client(&certificate)
+        .get(
+            &server.url("/declared-oversized"),
+            "application/octet-stream",
+            4,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect_err("oversized Content-Length must fail");
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn not_found_status_maps_to_not_found() {
+    let (config, certificate) = tls_material();
+    let server = TestServer::spawn(config, Response::not_found());
+    let error = client(&certificate)
+        .get(
+            &server.url("/missing"),
+            "application/json",
+            64,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect_err("404 must fail");
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+}
+
+#[test]
+fn truncated_body_is_rejected() {
+    let (config, certificate) = tls_material();
+    let server = TestServer::spawn(config, Response::truncated(5, "abc"));
+    let error = client(&certificate)
+        .get(
+            &server.url("/truncated"),
+            "application/octet-stream",
+            64,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect_err("truncated body must fail");
+    assert_eq!(error.kind(), io::ErrorKind::Other);
+}
+
+#[test]
+fn one_deadline_covers_redirect_and_body_wait() {
+    let (config, certificate) = tls_material();
+    let second = TestServer::spawn(config.clone(), Response::held(1));
+    let first = TestServer::spawn(
+        config,
+        Response::redirect(second.url("/slow")).delayed_headers(Duration::from_millis(1_400)),
+    );
+    let deadline = Instant::now() + Duration::from_millis(1_600);
+    let (done, result) = mpsc::channel();
+    let first_url = first.url("/redirect");
+    let thread = thread::spawn(move || {
+        let result = client(&certificate).get(&first_url, "application/octet-stream", 64, deadline);
+        done.send(result).unwrap();
+    });
+    let received = result.recv_timeout(SERVER_WAIT);
+    // Release both fixture servers and join the client even when the deadline
+    // assertion is about to fail; a failed test must not detach its worker.
+    drop(first);
+    drop(second);
+    thread.join().unwrap();
+    let error = received
+        .expect("global deadline should finish before fixture cleanup")
+        .expect_err("body wait must share the redirect deadline");
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+}
+
+#[test]
+fn real_tls_redirect_loop_stops_at_bound_without_external_contact() {
+    let (config, certificate) = tls_material();
+    let server = TestServer::spawn_redirect_loop(config);
+    let error = client(&certificate)
+        .get(
+            &server.url("/loop"),
+            "application/octet-stream",
+            64,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect_err("redirect loop must hit the local bound");
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(server.accepted(), MAX_REDIRECTS + 1);
+}

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -189,7 +189,11 @@ pub fn grammar() -> Command {
             ).ignore_case(true)),
         )
         .subcommand(general("completion", "Generate shell completion").arg(operand("shell", false)))
-        .subcommand(general("upgrade", "Upgrade the CLI and refresh skills"))
+        .subcommand(general("upgrade", "Upgrade the native CLI and refresh managed skills")
+            .visible_alias("update")
+            .arg(Arg::new("channel").long("channel").value_parser(tmt_core::native_install::Channel::ALL.map(|channel| channel.as_str())))
+            .arg(Arg::new("to").long("to").conflicts_with("unpin"))
+            .arg(Arg::new("unpin").long("unpin").action(ArgAction::SetTrue)))
         .subcommand(general("__native-refresh-skills", "Internal managed skill refresh").hide(true))
         .subcommand(
             general("__native-install", "Internal offline native installation")
@@ -197,7 +201,7 @@ pub fn grammar() -> Command {
                 .arg(Arg::new("archive").long("archive").required(true))
                 .arg(Arg::new("manifest").long("manifest").required(true))
                 .arg(Arg::new("prefix").long("prefix").required(true))
-                .arg(Arg::new("channel").long("channel").required(true).value_parser(["stable", "alpha"]))
+                .arg(Arg::new("channel").long("channel").required(true).value_parser(tmt_core::native_install::Channel::ALL.map(|channel| channel.as_str())))
                 .arg(Arg::new("pin").long("pin").action(ArgAction::SetTrue).conflicts_with("unpin"))
                 .arg(Arg::new("unpin").long("unpin").action(ArgAction::SetTrue)),
         )

--- a/rust/crates/tmt-cli/src/guidance_command.rs
+++ b/rust/crates/tmt-cli/src/guidance_command.rs
@@ -43,7 +43,7 @@ pub fn execute(skill: bool) -> io::Result<u8> {
         )?;
         writeln!(
             output,
-            "Read tmt learn --skill for complete current safety and usage guidance.\nUse tmt help for options. Native network upgrade is not available yet."
+            "Read tmt learn --skill for complete current safety and usage guidance.\nUse tmt help for options. Managed native installations use tmt upgrade; package-manager installations use their original manager."
         )?;
     }
     Ok(0)

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -55,7 +55,11 @@ pub enum Invocation {
         directory: Option<String>,
         force: bool,
     },
-    Upgrade,
+    Upgrade {
+        channel: Option<tmt_core::native_install::Channel>,
+        exact: Option<String>,
+        unpin: bool,
+    },
     NativeRefreshSkills,
     NativeInstall {
         archive: String,

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -12,6 +12,7 @@ mod init_command;
 mod install_command;
 mod invocation;
 mod native_install_command;
+mod native_upgrade_command;
 mod output;
 mod parser;
 mod profile_command;
@@ -49,7 +50,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, x attention, init, learn, and skill installation are available. Native network upgrade is not implemented yet. Use isolated test state only.\n"
+                "Native development preview: configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, x attention, init, learn, and skill installation are available. Managed native upgrade/update is supported; public release availability is a separate gate. Use isolated test state only.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;
@@ -130,13 +131,13 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
             drop(stdout);
             return binding_command::execute(request, parsed.mode);
         }
-        Invocation::Upgrade => {
+        Invocation::Upgrade {
+            channel,
+            exact,
+            unpin,
+        } => {
             drop(stdout);
-            return failure(
-                parsed.mode,
-                "NATIVE_NOT_IMPLEMENTED",
-                "This command is not implemented by the native development preview. No effects were performed; use the installed TypeScript CLI until native cutover.",
-            );
+            return native_upgrade_command::execute(channel, exact.as_deref(), unpin, parsed.mode);
         }
         Invocation::NativeRefreshSkills => {
             drop(stdout);

--- a/rust/crates/tmt-cli/src/native_upgrade_command.rs
+++ b/rust/crates/tmt-cli/src/native_upgrade_command.rs
@@ -1,0 +1,263 @@
+//! Native update composition; the newly activated executable owns skill refresh.
+
+use crate::{invocation::OutputMode, output::Failure};
+use serde_json::{Value, json};
+use std::{
+    fs,
+    io::{self, Write},
+    os::unix::fs::PermissionsExt,
+    path::Path,
+    time::{Duration, Instant},
+};
+use tmt_adapters::{
+    native_install::{self, UpgradeReport, UpgradeRequest},
+    process::{CommandFailure, CommandRequest, CommandRunner, UnixCommandRunner},
+};
+use tmt_core::native_install::Channel;
+
+pub fn execute(
+    channel: Option<Channel>,
+    exact: Option<&str>,
+    unpin: bool,
+    mode: OutputMode,
+) -> io::Result<u8> {
+    let interrupt = match tmt_adapters::interrupt::Interrupt::install() {
+        Ok(interrupt) => interrupt,
+        Err(error) => {
+            return Failure::new("NATIVE_UPGRADE_FAILED", error.to_string(), 1)
+                .caused_by(error)
+                .publish(mode);
+        }
+    };
+    let result = (|| {
+        let executable = std::env::current_exe()?;
+        native_install::upgrade(
+            UpgradeRequest {
+                executable: &executable,
+                channel,
+                exact,
+                unpin,
+            },
+            || {
+                if interrupt.is_interrupted() {
+                    Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "Native update interrupted.",
+                    ))
+                } else {
+                    Ok(())
+                }
+            },
+        )
+    })();
+    let report = match result {
+        Ok(report) => report,
+        Err(mut error) => {
+            let activated = error.activated.take();
+            let status = if error.kind() == io::ErrorKind::Interrupted {
+                130
+            } else {
+                1
+            };
+            let message = activated.as_deref().map_or_else(
+                || error.to_string(),
+                |report| format!("{} {}", error, retry_hint(report)),
+            );
+            let failure = Failure::new("NATIVE_UPGRADE_FAILED", message, status).caused_by(error);
+            return publish(activated.as_deref(), None, Some(failure), mode);
+        }
+    };
+    if report.skipped_pinned {
+        return publish(Some(&report), None, None, mode);
+    }
+    if interrupt.is_interrupted() {
+        return publish(
+            Some(&report),
+            None,
+            Some(Failure::new(
+                "NATIVE_UPGRADE_INTERRUPTED",
+                format!(
+                    "Native binary installation completed; managed skill refresh was interrupted. {}",
+                    retry_hint(&report)
+                ),
+                130,
+            )),
+            mode,
+        );
+    }
+    let refreshed =
+        native_install::with_active_release(&report.installation.active_executable, || {
+            refresh(&report.installation.active_executable, &UnixCommandRunner)
+        })
+        .unwrap_or_else(|error| Err((None, error)));
+    let (skills, mut failure) = match refreshed {
+        Ok(skills) => (Some(skills), None),
+        Err((skills, cause)) => (skills, Some(Failure::new(
+            "NATIVE_UPGRADE_SKILLS_FAILED",
+            format!("Native binary installation completed, but managed skill refresh failed. User-owned skill content was not overwritten. {}", retry_hint(&report)), 1,
+        ).caused_by(cause))),
+    };
+    if interrupt.is_interrupted() {
+        failure = Some(Failure::new(
+            "NATIVE_UPGRADE_INTERRUPTED",
+            format!(
+                "Native binary installation completed; update was interrupted during managed skill refresh. Inspect the skill report. {}",
+                retry_hint(&report)
+            ),
+            130,
+        ));
+    }
+    publish(Some(&report), skills, failure, mode)
+}
+
+fn refresh(
+    executable: &Path,
+    runner: &impl CommandRunner,
+) -> Result<Value, (Option<Value>, io::Error)> {
+    let result = runner.execute(CommandRequest {
+        program: executable.as_os_str(),
+        args: &["__native-refresh-skills".into(), "--json".into()],
+        input: &[],
+        deadline: Instant::now() + Duration::from_secs(30),
+        max_output_bytes: 4 * 1024 * 1024,
+    });
+    let (output, failure) = match result {
+        Ok(output) => (output, None),
+        Err(mut error) => {
+            if !matches!(
+                error.kind,
+                CommandFailure::Exit {
+                    code: Some(1),
+                    signal: None
+                }
+            ) || error.cleanup_failed()
+            {
+                return Err((None, io::Error::other(error)));
+            }
+            let Some(output) = error.output.take() else {
+                return Err((None, io::Error::other(error)));
+            };
+            (output, Some(error))
+        }
+    };
+    let document = crate::skill_refresh_command::parse_document(&output.stdout)
+        .filter(|value| {
+            output.stderr.is_empty() && value.get("error").is_some() == failure.is_some()
+        })
+        .ok_or_else(|| {
+            (
+                None,
+                io::Error::other("New executable returned an invalid managed-skill report."),
+            )
+        })?;
+    match failure {
+        None => Ok(document),
+        Some(error) => Err((Some(document), io::Error::other(error))),
+    }
+}
+
+fn publish(
+    report: Option<&UpgradeReport>,
+    skills: Option<Value>,
+    failure: Option<Failure>,
+    mode: OutputMode,
+) -> io::Result<u8> {
+    let mut document = report.map_or_else(|| json!({"changed": false}), |report| json!({
+        "executable": report.installation.executable, "version": report.installation.version,
+        "changed": report.installation.changed, "channel": report.state.channel.as_str(),
+        "pinnedVersion": report.state.pinned_version.as_ref().map(ToString::to_string),
+        "pinned": report.state.pinned_version.is_some(),
+        "skippedPinned": report.skipped_pinned,
+    }));
+    document["skills"] = skills.unwrap_or(Value::Null);
+    let warning = report.and_then(|report| path_warning(&report.installation.executable));
+    document["pathWarning"] = warning.clone().into();
+    if let Some(failure) = &failure {
+        document["error"] = failure.document()["error"].clone();
+    }
+    if mode.json {
+        writeln!(io::stdout().lock(), "{document}")?;
+    } else {
+        if let Some(report) = report {
+            writeln!(
+                io::stdout().lock(),
+                "{} tmt {} at {}",
+                if report.skipped_pinned {
+                    "Pinned"
+                } else if report.installation.changed {
+                    "Updated"
+                } else {
+                    "Current"
+                },
+                report.installation.version,
+                report.installation.executable.display()
+            )?;
+            if !report.skipped_pinned
+                && let Some(refreshed) = document["skills"]["refreshed"].as_array()
+            {
+                let skipped = document["skills"]["skipped"].as_array().map_or(0, Vec::len);
+                let conflicts = document["skills"]["conflicts"]
+                    .as_array()
+                    .expect("validated skill report");
+                writeln!(
+                    io::stdout().lock(),
+                    "Managed skills: {} current/refreshed, {skipped} missing, {} conflicts preserved.",
+                    refreshed.len(),
+                    conflicts.len()
+                )?;
+                for target in conflicts {
+                    writeln!(
+                        io::stdout().lock(),
+                        "Resolve skill conflict at {}",
+                        target.as_str().expect("validated skill path")
+                    )?;
+                }
+                if !refreshed.is_empty() {
+                    writeln!(
+                        io::stdout().lock(),
+                        "Reload or restart your agent to use updated guidance; existing conversations can read tmt learn --skill."
+                    )?;
+                }
+            }
+        }
+        if let Some(warning) = warning {
+            writeln!(io::stderr().lock(), "{warning}")?;
+        }
+        if let Some(failure) = &failure {
+            failure.publish(mode)?;
+        }
+    }
+    Ok(failure.map_or(0, |failure| failure.status))
+}
+
+fn path_warning(executable: &Path) -> Option<String> {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let selected = std::env::split_paths(&path)
+        .map(|directory| directory.join("tmt"))
+        .find(|candidate| {
+            fs::metadata(candidate).is_ok_and(|metadata| {
+                metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+            })
+        });
+    let expected = fs::canonicalize(executable).ok();
+    if expected.is_some() && selected.and_then(|path| fs::canonicalize(path).ok()) == expected {
+        return None;
+    }
+    Some(format!(
+        "PATH does not select this managed tmt. Use {} directly or put its bin directory first; no shell profile or package-manager files were changed.",
+        executable.display()
+    ))
+}
+
+fn retry_hint(report: &UpgradeReport) -> String {
+    match &report.state.pinned_version {
+        Some(version) => format!(
+            "Run the current managed tmt with upgrade --to {version} to retry without clearing the pin."
+        ),
+        None => "Run the current managed tmt upgrade to retry.".into(),
+    }
+}
+
+#[cfg(test)]
+#[path = "native_upgrade_command_tests.rs"]
+mod tests;

--- a/rust/crates/tmt-cli/src/native_upgrade_command_tests.rs
+++ b/rust/crates/tmt-cli/src/native_upgrade_command_tests.rs
@@ -1,0 +1,88 @@
+use super::*;
+use std::cell::Cell;
+use tmt_adapters::process::{CommandError, CommandOutput};
+
+struct Runner {
+    calls: Cell<usize>,
+    bytes: &'static [u8],
+}
+impl CommandRunner for Runner {
+    fn execute(&self, request: CommandRequest<'_>) -> Result<CommandOutput, CommandError> {
+        self.calls.set(self.calls.get() + 1);
+        assert_eq!(request.program, "/managed/releases/new/tmt");
+        assert_eq!(
+            request.args,
+            &[
+                std::ffi::OsString::from("__native-refresh-skills"),
+                "--json".into()
+            ]
+        );
+        assert!(request.input.is_empty());
+        assert!(request.deadline > Instant::now());
+        Ok(CommandOutput {
+            stdout: self.bytes.to_vec(),
+            stderr: vec![],
+        })
+    }
+}
+
+#[test]
+fn refresh_runs_new_immutable_executable_and_validates_its_report() {
+    let runner = Runner {
+        calls: Cell::new(0),
+        bytes:
+            br#"{"refreshed":[{"target":"/agent/tmt","changed":true}],"skipped":[],"conflicts":[]}"#,
+    };
+    let report = refresh(Path::new("/managed/releases/new/tmt"), &runner).unwrap();
+    assert_eq!(runner.calls.get(), 1);
+    assert_eq!(report["refreshed"][0]["changed"], true);
+    for bytes in [b"not JSON".as_slice(), br#"{"refreshed":[],"skipped":[],"conflicts":[],"unexpected":"field"}"#, br#"{"refreshed":[],"skipped":[],"conflicts":[],"error":{"code":"FAIL","message":"failed"}}"#] {
+        let runner = Runner { calls: Cell::new(0), bytes };
+        assert!(refresh(Path::new("/managed/releases/new/tmt"), &runner).is_err());
+    }
+}
+
+#[test]
+fn completed_nonzero_child_keeps_its_valid_partial_skill_report() {
+    struct ExitingRunner;
+    impl CommandRunner for ExitingRunner {
+        fn execute(&self, request: CommandRequest<'_>) -> Result<CommandOutput, CommandError> {
+            assert_eq!(request.program, "/managed/releases/new/tmt");
+            UnixCommandRunner.execute(CommandRequest {
+                program: std::ffi::OsStr::new("/bin/sh"),
+                args: &["-c".into(), "printf '%s' '{\"refreshed\":[{\"target\":\"/valid\",\"changed\":true}],\"skipped\":[],\"conflicts\":[\"/modified\"],\"error\":{\"code\":\"SKILL_REFRESH_FAILED\",\"message\":\"conflict\"}}'; exit 1".into()],
+                input: &[], deadline: request.deadline, max_output_bytes: request.max_output_bytes,
+            })
+        }
+    }
+    let (document, error) =
+        refresh(Path::new("/managed/releases/new/tmt"), &ExitingRunner).unwrap_err();
+    let document = document.expect("preserve the validated partial report");
+    assert_eq!(document["refreshed"][0]["target"], "/valid");
+    assert_eq!(document["conflicts"][0], "/modified");
+    assert!(!error.to_string().contains("/modified"));
+}
+
+#[test]
+fn retry_guidance_retains_an_explicit_pin() {
+    let mut report = UpgradeReport {
+        installation: native_install::InstallReport {
+            executable: "/managed/bin/tmt".into(),
+            active_executable: "/managed/releases/new/tmt".into(),
+            version: "5.0.0".into(),
+            changed: true,
+        },
+        state: tmt_core::native_install::InstalledVersion {
+            version: "5.0.0".parse().unwrap(),
+            channel: Channel::Stable,
+            pinned_version: None,
+        },
+        skipped_pinned: false,
+    };
+    assert_eq!(
+        retry_hint(&report),
+        "Run the current managed tmt upgrade to retry."
+    );
+    report.state.pinned_version = Some(report.state.version.clone());
+    assert!(retry_hint(&report).contains("upgrade --to 5.0.0"));
+}

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -64,7 +64,6 @@ pub fn parse(argv: &[OsString]) -> Result<Parsed, ParseError> {
                 | Invocation::Version
                 | Invocation::Completion(_)
                 | Invocation::Learn { .. }
-                | Invocation::Upgrade
         )
     {
         return Err(ParseError {
@@ -144,7 +143,12 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
         ["init"] => Invocation::Init,
         ["whoami"] => Invocation::Whoami,
         ["unbind"] => Invocation::Unbind,
-        ["upgrade"] => Invocation::Upgrade,
+        ["upgrade"] => Invocation::Upgrade {
+            channel: text(m, "channel")
+                .and_then(|value| tmt_core::native_install::Channel::parse(&value)),
+            exact: text(m, "to"),
+            unpin: flag(m, "unpin"),
+        },
         ["__native-refresh-skills"] => Invocation::NativeRefreshSkills,
         ["__native-install"] => Invocation::NativeInstall {
             archive: required(m, "archive"),

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -10,6 +10,45 @@ fn args(values: &[&str]) -> Vec<OsString> {
 }
 
 #[test]
+fn native_upgrade_alias_and_selection_share_one_typed_contract() {
+    for command in ["upgrade", "update"] {
+        let invocation = parsed(&[
+            command,
+            "--channel",
+            "alpha",
+            "--to",
+            "5.0.0-alpha.3",
+            "--json",
+        ]);
+        assert!(invocation.mode.json);
+        assert_eq!(
+            invocation.invocation,
+            Invocation::Upgrade {
+                channel: Some(tmt_core::native_install::Channel::Alpha),
+                exact: Some("5.0.0-alpha.3".into()),
+                unpin: false,
+            }
+        );
+        assert_eq!(
+            parsed(&[command, "--unpin"]).invocation,
+            Invocation::Upgrade {
+                channel: None,
+                exact: None,
+                unpin: true
+            }
+        );
+        assert_eq!(
+            parse_error(&[command, "--to", "5.0.0", "--unpin", "--json"]).code,
+            "USAGE_ERROR"
+        );
+        assert_eq!(
+            parse_error(&[command, "--channel", "beta", "--json"]).code,
+            "USAGE_ERROR"
+        );
+    }
+}
+
+#[test]
 fn internal_native_install_requires_explicit_inputs_and_typed_pin_policy() {
     use tmt_core::native_install::{Channel, PinAction};
     let input = [

--- a/rust/crates/tmt-cli/src/skill_refresh_command.rs
+++ b/rust/crates/tmt-cli/src/skill_refresh_command.rs
@@ -16,6 +16,37 @@ fn document(report: &RefreshReport) -> Value {
     })
 }
 
+/// The updater consumes this same owner's bounded JSON contract, not arbitrary
+/// child stdout. Error details retain the shared CLI error-envelope shape.
+pub(crate) fn parse_document(bytes: &[u8]) -> Option<Value> {
+    let value: Value = serde_json::from_slice(bytes).ok()?;
+    let object = value.as_object()?;
+    if object.len() != 3 + usize::from(object.contains_key("error")) {
+        return None;
+    }
+    if !value["refreshed"].as_array()?.iter().all(|item| {
+        item.as_object().is_some_and(|item| item.len() == 2)
+            && item["target"].is_string()
+            && item["changed"].is_boolean()
+    }) {
+        return None;
+    }
+    for key in ["skipped", "conflicts"] {
+        if !value[key].as_array()?.iter().all(Value::is_string) {
+            return None;
+        }
+    }
+    if !value["conflicts"].as_array()?.is_empty() && !object.contains_key("error") {
+        return None;
+    }
+    if let Some(error) = object.get("error")
+        && (!error["code"].is_string() || !error["message"].is_string())
+    {
+        return None;
+    }
+    Some(value)
+}
+
 pub fn execute(mode: OutputMode) -> io::Result<u8> {
     let (report, failure) = match ConfigPaths::discover() {
         Err(error) => (RefreshReport::default(), Some(Failure::from(error))),

--- a/rust/crates/tmt-cli/src/skill_reminder.rs
+++ b/rust/crates/tmt-cli/src/skill_reminder.rs
@@ -18,7 +18,7 @@ fn eligible(parsed: &Parsed, interactive: bool) -> bool {
                 | Invocation::Init
                 | Invocation::Learn { .. }
                 | Invocation::Install { .. }
-                | Invocation::Upgrade
+                | Invocation::Upgrade { .. }
                 | Invocation::NativeInstall { .. }
                 | Invocation::NativeRefreshSkills
         )
@@ -78,7 +78,11 @@ mod tests {
                 directory: None,
                 force: false,
             },
-            Invocation::Upgrade,
+            Invocation::Upgrade {
+                channel: None,
+                exact: None,
+                unpin: false,
+            },
             Invocation::NativeRefreshSkills,
             Invocation::NativeInstall {
                 archive: "archive.tar.gz".into(),

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -22,6 +22,7 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
             "sha2",
         ],
         "tmt-adapters" => &[
+            "ureq",
             "semver",
             "tar",
             "flate2",

--- a/rust/crates/tmt-core/src/native_install.rs
+++ b/rust/crates/tmt-core/src/native_install.rs
@@ -69,6 +69,7 @@ pub struct VersionPlan {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VersionError {
+    InvalidSelection,
     InvalidCurrentState,
     WrongChannel,
     Pinned,
@@ -79,6 +80,7 @@ pub enum VersionError {
 impl fmt::Display for VersionError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
+            Self::InvalidSelection => "Select a valid exact version or unpin, not both.",
             Self::InvalidCurrentState => "Installed version, channel and pin disagree.",
             Self::WrongChannel => "The selected version does not belong to the selected channel.",
             Self::Pinned => "The installation is pinned; explicitly select a version or unpin it.",
@@ -90,6 +92,78 @@ impl fmt::Display for VersionError {
     }
 }
 impl Error for VersionError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpgradeSelection {
+    Pinned,
+    Fetch {
+        channel: Channel,
+        exact: Option<Version>,
+        pin: PinAction,
+    },
+}
+
+/// Resolve explicit user intent before any release discovery or network effect.
+pub fn select_upgrade(
+    current: &InstalledVersion,
+    channel: Option<Channel>,
+    exact: Option<&str>,
+    unpin: bool,
+) -> Result<UpgradeSelection, VersionError> {
+    current.validate()?;
+    if unpin && exact.is_some() {
+        return Err(VersionError::InvalidSelection);
+    }
+    let channel = channel.unwrap_or(current.channel);
+    if current.pinned_version.is_some() && exact.is_none() && !unpin {
+        if channel != current.channel {
+            return Err(VersionError::Pinned);
+        }
+        return Ok(UpgradeSelection::Pinned);
+    }
+    let exact = exact
+        .map(|version| {
+            version
+                .parse::<Version>()
+                .map_err(|_| VersionError::InvalidSelection)
+        })
+        .transpose()?;
+    let pin = if exact.is_some() {
+        PinAction::PinCandidate
+    } else if unpin {
+        PinAction::Clear
+    } else {
+        PinAction::Preserve
+    };
+    if let Some(version) = &exact {
+        plan_version(Some(current), version, channel, pin)?;
+    }
+    Ok(UpgradeSelection::Fetch {
+        channel,
+        exact,
+        pin,
+    })
+}
+
+pub fn latest_in_channel(
+    versions: &[Version],
+    channel: Channel,
+) -> Result<Option<&Version>, VersionError> {
+    let selected = versions
+        .iter()
+        .filter(|version| channel.accepts(version))
+        .max_by(|a, b| a.cmp_precedence(b));
+    if let Some(selected) = selected
+        && versions.iter().any(|candidate| {
+            channel.accepts(candidate)
+                && candidate != selected
+                && candidate.cmp_precedence(selected) == Ordering::Equal
+        })
+    {
+        return Err(VersionError::EqualPrecedenceChange);
+    }
+    Ok(selected)
+}
 
 /// Filesystem ownership and equal-version artifact integrity are separate
 /// adapter checks. A version no-op never authorizes ignoring those checks.

--- a/rust/crates/tmt-core/src/native_install/tests.rs
+++ b/rust/crates/tmt-core/src/native_install/tests.rs
@@ -6,6 +6,68 @@ fn version(value: &str) -> Version {
     Version::parse(value).expect("test version must be valid")
 }
 
+#[test]
+fn upgrade_intent_is_resolved_before_discovery() {
+    let current = installed("5.0.0-alpha.2", Channel::Alpha, Some("5.0.0-alpha.2"));
+    assert_eq!(
+        select_upgrade(&current, None, None, false),
+        Ok(UpgradeSelection::Pinned)
+    );
+    assert_eq!(
+        select_upgrade(&current, Some(Channel::Stable), None, false),
+        Err(VersionError::Pinned)
+    );
+    assert_eq!(
+        select_upgrade(&current, None, Some("5.0.0-alpha.3"), true),
+        Err(VersionError::InvalidSelection)
+    );
+    assert_eq!(
+        select_upgrade(&current, None, Some("5.0.0-alpha.1"), false),
+        Err(VersionError::Downgrade)
+    );
+    assert_eq!(
+        select_upgrade(&current, None, Some("invalid"), false),
+        Err(VersionError::InvalidSelection)
+    );
+    assert_eq!(
+        select_upgrade(&current, None, Some("5.0.0-alpha.3"), false),
+        Ok(UpgradeSelection::Fetch {
+            channel: Channel::Alpha,
+            exact: Some(version("5.0.0-alpha.3")),
+            pin: PinAction::PinCandidate
+        })
+    );
+    assert_eq!(
+        select_upgrade(&current, None, None, true),
+        Ok(UpgradeSelection::Fetch {
+            channel: Channel::Alpha,
+            exact: None,
+            pin: PinAction::Clear
+        })
+    );
+}
+
+#[test]
+fn latest_selection_is_channel_scoped_semantic_and_unambiguous() {
+    let versions = ["5.0.0-alpha.2", "5.0.0-alpha.10", "5.0.0", "6.0.0-beta.1"].map(version);
+    assert_eq!(
+        latest_in_channel(&versions, Channel::Alpha).unwrap(),
+        Some(&versions[1])
+    );
+    assert_eq!(
+        latest_in_channel(&versions, Channel::Stable).unwrap(),
+        Some(&versions[2])
+    );
+    assert_eq!(latest_in_channel(&[], Channel::Stable).unwrap(), None);
+    assert_eq!(
+        latest_in_channel(
+            &[version("5.0.0+one"), version("5.0.0+two")],
+            Channel::Stable
+        ),
+        Err(VersionError::EqualPrecedenceChange)
+    );
+}
+
 fn installed(value: &str, channel: Channel, pinned: Option<&str>) -> InstalledVersion {
     InstalledVersion {
         version: version(value),

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -17,8 +17,9 @@ Rust executable is a development preview: use isolated test state only, never an
 existing user database (schema 9 is forward-only and TypeScript cannot reopen it).
 Its help explicitly identifies the native preview. It implements configuration,
 identity, talk/reply/result, check/read, role/preamble, X, initialization and
-skill viewing/installation. Native network upgrade is still a separate delivery
-gate; do not fall back to TypeScript on the same upgraded database. Native talk
+skill viewing/installation and managed native upgrade/update. Public native
+release availability and runtime cutover remain separate delivery gates; do not
+fall back to TypeScript on the same upgraded database. Native talk
 supplies a compact `v2_` receipt; use it unchanged. Native reply also accepts
 retained legacy receipts, but TypeScript cannot consume native receipts or
 schema 9. The common communication contracts below apply to both runtimes;
@@ -80,8 +81,9 @@ Timeout and interruption end only the observer, never recipient work. A
 retrying. Missing visible output is not permission to resend.
 
 `help`, `version`, `completion` and `learn` are text-only and reject
-`--json` with `JSON_UNSUPPORTED`; run them without that flag. `upgrade`
-also rejects JSON mode because it streams installer output.
+`--json` with `JSON_UNSUPPORTED`; run them without that flag. TypeScript `upgrade`
+also rejects JSON mode because it streams installer output. Native managed
+`upgrade`/`update` supports one structured JSON result, including partial failures.
 
 ## Durable replies and results
 
@@ -384,7 +386,8 @@ identities. Use `name`, `this`, or `add` explicitly to bind such a pane. Invalid
 metadata is not active presence; do not delete durable data or old files to
 repair it. Direct pane targeting remains separate from identity discovery.
 
-V5 does not support `update`, `remove`/`rm`, or `migrate`. Use explicit binding
+The installed TypeScript runtime does not support `update`, `remove`/`rm`, or
+`migrate`; native-only update/removal behavior is described separately. Use explicit binding
 commands above; `unbind` only detaches the current pane and retains its durable
 identity/profile. Do not delete old user files as a migration workaround.
 
@@ -410,7 +413,7 @@ using `--force`, which creates recoverable skill backups outside the discovery r
 An old Claude `commands/team.md`
 is preserved with a warning by default; explicit forced Claude installation can
 back it up after the native skill is installed. Plugin settings are never modified.
-Managed links follow package updates. `tmt upgrade` tracks npm `latest`, not
+Managed links follow package updates. TypeScript `tmt upgrade` tracks npm `latest`, not
 commit-pinned previews; follow the selected release's installation instructions.
 After upgrading the CLI, run `tmt install` and reload or restart the agent.
 For an existing conversation, run `tmt learn --skill` and read its complete output
@@ -535,5 +538,23 @@ not all-or-nothing. Custom target intents are recorded in `skill-installations.j
 for future managed refresh, never as permission to overwrite their content.
 Native passive reminders cover known defaults only during interactive human
 commands; JSON and piped automation do not perform that scan. Neither installation
-nor a reminder reloads an active conversation. Native network `upgrade` remains
-unavailable until the separate distribution gate is complete.
+nor a reminder reloads an active conversation.
+
+For a managed native installation, `tmt upgrade` (alias `tmt update`) retains the
+receipt's channel. `--channel stable|alpha` selects a channel, `--to <version>`
+pins an exact version, and `--unpin` resumes channel updates; do not combine
+`--to` and `--unpin`. Downgrades are rejected. An ordinary pinned invocation is
+a no-network no-op. Package-manager or unmanaged binaries refuse native updates;
+use their original manager, not an overwrite workaround. No public native
+download is implied until its separate release gate is complete.
+
+Successful native updates use the new executable to refresh only recorded
+managed skills. Missing integrations stay missing and modified content is
+preserved. With `--json`, inspect `changed`, `version`, `pinnedVersion`, `skills`
+and any `error`; a nonzero result can mean the binary is already active while
+skill refresh or finalization failed. Resolve the reported conflict and repeat
+the original update selection (including `--to <version>` when pinned); an
+ordinary pinned invocation will not retry skill work. Do not downgrade or
+delete user content. Check `pathWarning` before assuming the
+shell selects the updated binary. Reload/restart the agent, or read the complete
+`tmt learn --skill` output in an existing conversation.

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -64,7 +64,7 @@ describe('native grammar preview process contract', () => {
       expect(help.stdout).toContain(
         'configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, x attention, init, learn, and skill installation are available'
       );
-      expect(help.stdout).toContain('Native network upgrade is not implemented yet.');
+      expect(help.stdout).toContain('Managed native upgrade/update is supported');
       expect(help.stdout).toContain('Manage identity records without probing tmux');
       expect(help.stdout).toContain('temporary unless saved');
       expect(help.stdout).toContain('rm');
@@ -75,13 +75,17 @@ describe('native grammar preview process contract', () => {
     });
   });
 
-  it('does not attempt a network upgrade in the native preview', async () => {
+  it('rejects unmanaged upgrades before effects and supports structured alias failures', async () => {
     await withSandbox(async (sandbox) => {
       const before = fileSnapshot(sandbox.root);
       const result = await runCli(sandbox, ['upgrade']);
       expect(result.status).toBe(1);
       expect(result.stdout).toBe('');
-      expect(result.stderr).toContain('not implemented');
+      expect(result.stderr).toContain('not a managed native installation');
+      const alias = await runCli(sandbox, ['update', '--json']);
+      expect(alias.status).toBe(1);
+      expectError(alias, 'NATIVE_UPGRADE_FAILED');
+      expect(alias.stderr).toBe('');
       expect(fileSnapshot(sandbox.root)).toEqual(before);
       expect(existsSync(sandbox.database)).toBe(false);
     });

--- a/test/native/native-installation.test.ts
+++ b/test/native/native-installation.test.ts
@@ -256,6 +256,42 @@ describe('native installation process contract', () => {
           channel: 'alpha',
           pinned_version: fixture.version,
         });
+        const managed = {
+          ...sandbox,
+          cli: { executable: pinned.executable, args: [] },
+          env: { ...sandbox.env, PATH: path.dirname(pinned.executable) },
+        };
+        const pinnedReceipt = readFileSync(receiptPath(prefix));
+        for (const command of ['upgrade', 'update']) {
+          const result = await runCli(managed, [command, '--json']);
+          expect(result.status).toBe(0);
+          expect(result.stderr).toBe('');
+          expect(parseWholeStdout(result)).toMatchObject({
+            version: fixture.version,
+            changed: false,
+            channel: 'alpha',
+            pinned: true,
+            pinnedVersion: fixture.version,
+            skippedPinned: true,
+            skills: null,
+            pathWarning: null,
+          });
+        }
+        const shadowed = await runCli({ ...managed, env: { ...managed.env, PATH: '' } }, [
+          'upgrade',
+          '--json',
+        ]);
+        expect(shadowed.status).toBe(0);
+        expect(parseWholeStdout(shadowed).pathWarning).toContain('PATH does not select');
+        const badChannel = await runCli(managed, ['upgrade', '--channel', 'stable', '--json']);
+        expect(badChannel.status).toBe(1);
+        expectError(
+          badChannel,
+          'NATIVE_UPGRADE_FAILED',
+          'The installation is pinned; explicitly select a version or unpin it.'
+        );
+        expect(readFileSync(receiptPath(prefix))).toEqual(pinnedReceipt);
+        expect(existsSync(sandbox.database)).toBe(false);
         expect(
           readFileSync(path.join(prefix, 'lib', 'tmux-team', 'releases', originalId, 'tmt')).equals(
             originalBytes
@@ -265,6 +301,23 @@ describe('native installation process contract', () => {
         const unpinned = await install(sandbox, fixture, prefix, ['--unpin']);
         const unpinnedId = currentReleaseId(prefix);
         expect(unpinned.changed).toBe(true);
+        const stale = await runCli(
+          {
+            ...sandbox,
+            cli: {
+              executable: path.join(prefix, 'lib', 'tmux-team', 'releases', pinnedId, 'tmt'),
+              args: [],
+            },
+          },
+          ['upgrade', '--json']
+        );
+        expect(stale.status).toBe(1);
+        expectError(
+          stale,
+          'NATIVE_UPGRADE_FAILED',
+          'This executable is not the active managed release. Run the current native installation, or update using its original package manager.'
+        );
+        expect(currentReleaseId(prefix)).toBe(unpinnedId);
         expect(unpinnedId).not.toBe(pinnedId);
         expect(receipt(prefix)).toMatchObject({
           version: fixture.version,


### PR DESCRIPTION
## Scope

Closes #142. Implements native `tmt upgrade` and the exact `update` alias under #82/#93. Public shell bootstrap, release publication, and npm replacement remain separate work; this does not claim a downloadable native release exists.

## Architecture and primary review

Reviewed commit: `b0a513b52fa1131d05165931e9cdc614bb84ee75`.

The primary reviewed the changed production modules, callers, parser/output contracts, test fixtures and assertions, dependency graph and documentation. Pure channel/version/pin policy stays in core. Canonical GitHub acquisition and bounded HTTPS stay in adapters. Publication reuses #138's installation owner; skill refresh reuses #141 through the newly activated executable and the existing bounded process runner. No second publisher, process runner, skill registry, SQLite connection, or provider discovery was added.

Findings corrected during review:

- Fence refresh under the installation lock so an older updater cannot publish old skills after a newer binary activation. Lock order is installation then skill; downloads hold neither.
- Preserve explicit pin selection in partial-failure retry guidance; ordinary pinned updates intentionally perform no network or skill writes.
- Correct actual-artifact fixture target ownership and conflict assertions, and use distinct real old/new archives and embedded skill bytes.
- Strengthen the actual TLS deadline test to distinguish one shared deadline from per-hop resets, and join its worker before assertions on failure.
- Preserve bounded child output only for fully observed nonzero exits; validate the skill protocol and reject malformed, timed-out, oversized or unclean results.

The trust boundary is authenticated HTTPS to the fixed canonical GitHub origin plus immutable-release metadata and dual asset/manifest digests. This is not independent client-side attestation verification or protection against a compromised trusted origin. No endpoint override, TLS bypass, async runtime or curl fallback is present. ureq 3.4.0 uses native certificate trust and library proxy handling; complete target-filtered notices are retained. RustSec audit of the lockfile found zero vulnerabilities or warnings (1,242 advisories, database commit `bf25f6575a93a35f30796c65c0ed91bee7fa19fd`).

## Verification

- [x] Primary review of changed files and relevant callers/tests.
- [x] `cargo fmt --all --check`, strict locked Clippy, and Rust 1.88 locked build.
- [x] `cargo test --locked`: 393 passed; one explicitly ignored real-artifact gate is run separately below.
- [x] `pnpm check`; `pnpm test:run`: 1,131 tests in 72 files passed.
- [x] Final `pnpm test:native` with explicit native CLI/probe: 104 tests in 13 files passed (39.89 seconds).
- [x] Documented shared native parser subset: 8 passed; config subset: 6 passed. Excluded cases are not counted as native parity.
- [x] Independently verified final macOS arm64 cargo-dist archive: linkage, version, exact skill, managed installation and SQLite persistence in isolated temporary state.
- [x] Explicit `cargo_dist_upgrade_refreshes_real_artifacts_and_preserves_conflicts -- --ignored`: one selected test passed (1.76 seconds), using actual separately versioned archives. Canonical acquisition is injected; real old/new executables run with scrubbed environments. This does not claim public network availability.
- [x] Canonical skill authoring validation and target-filtered dependency notices.
- [x] Two final-source `pnpm test:e2e` Docker lifecycle passes: each passed 283 native adapter tests (one explicit real-artifact gate ignored), then 159 E2E scenarios in 34 files; one optional performance scenario skipped. Vitest durations 313.89 / 312.96 seconds. The shared suite includes explicitly native scenarios and TypeScript reference scenarios; it is not claimed as 159 native-only cases.
- [x] All 11 required CI checks passed on exact reviewed head `b0a513b52fa1131d05165931e9cdc614bb84ee75` before merge, on the first submitted candidate.

## Lifecycle

Architecture, development verification, native installation guidance, Rust roadmap and canonical installed skill are updated in this PR. Branch `feat/142-native-upgrade` has its own worktree; it will be removed only after a green authorized merge and clean/pushed-state checks. Next bounded work is curl bootstrap and fresh npm/pnpm replacement guidance, without data migration or automatic deletion of old data. No public tags, release, package publication, host installation or user-state changes were performed.
