### PR TITLE
feat(install): add verified curl bootstrap and npm replacement guidance

### DIFF
--- a/.agents/skills/tmt-release/SKILL.md
+++ b/.agents/skills/tmt-release/SKILL.md
@@ -36,6 +36,13 @@ Use this skill for release-line maintenance, v4 compatibility fixes, v5 promotio
   finalization and unchanged data. The internal preview entrypoint is not a
   public bootstrap or permission to replace a user/package-manager installation.
 - Promotion requires passing Code quality, Unit tests, and Docker E2E checks.
+- For curl bootstrap, follow DEVELOPMENT's native curl bootstrap verification.
+  Generate from final verified cargo-dist artifacts and invoke the existing
+  native publisher; do not enable a competing stock installer. Test an actual
+  matching-host archive without Node/Rust on runtime PATH, and distinguish
+  controlled-download evidence from an authorized public release smoke test.
+  npm/pnpm replacement is a fresh installation without data-transfer machinery,
+  not permission to delete old state or silently uninstall another manager.
 - Tags, GitHub Releases, npm publishing, and npm dist-tags are separate operations that require explicit authorization; this skill never assumes permission for them.
 - Update user-facing installation or channel documentation whenever a version change would make it inaccurate.
 - A future prerelease publish must use a non-`latest` npm dist-tag. Before declaring it available, inspect the registry dist-tags and install the exact published version in a clean temporary environment.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1342,9 +1342,11 @@ not merely a healthy empty database.
 
 This is a forward-only development boundary: installed TypeScript remains on
 schema 8 and rejects schema 9. Do not use the native preview against user state
-or run old and new writers on the same database. Before distribution, #82/#93
-must provide stopped-writer cutover, consistent backup/recovery and preserved
-old-receipt execution. Replacing a binary does not downgrade a database.
+or run old and new writers on the same database. The user-approved npm/pnpm
+transition is a fresh installation without new data-transfer or backup/recovery
+machinery. Installation leaves old data alone; existing schema/receipt tests
+remain safety evidence, not a mixed-runtime promise. Replacing a binary does not
+downgrade a database.
 
 `storage-probe` is a development-only example using that real adapter, not a
 public CLI command or alternate storage implementation. Shared bounded subprocess
@@ -1561,6 +1563,29 @@ preserves valid partial reports and returns failure without claiming binary
 rollback when skill refresh fails. Timeouts, malformed reports and oversized
 output are failures, not successful updates. Shell bootstrap, public publication
 and installed-runtime cutover are separate delivery gates.
+
+### Release-generated curl bootstrap
+
+Under #144, `scripts/native-bootstrap.mjs` consumes the final cargo-dist manifest
+and local archives through the existing independent artifact policy. It emits a
+version-specific POSIX script from `scripts/native-bootstrap.sh`, embedding only
+verified version/channel, target names, sizes and hashes. The uname mapping is
+platform dispatch, not another release catalog. Stock cargo-dist installers
+remain disabled because their persistent publication would duplicate TMT's owner.
+
+The generated release asset uses canonical HTTPS versioned downloads, verified
+sizes/SHA-256 and private temporary staging. It streams only the known executable
+to a fixed file; archive paths are never unpacked into the installation prefix.
+That executable's `__native-install` owns all persistent binary writes. Initial
+receipts stay truthfully local-archive provenance. This trusts the official script
+and HTTPS origin; it is not independent client attestation verification.
+
+The new absolute command optionally runs existing skill installation. Conflicts
+are never silently forced; a failure reports partial completion. Shell PATH
+inspection never invokes an old command, modifies profiles or uninstalls a
+package. npm replacement adds no data-transfer or deletion path. The generator
+and actual-artifact verifier are developer tools, not end-user Node dependencies.
+Public release publication and matching-target evidence remain separate gates.
 
 ## Maintenance contract
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -782,6 +782,13 @@ endpoint. It checks repeat/no-op, explicit pin followed by no-network upgrade,
 exact installed skill bytes, old npm command preservation, PATH warning and
 temporary cleanup. It is not live GitHub download or cross-target evidence.
 
+The existing `test/native/artifact.Dockerfile` also carries this verifier. After
+building its task-owned matching-architecture image, run the normal artifact
+entrypoint, then repeat with `--entrypoint node` and
+`scripts/verify-native-bootstrap.mjs --manifest native-manifest.json --archive
+artifacts/<archive-name> --target <target> --skill expected-skill.md`. Keep
+`--rm --init --network none` and remove only the task-owned image afterwards.
+
 `src/native-bootstrap.test.ts` covers the generated shell's negative paths with
 the existing bounded CLI sandbox and a synthetic executable for orchestration.
 Do not count that stub as native publication evidence; pair it with the actual

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -758,6 +758,40 @@ unpin advancement, a retained executable, no-op and downgrade rejection, exact
 embedded skill and unchanged SQLite bytes during installation. Its temporary
 prefix/application state is always invocation-owned and removed afterward.
 
+## Native curl bootstrap verification
+
+Generate the release-specific script only after final cargo-dist archives and
+their independent runtime verification. All selected archives must be present;
+the manifest, not a hand-maintained version table, owns the generated facts:
+
+```sh
+node scripts/generate-native-bootstrap.mjs \
+  --manifest /absolute/dist-manifest.json --archive-dir /absolute/artifacts \
+  > /absolute/artifacts/tmt-installer.sh
+sh -n /absolute/artifacts/tmt-installer.sh
+node scripts/verify-native-bootstrap.mjs \
+  --manifest /absolute/dist-manifest.json \
+  --archive /absolute/artifacts/tmt-cli-aarch64-apple-darwin.tar.gz \
+  --target aarch64-apple-darwin --skill skills/tmux-team/SKILL.md
+```
+
+The last command requires actual matching-host release artifacts, uses isolated
+HOME/state/PATH, real shell utilities and the new native executable. Only curl
+acquisition is replaced with task-owned fixture copies; production has no test
+endpoint. It checks repeat/no-op, explicit pin followed by no-network upgrade,
+exact installed skill bytes, old npm command preservation, PATH warning and
+temporary cleanup. It is not live GitHub download or cross-target evidence.
+
+`src/native-bootstrap.test.ts` covers the generated shell's negative paths with
+the existing bounded CLI sandbox and a synthetic executable for orchestration.
+Do not count that stub as native publication evidence; pair it with the actual
+artifact verifier. Run `pnpm check`, unit tests and two Docker lifecycle passes
+before the reviewed CI candidate. Keep generated outputs out of source control.
+No new runtime dependency, data migration or public publication is authorized
+by generation. An authorized release must upload the exact verified manifest,
+archives and generated script, establish immutable release/provenance evidence,
+and verify the public download before the README advertises it as available.
+
 ## Testing Strategy
 
 We prefer structured, deterministic assertions in tests. Human-facing formatting is validated sparingly; most tests assert on structured output or file contents.

--- a/NATIVE-INSTALL.md
+++ b/NATIVE-INSTALL.md
@@ -22,8 +22,8 @@ This example deliberately keeps its managed files in the temporary preview root.
 Choose a directory your provider discovers and reload its skills. Retain the
 included LICENSE and THIRD-PARTY-NOTICES.txt with redistributed binaries.
 
-Managed binary receipts and `upgrade`/`update` are implemented in the preview.
-Shell bootstrap and public native releases remain separate publication gates;
+Managed binary receipts, `upgrade`/`update`, and release-generated shell bootstrap
+are implemented in the preview. Public native releases remain a publication gate;
 do not assume a downloadable native release exists yet. Do not overwrite an
 npm, pnpm, Homebrew or manual installation.
 The selected executable's help is the capability authority; the shared alpha
@@ -50,3 +50,58 @@ separate release gate; do not describe locally generated checksums as signatures
 Target candidates are macOS x64/arm64 (deployment target 11.0) and Linux x64/arm64
 with a static musl runtime. Actual target execution and linkage must pass before
 release support is claimed; cross-compilation alone is not acceptance evidence.
+
+## Curl bootstrap
+
+Public native publication is still pending. Once published, use the release's
+exact `tmt-installer.sh` asset URL (replace `<VERSION>` with its version):
+
+```sh
+curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+  'https://github.com/wkh237/tmux-team/releases/download/v<VERSION>/tmt-installer.sh' | sh
+```
+
+The script fixes the initial version/channel, not a mutable alpha tag. Later
+`tmt upgrade` follows that channel. To inspect first, download the same URL to
+a file, read it, then run `sh tmt-installer.sh`. A failed/truncated download is
+not installation success; check the installed absolute command afterwards.
+
+Default prefix: `$HOME/.local`, with commands in `~/.local/bin`. Options after
+`sh -s --` (or the downloaded script):
+
+- `--prefix /absolute/directory`: another prefix, including paths with spaces.
+- `--pin`: pin this release; `tmt upgrade --unpin` resumes channel updates.
+- `--no-skill`: binary only. Otherwise the new absolute command runs the existing
+  non-interactive `tmt install`; no provider application is installed.
+
+Requires POSIX shell, curl, tar/gzip, standard filesystem utilities and
+`sha256sum` or `shasum`. No Node, Rust, jq or sudo. The script verifies manifest
+and archive sizes/digests before executing the temporary binary, then delegates
+permanent writes to the native installer. It does not edit shell profiles or
+touch SQLite. Initial receipts record local-archive verification, not independent
+attestation provenance. HTTPS and hashes do not protect a compromised origin.
+
+## Replacing npm or pnpm
+
+This is a fresh installation, not a data-transfer or compatibility tool. Stop old
+TMT commands/agents before switching. Installation neither migrates nor deletes
+old configuration/databases or uninstalls another manager's files.
+
+For an npm installation, use `npm uninstall -g tmux-team`; for pnpm, use
+`pnpm remove -g tmux-team`. Do not run both blindly. A collision in the selected
+prefix is refused: choose another prefix or remove the old package through its
+actual owner. Homebrew/manual installations likewise retain their own lifecycle.
+
+Put the new prefix's `bin` first in PATH, then run `hash -r` or open a new shell.
+Check `command -v tmt`, `command -v tmux-team` and the new absolute `tmt --help`.
+The installer warns about PATH shadowing and never runs the old command. An
+installed binary is not proof your shell selects it; aliases/functions and other
+open shells may need separate correction.
+
+Old npm-linked skills may conflict. Inspect them, then explicitly run the new
+absolute `tmt install --force` if replacement is intended. The shared installer
+makes recoverable backups; bootstrap never silently forces. Skill failure returns
+nonzero after binary installation, without claiming rollback. Reload the agent
+or ask it to read the complete `tmt learn --skill`. No historical-session
+continuity or SQLite downgrade is promised; never use the old TypeScript writer
+on a schema-9 database.

--- a/README.md
+++ b/README.md
@@ -134,12 +134,15 @@ an older command or plugin installed.
 ## Native rewrite development
 
 The Rust executable is an isolated development preview, not the installer above.
-It supports configuration, `identity create/show/list`, and pane identity
-`name`/`this`/`add`/`whoami`/`unbind`/`rm`/`ls`. Native bindings are temporary
+It supports collaboration, complete durable replies, X attention, profiles,
+configuration, skill installation and managed `upgrade`/`update`. Bindings are temporary
 unless saved with `-s`; `ls` shows lifetime and active/offline/unknown presence.
-Messaging still requires the TypeScript runtime. Do not point
-the native preview at existing user data: its schema upgrade is forward-only.
-See [development and verification](DEVELOPMENT.md#native-development-preview).
+The verified curl installer is generated with each native release; public release
+publication is still pending. It installs without Node, Rust or sudo, then uses
+`tmt upgrade`. See [native installation and npm replacement](NATIVE-INSTALL.md#curl-bootstrap)
+for the release-URL workflow and PATH handling. The approved transition is a fresh
+installation without data transfer or automatic deletion. Do not share upgraded
+SQLite state with the old TypeScript writer.
 
 ## License
 

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -493,14 +493,12 @@ upgrade. Do not weaken history validation or maintain a second native legacy
 mode just to preserve a transitional test. Native development uses isolated
 fixtures, never a live user database.
 
-Before release, #82/#93 must stop old writers, create a consistent recoverable
-backup and explain that binary rollback is not schema downgrade. Acceptance
-still requires every supported historical prefix, exact retained records,
-native concurrent lifecycle/attention races, and execution of old v1 receipts
-against migrated in-flight and retained requests. #106 owns receipt transition;
-this schema slice proves preservation, not execution. A restored pre-upgrade
-backup cannot include work written after upgrade; recovery must not promise
-lossless downgrade. Final cutover removes the production TS runtime and
+The user approved a fresh npm/pnpm replacement without data-transfer or
+backup/recovery machinery. Stop old writers before switching; the installer does
+not open, migrate or delete application data. Existing historical-schema,
+retained-record, native concurrency and receipt tests remain regression evidence,
+not a promise of mixed-runtime continuity or lossless downgrade. Binary rollback
+is not schema downgrade. Final cutover removes the production TS runtime and
 redundant transitional adapters; Node-based tests and historical fixtures may stay.
 
 ## Delivery gates
@@ -510,7 +508,7 @@ Next comes [executable selection (#95)](https://github.com/wkh237/tmux-team/issu
 then [native grammar (#96)](https://github.com/wkh237/tmux-team/issues/96) and
 [storage foundations (#97)](https://github.com/wkh237/tmux-team/issues/97), then
 the smallest identity-to-durable-reply vertical slice. Complete the remaining
-contracts and mixed-runtime matrix before cutover and distribution readiness.
+contracts and the approved native acceptance matrix before cutover and distribution readiness.
 Each implementation PR has its own issue/worktree, bounded contract matrix,
 local checks, primary review and one candidate CI push. Split any slice that
 cannot remain reviewable; preparation does not pre-authorize one giant rewrite PR.
@@ -537,6 +535,8 @@ Managed skill refresh prerequisite #141 supplies an internal new-executable
 entrypoint over the existing skill owner, preserving modified and missing
 integrations with partial-effect reporting. #142 wires it to native upgrade/update
 with bounded canonical HTTPS discovery and compare-before-activation fencing.
-HTTPS bootstrap, authenticated
-public provenance and installed-runtime cutover remain #82/#93 work, not
-capabilities supplied by the archive generator or offline installer alone.
+#144 adds a release-generated curl bootstrap over that same offline installer,
+with manifest-derived sizes/digests and fresh npm replacement guidance. Actual
+matching-host archives are tested without Node/Rust on runtime PATH. Public
+immutable publication, remaining target execution and installed-runtime cutover
+remain #82/#93 gates; a local generated installer is not a live download.

--- a/scripts/generate-native-bootstrap.mjs
+++ b/scripts/generate-native-bootstrap.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { parseArgs } from 'node:util';
+import { generateNativeBootstrap } from './native-bootstrap.mjs';
+
+const { values } = parseArgs({
+  options: { manifest: { type: 'string' }, 'archive-dir': { type: 'string' } },
+});
+assert(
+  values.manifest && values['archive-dir'],
+  'Usage: --manifest <file> --archive-dir <directory>'
+);
+process.stdout.write(await generateNativeBootstrap(values.manifest, values['archive-dir']));

--- a/scripts/native-artifact-policy.mjs
+++ b/scripts/native-artifact-policy.mjs
@@ -15,7 +15,7 @@ function archiveRootName(name) {
   return name.slice(0, -'.tar.gz'.length);
 }
 
-function readBoundedFile(file, limit) {
+export function readBoundedFile(file, limit) {
   const descriptor = fs.openSync(
     file,
     fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK

--- a/scripts/native-bootstrap.mjs
+++ b/scripts/native-bootstrap.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  readBoundedFile,
+  selectNativeArtifact,
+  withNativeArtifact,
+} from './native-artifact-policy.mjs';
+
+// This maps uname evidence, not a second release inventory. Only artifacts in
+// the verified cargo-dist manifest are emitted into the generated installer.
+const hosts = {
+  'aarch64-apple-darwin': 'Darwin:arm64|Darwin:aarch64',
+  'x86_64-apple-darwin': 'Darwin:x86_64',
+  'aarch64-unknown-linux-musl': 'Linux:aarch64|Linux:arm64',
+  'x86_64-unknown-linux-musl': 'Linux:x86_64',
+};
+
+/** Release tooling only: verify local artifacts before generating executable code. */
+export async function generateNativeBootstrap(manifestFile, archiveDirectory) {
+  const bytes = readBoundedFile(manifestFile, 4 * 1024 * 1024);
+  const manifest = JSON.parse(bytes);
+  const entries = Object.entries(manifest.artifacts ?? {}).filter(
+    ([, artifact]) => artifact.kind === 'executable-zip'
+  );
+  assert(entries.length > 0 && entries.length <= 4, 'Require one to four native artifacts');
+  const seen = new Set();
+  const cases = [];
+  let version;
+  for (const [name, artifact] of entries) {
+    assert(/^[a-zA-Z0-9][a-zA-Z0-9._-]*\.tar\.gz$/.test(name), 'Unsafe native archive name');
+    assert.equal(artifact.target_triples?.length, 1, 'Require one native target per archive');
+    const target = artifact.target_triples[0];
+    assert(Object.hasOwn(hosts, target), 'Unsupported bootstrap target');
+    assert(!seen.has(target), 'Duplicate bootstrap target');
+    seen.add(target);
+    const archive = path.join(archiveDirectory, name);
+    const metadata = selectNativeArtifact(manifestFile, archive, target);
+    // Restrict code interpolation to URL-safe version tokens. Runtime semver and
+    // forward-only pin policy remain in the native installer, not this generator.
+    assert(
+      /^\d+\.\d+\.\d+(?:-alpha(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(
+        metadata.version
+      ),
+      'Unsafe or unsupported bootstrap version'
+    );
+    version ??= metadata.version;
+    assert.equal(metadata.version, version, 'Bootstrap artifacts must share one version');
+    await withNativeArtifact(archive, metadata, () => undefined);
+    const size = readBoundedFile(archive, 64 * 1024 * 1024).length;
+    cases.push(
+      `    ${hosts[target]}) archive='${name}'; archive_hash='${metadata.sha256}'; archive_size=${size} ;;`
+    );
+  }
+  assert(
+    readBoundedFile(manifestFile, 4 * 1024 * 1024).equals(bytes),
+    'Manifest changed during generation'
+  );
+  const template = fs.readFileSync(new URL('./native-bootstrap.sh', import.meta.url), 'utf8');
+  const replacements = {
+    VERSION: version,
+    CHANNEL: version.split('+')[0].includes('-') ? 'alpha' : 'stable',
+    MANIFEST_HASH: createHash('sha256').update(bytes).digest('hex'),
+    MANIFEST_SIZE: String(bytes.length),
+    TARGET_CASES: cases.sort().join('\n'),
+  };
+  return template.replace(/@@([A-Z_]+)@@/g, (_, key) => {
+    assert(Object.hasOwn(replacements, key), `Unknown bootstrap template field ${key}`);
+    return replacements[key];
+  });
+}

--- a/scripts/native-bootstrap.sh
+++ b/scripts/native-bootstrap.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Generated from verified cargo-dist artifacts; do not maintain release facts here.
+# HTTPS and embedded digests trust the official origin, not an independent signature.
+set -eu
+
+main() {
+  version='@@VERSION@@'
+  channel='@@CHANNEL@@'
+  prefix=${HOME:?HOME is required}/.local
+  pin=no
+  skill=yes
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --prefix)
+        [ "$#" -ge 2 ] || fail '--prefix requires an absolute directory.'
+        prefix=$2
+        shift 2 ;;
+      --pin) pin=yes; shift ;;
+      --no-skill) skill=no; shift ;;
+      --help)
+        printf '%s\n' 'Usage: sh installer.sh [--prefix /absolute/directory] [--pin] [--no-skill]'
+        return 0 ;;
+      *) fail "Unknown installer option: $1" ;;
+    esac
+  done
+  case "$prefix" in /*) ;; *) fail '--prefix must be absolute.' ;; esac
+  [ "$prefix" != / ] || fail 'Refusing the filesystem root as an installation prefix.'
+  for utility in curl uname mktemp rm wc tar chmod; do
+    command -v "$utility" >/dev/null 2>&1 || fail "Required utility is missing: $utility"
+  done
+  if command -v sha256sum >/dev/null 2>&1; then
+    hash_tool=sha256sum
+  elif command -v shasum >/dev/null 2>&1; then
+    hash_tool=shasum
+  else
+    fail 'SHA-256 verification requires sha256sum or shasum.'
+  fi
+  host="$(uname -s):$(uname -m)"
+  case "$host" in
+@@TARGET_CASES@@
+    *) fail "This installer has no verified artifact for $host." ;;
+  esac
+
+  umask 077
+  # Only successful mktemp creation grants deletion ownership. The trap is
+  # installed immediately; no existing install or abandoned stage is removed.
+  stage=$(mktemp -d "${TMPDIR:-/tmp}/tmt-bootstrap.XXXXXXXX")
+  trap 'cleanup' 0
+  trap 'exit 130' INT
+  trap 'exit 143' TERM HUP
+  base="https://github.com/wkh237/tmux-team/releases/download/v$version"
+  download "$base/dist-manifest.json" "$stage/dist-manifest.json" @@MANIFEST_SIZE@@
+  verify "$stage/dist-manifest.json" @@MANIFEST_SIZE@@ '@@MANIFEST_HASH@@'
+  download "$base/$archive" "$stage/$archive" "$archive_size"
+  verify "$stage/$archive" "$archive_size" "$archive_hash"
+
+  # Do not extract archive paths into the filesystem. The generator has checked
+  # the complete archive inventory; its digest binds this one selected stream.
+  tar -xzOf "$stage/$archive" "${archive%.tar.gz}/tmt" > "$stage/tmt"
+  chmod 700 "$stage/tmt"
+  set -- __native-install --archive "$stage/$archive" \
+    --manifest "$stage/dist-manifest.json" --prefix "$prefix" --channel "$channel"
+  if [ "$pin" = yes ]; then set -- "$@" --pin; fi
+  if "$stage/tmt" "$@"; then
+    :
+  else
+    status=$?
+    printf '%s\n' 'Native installation did not finish cleanly; inspect the error above before retrying.' \
+      'If the prefix contains an npm/pnpm/brew/manual command, choose another prefix or remove it with its original manager. This installer never overwrites that command.' >&2
+    return "$status"
+  fi
+
+  printf '%s\n' "Native tmt is installed at $prefix/bin/tmt."
+  selected=$(command -v tmt || :)
+  selected_alias=$(command -v tmux-team || :)
+  if [ "$selected" != "$prefix/bin/tmt" ] || [ "$selected_alias" != "$prefix/bin/tmux-team" ]; then
+    printf '%s\n' "PATH may still select another installation (tmt: ${selected:-not found}; tmux-team: ${selected_alias:-not found})." \
+      "Put $prefix/bin first in PATH, then run hash -r or open a new shell." \
+      'If replacing an npm/pnpm installation, remove it with npm uninstall -g tmux-team or pnpm remove -g tmux-team using its original manager.' \
+      'For Homebrew/manual installs, use their original uninstall procedure. No old installation or shell profile was changed.'
+  fi
+  if [ "$skill" = yes ]; then
+    if ! "$prefix/bin/tmt" install; then
+      printf '%s\n' 'The native binary is installed, but skill setup failed. Inspect conflicts before explicitly running the new tmt install --force; it backs up conflicting links/content.' \
+        'No data was migrated or deleted. Retry with the absolute new tmt path.' >&2
+      return 1
+    fi
+    printf '%s\n' 'Reload your agent, or read tmt learn --skill in an existing conversation.'
+  fi
+  printf '%s\n' 'Use the new tmt upgrade for subsequent native updates. Application data was not migrated or deleted.'
+}
+
+fail() { printf '%s\n' "$*" >&2; exit 1; }
+
+download() {
+  # Disable user curl configuration; never accept an inherited insecure flag.
+  curl --disable --fail --silent --show-error --location --proto '=https' \
+    --proto-redir '=https' --max-redirs 3 --connect-timeout 10 --max-time 60 \
+    --max-filesize "$3" --output "$2" "$1"
+}
+
+verify() {
+  actual_size=$(wc -c < "$1")
+  [ "$actual_size" -eq "$2" ] || fail 'Downloaded asset size mismatch.'
+  if [ "$hash_tool" = sha256sum ]; then
+    actual_hash=$(sha256sum "$1")
+  else
+    actual_hash=$(shasum -a 256 "$1")
+  fi
+  actual_hash=${actual_hash%% *}
+  [ "$actual_hash" = "$3" ] || fail 'Downloaded asset SHA-256 mismatch.'
+}
+
+cleanup() {
+  status=$?
+  trap - 0
+  if ! rm -rf -- "$stage"; then
+    printf '%s\n' 'Could not remove the private bootstrap staging directory.' >&2
+    [ "$status" -ne 0 ] || status=1
+  fi
+  exit "$status"
+}
+
+# Parse the complete final compound command before invoking main. A download
+# truncated after the word 'main' must not run with missing caller arguments.
+case complete in
+  complete) main "$@" ;;
+esac

--- a/scripts/native-bootstrap.sh
+++ b/scripts/native-bootstrap.sh
@@ -123,6 +123,6 @@ cleanup() {
 
 # Parse the complete final compound command before invoking main. A download
 # truncated after the word 'main' must not run with missing caller arguments.
-case complete in
-  complete) main "$@" ;;
-esac
+{
+  main "$@"
+}

--- a/scripts/verify-native-bootstrap.mjs
+++ b/scripts/verify-native-bootstrap.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+import { generateNativeBootstrap } from './native-bootstrap.mjs';
+import { selectNativeArtifact } from './native-artifact-policy.mjs';
+import { runPackedCommand } from './packed-command.mjs';
+
+const { values } = parseArgs({
+  options: Object.fromEntries(
+    ['manifest', 'archive', 'target', 'skill'].map((name) => [name, { type: 'string' }])
+  ),
+});
+for (const name of ['manifest', 'archive', 'target', 'skill']) {
+  assert(values[name], `--${name} is required`);
+}
+const metadata = selectNativeArtifact(values.manifest, values.archive, values.target);
+const architecture = { arm64: 'aarch64', x64: 'x86_64' }[process.arch];
+const platform = { darwin: 'apple-darwin', linux: 'unknown-linux-musl' }[process.platform];
+assert(architecture && platform, 'Unsupported verification host');
+assert.equal(values.target, `${architecture}-${platform}`, 'Use matching-host release artifacts');
+const script = await generateNativeBootstrap(values.manifest, path.dirname(values.archive));
+const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "tmt bootstrap's ")));
+try {
+  const tools = path.join(root, 'tools');
+  const old = path.join(root, 'old npm bin');
+  const prefix = path.join(root, 'native prefix');
+  const state = path.join(root, 'app state');
+  fs.mkdirSync(tools);
+  fs.mkdirSync(old);
+  const oldBytes = '#!/bin/sh\nexit 99\n';
+  fs.writeFileSync(path.join(old, 'tmt'), oldBytes, { mode: 0o755 });
+  for (const utility of ['uname', 'mktemp', 'rm', 'wc', 'tar', 'gzip', 'chmod', 'cp', 'sh']) {
+    const executable = runPackedCommand('/bin/sh', ['-c', 'command -v "$1"', 'resolve', utility], {
+      cwd: root,
+      env: process.env,
+    }).trim();
+    assert(path.isAbsolute(executable), `Expected a real system ${utility}`);
+    fs.symlinkSync(executable, path.join(tools, utility));
+  }
+  const hashTool = process.platform === 'darwin' ? 'shasum' : 'sha256sum';
+  const hashExecutable = runPackedCommand(
+    '/bin/sh',
+    ['-c', 'command -v "$1"', 'resolve', hashTool],
+    {
+      cwd: root,
+      env: process.env,
+    }
+  ).trim();
+  fs.symlinkSync(hashExecutable, path.join(tools, hashTool));
+  // Test-only acquisition replacement. The production installer has no endpoint
+  // override. All remaining shell/native work uses real tools and real archives.
+  fs.writeFileSync(
+    path.join(tools, 'curl'),
+    `#!/bin/sh
+set -eu
+destination=
+while [ "$#" -gt 1 ]; do
+  case "$1" in --output) destination=$2; shift 2 ;; *) shift ;; esac
+done
+case "$1" in
+  "https://github.com/wkh237/tmux-team/releases/download/v$TMT_FIXTURE_VERSION/dist-manifest.json") source=$TMT_FIXTURE_MANIFEST ;;
+  "https://github.com/wkh237/tmux-team/releases/download/v$TMT_FIXTURE_VERSION/$TMT_FIXTURE_NAME") source=$TMT_FIXTURE_ARCHIVE ;;
+  *) exit 91 ;;
+esac
+exec cp "$source" "$destination"
+`,
+    { mode: 0o755 }
+  );
+  const installer = path.join(root, 'installer.sh');
+  fs.writeFileSync(installer, script, { mode: 0o600 });
+  const env = {
+    HOME: root,
+    TMPDIR: root,
+    TMUX_TEAM_HOME: state,
+    LANG: 'C',
+    PATH: [old, tools].join(path.delimiter),
+    TMT_FIXTURE_VERSION: metadata.version,
+    TMT_FIXTURE_NAME: metadata.name,
+    TMT_FIXTURE_MANIFEST: path.resolve(values.manifest),
+    TMT_FIXTURE_ARCHIVE: path.resolve(values.archive),
+  };
+  const options = { cwd: root, env, timeoutMs: 30_000 };
+  const bootstrap = (flags = []) =>
+    runPackedCommand('/bin/sh', [installer, '--prefix', prefix, ...flags], options);
+  const first = bootstrap(['--no-skill']);
+  assert.match(first, /PATH may still select another installation/);
+  assert.match(first, /npm uninstall -g tmux-team/);
+  assert(!fs.existsSync(state), 'Binary-only bootstrap must not create application state');
+  const executable = path.join(prefix, 'bin/tmt');
+  const run = (args) => runPackedCommand(executable, args, options);
+  assert.equal(run(['--version']).trim(), metadata.version);
+  const pointer = path.join(prefix, 'lib/tmux-team/current');
+  const initial = fs.readlinkSync(pointer);
+  bootstrap();
+  assert.equal(fs.readlinkSync(pointer), initial, 'Repeat bootstrap must not create a release');
+  assert.equal(run(['learn', '--skill']), fs.readFileSync(values.skill, 'utf8'));
+  const installedSkill = path.join(root, '.agents/skills/tmux-team/SKILL.md');
+  assert.equal(fs.readFileSync(installedSkill, 'utf8'), fs.readFileSync(values.skill, 'utf8'));
+  assert(!fs.existsSync(path.join(state, 'tmux-team.db')), 'Skill setup must not open SQLite');
+  bootstrap(['--pin']);
+  const receipt = JSON.parse(
+    fs.readFileSync(path.join(prefix, 'lib/tmux-team/current/receipt.json'))
+  );
+  assert.equal(receipt.pinned_version, metadata.version);
+  const pinned = JSON.parse(run(['upgrade', '--json']));
+  assert.equal(pinned.skippedPinned, true, 'Pinned managed executable must update without network');
+  assert.equal(fs.readFileSync(path.join(old, 'tmt'), 'utf8'), oldBytes);
+  runPackedCommand('/bin/sh', [installer, '--no-skill'], options);
+  const defaultExecutable = path.join(root, '.local/bin/tmt');
+  assert.equal(
+    runPackedCommand(defaultExecutable, ['--version'], options).trim(),
+    metadata.version
+  );
+  assert(
+    !fs.readdirSync(root).some((name) => name.startsWith('tmt-bootstrap.')),
+    'Bootstrap staging leaked'
+  );
+  console.log(
+    `Verified actual native bootstrap: ${metadata.version} (${values.target}), isolated curl fixture, no Node/Rust runtime PATH`
+  );
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -521,6 +521,18 @@ from provider discovery.
 
 ### Native preview installation differences
 
+Native release installers use a versioned `tmt-installer.sh` URL supplied by the
+release; public publication may still be pending. Never invent a working URL or
+use npm `upgrade` as a native migration. The shell bootstrap defaults to
+`~/.local/bin/tmt`, supports `--prefix`, `--pin` and `--no-skill`, and otherwise
+runs the new absolute command's skill installer. It does not migrate/delete data
+or uninstall npm/pnpm. Check both `tmt` and `tmux-team` PATH selection; stop old
+writers before switching and never share upgraded state with TypeScript.
+Old npm skill links can conflict: inspect first, then explicitly use the new
+absolute `tmt install --force` if replacement is intended. A skill failure can
+leave the native binary installed; do not report rollback or silently force.
+Read this skill again through the new executable before using remembered syntax.
+
 The selected Rust executable embeds this exact skill; viewing and installation
 work after moving the binary, without Node or a checkout. Native installs link
 an immutable digest-addressed source under TMT's global directory

--- a/src/native-bootstrap.test.ts
+++ b/src/native-bootstrap.test.ts
@@ -1,0 +1,414 @@
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import * as tar from 'tar';
+import { runCli, withSandbox, type Sandbox } from './test-support/cli-process.js';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { generateNativeBootstrap } = (await import(
+  pathToFileURL(path.join(repositoryRoot, 'scripts', 'native-bootstrap.mjs')).href
+)) as unknown as {
+  generateNativeBootstrap: (manifestFile: string, archiveDirectory: string) => Promise<string>;
+};
+
+const REQUIRED_FILES = ['tmt', 'LICENSE', 'NATIVE-INSTALL.md', 'THIRD-PARTY-NOTICES.txt'];
+
+function nativeTarget(): string {
+  const architecture = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
+  const platform = process.platform === 'darwin' ? 'apple-darwin' : 'unknown-linux-musl';
+  return `${architecture}-${platform}`;
+}
+
+type Fixture = {
+  readonly archive: string;
+  readonly manifest: string;
+  readonly version: string;
+  readonly target: string;
+};
+
+async function createFixture(
+  sandbox: Sandbox,
+  options: { readonly version?: string; readonly target?: string } = {}
+): Promise<Fixture> {
+  const version = options.version ?? '5.0.0-alpha.1';
+  const target = options.target ?? nativeTarget();
+  const name = `tmux-team-${version}-${target}.tar.gz`;
+  const rootName = name.slice(0, -'.tar.gz'.length);
+  const fixtureRoot = mkdtempSync(path.join(sandbox.root, 'bootstrap-fixture-'));
+  const tree = path.join(fixtureRoot, 'tree');
+  const root = path.join(tree, rootName);
+  const archive = path.join(fixtureRoot, name);
+  const manifest = path.join(fixtureRoot, 'dist-manifest.json');
+  mkdirSync(root, { recursive: true });
+  writeFileSync(path.join(root, 'tmt'), stubExecutable(), { mode: 0o755 });
+  chmodSync(path.join(root, 'tmt'), 0o755);
+  for (const file of REQUIRED_FILES.slice(1)) writeFileSync(path.join(root, file), `${file}\n`);
+  await tar.c({ cwd: tree, file: archive, gzip: true }, [rootName]);
+  const checksum = createHash('sha256').update(readFileSync(archive)).digest('hex');
+  writeFileSync(
+    manifest,
+    `${JSON.stringify({
+      artifacts: {
+        [name]: {
+          kind: 'executable-zip',
+          name,
+          target_triples: [target],
+          checksums: { sha256: checksum },
+          assets: REQUIRED_FILES.map((file) => ({ path: file })),
+        },
+      },
+      releases: [{ app_name: 'tmt-cli', app_version: version, artifacts: [name] }],
+    })}\n`
+  );
+  return { archive, manifest, version, target };
+}
+
+function stubExecutable(): string {
+  return `#!/bin/sh
+set -eu
+log="\${TMT_BOOTSTRAP_STUB_LOG:?}"
+command=\${1-}
+printf 'command=%s\\n' "$command" >> "$log"
+shift || true
+prefix=
+for argument do
+  printf 'arg=%s\\n' "$argument" >> "$log"
+  if [ "$argument" = --prefix ]; then prefix=\${2:?}; fi
+  shift
+done
+case "$command" in
+  __native-install)
+    mkdir -p "$prefix/bin"
+    cp "$0" "$prefix/bin/tmt"
+    chmod 755 "$prefix/bin/tmt"
+    printf '%s\\n' '{"installed":true}'
+    ;;
+  install)
+    if [ "\${TMT_BOOTSTRAP_SKILL_FAILURE-}" = 1 ]; then exit 7; fi
+    printf '%s\\n' '{"installed":true}'
+    ;;
+  *) exit 64 ;;
+esac
+`;
+}
+
+function writeCurlFixture(directory: string): void {
+  const script = `#!/bin/sh
+set -eu
+: "\${TMT_BOOTSTRAP_CURL_LOG:?}"
+printf '%s\\n' "$@" >> "$TMT_BOOTSTRAP_CURL_LOG.args"
+output=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output|-o) output=$2; shift 2 ;;
+    --proto|--proto-redir|--max-redirs|--connect-timeout|--max-time|--max-filesize) shift 2 ;;
+    --disable|--fail|--silent|--show-error|--location|--tlsv1.2|-f|-s|-S|-L|-fsSL|-sSfL) shift ;;
+    *) url=$1; shift ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$TMT_BOOTSTRAP_CURL_LOG"
+case "$url" in
+  *dist-manifest.json) source=\${TMT_BOOTSTRAP_MANIFEST:?} ;;
+  *.tar.gz) source=\${TMT_BOOTSTRAP_ARCHIVE:?} ;;
+  *) exit 22 ;;
+esac
+if [ "\${TMT_BOOTSTRAP_CURL_FAILURE-}" = 1 ]; then
+  printf 'partial download' > "$output"
+  exit 56
+fi
+if [ "\${TMT_BOOTSTRAP_INTERRUPT-}" = 1 ]; then
+  printf 'partial download' > "$output"
+  kill -TERM "$PPID"
+  exit 143
+fi
+cp "$source" "$output"
+if [ "\${TMT_BOOTSTRAP_SHORT-}" = 1 ]; then : > "$output"; fi
+if [ "\${TMT_BOOTSTRAP_CORRUPT-}" = manifest ] && printf '%s' "$url" | grep -q dist-manifest; then
+  printf 'X' | dd of="$output" bs=1 count=1 conv=notrunc 2>/dev/null
+elif [ "\${TMT_BOOTSTRAP_CORRUPT-}" = archive ] && printf '%s' "$url" | grep -q tar.gz; then
+  printf 'X' | dd of="$output" bs=1 count=1 conv=notrunc 2>/dev/null
+fi
+`;
+  const target = path.join(directory, 'curl');
+  writeFileSync(target, script, { mode: 0o755 });
+  chmodSync(target, 0o755);
+}
+
+function writeUnameFixture(directory: string): void {
+  const target = path.join(directory, 'uname');
+  writeFileSync(target, '#!/bin/sh\nprintf "%s\\n" "Plan9"\n', { mode: 0o755 });
+  chmodSync(target, 0o755);
+}
+
+async function runBootstrap(
+  sandbox: Sandbox,
+  script: string,
+  fixture: Fixture,
+  args: readonly string[] = [],
+  options: {
+    readonly prefix?: string;
+    readonly corrupt?: 'manifest' | 'archive';
+    readonly curlFailure?: boolean;
+    readonly interrupted?: boolean;
+    readonly shortDownload?: boolean;
+    readonly skillFailure?: boolean;
+    readonly unsupportedPlatform?: boolean;
+    readonly endpointOverride?: string;
+  } = {}
+) {
+  const stage = mkdtempSync(path.join(sandbox.root, 'bootstrap-tmp-'));
+  const fakeBin = mkdtempSync(path.join(sandbox.root, 'bootstrap-tools-'));
+  const installer = path.join(sandbox.root, 'native-bootstrap.sh');
+  writeFileSync(installer, script, { mode: 0o700 });
+  chmodSync(installer, 0o700);
+  writeCurlFixture(fakeBin);
+  if (options.unsupportedPlatform) writeUnameFixture(fakeBin);
+  const prefix = options.prefix ?? path.join(sandbox.home, '.local');
+  const log = path.join(sandbox.root, 'stub.log');
+  const curlLog = path.join(sandbox.root, 'curl.log');
+  const systemPath = process.env.PATH ?? '/usr/bin:/bin';
+  const result = await runCli(
+    {
+      ...sandbox,
+      cli: { executable: '/bin/sh', args: [installer] },
+      env: {
+        ...sandbox.env,
+        PATH: `${fakeBin}:${systemPath}`,
+        TMPDIR: stage,
+        TMT_BOOTSTRAP_STUB_LOG: log,
+        TMT_BOOTSTRAP_CURL_LOG: curlLog,
+        TMT_BOOTSTRAP_MANIFEST: fixture.manifest,
+        TMT_BOOTSTRAP_ARCHIVE: fixture.archive,
+        ...(options.corrupt === undefined ? {} : { TMT_BOOTSTRAP_CORRUPT: options.corrupt }),
+        ...(options.curlFailure ? { TMT_BOOTSTRAP_CURL_FAILURE: '1' } : {}),
+        ...(options.interrupted ? { TMT_BOOTSTRAP_INTERRUPT: '1' } : {}),
+        ...(options.shortDownload ? { TMT_BOOTSTRAP_SHORT: '1' } : {}),
+        ...(options.skillFailure ? { TMT_BOOTSTRAP_SKILL_FAILURE: '1' } : {}),
+        ...(options.endpointOverride
+          ? { TMT_NATIVE_BOOTSTRAP_ENDPOINT: options.endpointOverride }
+          : {}),
+      },
+    },
+    ['--prefix', prefix, ...args],
+    { deadlineMs: 15_000 }
+  );
+  return { result, prefix, log: existsSync(log) ? readFileSync(log, 'utf8') : '', stage, curlLog };
+}
+
+function expectCleanStage(stage: string): void {
+  expect(readdirSync(stage)).toEqual([]);
+}
+
+describe('native curl bootstrap', () => {
+  it('generates a release-specific script from verified cargo-dist artifacts', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createFixture(sandbox);
+      const script = await generateNativeBootstrap(fixture.manifest, path.dirname(fixture.archive));
+      expect(script).toContain(fixture.version);
+      expect(script).toContain(fixture.target);
+      expect(script).toContain(path.basename(fixture.archive));
+      expect(script).toContain(
+        createHash('sha256').update(readFileSync(fixture.archive)).digest('hex')
+      );
+      expect(script).toContain('https://github.com/wkh237/tmux-team/releases/download/');
+      expect(script).not.toContain('endpointOverride');
+    });
+  });
+
+  it(
+    'publishes through __native-install, handles spaces and pinning, and skips skills on request',
+    { timeout: 20_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const fixture = await createFixture(sandbox);
+        const script = await generateNativeBootstrap(
+          fixture.manifest,
+          path.dirname(fixture.archive)
+        );
+        const prefix = path.join(sandbox.root, 'native prefix with spaces');
+        mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+        writeFileSync(path.join(prefix, 'bin', 'npm-owned'), 'preserve me\n');
+        const run = await runBootstrap(sandbox, script, fixture, ['--pin', '--no-skill'], {
+          prefix,
+        });
+
+        expect(run.result.status).toBe(0);
+        expect(run.result.stderr).toBe('');
+        expect(run.log).toContain('command=__native-install');
+        expect(run.log).toContain(`arg=${prefix}`);
+        expect(run.log).toContain('arg=--pin\n');
+        expect(run.log).toContain('arg=--channel\narg=alpha\n');
+        expect(run.log).not.toContain('command=install');
+        const curlArgs = readFileSync(`${run.curlLog}.args`, 'utf8');
+        expect(curlArgs).toMatch(/^--disable\n/);
+        expect(curlArgs).toContain('--proto\n=https\n--proto-redir\n=https\n');
+        expect(curlArgs).toContain('--max-redirs\n3\n');
+        expect(curlArgs).toContain('--max-time\n60\n');
+        expect(curlArgs).not.toContain('--insecure');
+        expect(readFileSync(path.join(prefix, 'bin', 'npm-owned'), 'utf8')).toBe('preserve me\n');
+        expect(existsSync(path.join(prefix, 'bin', 'tmt'))).toBe(true);
+        expectCleanStage(run.stage);
+      });
+    }
+  );
+
+  it(
+    'runs skills through the absolute published command and preserves partial success',
+    { timeout: 20_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const fixture = await createFixture(sandbox);
+        const script = await generateNativeBootstrap(
+          fixture.manifest,
+          path.dirname(fixture.archive)
+        );
+        const run = await runBootstrap(sandbox, script, fixture, [], { skillFailure: true });
+
+        expect(run.result.status).toBe(1);
+        expect(run.result.stderr).toContain('native binary is installed, but skill setup failed');
+        expect(run.log).toContain('command=__native-install');
+        expect(run.log).toContain('command=install');
+        expect(existsSync(path.join(run.prefix, 'bin', 'tmt'))).toBe(true);
+        expect(existsSync(sandbox.database)).toBe(false);
+        expectCleanStage(run.stage);
+      });
+    }
+  );
+
+  it.each(['manifest', 'archive'] as const)(
+    'does not execute an unverified %s',
+    async (corrupt) => {
+      await withSandbox(async (sandbox) => {
+        const fixture = await createFixture(sandbox);
+        const script = await generateNativeBootstrap(
+          fixture.manifest,
+          path.dirname(fixture.archive)
+        );
+        const run = await runBootstrap(sandbox, script, fixture, [], {
+          corrupt,
+          endpointOverride: 'https://evil.example.invalid/replacement',
+        });
+
+        expect(run.result.status).toBe(1);
+        expect(run.result.stderr).toContain('Downloaded asset SHA-256 mismatch.');
+        expect(run.log).toBe('');
+        expect(existsSync(path.join(run.prefix, 'bin', 'tmt'))).toBe(false);
+        const urls = readFileSync(run.curlLog, 'utf8').trim().split('\n');
+        const base = `https://github.com/wkh237/tmux-team/releases/download/v${fixture.version}`;
+        expect(urls).toEqual([
+          `${base}/dist-manifest.json`,
+          ...(corrupt === 'archive' ? [`${base}/${path.basename(fixture.archive)}`] : []),
+        ]);
+        expectCleanStage(run.stage);
+      });
+    }
+  );
+
+  it('propagates a curl failure without invoking the downloaded executable', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createFixture(sandbox);
+      const script = await generateNativeBootstrap(fixture.manifest, path.dirname(fixture.archive));
+      const run = await runBootstrap(sandbox, script, fixture, [], { curlFailure: true });
+
+      expect(run.result.status).toBe(56);
+      expect(run.log).toBe('');
+      expect(existsSync(path.join(run.prefix, 'bin', 'tmt'))).toBe(false);
+      expect(readFileSync(run.curlLog, 'utf8').trim()).toBe(
+        `https://github.com/wkh237/tmux-team/releases/download/v${fixture.version}/dist-manifest.json`
+      );
+      expectCleanStage(run.stage);
+    });
+  });
+
+  it('rejects a short body and cleans a terminated partial download before publication', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createFixture(sandbox);
+      const script = await generateNativeBootstrap(fixture.manifest, path.dirname(fixture.archive));
+      const short = await runBootstrap(sandbox, script, fixture, [], { shortDownload: true });
+      expect(short.result.status).toBe(1);
+      expect(short.result.stderr).toContain('Downloaded asset size mismatch.');
+      expect(short.log).toBe('');
+      expectCleanStage(short.stage);
+      const interrupted = await runBootstrap(sandbox, script, fixture, [], { interrupted: true });
+      expect(interrupted.result.status).toBe(143);
+      expect(interrupted.log).toBe('');
+      expect(existsSync(path.join(interrupted.prefix, 'bin/tmt'))).toBe(false);
+      expectCleanStage(interrupted.stage);
+    });
+  });
+
+  it('rejects invalid options and unsupported hosts before downloading', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createFixture(sandbox);
+      const script = await generateNativeBootstrap(fixture.manifest, path.dirname(fixture.archive));
+      const invalid = await runBootstrap(sandbox, script, fixture, ['--unexpected']);
+      expect(invalid.result.status).toBe(1);
+      expect(invalid.result.stderr).toContain('Unknown installer option');
+      expect(invalid.log).toBe('');
+      expect(existsSync(invalid.curlLog)).toBe(false);
+
+      const unsupported = await runBootstrap(sandbox, script, fixture, [], {
+        unsupportedPlatform: true,
+      });
+      expect(unsupported.result.status).toBe(1);
+      expect(unsupported.result.stderr).toContain('no verified artifact for Plan9:Plan9');
+      expect(unsupported.log).toBe('');
+      expect(existsSync(unsupported.curlLog)).toBe(false);
+    });
+  });
+
+  it('does not install when the piped script is truncated at its final invocation', async () => {
+    await withSandbox(async (sandbox) => {
+      const fixture = await createFixture(sandbox);
+      const script = await generateNativeBootstrap(fixture.manifest, path.dirname(fixture.archive));
+      const invocation = script.lastIndexOf('main "$@"');
+      expect(invocation).toBeGreaterThan(0);
+      const run = await runBootstrap(sandbox, script.slice(0, invocation + 4), fixture);
+      expect(run.result.status).toBe(2);
+      expect(run.result.stderr).toMatch(/syntax error|Syntax error/);
+      expect(run.log).toBe('');
+      expect(existsSync(run.curlLog)).toBe(false);
+      expect(existsSync(run.prefix)).toBe(false);
+    });
+  });
+
+  it('rejects duplicate targets and unsafe versions during generation', async () => {
+    await withSandbox(async (sandbox) => {
+      const first = await createFixture(sandbox);
+      const second = await createFixture(sandbox, { version: '5.0.0-alpha.2' });
+      const duplicate = JSON.parse(readFileSync(first.manifest, 'utf8')) as {
+        artifacts: Record<string, unknown>;
+        releases: Array<Record<string, unknown>>;
+      };
+      const secondManifest = JSON.parse(readFileSync(second.manifest, 'utf8')) as typeof duplicate;
+      Object.assign(duplicate.artifacts, secondManifest.artifacts);
+      duplicate.releases.push(...secondManifest.releases);
+      writeFileSync(first.manifest, JSON.stringify(duplicate));
+      await expect(
+        generateNativeBootstrap(first.manifest, path.dirname(first.archive))
+      ).rejects.toThrow('Duplicate bootstrap target');
+
+      const unsafe = JSON.parse(readFileSync(first.manifest, 'utf8')) as typeof duplicate;
+      const name = path.basename(first.archive);
+      unsafe.artifacts = { [name]: unsafe.artifacts[name] };
+      unsafe.releases = [
+        { app_name: 'tmt-cli', app_version: '5.0.0;echo-pwned', artifacts: [name] },
+      ];
+      writeFileSync(first.manifest, JSON.stringify(unsafe));
+      await expect(
+        generateNativeBootstrap(first.manifest, path.dirname(first.archive))
+      ).rejects.toThrow('Unsafe or unsupported bootstrap version');
+    });
+  });
+});

--- a/test/native/artifact.Dockerfile
+++ b/test/native/artifact.Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /verification
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY scripts/native-artifact-policy.mjs scripts/verify-native-artifact.mjs scripts/verify-native-installation.mjs scripts/packed-command.mjs scripts/
+COPY scripts/native-bootstrap.mjs scripts/native-bootstrap.sh scripts/generate-native-bootstrap.mjs scripts/verify-native-bootstrap.mjs scripts/
 COPY skills/tmux-team/SKILL.md expected-skill.md
 COPY --from=build /workspace/native-manifest.json ./
 COPY --from=build /workspace/rust/target/native-notices/THIRD-PARTY-NOTICES.txt expected-notices.txt


### PR DESCRIPTION
## Scope

Closes #144 under #82/#93. Adds a release-generated, verified POSIX curl bootstrap and fresh npm/pnpm replacement guidance. Depends on merged #145. No public release, tag, upload, global installation, package uninstallation, or user-data mutation was performed.

The installer defaults to `$HOME/.local`, supports an absolute `--prefix`, `--pin` and `--no-skill`, and otherwise installs the canonical skill through the new absolute command. Version/channel and artifact names/sizes/hashes come from cargo-dist, not a second release catalog. Public immutable release publication remains a separate gate; README does not advertise a nonexistent live native download.

## Architecture and primary review

Reviewed head: `288f63d8b9aa60153a25803039bc61dc8a2c453d`.

The primary reviewed every changed script, test, Docker fixture and documentation diff, plus the existing artifact validator, bounded process runner, native installer/publication callers and installed-skill ownership. A bounded Luna pattern audit and test implementation assisted; architectural decisions and acceptance remained with the primary.

- Reuse `selectNativeArtifact`, `withNativeArtifact` and bounded no-follow reads. Generated shell never publishes its own permanent files; the verified temporary executable invokes the existing `__native-install` owner.
- Preserve fixed canonical HTTPS source URLs, curl TLS/protocol/transfer options and size/SHA verification before executing downloaded bytes. Initial receipts stay truthfully local-archive provenance, not independent attestation verification. The script and HTTPS origin remain trust roots.
- Extract only the known executable stream to a fixed private temporary file. Trap cleanup removes only successful mktemp-owned staging. No application database is opened by binary installation.
- Never invoke an old PATH command or silently uninstall npm/pnpm/brew/manual files. Report PATH ambiguity, skill conflicts and post-binary partial failure without claiming rollback. Skill force remains an explicit existing backup operation.
- User-approved fresh replacement supersedes new data-transfer/backup/coexistence machinery. Existing storage guards/tests remain intact and old files are not deleted.

Review findings corrected: preserve the archive's manifest filename when calling the native owner; assert exact pin/channel arguments and causal diagnostics instead of accepting arbitrary test failures; use real SHA tools and same-size corruption; verify termination/partial-download cleanup; guard the entire final invocation with a POSIX compound command so truncation cannot execute with lost arguments. ShellCheck passes without suppressing the guard warning.

## Verification

- [x] `pnpm check` (type, lint, formatting and docs).
- [x] `pnpm test:run`: 1,141 tests in 73 files passed. Final shell-only guard correction: all 10 focused bootstrap tests rerun and passed.
- [x] `pnpm test:native` with explicit rebuilt native CLI/storage probe: 104 tests in 13 files passed (38.75 seconds). Rust production source/dependencies are unchanged from the reviewed/green #145; canonical embedded guidance is rebuilt and tested.
- [x] Generated script: `sh -n` and `shellcheck --shell sh`, no warnings/suppressions.
- [x] Canonical end-user and repo release skills pass the skill-authoring validator; maintained links and guidance were reviewed.
- [x] Actual macOS arm64 cargo-dist archive: independent linkage/version/exact-skill/SQLite verification, then generated bootstrap with no Node/Rust runtime PATH. Verified custom/default prefixes, repeat no-op, pinned no-network upgrade, exact installed guidance, old npm-file preservation and cleanup.
- [x] Actual Linux arm64 static-musl archive: the same independent artifact and bootstrap verifiers in a task-owned native-architecture container with networking disabled. The final shell template was verified through a read-only mount. These are controlled curl acquisition fixtures, not live GitHub availability or x64 target evidence.
- [x] Two local `pnpm test:e2e` Docker lifecycle passes: each passed 283 native adapter tests (one explicit artifact gate separately exercised) and 159 E2E scenarios in 34 files, with one optional performance skip; durations 303.85 / 306.14 seconds. Native/guidance/E2E inputs are unchanged between the runs; later shell-only corrections were separately rerun through focused and actual-artifact checks.
- [x] All 11 required CI checks passed on exact reviewed head `288f63d8b9aa60153a25803039bc61dc8a2c453d`, first candidate, run `34221859378`. No CI rerun or weakened gate.

The shell unit fixture uses a synthetic executable to test orchestration, not to prove native publication. Real release-format binaries supply the independent publication/skill proof. The existing Docker suite includes native-specific and TypeScript-reference scenarios; it is not described as native-only parity.

## Lifecycle

Architecture, native install guide, development verification, release skill, Rust roadmap, README and canonical user skill are updated. GitHub #82/#93 record the approved no-data-migration scope and #144 owns this dedicated branch/worktree. Clean up only after reviewed-head green merge and pushed-state checks. Public release authorization, immutable publication/attestation evidence and remaining target execution remain explicit gates, not silently claimed done.
