### PR TITLE
Validate paired native performance before cutover

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,6 +19,16 @@ explicitly identify native owners. Native lifetime rules (temporary by default,
 explicit save, retirement) supersede durable-only identity assumptions there.
 Source cleanup and measured performance acceptance remain tracked in #93.
 
+Paired performance acceptance (#151) retains the TypeScript reference until
+measurements are captured. Both startup and private-tmux benchmarks reuse the
+test-only executable selector and a shared independent help-command oracle in
+`src/test-support/performance-contract.mjs`; they do not import runtime grammar.
+The E2E Dockerfile can select an optimized CLI with `TMT_NATIVE_PROFILE=release`
+without changing the default regression profile or creating another harness.
+Timing never replaces exact output, independent state, mock-submission and
+cleanup assertions. Resource precision and unmeasured workload limits belong
+in PERFORMANCE-BASELINE, not a claimed universal speedup.
+
 Release preparation is orchestration, not a second artifact or install owner.
 `dist-workspace.toml` selects artifacts; cargo-dist merges per-host manifests
 from `target/distrib/*-dist-manifest.json` into the authoritative final manifest.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,9 +29,9 @@ pnpm dev -- --help
 
 ## Running Tests
 
-### Native development preview
+### Native runtime development
 
-The `rust/` workspace is not the installed runtime yet. It implements only
+The `rust/` workspace owns the published standalone native alpha. It implements
 help/version/completion, typed grammar, the existing `config` command and
 storage-only `identity create/show/list` under #113, and pane identity
 `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` under #109, plus storage-only
@@ -40,7 +40,10 @@ storage-only `identity create/show/list` under #113, and pane identity
 and `init`/`learn`/managed skill installation under #133.
 Native `upgrade`/`update` under #142 compose verified HTTPS acquisition, the
 offline publication owner and new-executable managed-skill refresh. Public
-release availability and installed-runtime cutover remain separate gates.
+release alpha.2 is verified under #147; removing the transitional TypeScript
+reference and its test/packaging dependencies remains #93. The detailed slice
+notes below distinguish unit, adapter and end-to-end evidence; an earlier
+slice's limited coverage is not the current command inventory.
 The #118 request/final service is the shared transactional foundation;
 public reply/result composition is supplied by #122 and talk by #129. Its real SQLite
 tests run in ordinary adapter Cargo tests and therefore in the existing Docker
@@ -251,6 +254,12 @@ For runtime-rewrite work, read [RUST-REWRITE.md](RUST-REWRITE.md) for the propos
 boundaries and parity gates. The optional [performance baseline](PERFORMANCE-BASELINE.md)
 reuses the Docker E2E harness and separately measures macOS startup resources.
 Its wall-clock samples are diagnostic evidence, not an ordinary CI timing gate.
+For paired measurements, build that same Dockerfile with
+`--build-arg TMT_NATIVE_PROFILE=release`. The default remains `dev` for ordinary
+regression runs; only the measured CLI changes profile, while adapter tests and
+the development probe remain debug builds. Select `/opt/tmt-tests/tmt` explicitly
+with `TMT_TEST_CLI`; the mock peer inherits that selection. Never compare the
+default debug executable to the TypeScript reference and call it release evidence.
 
 - Watch mode:
 

--- a/PERFORMANCE-BASELINE.md
+++ b/PERFORMANCE-BASELINE.md
@@ -1,4 +1,97 @@
-# TypeScript runtime baseline
+# Runtime performance evidence
+
+## Native closeout comparison (#151)
+
+The native alpha is published. Before removing the TypeScript reference, this
+comparison measures both runtimes from source `e3c8bd7e9a2fdaab0ccfe59a03be7967a7719fcb`
+on the same host with unchanged command defaults. All raw observations, source
+trees, build identity and failed-calibration dispositions are retained in
+[paired evidence](benchmarks/native-paired-performance.json). The historical
+baseline below remains unchanged evidence, not the denominator for this comparison.
+
+The native build uses Rust 1.97.0, locked dependencies, release optimization,
+thin LTO and stripped debug information. macOS uses aarch64-apple-darwin; Docker
+uses aarch64-unknown-linux-gnu in the existing pinned Bookworm fixture. The latter
+is not the published static-musl archive. The measured macOS executable is
+7,344,960 bytes. These are same-source optimized builds, not an installed-binary
+update or a claim that different target linkages have identical performance.
+
+### Paired startup resources
+
+Collected on 2026-09-08, Apple M4 Pro/arm64, Darwin 25.6.0 and Node 24.20.0
+for test tooling. Order was TS, native, native, TS, with seven fresh-process
+samples per scenario per run. No other task-owned build/test workload ran during
+collection; host-wide quiescence and dropped OS caches are not claimed.
+
+| Scenario              | TS median ms, runs 1 / 2 | Native median ms, runs 1 / 2 | TS median RSS MB, runs 1 / 2 | Native median RSS MB, runs 1 / 2 |
+| --------------------- | ------------------------ | ---------------------------- | ---------------------------- | -------------------------------- |
+| Help                  | 156.72 / 158.82          | 14.85 / 15.03                | 100.73 / 100.37              | 8.39 / 8.36                      |
+| Fresh storage create  | 162.37 / 165.69          | 18.90 / 19.16                | 102.25 / 102.04              | 11.17 / 11.16                    |
+| Existing storage show | 158.66 / 158.81          | 15.41 / 16.42                | 100.30 / 100.56              | 10.47 / 10.47                    |
+
+All paired medians exceed the previously recorded 30% wall/RSS improvement goal:
+roughly 88–91% less wall time and 89–92% less maximum RSS in these scenarios.
+TS median per-sample user+system CPU is 0.18–0.19 seconds; native medians round
+to 0.00 at the time tool's centisecond precision. This is not zero CPU usage.
+RSS is a process-tree maximum, not summed concurrent memory. Wall time includes
+the measurement wrappers. Show must return the exact identity UUID/content
+created by the preceding process, not merely a matching display name.
+
+### Paired private-tmux latency
+
+For each peer delay, collection order was TS, native, native, TS in separate
+network-isolated containers from the same image.
+The Docker VM exposes 12 CPUs and 8,319,238,144 bytes of memory, without additional
+per-container CPU or memory limits in either runtime's run. Both originator and mock-reply
+CLI descriptors select the same runtime. Each repeated series has seven samples;
+fresh identity creation has one per container. All eight reports passed exact
+reply/result, independent identity-state, no-tmux and fixture-cleanup assertions.
+
+| Scenario                   | TS median ms, runs 1 / 2 | Native median ms, runs 1 / 2 | Traced tmux calls TS / native |
+| -------------------------- | ------------------------ | ---------------------------- | ----------------------------- |
+| Whoami, small              | 167.20 / 156.20          | 10.05 / 7.99                 | 5 / 4                         |
+| Whoami, 201 panes          | 167.39 / 160.90          | 9.66 / 10.77                 | 5 / 4                         |
+| Check, small               | 165.00 / 157.00          | 9.68 / 10.83                 | 6 / 5                         |
+| Check, 201 panes           | 167.76 / 161.17          | 13.11 / 12.17                | 6 / 5                         |
+| Talk, immediate mock final | 707.01 / 707.79          | 538.87 / 543.08              | 13 / 12                       |
+| Result, immediate series   | 151.37 / 143.47          | 2.04 / 2.11                  | 0 / 0                         |
+| Talk, 1,500 ms mock delay  | 2720.55 / 2717.57        | 1544.16 / 1543.94            | 13 / 12                       |
+
+The deterministic small/large scoped subprocess-count gates pass for every
+sample, and there is no repeated native-versus-TS scoped median regression.
+Constant call counts do not imply constant internal tmux traversal time: native
+large-session checks still take several milliseconds more than small ones.
+Counts include fixture session discovery and are not total OS process counts.
+
+Both reports observe the same 500 ms paste/Enter delay and 1-second poll interval;
+the benchmark uses an 8-second timeout and no preamble. Reply arrival relative
+to polling can move completion by an entire interval. The delayed round-trip
+difference is not a direct measurement of pure TMT processing or permission to
+subtract the mock delay and claim service time. No production timing changed.
+
+### Measurement corrections and remaining limits
+
+The old help-heading assertion rejected native output. Both benchmarks now use
+one independent command-presence oracle with missing-command/false-output tests.
+An initial native tmux calibration then failed because the trace labeled the
+global `-S` option as the command. Tracing now shares the fixture's existing
+argv inspection; actual ambient/explicit-socket buffer round trips preserve
+multiline and option-like payload bytes. Neither failed calibration produced
+accepted native timing evidence; all paired Docker runs were recollected.
+
+Reproduce using the existing commands below, adding
+`--build-arg TMT_NATIVE_PROFILE=release` to Docker build and selecting
+`TMT_TEST_CLI='{"executable":"/opt/tmt-tests/tmt","args":[]}'` for native container
+runs. The peer inherits that descriptor. Default Docker regression builds remain
+debug; the profile option only selects the measured CLI, not another harness.
+
+This satisfies paired startup/scoped-latency acceptance, not all of #93.
+Complete Docker request-process CPU/RSS, sustained contention, multiple active
+peers and cross-platform distributions remain unmeasured. No high-volume capacity
+or universal speedup claim follows from these results. Source/test ownership
+cleanup is sequenced in #152 before removal of the reference runtime.
+
+## Historical TypeScript baseline
 
 Owner: [#94](https://github.com/wkh237/tmux-team/issues/94), under the
 [Rust rewrite decision](RUST-REWRITE.md). Production reference:

--- a/benchmarks/native-paired-performance.json
+++ b/benchmarks/native-paired-performance.json
@@ -1,0 +1,5373 @@
+{
+  "sourceRevision": "e3c8bd7e9a2fdaab0ccfe59a03be7967a7719fcb",
+  "nativeSourceTree": "f0fd0fdb01a6837ccd9c47bb8ed1a0dca45d144f",
+  "typescriptReferenceTree": "7600257ee2fa151d775b835d6c6b70a3a9562d50",
+  "productionChanges": "None; measurement assertions, shared trace inspection and optional Docker CLI profile differ from the source revision.",
+  "nativeBuild": {
+    "toolchain": "1.97.0",
+    "profile": "release",
+    "lto": "thin",
+    "strip": "debuginfo",
+    "cargoLockSha256": "9f8ea42574a69c5a1c8b5c292ff3fefe5eab4532493e6e10b6d95294ff18216f",
+    "macosBinaryBytes": 7344960,
+    "macosBinarySha256": "686a8a7c7da83461a001231fe68e3f7824d3e2edf64d0a25acd7ed76d087b87f",
+    "macosTarget": "aarch64-apple-darwin",
+    "dockerTarget": "aarch64-unknown-linux-gnu",
+    "dockerBinaryBytes": 8314176,
+    "dockerBinarySha256": "7e66d6fecee168cc31751477ee340c68abc2389d0412d2deea99da1179ef18df",
+    "dockerLinkage": ["libgcc_s.so.1", "libm.so.6", "libc.so.6", "ld-linux-aarch64.so.1"],
+    "dockerVmCpus": 12,
+    "dockerVmMemoryBytes": 8319238144,
+    "containerLimits": "No additional per-container CPU or memory limits; identical Docker VM resources for all paired runs.",
+    "dockerImage": "sha256:94d469ffbad79e7e180893dd8ea4d5d915bdebb812791c2d9e83a2f5be44ac01",
+    "note": "Same-source optimized builds, not a claim that the glibc Docker binary is the published static-musl archive."
+  },
+  "invalidCalibrations": [
+    "Native startup rejected the old TALK OPTIONS heading assertion; no accepted report. Replaced it with shared independently tested command presence.",
+    "Initial native Docker calibration rejected -S as an unknown trace command; no accepted report. Reused existing fixture argument inspection and verified explicit socket/multiline payload preservation, then recollected all eight paired runs."
+  ],
+  "startup": [
+    {
+      "runtime": "ts",
+      "run": 1,
+      "report": {
+        "schemaVersion": 1,
+        "executable": {
+          "executable": "/Users/benhsieh/.local/share/fnm/node-versions/v24.20.0/installation/bin/node",
+          "args": ["/Users/benhsieh/dev/tmt-151-native-performance/bin/tmux-team"]
+        },
+        "platform": "darwin",
+        "arch": "arm64",
+        "kernel": "25.6.0",
+        "node": "v24.20.0",
+        "cpu": "Apple M4 Pro",
+        "tool": "/usr/bin/time -lp",
+        "samples": [
+          {
+            "scenario": "help",
+            "wallMs": 526.5453329999999,
+            "userSeconds": 0.28,
+            "systemSeconds": 0.07,
+            "maximumResidentSetBytes": 104464384
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 302.22783400000003,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 101613568
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 159.03054199999997,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.02,
+            "maximumResidentSetBytes": 100515840
+          },
+          {
+            "scenario": "help",
+            "wallMs": 159.97450000000015,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100941824
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 178.56716700000015,
+            "userSeconds": 0.17,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 103006208
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 156.88795800000003,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100286464
+          },
+          {
+            "scenario": "help",
+            "wallMs": 156.72329200000013,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.02,
+            "maximumResidentSetBytes": 101302272
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 162.36520799999994,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 102596608
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 157.09537499999988,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.02,
+            "maximumResidentSetBytes": 99942400
+          },
+          {
+            "scenario": "help",
+            "wallMs": 156.90766599999984,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.02,
+            "maximumResidentSetBytes": 100171776
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 159.20191700000032,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.02,
+            "maximumResidentSetBytes": 102039552
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 158.3382499999998,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.02,
+            "maximumResidentSetBytes": 100106240
+          },
+          {
+            "scenario": "help",
+            "wallMs": 154.90149999999994,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 99942400
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 161.94820900000013,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 101629952
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 158.66383300000007,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100302848
+          },
+          {
+            "scenario": "help",
+            "wallMs": 156.3414170000001,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.02,
+            "maximumResidentSetBytes": 99942400
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 161.20262500000035,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 102252544
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 160.22800000000007,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.02,
+            "maximumResidentSetBytes": 100892672
+          },
+          {
+            "scenario": "help",
+            "wallMs": 155.32749999999987,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.02,
+            "maximumResidentSetBytes": 100728832
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 165.98291699999982,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 102825984
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 171.73491700000022,
+            "userSeconds": 0.17,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 101433344
+          }
+        ],
+        "interpretation": "Fresh processes, not dropped OS caches. CPU includes waited descendants; maximum RSS is not the sum of simultaneously live processes. Timing includes measurement wrappers. No tmux or agent work is measured."
+      }
+    },
+    {
+      "runtime": "native",
+      "run": 1,
+      "report": {
+        "schemaVersion": 1,
+        "executable": {
+          "executable": "/Users/benhsieh/dev/tmt-151-native-performance/rust/target/release/tmt",
+          "args": []
+        },
+        "platform": "darwin",
+        "arch": "arm64",
+        "kernel": "25.6.0",
+        "node": "v24.20.0",
+        "cpu": "Apple M4 Pro",
+        "tool": "/usr/bin/time -lp",
+        "samples": [
+          {
+            "scenario": "help",
+            "wallMs": 15.434833000000001,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8388608
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 20.322041000000006,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11091968
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 15.281625000000005,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10469376
+          },
+          {
+            "scenario": "help",
+            "wallMs": 13.884083000000004,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8421376
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 18.101208999999997,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11124736
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 15.297042000000005,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10584064
+          },
+          {
+            "scenario": "help",
+            "wallMs": 15.155875000000009,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8404992
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 18.980290999999994,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11223040
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 16.725583999999998,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10469376
+          },
+          {
+            "scenario": "help",
+            "wallMs": 14.049457999999987,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8273920
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 19.573167000000012,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11173888
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 15.486125000000015,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10469376
+          },
+          {
+            "scenario": "help",
+            "wallMs": 14.653790999999984,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8323072
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 18.899999999999977,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11223040
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 15.218125000000015,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10452992
+          },
+          {
+            "scenario": "help",
+            "wallMs": 15.169750000000022,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8339456
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 18.852125,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11108352
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 15.410624999999982,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10420224
+          },
+          {
+            "scenario": "help",
+            "wallMs": 14.84758400000004,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8404992
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 17.967416000000014,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11173888
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 16.06370800000002,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10452992
+          }
+        ],
+        "interpretation": "Fresh processes, not dropped OS caches. CPU includes waited descendants; maximum RSS is not the sum of simultaneously live processes. Timing includes measurement wrappers. No tmux or agent work is measured."
+      }
+    },
+    {
+      "runtime": "native",
+      "run": 2,
+      "report": {
+        "schemaVersion": 1,
+        "executable": {
+          "executable": "/Users/benhsieh/dev/tmt-151-native-performance/rust/target/release/tmt",
+          "args": []
+        },
+        "platform": "darwin",
+        "arch": "arm64",
+        "kernel": "25.6.0",
+        "node": "v24.20.0",
+        "cpu": "Apple M4 Pro",
+        "tool": "/usr/bin/time -lp",
+        "samples": [
+          {
+            "scenario": "help",
+            "wallMs": 16.162667,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8323072
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 19.749833000000002,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11173888
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 15.826166999999998,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10502144
+          },
+          {
+            "scenario": "help",
+            "wallMs": 15.026291,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8306688
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 18.021459000000007,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11223040
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 16.666167,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10387456
+          },
+          {
+            "scenario": "help",
+            "wallMs": 15.188292000000004,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8421376
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 18.505041000000006,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11075584
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 16.900125000000003,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10469376
+          },
+          {
+            "scenario": "help",
+            "wallMs": 14.684167000000002,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8306688
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 19.157332999999994,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11173888
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 16.365542000000005,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10502144
+          },
+          {
+            "scenario": "help",
+            "wallMs": 14.567791999999997,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8470528
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 18.81408300000001,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11157504
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 17.357792000000018,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10469376
+          },
+          {
+            "scenario": "help",
+            "wallMs": 15.593958000000043,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8355840
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 19.59137499999997,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11157504
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 16.417708000000005,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10436608
+          },
+          {
+            "scenario": "help",
+            "wallMs": 13.896582999999964,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 8404992
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 19.299874999999986,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 11141120
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 15.868540999999993,
+            "userSeconds": 0,
+            "systemSeconds": 0,
+            "maximumResidentSetBytes": 10436608
+          }
+        ],
+        "interpretation": "Fresh processes, not dropped OS caches. CPU includes waited descendants; maximum RSS is not the sum of simultaneously live processes. Timing includes measurement wrappers. No tmux or agent work is measured."
+      }
+    },
+    {
+      "runtime": "ts",
+      "run": 2,
+      "report": {
+        "schemaVersion": 1,
+        "executable": {
+          "executable": "/Users/benhsieh/.local/share/fnm/node-versions/v24.20.0/installation/bin/node",
+          "args": ["/Users/benhsieh/dev/tmt-151-native-performance/bin/tmux-team"]
+        },
+        "platform": "darwin",
+        "arch": "arm64",
+        "kernel": "25.6.0",
+        "node": "v24.20.0",
+        "cpu": "Apple M4 Pro",
+        "tool": "/usr/bin/time -lp",
+        "samples": [
+          {
+            "scenario": "help",
+            "wallMs": 153.371958,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 99696640
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 167.03712499999997,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 101662720
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 156.29920799999996,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100794368
+          },
+          {
+            "scenario": "help",
+            "wallMs": 156.41941699999995,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100909056
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 161.72954200000004,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 101269504
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 158.088125,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100564992
+          },
+          {
+            "scenario": "help",
+            "wallMs": 159.2811250000001,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100417536
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 165.6941670000001,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 102465536
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 155.571375,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100253696
+          },
+          {
+            "scenario": "help",
+            "wallMs": 160.0854999999999,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100368384
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 165.94354199999998,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 103350272
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 166.02145799999994,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 101564416
+          },
+          {
+            "scenario": "help",
+            "wallMs": 163.88770799999975,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 101269504
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 164.19974999999977,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 101548032
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 160.99604099999988,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100237312
+          },
+          {
+            "scenario": "help",
+            "wallMs": 158.8197500000001,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100057088
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 168.4130839999998,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 103006208
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 158.97716599999967,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 101695488
+          },
+          {
+            "scenario": "help",
+            "wallMs": 158.02854099999968,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 99942400
+          },
+          {
+            "scenario": "fresh-storage-create",
+            "wallMs": 165.0704999999998,
+            "userSeconds": 0.16,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 102039552
+          },
+          {
+            "scenario": "existing-storage-show",
+            "wallMs": 158.8067500000002,
+            "userSeconds": 0.15,
+            "systemSeconds": 0.03,
+            "maximumResidentSetBytes": 100483072
+          }
+        ],
+        "interpretation": "Fresh processes, not dropped OS caches. CPU includes waited descendants; maximum RSS is not the sum of simultaneously live processes. Timing includes measurement wrappers. No tmux or agent work is measured."
+      }
+    }
+  ],
+  "docker": [
+    {
+      "runtime": "ts",
+      "delay": "fast",
+      "order": 1,
+      "report": {
+        "executables": {
+          "cli": {
+            "executable": "/usr/local/bin/node",
+            "args": ["/workspace/bin/tmux-team"]
+          },
+          "peer": {
+            "executable": "/usr/local/bin/node",
+            "args": ["/workspace/bin/tmux-team"]
+          }
+        },
+        "schemaVersion": 1,
+        "benchmark": "tmt-performance-baseline",
+        "generatedAt": "2026-09-08T13:43:36.953Z",
+        "sampleCount": 7,
+        "warmSampleCount": 6,
+        "semantics": {
+          "firstObservation": "The first observation runs after fixture setup and is reported separately; it is not an OS-cache-cold measurement.",
+          "warmFreshProcess": "Each warm sample launches a new CLI process after the first observation.",
+          "osCache": "Not controlled or claimed cold; filesystem and process caches may be warm."
+        },
+        "timingDefaults": {
+          "timeoutSeconds": 180,
+          "pollIntervalSeconds": 1,
+          "pasteEnterDelayMs": 500,
+          "benchmarkTalkTimeoutSeconds": 8,
+          "injectedMockReplyDelayMs": 0
+        },
+        "environment": {
+          "node": "v22.23.2",
+          "tmux": "tmux 3.3a",
+          "platform": "linux",
+          "kernel": "7.0.12-linuxkit",
+          "arch": "arm64"
+        },
+        "resourceUsage": {
+          "cpu": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness exposes child PIDs but no child CPU accounting; parent Vitest usage is not a child metric."
+          },
+          "peakRss": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness does not sample child peak RSS; parent Vitest RSS is not a child metric."
+          }
+        },
+        "scenarios": {
+          "help": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 192.33,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 144.194,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 145.408,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 143.673,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 144.727,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 142.703,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 145.672,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 144.727,
+            "warmMedianMs": 144.4605
+          },
+          "identityCreate": {
+            "sampleCount": 1,
+            "warmSampleCount": 0,
+            "firstObservation": {
+              "wallMs": 160.314,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [],
+            "medianMs": 160.314,
+            "warmMedianMs": null
+          },
+          "identityShow": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 152.946,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 151.437,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 153.09,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 151.572,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 160.99,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 153.943,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 150.387,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 152.946,
+            "warmMedianMs": 152.33100000000002
+          },
+          "whoamiSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 167.199,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 165.087,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 168.803,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 170.355,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 166.73,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 170.229,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 165.979,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 167.199,
+            "warmMedianMs": 167.7665
+          },
+          "whoamiLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 167.388,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 165.699,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 170.382,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 163.504,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 165.889,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 167.814,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 171.525,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 167.388,
+            "warmMedianMs": 166.8515
+          },
+          "checkSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 161.569,
+              "subprocesses": 6,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 164.485,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 165.003,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 165.837,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 168.129,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 167.45,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 162.468,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 165.003,
+            "warmMedianMs": 165.42
+          },
+          "checkLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 167.755,
+              "subprocesses": 6,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 168.027,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 166.002,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 167.919,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 166.025,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 171.739,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 166.018,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 167.755,
+            "warmMedianMs": 166.972
+          },
+          "talkNoPreamble": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 704.441,
+              "subprocesses": 13,
+              "commandCounts": {
+                "display-message": 4,
+                "show-options": 3,
+                "list-panes": 3,
+                "set-buffer": 1,
+                "paste-buffer": 1,
+                "send-keys": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 700.96,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 704.706,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 707.005,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 718.228,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 716.907,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 795.865,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              }
+            ],
+            "medianMs": 707.005,
+            "warmMedianMs": 711.956
+          },
+          "result": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 149.26,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 150.041,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 187.236,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 151.369,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 146.867,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 153.477,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 152.377,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 151.369,
+            "warmMedianMs": 151.873
+          }
+        }
+      }
+    },
+    {
+      "runtime": "native",
+      "delay": "fast",
+      "order": 2,
+      "report": {
+        "executables": {
+          "cli": {
+            "executable": "/opt/tmt-tests/tmt",
+            "args": []
+          },
+          "peer": {
+            "executable": "/opt/tmt-tests/tmt",
+            "args": []
+          }
+        },
+        "schemaVersion": 1,
+        "benchmark": "tmt-performance-baseline",
+        "generatedAt": "2026-09-08T13:43:43.520Z",
+        "sampleCount": 7,
+        "warmSampleCount": 6,
+        "semantics": {
+          "firstObservation": "The first observation runs after fixture setup and is reported separately; it is not an OS-cache-cold measurement.",
+          "warmFreshProcess": "Each warm sample launches a new CLI process after the first observation.",
+          "osCache": "Not controlled or claimed cold; filesystem and process caches may be warm."
+        },
+        "timingDefaults": {
+          "timeoutSeconds": 180,
+          "pollIntervalSeconds": 1,
+          "pasteEnterDelayMs": 500,
+          "benchmarkTalkTimeoutSeconds": 8,
+          "injectedMockReplyDelayMs": 0
+        },
+        "environment": {
+          "node": "v22.23.2",
+          "tmux": "tmux 3.3a",
+          "platform": "linux",
+          "kernel": "7.0.12-linuxkit",
+          "arch": "arm64"
+        },
+        "resourceUsage": {
+          "cpu": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness exposes child PIDs but no child CPU accounting; parent Vitest usage is not a child metric."
+          },
+          "peakRss": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness does not sample child peak RSS; parent Vitest RSS is not a child metric."
+          }
+        },
+        "scenarios": {
+          "help": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 3.422,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 1.866,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 3.248,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.768,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.844,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.012,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.707,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 2.768,
+            "warmMedianMs": 2.3899999999999997
+          },
+          "identityCreate": {
+            "sampleCount": 1,
+            "warmSampleCount": 0,
+            "firstObservation": {
+              "wallMs": 8.971,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [],
+            "medianMs": 8.971,
+            "warmMedianMs": null
+          },
+          "identityShow": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 3.537,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 3.024,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.13,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.509,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.093,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.777,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.037,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 2.13,
+            "warmMedianMs": 2.1115
+          },
+          "whoamiSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 10.339,
+              "subprocesses": 4,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 9.66,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.324,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 9.362,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.047,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.623,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 9.479,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 10.047,
+            "warmMedianMs": 9.8535
+          },
+          "whoamiLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 9.533,
+              "subprocesses": 4,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 9.661,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 9.559,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 9.581,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 9.947,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 11.537,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 11.171,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 9.661,
+            "warmMedianMs": 9.803999999999998
+          },
+          "checkSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 9.969,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 9.517,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.487,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.683,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 10.296,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.936,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.585,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 9.683,
+            "warmMedianMs": 9.634
+          },
+          "checkLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 13.329,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 13.109,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 12.113,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 13.205,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 13.11,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 11.904,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 13.674,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 13.11,
+            "warmMedianMs": 13.1095
+          },
+          "talkNoPreamble": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 537.415,
+              "subprocesses": 12,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 3,
+                "list-panes": 3,
+                "set-buffer": 1,
+                "paste-buffer": 1,
+                "send-keys": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 537.43,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 544.308,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 535.516,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 538.872,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 539.27,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 543.076,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              }
+            ],
+            "medianMs": 538.872,
+            "warmMedianMs": 539.0709999999999
+          },
+          "result": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 2.531,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 1.909,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.035,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.085,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.802,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.8,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.494,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 2.035,
+            "warmMedianMs": 1.972
+          }
+        }
+      }
+    },
+    {
+      "runtime": "native",
+      "delay": "fast",
+      "order": 3,
+      "report": {
+        "executables": {
+          "cli": {
+            "executable": "/opt/tmt-tests/tmt",
+            "args": []
+          },
+          "peer": {
+            "executable": "/opt/tmt-tests/tmt",
+            "args": []
+          }
+        },
+        "schemaVersion": 1,
+        "benchmark": "tmt-performance-baseline",
+        "generatedAt": "2026-09-08T13:43:50.036Z",
+        "sampleCount": 7,
+        "warmSampleCount": 6,
+        "semantics": {
+          "firstObservation": "The first observation runs after fixture setup and is reported separately; it is not an OS-cache-cold measurement.",
+          "warmFreshProcess": "Each warm sample launches a new CLI process after the first observation.",
+          "osCache": "Not controlled or claimed cold; filesystem and process caches may be warm."
+        },
+        "timingDefaults": {
+          "timeoutSeconds": 180,
+          "pollIntervalSeconds": 1,
+          "pasteEnterDelayMs": 500,
+          "benchmarkTalkTimeoutSeconds": 8,
+          "injectedMockReplyDelayMs": 0
+        },
+        "environment": {
+          "node": "v22.23.2",
+          "tmux": "tmux 3.3a",
+          "platform": "linux",
+          "kernel": "7.0.12-linuxkit",
+          "arch": "arm64"
+        },
+        "resourceUsage": {
+          "cpu": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness exposes child PIDs but no child CPU accounting; parent Vitest usage is not a child metric."
+          },
+          "peakRss": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness does not sample child peak RSS; parent Vitest RSS is not a child metric."
+          }
+        },
+        "scenarios": {
+          "help": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 3.178,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 1.69,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.465,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.504,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.951,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.57,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.39,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 1.57,
+            "warmMedianMs": 1.537
+          },
+          "identityCreate": {
+            "sampleCount": 1,
+            "warmSampleCount": 0,
+            "firstObservation": {
+              "wallMs": 9.142,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [],
+            "medianMs": 9.142,
+            "warmMedianMs": null
+          },
+          "identityShow": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 1.992,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 3.065,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.962,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.885,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.075,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.075,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.871,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 1.992,
+            "warmMedianMs": 2.0185
+          },
+          "whoamiSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 7.993,
+              "subprocesses": 4,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 7.98,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 7.978,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 7.898,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.237,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 8.037,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 8.061,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 7.993,
+            "warmMedianMs": 8.008500000000002
+          },
+          "whoamiLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 10.17,
+              "subprocesses": 4,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 10.771,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 11.7,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.545,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.892,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.945,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.465,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 10.771,
+            "warmMedianMs": 10.8315
+          },
+          "checkSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 12.647,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 11.27,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 10.26,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 11.385,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.831,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 10.738,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 10.826,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 10.826,
+            "warmMedianMs": 10.782
+          },
+          "checkLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 11.929,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 12.189,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 12.163,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 12.171,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 12.482,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 12.527,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 11.938,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 12.171,
+            "warmMedianMs": 12.18
+          },
+          "talkNoPreamble": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 540.449,
+              "subprocesses": 12,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 3,
+                "list-panes": 3,
+                "set-buffer": 1,
+                "paste-buffer": 1,
+                "send-keys": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 540.185,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 545.095,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 546.806,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 543.081,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 542.737,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 545.709,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              }
+            ],
+            "medianMs": 543.081,
+            "warmMedianMs": 544.088
+          },
+          "result": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 2.658,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 2.444,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.108,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.998,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.931,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.86,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.307,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 2.108,
+            "warmMedianMs": 2.053
+          }
+        }
+      }
+    },
+    {
+      "runtime": "ts",
+      "delay": "fast",
+      "order": 4,
+      "report": {
+        "executables": {
+          "cli": {
+            "executable": "/usr/local/bin/node",
+            "args": ["/workspace/bin/tmux-team"]
+          },
+          "peer": {
+            "executable": "/usr/local/bin/node",
+            "args": ["/workspace/bin/tmux-team"]
+          }
+        },
+        "schemaVersion": 1,
+        "benchmark": "tmt-performance-baseline",
+        "generatedAt": "2026-09-08T13:44:05.313Z",
+        "sampleCount": 7,
+        "warmSampleCount": 6,
+        "semantics": {
+          "firstObservation": "The first observation runs after fixture setup and is reported separately; it is not an OS-cache-cold measurement.",
+          "warmFreshProcess": "Each warm sample launches a new CLI process after the first observation.",
+          "osCache": "Not controlled or claimed cold; filesystem and process caches may be warm."
+        },
+        "timingDefaults": {
+          "timeoutSeconds": 180,
+          "pollIntervalSeconds": 1,
+          "pasteEnterDelayMs": 500,
+          "benchmarkTalkTimeoutSeconds": 8,
+          "injectedMockReplyDelayMs": 0
+        },
+        "environment": {
+          "node": "v22.23.2",
+          "tmux": "tmux 3.3a",
+          "platform": "linux",
+          "kernel": "7.0.12-linuxkit",
+          "arch": "arm64"
+        },
+        "resourceUsage": {
+          "cpu": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness exposes child PIDs but no child CPU accounting; parent Vitest usage is not a child metric."
+          },
+          "peakRss": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness does not sample child peak RSS; parent Vitest RSS is not a child metric."
+          }
+        },
+        "scenarios": {
+          "help": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 178.793,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 135.677,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 132.037,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 130.537,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 130.008,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 127.718,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 131.094,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 131.094,
+            "warmMedianMs": 130.8155
+          },
+          "identityCreate": {
+            "sampleCount": 1,
+            "warmSampleCount": 0,
+            "firstObservation": {
+              "wallMs": 147.628,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [],
+            "medianMs": 147.628,
+            "warmMedianMs": null
+          },
+          "identityShow": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 140.775,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 143.056,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 140.873,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 140.952,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 141.3,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 139.666,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 140.265,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 140.873,
+            "warmMedianMs": 140.9125
+          },
+          "whoamiSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 153.522,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 156.195,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 157.77,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 155.223,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 151.837,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 158.616,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 157.861,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 156.195,
+            "warmMedianMs": 156.98250000000002
+          },
+          "whoamiLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 162.136,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 163.433,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 160.547,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 160.903,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 155.93,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 158.208,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 162.253,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 160.903,
+            "warmMedianMs": 160.725
+          },
+          "checkSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 156.996,
+              "subprocesses": 6,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 158.057,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 158.931,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 156.985,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 156.606,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 155.881,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 157.076,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 156.996,
+            "warmMedianMs": 157.03050000000002
+          },
+          "checkLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 161.174,
+              "subprocesses": 6,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 159.184,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 165.515,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 160.98,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 161.964,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 158.688,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 165.351,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 161.174,
+            "warmMedianMs": 161.47199999999998
+          },
+          "talkNoPreamble": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 698.371,
+              "subprocesses": 13,
+              "commandCounts": {
+                "display-message": 4,
+                "show-options": 3,
+                "list-panes": 3,
+                "set-buffer": 1,
+                "paste-buffer": 1,
+                "send-keys": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 713.927,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 710.285,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 710.157,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 707.786,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 704.118,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 702.479,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              }
+            ],
+            "medianMs": 707.786,
+            "warmMedianMs": 708.9715
+          },
+          "result": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 146.137,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 142.11,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 143.721,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 142.049,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 143.644,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 143.467,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 142.032,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 143.467,
+            "warmMedianMs": 142.7885
+          }
+        }
+      }
+    },
+    {
+      "runtime": "ts",
+      "delay": "slow",
+      "order": 1,
+      "report": {
+        "executables": {
+          "cli": {
+            "executable": "/usr/local/bin/node",
+            "args": ["/workspace/bin/tmux-team"]
+          },
+          "peer": {
+            "executable": "/usr/local/bin/node",
+            "args": ["/workspace/bin/tmux-team"]
+          }
+        },
+        "schemaVersion": 1,
+        "benchmark": "tmt-performance-baseline",
+        "generatedAt": "2026-09-08T13:44:37.109Z",
+        "sampleCount": 7,
+        "warmSampleCount": 6,
+        "semantics": {
+          "firstObservation": "The first observation runs after fixture setup and is reported separately; it is not an OS-cache-cold measurement.",
+          "warmFreshProcess": "Each warm sample launches a new CLI process after the first observation.",
+          "osCache": "Not controlled or claimed cold; filesystem and process caches may be warm."
+        },
+        "timingDefaults": {
+          "timeoutSeconds": 180,
+          "pollIntervalSeconds": 1,
+          "pasteEnterDelayMs": 500,
+          "benchmarkTalkTimeoutSeconds": 8,
+          "injectedMockReplyDelayMs": 1500
+        },
+        "environment": {
+          "node": "v22.23.2",
+          "tmux": "tmux 3.3a",
+          "platform": "linux",
+          "kernel": "7.0.12-linuxkit",
+          "arch": "arm64"
+        },
+        "resourceUsage": {
+          "cpu": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness exposes child PIDs but no child CPU accounting; parent Vitest usage is not a child metric."
+          },
+          "peakRss": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness does not sample child peak RSS; parent Vitest RSS is not a child metric."
+          }
+        },
+        "scenarios": {
+          "help": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 180.649,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 138.049,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 134.032,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 132.418,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 132.565,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 136.896,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 136.073,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 136.073,
+            "warmMedianMs": 135.0525
+          },
+          "identityCreate": {
+            "sampleCount": 1,
+            "warmSampleCount": 0,
+            "firstObservation": {
+              "wallMs": 157.408,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [],
+            "medianMs": 157.408,
+            "warmMedianMs": null
+          },
+          "identityShow": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 149.233,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 156.163,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 154.801,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 156.497,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 149.328,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 161.333,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 216.859,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 156.163,
+            "warmMedianMs": 156.33
+          },
+          "whoamiSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 161.189,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 172.236,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 171.066,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 161.499,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 156.125,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 160.172,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 160.896,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 161.189,
+            "warmMedianMs": 161.1975
+          },
+          "whoamiLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 163.835,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 159.75,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 161.821,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 156.483,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 158.226,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 157.284,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 157.372,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 158.226,
+            "warmMedianMs": 157.799
+          },
+          "checkSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 159.301,
+              "subprocesses": 6,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 156.709,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 154.89,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 156.895,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 159.309,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 157.514,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 157.898,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 157.514,
+            "warmMedianMs": 157.2045
+          },
+          "checkLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 160.216,
+              "subprocesses": 6,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 163.54,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 169.075,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 163.158,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 161.716,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 159.774,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 166.157,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 163.158,
+            "warmMedianMs": 163.349
+          },
+          "talkNoPreamble": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 2719.397,
+              "subprocesses": 13,
+              "commandCounts": {
+                "display-message": 4,
+                "show-options": 3,
+                "list-panes": 3,
+                "set-buffer": 1,
+                "paste-buffer": 1,
+                "send-keys": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 2723.18,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2720.431,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2720.551,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2714.592,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2730.711,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2732.848,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              }
+            ],
+            "medianMs": 2720.551,
+            "warmMedianMs": 2721.8655
+          },
+          "result": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 151.654,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 143.395,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 141.795,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 143.964,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 141.404,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 151.961,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 147.077,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 143.964,
+            "warmMedianMs": 143.67950000000002
+          }
+        }
+      }
+    },
+    {
+      "runtime": "native",
+      "delay": "slow",
+      "order": 2,
+      "report": {
+        "executables": {
+          "cli": {
+            "executable": "/opt/tmt-tests/tmt",
+            "args": []
+          },
+          "peer": {
+            "executable": "/opt/tmt-tests/tmt",
+            "args": []
+          }
+        },
+        "schemaVersion": 1,
+        "benchmark": "tmt-performance-baseline",
+        "generatedAt": "2026-09-08T13:44:52.714Z",
+        "sampleCount": 7,
+        "warmSampleCount": 6,
+        "semantics": {
+          "firstObservation": "The first observation runs after fixture setup and is reported separately; it is not an OS-cache-cold measurement.",
+          "warmFreshProcess": "Each warm sample launches a new CLI process after the first observation.",
+          "osCache": "Not controlled or claimed cold; filesystem and process caches may be warm."
+        },
+        "timingDefaults": {
+          "timeoutSeconds": 180,
+          "pollIntervalSeconds": 1,
+          "pasteEnterDelayMs": 500,
+          "benchmarkTalkTimeoutSeconds": 8,
+          "injectedMockReplyDelayMs": 1500
+        },
+        "environment": {
+          "node": "v22.23.2",
+          "tmux": "tmux 3.3a",
+          "platform": "linux",
+          "kernel": "7.0.12-linuxkit",
+          "arch": "arm64"
+        },
+        "resourceUsage": {
+          "cpu": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness exposes child PIDs but no child CPU accounting; parent Vitest usage is not a child metric."
+          },
+          "peakRss": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness does not sample child peak RSS; parent Vitest RSS is not a child metric."
+          }
+        },
+        "scenarios": {
+          "help": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 4.114,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 1.799,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.791,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 3.17,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.767,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 3.317,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.597,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 1.799,
+            "warmMedianMs": 1.795
+          },
+          "identityCreate": {
+            "sampleCount": 1,
+            "warmSampleCount": 0,
+            "firstObservation": {
+              "wallMs": 8.908,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [],
+            "medianMs": 8.908,
+            "warmMedianMs": null
+          },
+          "identityShow": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 2.275,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 2.396,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.273,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.947,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.894,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.972,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.456,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 2.275,
+            "warmMedianMs": 2.3345000000000002
+          },
+          "whoamiSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 10.427,
+              "subprocesses": 4,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 8.155,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 8.068,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 8.221,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 8.354,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 7.867,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 7.988,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 8.155,
+            "warmMedianMs": 8.1115
+          },
+          "whoamiLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 10.102,
+              "subprocesses": 4,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 10.051,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.47,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.982,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 12.578,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 11.121,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 11.441,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 10.982,
+            "warmMedianMs": 11.0515
+          },
+          "checkSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 13.802,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 11.088,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.324,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.282,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 10.368,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 10.816,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.492,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 10.368,
+            "warmMedianMs": 9.93
+          },
+          "checkLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 12.539,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 12.285,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 11.905,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 13.01,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 12.434,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 12.195,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 11.804,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 12.285,
+            "warmMedianMs": 12.24
+          },
+          "talkNoPreamble": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 1540.177,
+              "subprocesses": 12,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 3,
+                "list-panes": 3,
+                "set-buffer": 1,
+                "paste-buffer": 1,
+                "send-keys": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 1544.156,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 1544.489,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2550.448,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 1548.422,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 1541.611,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 1536.762,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              }
+            ],
+            "medianMs": 1544.156,
+            "warmMedianMs": 1544.3225
+          },
+          "result": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 4.424,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 3.985,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.238,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.545,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.864,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.764,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.083,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 2.764,
+            "warmMedianMs": 2.6544999999999996
+          }
+        }
+      }
+    },
+    {
+      "runtime": "native",
+      "delay": "slow",
+      "order": 3,
+      "report": {
+        "executables": {
+          "cli": {
+            "executable": "/opt/tmt-tests/tmt",
+            "args": []
+          },
+          "peer": {
+            "executable": "/opt/tmt-tests/tmt",
+            "args": []
+          }
+        },
+        "schemaVersion": 1,
+        "benchmark": "tmt-performance-baseline",
+        "generatedAt": "2026-09-08T13:45:08.293Z",
+        "sampleCount": 7,
+        "warmSampleCount": 6,
+        "semantics": {
+          "firstObservation": "The first observation runs after fixture setup and is reported separately; it is not an OS-cache-cold measurement.",
+          "warmFreshProcess": "Each warm sample launches a new CLI process after the first observation.",
+          "osCache": "Not controlled or claimed cold; filesystem and process caches may be warm."
+        },
+        "timingDefaults": {
+          "timeoutSeconds": 180,
+          "pollIntervalSeconds": 1,
+          "pasteEnterDelayMs": 500,
+          "benchmarkTalkTimeoutSeconds": 8,
+          "injectedMockReplyDelayMs": 1500
+        },
+        "environment": {
+          "node": "v22.23.2",
+          "tmux": "tmux 3.3a",
+          "platform": "linux",
+          "kernel": "7.0.12-linuxkit",
+          "arch": "arm64"
+        },
+        "resourceUsage": {
+          "cpu": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness exposes child PIDs but no child CPU accounting; parent Vitest usage is not a child metric."
+          },
+          "peakRss": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness does not sample child peak RSS; parent Vitest RSS is not a child metric."
+          }
+        },
+        "scenarios": {
+          "help": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 2.275,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 1.92,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.496,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.379,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.561,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.42,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.556,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 1.556,
+            "warmMedianMs": 1.526
+          },
+          "identityCreate": {
+            "sampleCount": 1,
+            "warmSampleCount": 0,
+            "firstObservation": {
+              "wallMs": 9.149,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [],
+            "medianMs": 9.149,
+            "warmMedianMs": null
+          },
+          "identityShow": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 2.005,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 1.999,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.755,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 3.343,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.957,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.164,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 1.929,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 2.005,
+            "warmMedianMs": 2.0815
+          },
+          "whoamiSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 8.27,
+              "subprocesses": 4,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 8.386,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 7.95,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 8.023,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 8.077,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 9.772,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 8.063,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 8.077,
+            "warmMedianMs": 8.07
+          },
+          "whoamiLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 10.804,
+              "subprocesses": 4,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 10.632,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 11.126,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 11.354,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 10.896,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 11.378,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 12.335,
+                "subprocesses": 4,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 11.126,
+            "warmMedianMs": 11.239999999999998
+          },
+          "checkSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 11.724,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 9.12,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 10.678,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.249,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.848,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 9.917,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 8.851,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 9.848,
+            "warmMedianMs": 9.5485
+          },
+          "checkLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 12.107,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 2,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 14.904,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 14.313,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 12.53,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 13.494,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 14.947,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 12.197,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 2,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 13.494,
+            "warmMedianMs": 13.903500000000001
+          },
+          "talkNoPreamble": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 1543.14,
+              "subprocesses": 12,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 3,
+                "list-panes": 3,
+                "set-buffer": 1,
+                "paste-buffer": 1,
+                "send-keys": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 1543.239,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 1543.936,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 1545.218,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 1548.765,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 1546.953,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 1541.471,
+                "subprocesses": 12,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              }
+            ],
+            "medianMs": 1543.936,
+            "warmMedianMs": 1544.577
+          },
+          "result": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 4.885,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 2.816,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.353,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 5.324,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.268,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.817,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 2.39,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 2.816,
+            "warmMedianMs": 2.6029999999999998
+          }
+        }
+      }
+    },
+    {
+      "runtime": "ts",
+      "delay": "slow",
+      "order": 4,
+      "report": {
+        "executables": {
+          "cli": {
+            "executable": "/usr/local/bin/node",
+            "args": ["/workspace/bin/tmux-team"]
+          },
+          "peer": {
+            "executable": "/usr/local/bin/node",
+            "args": ["/workspace/bin/tmux-team"]
+          }
+        },
+        "schemaVersion": 1,
+        "benchmark": "tmt-performance-baseline",
+        "generatedAt": "2026-09-08T13:45:39.710Z",
+        "sampleCount": 7,
+        "warmSampleCount": 6,
+        "semantics": {
+          "firstObservation": "The first observation runs after fixture setup and is reported separately; it is not an OS-cache-cold measurement.",
+          "warmFreshProcess": "Each warm sample launches a new CLI process after the first observation.",
+          "osCache": "Not controlled or claimed cold; filesystem and process caches may be warm."
+        },
+        "timingDefaults": {
+          "timeoutSeconds": 180,
+          "pollIntervalSeconds": 1,
+          "pasteEnterDelayMs": 500,
+          "benchmarkTalkTimeoutSeconds": 8,
+          "injectedMockReplyDelayMs": 1500
+        },
+        "environment": {
+          "node": "v22.23.2",
+          "tmux": "tmux 3.3a",
+          "platform": "linux",
+          "kernel": "7.0.12-linuxkit",
+          "arch": "arm64"
+        },
+        "resourceUsage": {
+          "cpu": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness exposes child PIDs but no child CPU accounting; parent Vitest usage is not a child metric."
+          },
+          "peakRss": {
+            "status": "unavailable",
+            "reason": "The existing E2E harness does not sample child peak RSS; parent Vitest RSS is not a child metric."
+          }
+        },
+        "scenarios": {
+          "help": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 175.168,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 130.599,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 135.273,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 132.448,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 138.076,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 135.355,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 137.555,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 135.355,
+            "warmMedianMs": 135.314
+          },
+          "identityCreate": {
+            "sampleCount": 1,
+            "warmSampleCount": 0,
+            "firstObservation": {
+              "wallMs": 151.121,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [],
+            "medianMs": 151.121,
+            "warmMedianMs": null
+          },
+          "identityShow": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 145.141,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 142.79,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 140.598,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 140.91,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 142.34,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 141.665,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 142.641,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 142.34,
+            "warmMedianMs": 142.0025
+          },
+          "whoamiSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 154.514,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 153.541,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 150.091,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 154.755,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 153.819,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 160.506,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 158.732,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 154.514,
+            "warmMedianMs": 154.28699999999998
+          },
+          "whoamiLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 159.562,
+              "subprocesses": 5,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 158.672,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 163.002,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 158.269,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 158.259,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 159.105,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              },
+              {
+                "wallMs": 159.121,
+                "subprocesses": 5,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1
+                }
+              }
+            ],
+            "medianMs": 159.105,
+            "warmMedianMs": 158.8885
+          },
+          "checkSmall": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 168.108,
+              "subprocesses": 6,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 157.215,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 157.04,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 157.938,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 157.002,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 157.013,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 160.894,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 157.215,
+            "warmMedianMs": 157.1275
+          },
+          "checkLarge": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 160.354,
+              "subprocesses": 6,
+              "commandCounts": {
+                "display-message": 3,
+                "show-options": 1,
+                "list-panes": 1,
+                "capture-pane": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 159.587,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 159.603,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 161.428,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 159.023,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 162.435,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              },
+              {
+                "wallMs": 166.896,
+                "subprocesses": 6,
+                "commandCounts": {
+                  "display-message": 3,
+                  "show-options": 1,
+                  "list-panes": 1,
+                  "capture-pane": 1
+                }
+              }
+            ],
+            "medianMs": 160.354,
+            "warmMedianMs": 160.5155
+          },
+          "talkNoPreamble": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 2711.103,
+              "subprocesses": 13,
+              "commandCounts": {
+                "display-message": 4,
+                "show-options": 3,
+                "list-panes": 3,
+                "set-buffer": 1,
+                "paste-buffer": 1,
+                "send-keys": 1
+              }
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 2709.417,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2717.566,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2721.074,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2718.332,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2715.756,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              },
+              {
+                "wallMs": 2724.166,
+                "subprocesses": 13,
+                "commandCounts": {
+                  "display-message": 4,
+                  "show-options": 3,
+                  "list-panes": 3,
+                  "set-buffer": 1,
+                  "paste-buffer": 1,
+                  "send-keys": 1
+                }
+              }
+            ],
+            "medianMs": 2717.566,
+            "warmMedianMs": 2717.9489999999996
+          },
+          "result": {
+            "sampleCount": 7,
+            "warmSampleCount": 6,
+            "firstObservation": {
+              "wallMs": 140.858,
+              "subprocesses": 0,
+              "commandCounts": {}
+            },
+            "warmFreshProcess": [
+              {
+                "wallMs": 147.397,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 144.714,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 141.748,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 143.182,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 142.905,
+                "subprocesses": 0,
+                "commandCounts": {}
+              },
+              {
+                "wallMs": 142.742,
+                "subprocesses": 0,
+                "commandCounts": {}
+              }
+            ],
+            "medianMs": 142.905,
+            "warmMedianMs": 143.0435
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/benchmark-startup.mjs
+++ b/scripts/benchmark-startup.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { runPackedCommand } from './packed-command.mjs';
 import { resolveCliExecutables } from '../src/test-support/cli-executable.mjs';
+import { assertBenchmarkHelp } from '../src/test-support/performance-contract.mjs';
 
 // Resource measurement is deliberately macOS-only. Docker scenarios own tmux
 // latency; do not compare these resource samples to Linux timing samples.
@@ -68,13 +69,19 @@ try {
     assert.equal(fs.existsSync(forbidden), false, 'Storage/startup invoked tmux.');
   };
   for (let index = 0; index < 7; index += 1) {
-    measure('help', ['--help'], (stdout) => assert.match(stdout, /TALK OPTIONS/));
+    measure('help', ['--help'], assertBenchmarkHelp);
     env.TMUX_TEAM_HOME = path.join(home, `fresh-${index}`);
+    let createdIdentity;
     measure('fresh-storage-create', ['--json', 'identity', 'create', 'Bench'], (stdout) => {
-      assert.equal(JSON.parse(stdout).created, true);
+      const result = JSON.parse(stdout);
+      assert.equal(result.created, true);
+      assert.equal(result.identity.name, 'Bench');
+      assert.equal(result.identity.canonicalName, 'bench');
+      assert.match(result.identity.id, /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/);
+      createdIdentity = result.identity;
     });
     measure('existing-storage-show', ['--json', 'identity', 'show', 'Bench'], (stdout) => {
-      assert.equal(JSON.parse(stdout).identity.name, 'Bench');
+      assert.deepEqual(JSON.parse(stdout).identity, createdIdentity);
     });
   }
   console.log(

--- a/src/performance-contract.test.ts
+++ b/src/performance-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { assertBenchmarkHelp } from './test-support/performance-contract.mjs';
+
+const commands = ['talk', 'reply', 'result', 'identity', 'config'];
+const inventory = commands.map((command) => `  ${command} <arguments>  Description`).join('\n');
+
+describe('performance help evidence', () => {
+  it.each(['COMMANDS', 'Commands:'])(
+    'accepts %s without a renderer-specific heading',
+    (heading) => {
+      expect(() => assertBenchmarkHelp(`${heading}\n${inventory}\n`)).not.toThrow();
+    }
+  );
+
+  it.each(commands)('rejects a missing %s command even with the old heading', (missing) => {
+    const incomplete = commands
+      .filter((command) => command !== missing)
+      .map((command) => `  ${command} <arguments>`)
+      .join('\n');
+    expect(() => assertBenchmarkHelp(`TALK OPTIONS\n${incomplete}\n`)).toThrow(
+      `Missing help command: ${missing}`
+    );
+  });
+
+  it.each(['', 'talk reply result identity config', '  talkative reply result identity config'])(
+    'rejects non-command output %j',
+    (stdout) => {
+      expect(() => assertBenchmarkHelp(stdout)).toThrow('Missing help command: talk');
+    }
+  );
+});

--- a/src/test-support/performance-contract.d.mts
+++ b/src/test-support/performance-contract.d.mts
@@ -1,0 +1,1 @@
+export function assertBenchmarkHelp(stdout: string): void;

--- a/src/test-support/performance-contract.mjs
+++ b/src/test-support/performance-contract.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+
+// Measurement evidence requires the public command inventory, not a particular
+// renderer's section heading. This is an independent test oracle, not CLI grammar.
+export function assertBenchmarkHelp(stdout) {
+  for (const command of ['talk', 'reply', 'result', 'identity', 'config']) {
+    assert.match(stdout, new RegExp(`^  ${command}\\s`, 'm'), `Missing help command: ${command}`);
+  }
+}

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -2,12 +2,14 @@ FROM rust:1.97.0-bookworm@sha256:8fa55b2f3ddf97471ab6a767bfa3f37e6bad0986ba823e7
 WORKDIR /native/rust
 COPY rust/ ./
 COPY skills/ ../skills/
+ARG TMT_NATIVE_PROFILE=dev
 RUN cargo build --locked --example tmux-probe \
-  && cargo build --locked -p tmt-cli \
+  && case "$TMT_NATIVE_PROFILE" in dev) native_output=debug ;; release) native_output=release ;; *) exit 2 ;; esac \
+  && cargo build --locked --profile "$TMT_NATIVE_PROFILE" -p tmt-cli \
   && cargo test --locked --no-run -p tmt-adapters \
   && mkdir /native-artifacts \
   && cp target/debug/examples/tmux-probe /native-artifacts/tmux-probe \
-  && cp target/debug/tmt /native-artifacts/tmt \
+  && cp "target/$native_output/tmt" /native-artifacts/tmt \
   && find target/debug/deps -maxdepth 1 -type f -name 'tmt_adapters-*' -executable \
     -exec cp {} /native-artifacts/adapter-tests \;
 

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { TMUX_COMMAND_INSPECTION } from './tmux-command-inspection.js';
 import {
   resolveCliExecutables,
   type CliExecutables,
@@ -200,23 +201,7 @@ metadata_write=0
 metadata_clear=0
 # Keep explicit-socket native calls visible to the same barriers and fault injection.
 # Inspect the command without changing argv passed to the real tmux binary.
-tmux_command=""
-tmux_command_arg_count=0
-tmux_last_arg=""
-skip_option_value=0
-for arg in "${'$'}@"; do
-  if [ -n "${'$'}tmux_command" ]; then
-    tmux_command_arg_count=${'$'}((tmux_command_arg_count + 1))
-    tmux_last_arg="${'$'}arg"
-    continue
-  fi
-  if [ "${'$'}skip_option_value" = "1" ]; then skip_option_value=0; continue; fi
-  case "${'$'}arg" in
-    -S|-L|-f) skip_option_value=1 ;;
-    -*) ;;
-    *) tmux_command="${'$'}arg" ;;
-  esac
-done
+${TMUX_COMMAND_INSPECTION}
 if [ "${'$'}tmux_command" = "capture-pane" ]; then
   case "${'$'}{TMT_E2E_CAPTURE_FAULT:-}" in
     exit) exit 97 ;;

--- a/test/e2e/performance-baseline.e2e.test.ts
+++ b/test/e2e/performance-baseline.e2e.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import type { CliExecutables } from '../../src/test-support/cli-executable.mjs';
+import { assertBenchmarkHelp } from '../../src/test-support/performance-contract.mjs';
 import { performance } from 'node:perf_hooks';
 import { describe, expect, it } from 'vitest';
 import { durableState } from './identity-state-oracle.js';
@@ -291,7 +292,7 @@ baselineSuite('TMT performance baseline', () => {
               (result) => {
                 expect(result.code).toBe(0);
                 expect(result.stderr).toBe('');
-                expect(result.stdout).toContain('TALK OPTIONS');
+                assertBenchmarkHelp(result.stdout);
               }
             );
 

--- a/test/e2e/tmux-command-inspection.ts
+++ b/test/e2e/tmux-command-inspection.ts
@@ -1,0 +1,21 @@
+// Shared shell fragment for fixture barriers and invocation tracing. Inspect
+// supported global socket/config options without changing the forwarded argv.
+export const TMUX_COMMAND_INSPECTION = `
+tmux_command=""
+tmux_command_arg_count=0
+tmux_last_arg=""
+skip_option_value=0
+for arg in "${'$'}@"; do
+  if [ -n "${'$'}tmux_command" ]; then
+    tmux_command_arg_count=${'$'}((tmux_command_arg_count + 1))
+    tmux_last_arg="${'$'}arg"
+    continue
+  fi
+  if [ "${'$'}skip_option_value" = "1" ]; then skip_option_value=0; continue; fi
+  case "${'$'}arg" in
+    -S|-L|-f) skip_option_value=1 ;;
+    -*) ;;
+    *) tmux_command="${'$'}arg" ;;
+  esac
+done
+`;

--- a/test/e2e/tmux-trace.e2e.test.ts
+++ b/test/e2e/tmux-trace.e2e.test.ts
@@ -3,33 +3,38 @@ import { withE2EFixture } from './harness.js';
 import { installTmuxTrace } from './tmux-trace.js';
 
 describe.sequential('tmux invocation trace', () => {
-  it('normalizes multiline logged arguments without changing tmux payloads', async () => {
-    await withE2EFixture(async (fixture) => {
-      const trace = installTmuxTrace(fixture);
-      const bufferName = `trace-baseline-${process.pid}`;
-      const payload = 'first line\nsecond line\n<html>request body</html>';
+  it.each(['ambient', 'explicit socket'])(
+    'traces %s commands without changing multiline or option-like payloads',
+    async (selection) => {
+      await withE2EFixture(async (fixture) => {
+        const trace = installTmuxTrace(fixture);
+        const bufferName = `trace-baseline-${process.pid}`;
+        const payload = 'first line\nsecond line\n<html>request body</html>\n-S not-a-socket';
+        const prefix = selection === 'explicit socket' ? ['-S', fixture.socketPath] : [];
 
-      try {
-        trace.clear();
-        fixture.tmux(['set-buffer', '-b', bufferName, '--', payload]);
-
-        const invocations = trace.invocations();
-        expect(invocations).toHaveLength(1);
-        expect(trace.commands()).toEqual(['set-buffer']);
-        expect(invocations[0]).toContain('first line second line');
-        expect(invocations[0]).not.toContain('\n');
-
-        const saved = fixture.tmux(['save-buffer', '-b', bufferName, '-']);
-        expect(saved).toBe(payload);
-      } finally {
         try {
-          fixture.tmux(['delete-buffer', '-b', bufferName]);
-        } catch {
-          // The fixture server still owns cleanup if set-buffer failed early.
-        }
-      }
+          trace.clear();
+          fixture.tmux([...prefix, 'set-buffer', '-b', bufferName, '--', payload]);
 
-      expect(fixture.tmux(['list-buffers', '-F', '#{buffer_name}'])).not.toContain(bufferName);
-    });
-  });
+          const invocations = trace.invocations();
+          expect(invocations).toHaveLength(1);
+          expect(trace.commands()).toEqual(['set-buffer']);
+          expect(invocations[0]).toContain('first line second line');
+          expect(invocations[0]).not.toContain('\n');
+
+          const saved = fixture.tmux([...prefix, 'save-buffer', '-b', bufferName, '-']);
+          expect(saved).toBe(payload);
+          expect(trace.commands()).toEqual(['set-buffer', 'save-buffer']);
+        } finally {
+          try {
+            fixture.tmux(['delete-buffer', '-b', bufferName]);
+          } catch {
+            // The fixture server still owns cleanup if set-buffer failed early.
+          }
+        }
+
+        expect(fixture.tmux(['list-buffers', '-F', '#{buffer_name}'])).not.toContain(bufferName);
+      });
+    }
+  );
 });

--- a/test/e2e/tmux-trace.ts
+++ b/test/e2e/tmux-trace.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { E2EFixture } from './harness.js';
+import { TMUX_COMMAND_INSPECTION } from './tmux-command-inspection.js';
 
 export interface TmuxTrace {
   readonly path: string;
@@ -34,7 +35,8 @@ trace_args="${'$'}*"
 case "${'$'}trace_args" in
   *"${'$'}trace_newline"*) trace_args=$(printf '%s' "${'$'}trace_args" | tr '\n' ' ') ;;
 esac
-printf '%s\\t%s\\n' "${'$'}1" "${'$'}trace_args" >> ${shellQuote(tracePath)}
+${TMUX_COMMAND_INSPECTION}
+printf '%s\\t%s\\n' "${'$'}tmux_command" "${'$'}trace_args" >> ${shellQuote(tracePath)}
 exec ${shellQuote(delegatedWrapperPath)} "${'$'}@"
 `,
     { mode: 0o755 }


### PR DESCRIPTION
## Summary

- Capture paired same-source TypeScript/optimized-Rust startup and private-tmux performance evidence before removing the reference runtime.
- Reuse one independent help-command assertion and the fixture's existing tmux argv inspection; fix explicit `-S` trace misclassification without changing delegated payloads or fault barriers.
- Add an opt-in release CLI profile to the existing Dockerfile, keeping ordinary regression builds and CI defaults unchanged.
- Record all raw samples, source/build identities, rejected calibrations, resource precision and remaining capacity limits.

Closes #151. Part of #93; #152 owns test-infrastructure decoupling before source deletion. No production command/state/default, runtime dependency, user installation, publication or CI/protection change.

## Primary architecture review

Primary reviewed every source/test/documentation diff and the existing trace/barrier consumers. The extracted shell fragment is exactly the existing fixture inspection, not another tmux parser; trace now uses its command field while forwarding original argv. Real buffer tests verify ambient and explicit-socket command classification, multiline/option-like bytes and cleanup. Both benchmark callers use one independent public help oracle, never runtime grammar. The startup probe now checks the exact created identity across separate processes. The native runtime and lockfile are unchanged. ARCHITECTURE and DEVELOPMENT record test ownership/profile selection; PERFORMANCE-BASELINE distinguishes measured results from unmeasured sustained capacity.

## Measurements

- macOS startup: TS about 157–166 ms / 100–102 MB maximum RSS; optimized native about 15–19 ms / 8–11 MB. Both paired runs exceed the pre-existing 30% wall/RSS target. Native CPU rounds to zero at centisecond precision, not zero CPU usage.
- Four paired fast and four delayed Docker reports passed exact reply/state/mock/cleanup checks. Scoped tmux counts stay constant from small fixtures to 201 panes. No production polling/send delay was changed; end-to-end results are not pure service time.
- Raw reports preserve every first/repeated sample and both rejected calibration causes. macOS native and Docker glibc binaries are identified separately; this does not claim published-musl timing parity or high-volume capacity.

## Verification

- [x] Focused help oracle: 10 tests; actual tmux trace: 2 tests. Native startup's old heading assertion and native Docker's old `-S` classification failed before correction; all accepted Docker reports were recollected.
- [x] Local `pnpm check`, final formatting and `git diff --check`.
- [x] 1,153 unit tests and unchanged 90% coverage / 85% branch gates. Initial default-parallel run had one unchanged 1-second native-cargo wrapper timeout; its focused 10 tests and full run with two local workers passed without changing assertions/deadlines. This resource limit is not committed or applied to CI.
- [x] All 104 native process/storage tests against the measured release binary.
- [x] Two complete local Docker lifecycle passes: each 283 adapter tests (one intentional ignored archive test) and 160 E2E tests across 34 files (one intentionally opt-in performance scenario skipped). Durations 312.39 s and 304.71 s; wrapper-owned image cleanup completed. The separate performance image was explicitly removed after measurement.
- [x] All eleven required checks passed on reviewed head `572be1680362fc6c5dc3aee37ddc38d2c35f7265`, run `34235410991`, before merge. Merged as `7afe846c4d85219e11559ee82e6d596a7437624e`.
