### PR TITLE
Prepare verified native alpha distribution

### DIFF
--- a/.agents/skills/tmt-release/SKILL.md
+++ b/.agents/skills/tmt-release/SKILL.md
@@ -36,6 +36,13 @@ Use this skill for release-line maintenance, v4 compatibility fixes, v5 promotio
   finalization and unchanged data. The internal preview entrypoint is not a
   public bootstrap or permission to replace a user/package-manager installation.
 - Promotion requires passing Code quality, Unit tests, and Docker E2E checks.
+- For a public native alpha, follow DEVELOPMENT's explicit multi-platform
+  release preparation procedure. The manual artifact workflow never publishes;
+  all four final native verifiers must pass on the recorded reviewed commit.
+  Keep cargo-dist as the merged manifest owner. Authorized publication uses an
+  immutable draft-to-published GitHub release and verifies its attestation and
+  public installer before promoting README instructions. Do not equate a
+  downloadable CI bundle with a published or accepted release.
 - For curl bootstrap, follow DEVELOPMENT's native curl bootstrap verification.
   Generate from final verified cargo-dist artifacts and invoke the existing
   native publisher; do not enable a competing stock installer. Test an actual

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -1,0 +1,169 @@
+name: Native release artifacts
+
+# Explicit preparation only. Publishing a reviewed bundle is a separate,
+# authorized operation; ordinary pull requests do not run this costly matrix.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    if: github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix: &native-targets
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-15
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install native build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y musl-tools
+      - name: Install pinned Rust
+        run: rustup toolchain install 1.97.0 --profile minimal --target '${{ matrix.target }}'
+      - name: Cache packaging tools
+        id: tools
+        uses: actions/cache@v4
+        with:
+          path: ~/.tmt-packaging
+          key: native-tools-${{ runner.os }}-${{ runner.arch }}-rust1.97-dist0.32.0-about0.9.2
+      - name: Build pinned packaging tools
+        if: steps.tools.outputs.cache-hit != 'true'
+        run: |
+          cargo +1.97.0 install cargo-dist --version 0.32.0 --locked --root "$HOME/.tmt-packaging"
+          cargo +1.97.0 install cargo-about --version 0.9.2 --features cli --locked --root "$HOME/.tmt-packaging"
+      - name: Build release archive and target manifest
+        env:
+          TARGET: ${{ matrix.target }}
+          MACOSX_DEPLOYMENT_TARGET: '11.0'
+        run: |
+          export PATH="$HOME/.tmt-packaging/bin:$PATH"
+          cargo +1.97.0 fetch --manifest-path rust/Cargo.toml --locked
+          scripts/build-native-artifact.sh "$TARGET" > "$RUNNER_TEMP/$TARGET-dist-manifest.json"
+          cp "$RUNNER_TEMP/$TARGET-dist-manifest.json" target/distrib/
+          cp rust/target/native-notices/THIRD-PARTY-NOTICES.txt "target/distrib/$TARGET-notices.txt"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.target }}
+          path: |
+            target/distrib/*.tar.gz
+            target/distrib/*.sha256
+            target/distrib/*-dist-manifest.json
+            target/distrib/*-notices.txt
+          if-no-files-found: error
+          retention-days: 7
+
+  assemble:
+    name: Assemble authoritative release manifest
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.2
+      - name: Install pinned Rust
+        run: rustup toolchain install 1.97.0 --profile minimal
+      - uses: actions/cache/restore@v4
+        with:
+          path: ~/.tmt-packaging
+          key: native-tools-${{ runner.os }}-${{ runner.arch }}-rust1.97-dist0.32.0-about0.9.2
+          fail-on-cache-miss: true
+      - name: Install verification dependencies
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.0 --activate
+          pnpm install --frozen-lockfile --ignore-scripts
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: native-*
+          merge-multiple: true
+          path: target/distrib
+      - name: Merge with cargo-dist and verify bootstrap inputs
+        run: |
+          export PATH="$HOME/.tmt-packaging/bin:$PATH"
+          export RUSTUP_TOOLCHAIN=1.97.0
+          TMT_NATIVE_REAL_CARGO=$(command -v cargo)
+          export TMT_NATIVE_REAL_CARGO
+          export CARGO="$GITHUB_WORKSPACE/scripts/native-cargo.sh"
+          dist plan --output-format=json --no-local-paths > "$RUNNER_TEMP/plan.json"
+          dist build --artifacts global --output-format=json --no-local-paths > "$RUNNER_TEMP/dist-manifest.json"
+          cp "$RUNNER_TEMP/dist-manifest.json" target/distrib/dist-manifest.json
+          node scripts/generate-native-bootstrap.mjs --manifest target/distrib/dist-manifest.json --archive-dir target/distrib --plan "$RUNNER_TEMP/plan.json" > target/distrib/tmt-installer.sh
+          sh -n target/distrib/tmt-installer.sh
+          shellcheck --shell sh target/distrib/tmt-installer.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-release-bundle
+          path: |
+            target/distrib/*.tar.gz
+            target/distrib/*.sha256
+            target/distrib/sha256.sum
+            target/distrib/dist-manifest.json
+            target/distrib/tmt-installer.sh
+            target/distrib/*-notices.txt
+          if-no-files-found: error
+          retention-days: 7
+
+  verify:
+    name: Verify final bundle (${{ matrix.target }})
+    needs: assemble
+    strategy:
+      fail-fast: false
+      matrix: *native-targets
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.2
+      - name: Install verification dependencies
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.0 --activate
+          pnpm install --frozen-lockfile --ignore-scripts
+      - uses: actions/download-artifact@v4
+        with:
+          name: native-release-bundle
+          path: target/distrib
+      - name: Execute final archive and bootstrap on matching native host
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          node scripts/verify-native-artifact.mjs \
+            --manifest target/distrib/dist-manifest.json \
+            --archive "target/distrib/tmt-cli-$TARGET.tar.gz" --target "$TARGET" \
+            --skill skills/tmux-team/SKILL.md --license LICENSE \
+            --notices "target/distrib/$TARGET-notices.txt"
+          node scripts/verify-native-bootstrap.mjs \
+            --manifest target/distrib/dist-manifest.json \
+            --archive "target/distrib/tmt-cli-$TARGET.tar.gz" --target "$TARGET" \
+            --skill skills/tmux-team/SKILL.md
+          node scripts/generate-native-bootstrap.mjs --manifest target/distrib/dist-manifest.json --archive-dir target/distrib > "$RUNNER_TEMP/installer.sh"
+          cmp "$RUNNER_TEMP/installer.sh" target/distrib/tmt-installer.sh

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,6 +7,33 @@ already enforced. [AGENTS.md](AGENTS.md) owns review policy,
 [DEVELOPMENT.md](DEVELOPMENT.md) owns verification commands. Issue specifications
 describe proposals; update this map when the implemented changes land.
 
+## Runtime and release boundary
+
+The standalone Rust native alpha is prepared through the explicit
+`native-release.yml` workflow. The user-facing README advertises its installer
+only after immutable publication and live-download verification. `rust/` owns
+the native runtime; root `src/` and npm entrypoints remain the transitional
+TypeScript reference and test tooling, not a wrapper that downloads Rust.
+The older sections below describe that reference implementation unless they
+explicitly identify native owners. Native lifetime rules (temporary by default,
+explicit save, retirement) supersede durable-only identity assumptions there.
+Source cleanup and measured performance acceptance remain tracked in #93.
+
+Release preparation is orchestration, not a second artifact or install owner.
+`dist-workspace.toml` selects artifacts; cargo-dist merges per-host manifests
+from `target/distrib/*-dist-manifest.json` into the authoritative final manifest.
+The workflow's shared runner matrix maps supported targets to native hosts;
+bootstrap `--plan` compares the final inventory with cargo-dist's complete plan
+so a missing build target cannot silently reduce release coverage. Independent
+artifact selection also requires the same `tmt-cli` owner as native publication.
+Existing bounded archive and bootstrap verifiers execute the final bundle on
+each matching host, including SQLite persistence and exact embedded skills.
+The workflow has read-only repository permission and never publishes. Authorized
+publication uses a draft, exact verified assets and immutable GitHub release
+attestation; the native updater still enforces immutable metadata and dual
+digests. Initial bootstrap trust remains the downloaded script and HTTPS origin,
+not independent client-side attestation verification.
+
 ## Product and state boundaries
 
 TMT is a CLI-owned, local collaboration tool. Each invocation performs its work

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -600,6 +600,45 @@ matrix.
 
 ## Native Rust release archives
 
+### Explicit multi-platform release preparation
+
+`Native release artifacts` (`.github/workflows/native-release.yml`) is manually
+dispatched, not part of every PR. Dispatch on the authorized release's reviewed,
+required-checks-green main commit and record the run ID and exact SHA in its
+issue. It builds on native macOS arm64/x64 and Linux arm64/x64 hosts using the
+existing pinned tools and `build-native-artifact.sh`. A shared matrix keeps
+build and final verification hosts aligned; dispatches outside main are skipped.
+Cached packaging tools are keyed
+by OS, architecture and exact tool versions; they are developer tools only.
+
+cargo-dist itself merges the downloaded `*-dist-manifest.json` inputs through
+`dist build --artifacts global --output-format=json --no-local-paths`. Do not
+hand-merge artifact JSON or enable another installer. Generate a complete
+`dist plan` on the same source and pass it as bootstrap `--plan`: the generator
+requires exact planned archive names/targets, preventing a missing matrix target
+from silently shrinking the release. Bootstrap generation verifies TMT ownership
+and archive inventory/digests before generating code; the final matrix
+then executes both existing verifiers against this final manifest and compares
+the regenerated script bytes. All jobs must pass before publication, even if
+the assembled artifact can already be downloaded. CI artifacts expire in seven
+days. Notices alongside the bundle are verification inputs; each archive also
+contains its own target-filtered notices.
+
+Publication remains a separately authorized operation, not a workflow side
+effect. Verify the run's exact commit and all required PR checks; enable GitHub
+release immutability before creating a draft prerelease. Attach the four tar.gz
+archives, final `dist-manifest.json` and `tmt-installer.sh`, verify their uploaded
+SHA-256 digests and only then publish the draft. Verify `immutable: true`, tag
+commit and GitHub release attestation (`gh release verify` and
+`gh release verify-asset`). Never replace an immutable release's assets or move
+its tag. A repair needs a new reviewed version.
+
+Before promoting README installation instructions, run the actual public script
+with an isolated HOME, application root and prefix, verify version, exact skill,
+PATH selection and `tmt upgrade --json` against live immutable metadata. Do not
+mutate a host installation. Record this separately from controlled-curl fixture
+evidence. npm publication is not part of native GitHub release publication.
+
 This is separate from the transitional npm packed matrix above. #135 adds
 archive generation and isolated runtime verification, not a public installer.
 The target inventory and artifact metadata live in `dist-workspace.toml` and

--- a/NATIVE-INSTALL.md
+++ b/NATIVE-INSTALL.md
@@ -1,14 +1,16 @@
-# TMT native artifact preview
+# TMT native alpha installation
 
-This archive contains a standalone Rust development preview, not a published
-replacement for the npm runtime. It needs no Node.js, Rust toolchain or source
-checkout to run. tmux is still required for pane operations.
+This archive contains the standalone Rust native alpha runtime. It needs no
+Node.js, Rust toolchain or source checkout to run. tmux is still required for
+pane operations. Use the installer asset from a published release; the README
+supplies the verified version URL when one is available.
 
-Use isolated test state until native cutover. Native schema 9 is forward-only:
-the TypeScript runtime cannot reopen it. Replacing a binary is not a database
-downgrade. Do not run this preview against an existing user database.
+Native schema 9 is forward-only: the TypeScript runtime cannot reopen it.
+Installing or replacing a native binary does not migrate, delete or downgrade
+application data. Stop older TMT writers before switching, and do not run the
+native runtime against a database that the TypeScript runtime still uses.
 
-After extracting a verified archive into a chosen test directory:
+After extracting a verified archive into a chosen directory:
 
 ```sh
 tmt_preview_root=$(mktemp -d)
@@ -18,14 +20,16 @@ TMUX_TEAM_HOME="$tmt_preview_root" ./tmt install --dir "$tmt_preview_root/skills
 ```
 
 Skill installation is non-interactive and does not install agent applications.
-This example deliberately keeps its managed files in the temporary preview root.
-Choose a directory your provider discovers and reload its skills. Retain the
-included LICENSE and THIRD-PARTY-NOTICES.txt with redistributed binaries.
+The example keeps its managed files in a temporary directory; for normal use,
+choose a directory your provider discovers and reload its skills. Native pane
+bindings are temporary by default: use `-s`/`--save` with `name` or `add` to
+preserve one, and use `rm <name>` to retire a temporary identity (`--force` is
+required for a saved identity). Retain the included LICENSE and
+THIRD-PARTY-NOTICES.txt with redistributed binaries.
 
 Managed binary receipts, `upgrade`/`update`, and release-generated shell bootstrap
-are implemented in the preview. Public native releases remain a publication gate;
-do not assume a downloadable native release exists yet. Do not overwrite an
-npm, pnpm, Homebrew or manual installation.
+are implemented by the native runtime. Do not overwrite an npm, pnpm, Homebrew
+or manual installation.
 The selected executable's help is the capability authority; the shared alpha
 version number alone does not distinguish native and TypeScript runtimes.
 
@@ -44,34 +48,39 @@ not retry skill work.
 The distribution manifest supplies archive names, target triples and SHA-256
 checksums. Checksums detect corruption, not compromise of the download origin.
 No local test artifact is authenticated by a published GitHub attestation.
-Public immutable-release provenance and verification instructions remain a
-separate release gate; do not describe locally generated checksums as signatures.
+For a published immutable release, `gh release verify <tag> --repo
+wkh237/tmux-team` verifies GitHub's release attestation; `gh release verify-asset
+<tag> <downloaded-file> --repo wkh237/tmux-team` also checks a local asset.
+This optional independent check requires GitHub CLI, not the installed TMT
+runtime. Do not describe locally generated checksums as signatures.
 
-Target candidates are macOS x64/arm64 (deployment target 11.0) and Linux x64/arm64
-with a static musl runtime. Actual target execution and linkage must pass before
-release support is claimed; cross-compilation alone is not acceptance evidence.
+Release targets are macOS x64/arm64 (build deployment target 11.0) and Linux
+x64/arm64 with a static musl runtime. Refer to the release's verification evidence
+for tested host OS versions; a deployment target is not testing on every OS.
 
 ## Curl bootstrap
 
-Public native publication is still pending. Once published, use the release's
-exact `tmt-installer.sh` asset URL (replace `<VERSION>` with its version):
+Use the exact `tmt-installer.sh` asset URL from a published release. The README
+supplies the verified version URL when one is available. Set that URL as
+`TMT_INSTALLER_URL` after checking the release asset before running:
 
 ```sh
 curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
-  'https://github.com/wkh237/tmux-team/releases/download/v<VERSION>/tmt-installer.sh' | sh
+  --output tmt-installer.sh "$TMT_INSTALLER_URL" &&
+sh tmt-installer.sh
 ```
 
-The script fixes the initial version/channel, not a mutable alpha tag. Later
-`tmt upgrade` follows that channel. To inspect first, download the same URL to
-a file, read it, then run `sh tmt-installer.sh`. A failed/truncated download is
-not installation success; check the installed absolute command afterwards.
+The script fixes the initial version and channel, not a mutable alpha tag.
+Later native `tmt upgrade` follows that channel. Inspect the downloaded file
+before running it; a failed or truncated download is not installation success.
+Check the installed absolute command afterwards.
 
 Default prefix: `$HOME/.local`, with commands in `~/.local/bin`. Options after
 `sh -s --` (or the downloaded script):
 
 - `--prefix /absolute/directory`: another prefix, including paths with spaces.
 - `--pin`: pin this release; `tmt upgrade --unpin` resumes channel updates.
-- `--no-skill`: binary only. Otherwise the new absolute command runs the existing
+- `--no-skill`: binary only. Otherwise the new absolute command runs the native
   non-interactive `tmt install`; no provider application is installed.
 
 Requires POSIX shell, curl, tar/gzip, standard filesystem utilities and

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -1,24 +1,36 @@
 # tmux-team user guide
 
-This guide covers the common v5 preview workflows. Start with the
-[README](README.md) for the tested preview installation, then use
+This guide covers the common v5 native alpha workflows. Start with the
+[README](README.md) for the current installation status and verified release
+URL, then use
 [`skills/README.md`](skills/README.md) for provider-specific installation and
 [`skills/tmux-team/SKILL.md`](skills/tmux-team/SKILL.md) for canonical agent
 guidance.
 
 ## Install and load the skill
 
-Use the pinned preview commands in the [README installation section](README.md#v5-preview-installation),
-then let TMT detect the supported agents with `tmt install`.
+Use the native installer asset from a published release as described by the
+README, then let the native executable detect supported agents with `tmt install`.
+The installer defaults to `$HOME/.local/bin/tmt` and runs skill installation
+unless `--no-skill` is supplied. Reload the agent after installation.
 
-The preview requires macOS or Linux, tmux, and Node.js `>=22.12`; Node 24 LTS
-is preferred. This archive path needs neither Git nor pnpm. Do not use
-`tmt upgrade` with this preview: it follows npm `latest` rather than the v5
-archive. Re-run the pinned install when you need to refresh this revision.
+The native runtime requires macOS or Linux and tmux for pane operations, but no
+Node.js, Rust toolchain or source checkout. Native `tmt upgrade` (also
+available as `tmt update`) follows its retained stable/alpha channel; use
+`--to <version>` to pin or `--unpin` to resume channel updates. Package-manager
+installations are a separate legacy TypeScript runtime and must use their
+original manager.
 
 After installation, load or reload the `tmux-team` skill in every agent that
 will send or receive TMT work. Installation places the provider integration;
 it does not reload an already running agent session.
+
+Native `name` and `add` bindings are temporary by default. Add `-s`/`--save`
+to preserve an identity, and use `tmt rm <name>` to retire a temporary identity
+(`--force` is required for a saved identity). Switching from npm or pnpm is a
+fresh installation: stop old writers first; no configuration, database or
+historical exchange is migrated or deleted. Native schema 9 is forward-only,
+so never use the old TypeScript writer on a native database.
 
 ## Name panes and inspect presence
 
@@ -41,8 +53,8 @@ tmt whoami
 
 `name` and `whoami` need a live caller pane. `add` accepts `%pane_id`,
 `window.pane`, or `session:window.pane`; the current order is pane target first,
-global name second. `tmt unbind` removes only the current pane's binding and
-keeps the durable identity record.
+global name second. `tmt unbind` retires a temporary identity; a saved identity
+and its profile remain offline. Neither operation kills the pane.
 
 Global names are independent of the working directory. A durable identity can
 exist without an active pane:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-team",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.2",
   "description": "CLI tool for AI agent collaboration in tmux - manage cross-pane communication",
   "type": "module",
   "bin": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "tmt-adapters"
-version = "5.0.0-alpha.1"
+version = "5.0.0-alpha.2"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "tmt-cli"
-version = "5.0.0-alpha.1"
+version = "5.0.0-alpha.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "tmt-core"
-version = "5.0.0-alpha.1"
+version = "5.0.0-alpha.2"
 dependencies = [
  "icu_casemap",
  "icu_locale_core",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/tmt-core", "crates/tmt-adapters", "crates/tmt-cli"]
 resolver = "3"
 
 [workspace.package]
-version = "5.0.0-alpha.1"
+version = "5.0.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/rust/crates/tmt-cli/src/guidance_command.rs
+++ b/rust/crates/tmt-cli/src/guidance_command.rs
@@ -14,7 +14,7 @@ pub fn execute(skill: bool) -> io::Result<u8> {
         )?;
         writeln!(
             output,
-            "Native development preview: use isolated state until native cutover.\n"
+            "Native alpha: standalone runtime, no Node.js or daemon required.\n"
         )?;
         writeln!(
             output,

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -50,7 +50,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::Help => {
             writeln!(
                 stdout,
-                "Native development preview: configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, x attention, init, learn, and skill installation are available. Managed native upgrade/update is supported; public release availability is a separate gate. Use isolated test state only.\n"
+                "TMT native alpha — collaborate with terminal agents through durable exchanges.\nRun tmt install to set up agent skills; managed installations use tmt upgrade.\n"
             )?;
             grammar::public_grammar(&grammar::grammar(), true).write_long_help(&mut stdout)?;
             writeln!(stdout)?;

--- a/scripts/generate-native-bootstrap.mjs
+++ b/scripts/generate-native-bootstrap.mjs
@@ -4,10 +4,16 @@ import { parseArgs } from 'node:util';
 import { generateNativeBootstrap } from './native-bootstrap.mjs';
 
 const { values } = parseArgs({
-  options: { manifest: { type: 'string' }, 'archive-dir': { type: 'string' } },
+  options: {
+    manifest: { type: 'string' },
+    'archive-dir': { type: 'string' },
+    plan: { type: 'string' },
+  },
 });
 assert(
   values.manifest && values['archive-dir'],
-  'Usage: --manifest <file> --archive-dir <directory>'
+  'Usage: --manifest <file> --archive-dir <directory> [--plan <cargo-dist plan>]'
 );
-process.stdout.write(await generateNativeBootstrap(values.manifest, values['archive-dir']));
+process.stdout.write(
+  await generateNativeBootstrap(values.manifest, values['archive-dir'], values.plan)
+);

--- a/scripts/native-artifact-policy.mjs
+++ b/scripts/native-artifact-policy.mjs
@@ -49,6 +49,7 @@ export function selectNativeArtifact(manifestFile, archiveFile, target) {
   assert(/^[a-f0-9]{64}$/.test(artifact.checksums?.sha256), 'Manifest requires SHA-256');
   const releases = manifest.releases?.filter((release) => release.artifacts.includes(name));
   assert.equal(releases?.length, 1, 'Archive must belong to exactly one release');
+  assert.equal(releases[0].app_name, 'tmt-cli', 'Archive must belong to the TMT release');
   const version = releases[0].app_version;
   assert(typeof version === 'string' && version.length > 0, 'Manifest requires a version');
   assert.deepEqual(

--- a/scripts/native-bootstrap.mjs
+++ b/scripts/native-bootstrap.mjs
@@ -18,13 +18,28 @@ const hosts = {
 };
 
 /** Release tooling only: verify local artifacts before generating executable code. */
-export async function generateNativeBootstrap(manifestFile, archiveDirectory) {
+export async function generateNativeBootstrap(manifestFile, archiveDirectory, planFile) {
   const bytes = readBoundedFile(manifestFile, 4 * 1024 * 1024);
   const manifest = JSON.parse(bytes);
   const entries = Object.entries(manifest.artifacts ?? {}).filter(
     ([, artifact]) => artifact.kind === 'executable-zip'
   );
   assert(entries.length > 0 && entries.length <= 4, 'Require one to four native artifacts');
+  // Release preparation must cover cargo-dist's complete configured plan. Local
+  // single-target verification deliberately omits this optional release gate.
+  if (planFile !== undefined) {
+    const plan = JSON.parse(readBoundedFile(planFile, 4 * 1024 * 1024));
+    const planned = Object.entries(plan.artifacts ?? {}).filter(
+      ([, artifact]) => artifact.kind === 'executable-zip'
+    );
+    const inventory = (artifacts) =>
+      artifacts.map(([name, artifact]) => [name, artifact.target_triples]).sort();
+    assert.deepEqual(
+      inventory(entries),
+      inventory(planned),
+      'Release must contain every planned native artifact'
+    );
+  }
   const seen = new Set();
   const cases = [];
   let version;

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,8 +1,16 @@
 # Agent skill installation
 
-Install the CLI using the [README instructions](../README.md#v5-preview-installation),
-then run `tmt install`. No plugin, marketplace, or separate slash-command package
-is required. All providers use the same bundled [skill](tmux-team/SKILL.md).
+Install the native alpha using the [README instructions](../README.md), then run
+`tmt install`. Use the installer asset from a published release; the README
+supplies the verified version URL when one is available. No plugin, marketplace
+or separate slash-command package is required. All providers use the same bundled
+[skill](tmux-team/SKILL.md).
+
+The native runtime needs no Node.js, Rust toolchain or source checkout; tmux is
+still required for pane operations. Native bindings are temporary by default:
+use `-s`/`--save` to keep one, and `tmt rm <name>` to retire a temporary identity
+(`--force` is required for a saved identity). Native schema 9 is forward-only;
+do not use the legacy TypeScript runtime on a native database.
 
 ## Install
 
@@ -35,11 +43,16 @@ OpenCode's configuration directory is used for detection, including
 `OPENCODE_CONFIG_DIR` or `XDG_CONFIG_HOME`, but its installed skill remains in the shared home location.
 Use `--dir` for a different skill discovery root; TMT does not edit provider settings.
 
-The containing directory is a managed link to the installed package. Repeating
-installation is a no-op when the link is correct. Package updates at the same
-location update the linked instructions; rerun installation after relocation.
-`tmt upgrade` follows npm `latest`, not the unpublished v5 preview; follow the
-README's preview instructions to select a new revision.
+The containing directory is a managed link to the installed native skill
+package. Repeating installation is a no-op when the link is correct. Native
+`tmt upgrade`/`tmt update` refreshes recorded managed skills through the newly
+activated executable; use `--channel stable|alpha`, `--to <version>`, or
+`--unpin` as needed. A skill refresh can fail after binary activation and is
+reported as partial completion; resolve the conflict and repeat the same
+selection.
+
+The legacy TypeScript `tmt upgrade` follows npm `latest` and cannot update a
+native installation. Use the original manager for package-manager installations.
 
 Load the skill in your agent before collaborating. Claude Code's native skill
 can be invoked as `/tmux-team`; the CLI remains `tmt`. Installing files does not
@@ -77,10 +90,14 @@ arbitrary custom folders.
 
 ## Existing installations
 
-Update the CLI using your chosen release's installation command, run
-`tmt install`, then reload or restart the agent. For an existing conversation,
+Update the native CLI using a published release's installer asset, run
+`tmt install` if needed, then reload or restart the agent. For an existing conversation,
 ask the agent to run `tmt learn --skill`, read the complete output, and use it
 instead of remembered instructions from an older version.
+
+Replacing npm, pnpm, Homebrew or manual installations does not migrate or delete
+their application data or files. Stop old writers before switching and verify
+`command -v tmt`, `command -v tmux-team`, and the new absolute `tmt --help`.
 
 Existing unmanaged targets are preserved by default. Inspect a conflict before
 using `tmt install <provider> --force`; replacement creates a recoverable backup.

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -12,20 +12,18 @@ directory. Active presence also requires matching live tmux binding metadata.
 
 ## Runtime boundary
 
-The instructions below describe the installed TypeScript runtime. The separate
-Rust executable is a development preview: use isolated test state only, never an
-existing user database (schema 9 is forward-only and TypeScript cannot reopen it).
-Its help explicitly identifies the native preview. It implements configuration,
-identity, talk/reply/result, check/read, role/preamble, X, initialization and
-skill viewing/installation and managed native upgrade/update. Public native
-release availability and runtime cutover remain separate delivery gates; do not
-fall back to TypeScript on the same upgraded database. Native talk
-supplies a compact `v2_` receipt; use it unchanged. Native reply also accepts
-retained legacy receipts, but TypeScript cannot consume native receipts or
-schema 9. The common communication contracts below apply to both runtimes;
-the native-only lifetime and installation differences are called out explicitly.
+These instructions target the standalone Rust native alpha. Older npm/pnpm
+installations use TypeScript and do not implement native identity lifetimes,
+removal or self-update. Check `tmt --help` when the installation is uncertain;
+do not fall back to TypeScript on native state. Native schema 9 is forward-only
+and TypeScript cannot reopen it. Switching installations does not migrate or
+delete old data. Stop old writers before switching.
 
-For an explicitly selected native preview, `name`, retained alias `this`, and
+Native talk supplies a compact `v2_` receipt; use it unchanged. Native reply
+also accepts retained legacy receipts, but TypeScript cannot consume native
+receipts or schema 9. Do not mix runtimes for an active exchange.
+
+`name`, retained alias `this`, and
 `add <pane-target> <name>` default to temporary identities; `-s`/`--save` saves
 the same UUID without downgrading existing saved identities. Names remain
 globally unique, not folder-scoped. `identity create` creates or promotes saved
@@ -38,9 +36,8 @@ saved removal needs `--force`. Removal never kills a pane and removes only its
 role/preamble, retaining exchanges and historical ownership. Reusing a retired
 name gets a fresh UUID. A failed publication can leave a never-bound temporary
 identity offline for retry; do not mistake missing binding for pane death.
-These native-only lifetime/removal rules do not apply to the installed runtime
-described below. Check the selected executable's help instead of inferring
-capabilities from the shared alpha version number.
+Check the selected executable's help instead of inferring capabilities from
+a remembered version number.
 
 ## Delivery safety
 
@@ -81,8 +78,7 @@ Timeout and interruption end only the observer, never recipient work. A
 retrying. Missing visible output is not permission to resend.
 
 `help`, `version`, `completion` and `learn` are text-only and reject
-`--json` with `JSON_UNSUPPORTED`; run them without that flag. TypeScript `upgrade`
-also rejects JSON mode because it streams installer output. Native managed
+`--json` with `JSON_UNSUPPORTED`; run them without that flag. Native managed
 `upgrade`/`update` supports one structured JSON result, including partial failures.
 
 ## Durable replies and results
@@ -211,8 +207,8 @@ UUID, original display name, profiles and any pane binding. It never logs in,
 binds a pane or takes over another caller's identity. Multiple local callers
 may explicitly select the same identity; this is not authentication.
 
-Create returns `{identity:{id,name,canonicalName},created}`; show returns
-`{identity:{id,name,canonicalName}}`; list returns `{identities:[...]}` in
+Create returns `{identity:{id,name,canonicalName,lifetime},created}`; show returns
+`{identity:{id,name,canonicalName,lifetime}}`; list returns `{identities:[...]}` in
 canonical-name order, including unbound identities. It does not report presence.
 Use ordinary `tmt list` for verified active destinations. A new identity alone
 cannot receive talk: bind a live pane with `add`, `name` or `this` first.
@@ -220,7 +216,7 @@ cannot receive talk: bind a live pane with `add`, `name` or `this` first.
 Names are required for create/show; omission never selects the current pane.
 Invalid names return `INVALID_NAME` (exit 1); valid missing show names return
 `NAME_NOT_FOUND` (exit 3). Creation does not alter anonymous talk or request-ID
-result access. There is no identity rename/delete or listener command.
+result access. Use `rm <name>` for removal; no identity rename or listener command exists.
 
 ## Exchange attention
 
@@ -348,11 +344,12 @@ Use `list` for full active discovery; it is not a prerequisite for `talk` or `ch
 
 ```bash
 tmt list
-tmt name <global-name>               # bind the current pane globally
+tmt name <global-name>               # bind temporarily; add -s to save
 tmt this <global-name>               # exact supported alias for `name`
 tmt add <pane-target> <global-name>  # bind an explicit pane by stable `%pane_id`
 tmt whoami                            # show the current pane identity
 tmt unbind                            # remove the current pane identity
+tmt rm <global-name>                  # retire; saved identities require --force
 tmt talk <target> "message"          # target a global name or pane
 tmt check <target> [lines]
 tmt list [target]                     # list identities or one pane
@@ -386,10 +383,9 @@ identities. Use `name`, `this`, or `add` explicitly to bind such a pane. Invalid
 metadata is not active presence; do not delete durable data or old files to
 repair it. Direct pane targeting remains separate from identity discovery.
 
-The installed TypeScript runtime does not support `update`, `remove`/`rm`, or
-`migrate`; native-only update/removal behavior is described separately. Use explicit binding
-commands above; `unbind` only detaches the current pane and retains its durable
-identity/profile. Do not delete old user files as a migration workaround.
+`update` aliases `upgrade`; `remove` aliases `rm`. `unbind` retires a temporary
+identity but retains a saved identity/profile offline. There is no `migrate`
+command. Do not delete old user files as a migration workaround.
 
 `talk` sends text to another pane and can cause external input there. Only use
 it when the user has requested that communication or the surrounding task
@@ -413,9 +409,8 @@ using `--force`, which creates recoverable skill backups outside the discovery r
 An old Claude `commands/team.md`
 is preserved with a warning by default; explicit forced Claude installation can
 back it up after the native skill is installed. Plugin settings are never modified.
-Managed links follow package updates. TypeScript `tmt upgrade` tracks npm `latest`, not
-commit-pinned previews; follow the selected release's installation instructions.
-After upgrading the CLI, run `tmt install` and reload or restart the agent.
+Native `tmt upgrade` refreshes recorded managed skills. For a manual binary
+replacement, run `tmt install` again. Reload or restart the agent afterwards.
 For an existing conversation, run `tmt learn --skill` and read its complete output
 before using remembered commands. Pi can load `/skill:tmux-team`; OpenCode uses
 its `skill` tool. Installation does not bypass provider permissions or guarantee
@@ -486,7 +481,7 @@ or retrieval.
 
 Options apply only to commands that use them. `--timeout`, `--delay`,
 `--detach`, and `--no-preamble` belong to talk/send; `--lines` belongs to
-check/read; `--force` belongs to talk/send and install. Unrelated options
+check/read; `--force` belongs to talk/send, install and rm/remove. Unrelated options
 and the unsupported `--config` path override fail with `USAGE_ERROR` before
 execution. Use `tmt help` for the command-specific option inventory.
 
@@ -519,10 +514,10 @@ They do not reload an active agent, update provider-managed plugins, or track
 alpha release channels. Package upgrades and skill installation are separate
 from provider discovery.
 
-### Native preview installation differences
+### Native installation and updates
 
 Native release installers use a versioned `tmt-installer.sh` URL supplied by the
-release; public publication may still be pending. Never invent a working URL or
+release. Use the repository README or an actual published release; never invent a URL or
 use npm `upgrade` as a native migration. The shell bootstrap defaults to
 `~/.local/bin/tmt`, supports `--prefix`, `--pin` and `--no-skill`, and otherwise
 runs the new absolute command's skill installer. It does not migrate/delete data
@@ -537,7 +532,7 @@ The selected Rust executable embeds this exact skill; viewing and installation
 work after moving the binary, without Node or a checkout. Native installs link
 an immutable digest-addressed source under TMT's global directory
 (`skill-assets/<sha256>/tmux-team`). Re-run the intended `install` command after
-replacing a preview binary to refresh valid managed links. An edited current
+replacing a manual binary to refresh valid managed links. An edited current
 bundled source blocks installation even with force; inspect it before repair.
 Links to modified older sources are unmanaged conflicts: force can back up the
 link, never overwrite its source content. Old source
@@ -557,8 +552,7 @@ receipt's channel. `--channel stable|alpha` selects a channel, `--to <version>`
 pins an exact version, and `--unpin` resumes channel updates; do not combine
 `--to` and `--unpin`. Downgrades are rejected. An ordinary pinned invocation is
 a no-network no-op. Package-manager or unmanaged binaries refuse native updates;
-use their original manager, not an overwrite workaround. No public native
-download is implied until its separate release gate is complete.
+use their original manager, not an overwrite workaround.
 
 Successful native updates use the new executable to refresh only recorded
 managed skills. Missing integrations stay missing and modified content is

--- a/src/native-artifact-policy.test.ts
+++ b/src/native-artifact-policy.test.ts
@@ -120,7 +120,7 @@ async function createArchiveFixture(
         assets: REQUIRED_FILES.map((file) => ({ path: file })),
       },
     },
-    releases: [{ app_version: VERSION, artifacts: [name] }],
+    releases: [{ app_name: 'tmt-cli', app_version: VERSION, artifacts: [name] }],
   };
   fs.writeFileSync(manifestFile, `${JSON.stringify(manifest)}\n`);
   return {
@@ -238,6 +238,13 @@ describe('native artifact policy', () => {
       expect(() =>
         selectNativeArtifact(releaseFixture.manifestFile, releaseFixture.archiveFile, TARGET)
       ).toThrow('Archive must belong to exactly one release');
+
+      const wrongOwner = structuredClone(releaseFixture.manifest);
+      (wrongOwner.releases as Array<Record<string, unknown>>)[0].app_name = 'unrelated-app';
+      fs.writeFileSync(releaseFixture.manifestFile, JSON.stringify(wrongOwner));
+      expect(() =>
+        selectNativeArtifact(releaseFixture.manifestFile, releaseFixture.archiveFile, TARGET)
+      ).toThrow('Archive must belong to the TMT release');
     });
   });
 

--- a/src/native-bootstrap.test.ts
+++ b/src/native-bootstrap.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -18,7 +19,11 @@ const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url))
 const { generateNativeBootstrap } = (await import(
   pathToFileURL(path.join(repositoryRoot, 'scripts', 'native-bootstrap.mjs')).href
 )) as unknown as {
-  generateNativeBootstrap: (manifestFile: string, archiveDirectory: string) => Promise<string>;
+  generateNativeBootstrap: (
+    manifestFile: string,
+    archiveDirectory: string,
+    planFile?: string
+  ) => Promise<string>;
 };
 
 const REQUIRED_FILES = ['tmt', 'LICENSE', 'NATIVE-INSTALL.md', 'THIRD-PARTY-NOTICES.txt'];
@@ -211,6 +216,62 @@ function expectCleanStage(stage: string): void {
 }
 
 describe('native curl bootstrap', () => {
+  it('checks every archive in a multi-platform release before host selection', async () => {
+    await withSandbox(async (sandbox) => {
+      const targets = [
+        'aarch64-apple-darwin',
+        'x86_64-apple-darwin',
+        'aarch64-unknown-linux-musl',
+        'x86_64-unknown-linux-musl',
+      ];
+      const directory = mkdtempSync(path.join(sandbox.root, 'release-bundle-'));
+      const combined = {
+        artifacts: {} as Record<string, unknown>,
+        releases: [
+          { app_name: 'tmt-cli', app_version: '5.0.0-alpha.1', artifacts: [] as string[] },
+        ],
+      };
+      let host: Fixture | undefined;
+      let foreignArchive = '';
+      for (const target of targets) {
+        const fixture = await createFixture(sandbox, { target });
+        const metadata = JSON.parse(readFileSync(fixture.manifest, 'utf8')) as typeof combined;
+        Object.assign(combined.artifacts, metadata.artifacts);
+        combined.releases[0].artifacts.push(path.basename(fixture.archive));
+        const archive = path.join(directory, path.basename(fixture.archive));
+        copyFileSync(fixture.archive, archive);
+        if (target === nativeTarget()) host = { ...fixture, archive };
+        else foreignArchive = archive;
+      }
+      const manifest = path.join(directory, 'dist-manifest.json');
+      writeFileSync(manifest, JSON.stringify(combined));
+      const plan = path.join(directory, 'plan.json');
+      writeFileSync(plan, JSON.stringify(combined));
+      const script = await generateNativeBootstrap(manifest, directory, plan);
+      expect(host).toBeDefined();
+      const run = await runBootstrap(sandbox, script, { ...host!, manifest }, ['--no-skill']);
+      expect(run.result.status).toBe(0);
+      expect(readFileSync(run.curlLog, 'utf8')).toContain(path.basename(host!.archive));
+      expectCleanStage(run.stage);
+
+      const incomplete = structuredClone(combined);
+      delete incomplete.artifacts[path.basename(foreignArchive)];
+      writeFileSync(manifest, JSON.stringify(incomplete));
+      await expect(generateNativeBootstrap(manifest, directory, plan)).rejects.toThrow(
+        'Release must contain every planned native artifact'
+      );
+      writeFileSync(manifest, JSON.stringify(combined));
+
+      // Even an archive for a different CPU/OS is part of the release trust input.
+      const corrupt = readFileSync(foreignArchive);
+      corrupt[0] ^= 1;
+      writeFileSync(foreignArchive, corrupt);
+      await expect(generateNativeBootstrap(manifest, directory)).rejects.toThrow(
+        'Native archive checksum mismatch'
+      );
+    });
+  });
+
   it('generates a release-specific script from verified cargo-dist artifacts', async () => {
     await withSandbox(async (sandbox) => {
       const fixture = await createFixture(sandbox);

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -17,6 +17,12 @@ if (typeof packageVersion !== 'string') {
 }
 
 describe('version', () => {
+  it('keeps native workspace and package versions synchronized', () => {
+    const workspace = fs.readFileSync(path.join(repoRoot, 'rust/Cargo.toml'), 'utf8');
+    const packageSection = workspace.split('[workspace.package]')[1]?.split('\n[')[0];
+    expect(packageSection?.match(/^version = "([^"]+)"$/m)?.[1]).toBe(packageVersion);
+  });
+
   beforeEach(() => {
     vi.restoreAllMocks();
   });

--- a/src/version.ts
+++ b/src/version.ts
@@ -14,7 +14,7 @@ function getVersion(): string {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     return pkg.version;
   } catch {
-    return '5.0.0-alpha.1';
+    return '5.0.0-alpha.2';
   }
 }
 

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -9,11 +9,11 @@ import {
   withSandbox,
 } from '../../src/test-support/cli-process.js';
 
-// This suite is deliberately native-preview-specific. Requiring the shared
+// This suite is deliberately native-specific. Requiring the shared
 // descriptor prevents an omitted build from silently exercising TypeScript.
 if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
 
-describe('native grammar preview process contract', () => {
+describe('native grammar process contract', () => {
   it('generates valid shells without offering rejected or unrelated options', async () => {
     await withSandbox(async (sandbox) => {
       for (const shell of ['bash', 'zsh']) {
@@ -55,16 +55,25 @@ describe('native grammar preview process contract', () => {
       const before = fileSnapshot(sandbox.root);
       const version = await runCli(sandbox, ['--version']);
       expect(version.status).toBe(0);
-      expect(version.stdout).toBe('5.0.0-alpha.1\n');
+      expect(version.stdout).toBe('5.0.0-alpha.2\n');
       expect(version.stderr).toBe('');
       const help = await runCli(sandbox, ['help']);
       expect(help.status).toBe(0);
       expect(help.stderr).toBe('');
-      expect(help.stdout).toContain('Native development preview');
-      expect(help.stdout).toContain(
-        'configuration, identity create/show/list, talk/reply/result, pane identity name/this/add/whoami/unbind/rm/list, diagnostic check/read, role/preamble, x attention, init, learn, and skill installation are available'
-      );
-      expect(help.stdout).toContain('Managed native upgrade/update is supported');
+      expect(help.stdout).toContain('TMT native alpha');
+      expect(help.stdout).toContain('managed installations use tmt upgrade');
+      for (const command of [
+        'talk',
+        'reply',
+        'result',
+        'check',
+        'role',
+        'preamble',
+        'x',
+        'install',
+      ]) {
+        expect(help.stdout).toMatch(new RegExp(`^  ${command}\\s`, 'm'));
+      }
       expect(help.stdout).toContain('Manage identity records without probing tmux');
       expect(help.stdout).toContain('temporary unless saved');
       expect(help.stdout).toContain('rm');
@@ -129,7 +138,7 @@ describe('native grammar preview process contract', () => {
       copyFileSync(sandbox.cli.executable, executable);
       const result = await runCli({ ...sandbox, cli: { executable, args: [] } }, ['--version']);
       expect(result.status).toBe(0);
-      expect(result.stdout).toBe('5.0.0-alpha.1\n');
+      expect(result.stdout).toBe('5.0.0-alpha.2\n');
       expect(result.stderr).toBe('');
       expect(existsSync(sandbox.database)).toBe(false);
     });


### PR DESCRIPTION
## Summary

- Prepare standalone native alpha `5.0.0-alpha.2`, synchronize versions and native help/learn, and update canonical agent/installation guidance.
- Add an explicit main-only, read-only native release-artifact workflow, separate from ordinary PR CI. cargo-dist merges per-target manifests; all four matching native hosts verify the final bundle before authorized publication.
- Reuse the existing installer/updater and archive/bootstrap validation owners. Add complete cargo-dist plan coverage and TMT app ownership checks, with representative negative tests.

Refs #147. Verified public README promotion is the dependent #148; no unverified public URL is advertised in this PR. Native GitHub publication is authorized separately in the current user request, but this workflow does not publish. No npm publish/dist-tag changes, global install, database transfer or deletion.

## Architecture and primary review

The primary personally inspected all changed runtime/version/test/documentation files, workflow job/permissions boundaries, `build-native-artifact.sh`, cargo-dist 0.32.0 manifest aggregation implementation, archive policy and both actual-artifact verifiers. The runtime changes are version/guide text only; storage, request/reply and permanent installation owners remain unchanged. ARCHITECTURE and DEVELOPMENT describe reference/native boundaries, preparation and publication gates.

An independent Luna audit identified coverage and integrity alignment risks. Primary reproduced incomplete cargo-dist aggregation locally, then added `--plan` exact inventory acceptance rather than another target catalog. A manifest owned by an unrelated application now fails at the independent selector, matching native Rust validation. Both have specific negative assertions. Main-only dispatch prevents arbitrary branch preparation; publication still requires operator verification of exact run SHA and required-checks-green reviewed source.

## Verification

- [x] `pnpm check` locally; workflow `actionlint` and generated POSIX shell/ShellCheck validation.
- [x] Locked Rust fmt/Clippy, 393 Rust tests (one intentional ignore), MSRV 1.88 build and current-toolchain build.
- [x] Native process suite: 104 tests; shared parser/config subsets: 8 and 6 cases.
- [x] Full TypeScript unit/coverage suite; release tests include four-artifact host selection, corrupt foreign archive, omitted planned artifact and wrong app ownership.
- [x] Actual macOS arm64 alpha.2 archive: linkage, version, embedded skill, managed install and persisted SQLite; actual bootstrap with controlled curl acquisition and no Node/Rust runtime PATH.
- [x] cargo-dist local-to-global merge exercised locally; incomplete real manifest rejected against complete cargo-dist plan before generating installer code.
- [x] Two isolated local Docker lifecycle passes: each 283 adapter tests and 159 E2E cases (one intentional performance skip), 319.14s / 313.54s. Shipped runtime is unchanged by the subsequent verifier-only plan/app-owner review corrections; their focused tests and real archive proof also pass.
- [x] All 11 required/reported CI checks passed on reviewed head `ff507a907bc4e8a992b3cb0ec641554fa7bf171d`, run `34225476534`, first submitted candidate.

Initial local environment failures were diagnosed, not assertion-suppressed: host Node 26 emitted dependency deprecations (verified with supported Node 24); sandbox blocked loopback TLS and Xcode inspection (rerun with scoped escalation). A stale preview-help expectation was replaced with grammar-command assertions, then all native process tests reran successfully.

Four-platform artifacts and live public-download evidence are subsequent release gates, not claimed by the transitional npm matrix or local controlled-curl test. The release issue remains open until actual delivery and #148 README promotion.
