### PR TITLE
test: make shared Docker contracts native by default

### DIFF
--- a/.agents/skills/tmt-e2e/SKILL.md
+++ b/.agents/skills/tmt-e2e/SKILL.md
@@ -14,6 +14,9 @@ Use this skill for the repository's Docker E2E test foundation. Keep E2E tests s
 - Never touch the host user's tmux server, host credentials, or unrelated processes. The container must be network-isolated.
 - Reuse the existing E2E harness and its cleanup hooks. Every scenario must leave its temporary tmux server, socket, panes, and files cleaned up, including on assertion failure.
 - For lifecycle or cleanup changes, run the Docker suite twice to catch leaked state and non-idempotent teardown.
+- Docker selects its built Rust CLI by default; mock replies inherit that selection.
+  Verify the default path as well as fail-closed invalid selectors. Host TS unit
+  tests remain transitional evidence, not proof of native behavior.
 
 ## Test quality gate
 
@@ -27,6 +30,14 @@ Do not optimize for a passing suite or a larger test count. Every scenario must 
 - Use bounded polling for observable state changes. Do not use fixed sleeps to hide races or make a flaky scenario appear stable.
 - Verify state preservation after failed operations and verify cleanup with observable absence, not only by calling a cleanup function.
 - Prefer stable JSON fields, exit codes, pane IDs, metadata, and essential output over incidental formatting.
+- Identity scenarios must choose lifetime deliberately: plain `name`/`add` is
+  temporary; use `-s` only when persistence is part of the scenario. Global
+  listing includes offline saved rows but does not expand cross-server routing.
+  Correlate public UUID/lifetime with the existing read-only identity SQL oracle.
+  If reconciliation refreshes `last_verified_at`, exclude only that field from
+  preservation comparisons and validate its timestamp separately; retain every
+  other binding field. Grouped pane presentation follows inventory selection,
+  which need not match `display-message`'s chosen linked session.
 - Keep foundation tests focused on infrastructure invariants. Add feature semantics only through the issue that defines that feature's state matrix.
 - Treat a test that can pass without the intended action occurring as a test bug. Fix false positives before expanding coverage.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ describe proposals; update this map when the implemented changes land.
 
 ## Runtime and release boundary
 
-The standalone Rust native alpha is prepared through the explicit
+The standalone Rust native alpha is published through the explicit
 `native-release.yml` workflow. The user-facing README advertises its installer
 only after immutable publication and live-download verification. `rust/` owns
 the native runtime; root `src/` and npm entrypoints remain the transitional
@@ -17,10 +17,10 @@ TypeScript reference and test tooling, not a wrapper that downloads Rust.
 The older sections below describe that reference implementation unless they
 explicitly identify native owners. Native lifetime rules (temporary by default,
 explicit save, retirement) supersede durable-only identity assumptions there.
-Source cleanup and measured performance acceptance remain tracked in #93.
+Source cleanup remains tracked in #93; #151 completed paired performance acceptance.
 
-Paired performance acceptance (#151) retains the TypeScript reference until
-measurements are captured. Both startup and private-tmux benchmarks reuse the
+Paired performance acceptance (#151) records the retained TypeScript reference
+and release-native measurements. Both startup and private-tmux benchmarks reuse the
 test-only executable selector and a shared independent help-command oracle in
 `test/support/performance-contract.mjs`; they do not import runtime grammar.
 The E2E Dockerfile can select an optimized CLI with `TMT_NATIVE_PROFILE=release`
@@ -823,9 +823,9 @@ and test-support workers are excluded from the package; runtime TypeScript and
 the canonical skill remains distributed. Retired command/plugin assets are rejected
 by the package inventory check rather than maintained as compatibility copies.
 
-### Rust preview installation ownership (#133)
+### Native skill installation ownership (#133)
 
-The preview embeds the same authored skill bytes at compile time. The core
+The native executable embeds the same authored skill bytes at compile time. The core
 `skill_provider::Provider` inventory owns native names/order and feeds grammar,
 completion and adapter selection. `skill_installation::ProviderEnvironment`
 captures provider path inputs once; its target and legacy candidates are shared
@@ -873,11 +873,11 @@ provider detection or second registry is involved. Install and refresh share
 one explicit lock-release/error-composition helper.
 
 The hidden `__native-refresh-skills` command is a new-executable composition
-boundary for the future updater: only the activated executable has the new
+boundary for the managed updater (#142): only the activated executable has the new
 embedded skill. It uses existing path discovery without reading configuration
 contents, opening SQLite or probing tmux. Its one JSON document retains
 refreshed/skipped/conflicted paths on failure; the shared output owner formats
-the error envelope. This is not yet public network-update integration.
+the error envelope. Public upgrade/update invokes it after binary activation.
 
 ## Current module map
 
@@ -995,10 +995,10 @@ failure semantics; merely introducing an interface is not an architectural fix.
 
 ## Known deviations and planned work
 
-### Native grammar preview
+### Native grammar
 
-`rust/` contains a development-only native CLI under #96; installed entry points
-remain TypeScript. `tmt-core` owns numeric and settings policy, while `tmt-cli`
+`rust/` contains the published native CLI, originally introduced under #96.
+The npm entrypoints alone remain transitional TypeScript. `tmt-core` owns numeric and settings policy, while `tmt-cli`
 owns one Clap grammar, typed requests, presentation, configuration and identity command composition
 and explicit no-effects rejection for unimplemented commands. `tmt-adapters`
 owns the SQLite lifecycle under #97 and native schema 9 under #108, configuration files under #103,
@@ -1023,14 +1023,15 @@ The storage-only identity record foundation under #111 supplies shared creation,
 promotion and non-retired selection; #113 wires storage-only create/show/list.
 Binding command wiring, retirement and presence listing are implemented under
 #109. The durable-global invariants elsewhere in
-this map still describe the shipped TypeScript runtime, not the amended
+this map still describe the transitional TypeScript reference, not the amended
 native lifecycle. See [RUST-REWRITE.md](RUST-REWRITE.md) for transition boundaries.
 
 `test/native/` uses the existing CLI sandbox/executable selector for explicit
-native-preview process assertions. It requires a selected build, rather than
+native process assertions. It requires a selected build, rather than
 silently testing TS. The named shared parser-contract subset remains separate
 from full native parity. Native unit tests cover typed grammar and core policy;
-real tmux behavior remains gated by the existing Docker harness as it is ported.
+real tmux behavior is gated by the existing Docker harness, which now selects
+the built native CLI and inherited native mock replies by default (#153).
 
 #### Native architecture guards
 
@@ -1209,8 +1210,8 @@ The reviewed pure SHA-256 dependency is permitted only in core; base64 is
 permitted only in adapters. Existing serde_json handles bounded v1 envelopes,
 not v2 digest serialization. Architecture tests enforce these dependency edges
 with positive and adverse cases. This is local correlation, not remote access
-control. #129 uses compact receipts in native talk; #106 still owns the installed
-recipient-instruction transition before native cutover.
+control. #129 uses compact receipts in native talk; the published alpha and its
+embedded skill both use that instruction contract (#106).
 
 #122 adds `response_command` for public storage-only reply/result. It consumes
 the parser's existing typed invocation and the codec before any input acquisition.
@@ -1295,6 +1296,10 @@ hide retired owners; profile operations do not promote lifetime or change cadenc
 
 CLI `identity_context` composes explicit canonical lookup or existing verified
 caller/binding evidence, never pane-target routing for an explicit identity.
+Required implicit selection rejects an unavailable caller before opening or
+migrating storage. The resulting selector is resolved through the same verified
+binding owner; optional talk attribution uses that same selection path. This
+preflight is not permission to accept an unverified pane or bypass identity lookup.
 `profile_command` acquires role files before opening storage, resolves identity,
 normalizes content, applies the shared operation and closes before presentation.
 Explicit access does not load settings or probe tmux. Role and preamble retain
@@ -1474,7 +1479,8 @@ evaluation under [#93](https://github.com/wkh237/tmux-team/issues/93).
 It is not the shipped module map. [Preparation #94](https://github.com/wkh237/tmux-team/issues/94)
 adds opt-in measurement tools reusing the E2E fixture and bounded packed-command
 runner; [PERFORMANCE-BASELINE.md](PERFORMANCE-BASELINE.md) owns their protocol and
-limitations. Production remains TypeScript until an explicitly verified cutover.
+limitations. Published production is native; transitional TS source and npm
+artifact gates remain until their assertions are mapped and retired explicitly.
 The test-only tmux trace keeps one record per invocation by normalizing newlines
 in logged arguments, while forwarding the original arguments unchanged. A real
 tmux buffer round-trip verifies this separation; it is not a transport rewrite.
@@ -1513,10 +1519,10 @@ SQLite profile checks with an empty runtime PATH and isolated state. The existin
 npm packed matrix remains a distinct transitional TypeScript gate.
 
 Unsigned checksums detect corruption, not origin compromise. Native binary
-bootstrap, public network update and authenticated public release
-provenance remain #82 gates. These developer archives do not change installed
-entrypoints or authorize publication. Candidate targets require actual matching
-target execution before they become supported release platforms.
+bootstrap, public network update and public release provenance were verified
+for alpha2 under #149. Local developer archives alone do not authorize another
+publication. Future candidate targets still require actual matching-target
+execution before they become supported release platforms.
 
 ## Managed native installation boundary
 
@@ -1610,8 +1616,8 @@ nonzero exits retain bounded output in `CommandError`; formatting never exposes
 that output. The skill command owns its JSON protocol validator. The updater
 preserves valid partial reports and returns failure without claiming binary
 rollback when skill refresh fails. Timeouts, malformed reports and oversized
-output are failures, not successful updates. Shell bootstrap, public publication
-and installed-runtime cutover are separate delivery gates.
+output are failures, not successful updates. Shell bootstrap and public alpha2
+publication are delivered under #149; source/npm-gate retirement remains separate.
 
 ### Release-generated curl bootstrap
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -153,15 +153,16 @@ TMT_TEST_CLI='{"executable":"/absolute/checkout/rust/target/debug/tmt","args":[]
   pnpm test:native
 ```
 
-This preview-specific suite reuses the shared sandbox and bounded process
+This native-specific suite reuses the shared sandbox and bounded process
 launcher; it does not replace TypeScript or Docker verification. Storage tests
-create and close TypeScript schema-prefix fixtures, migrate through the actual
-Rust adapter, and compare independent SQL schema/data with the TypeScript result,
+materialize frozen TypeScript schema-prefix fixtures, migrate through the actual
+Rust adapter, and compare independent SQL schema/data with the frozen TypeScript result,
 allowing only the specified identity-table/index/history amendment. They verify
 saved backfill, name reuse without UUID inheritance, preserved dependent records,
-explicit TypeScript rejection of schema 9 without mutation, native reopen,
+native reopen,
 rollback, history rejection and bounded writer
-contention. Neither executable selector may silently fall back to TypeScript.
+contention. TS future-schema rejection remains a separate transitional unit
+test, not a cross-runtime native test. Neither executable selector may silently fall back to TypeScript.
 The probe accepts only a database path and runs open/health/checkpoint/close;
 it has no arbitrary SQL or failure-injection command and is not packaged.
 Runner-level Rust tests also hold a real rollback-journal reader across migration
@@ -247,7 +248,8 @@ on failure and never signal a recycled PID after observed reaping.
 `test/native/binding.test.ts` checks isolated public preflight, offline removal,
 and lifetime/presence output. `test/e2e/native-identity.e2e.test.ts` selects the
 Docker-built `TMT_TEST_NATIVE_CLI` through the same fixture descriptor; it does
-not change the selected runtime for unported TS transport scenarios. Exercise
+not create a separate fixture or runtime policy. The shared Docker scenarios
+also default to native under #153. Exercise
 real descendant caller resolution, temporary/save/unbind/rm lifecycle, global
 cross-directory/server discovery, grouped/linked presentation, publication
 failure/retry and theme-preserving badge behavior. The read-only SQL oracle
@@ -298,7 +300,7 @@ in `test/e2e/Dockerfile` from the current checkout, runs Vitest inside it with
 own tmux server on a private socket and
 launches the deterministic mock agent from `test/e2e/mock-agent.mjs`; no real
 agent, credentials, or host tmux session is used. The tests invoke
-`bin/tmux-team` by default as a subprocess and exercise CLI process propagation, tmux
+the Docker-built `/opt/tmt-tests/tmt` by default as a subprocess and exercise CLI process propagation, tmux
 transport, pane movement, and fixture cleanup. Failures include the
 container/Vitest output, and each fixture kills its private server and removes
 its temporary state.
@@ -306,7 +308,9 @@ its temporary state.
 ### Selecting the CLI under test
 
 `TMT_TEST_CLI` is a JSON descriptor with exactly `executable` (absolute path to an
-executable file) and `args` (string-array argv prefix). Omission selects the
+executable file) and `args` (string-array argv prefix). The Docker image sets it
+to its built Rust CLI; an omitted peer inherits that native selection. Outside
+Docker, omission still selects the
 current test runner's absolute Node executable plus the checkout's public
 TypeScript wrapper as its prefix. This preserves tests that deliberately remove
 Node/provider discovery from PATH; it does not skip the wrapper's child process.
@@ -317,14 +321,15 @@ Shell fragments are not parsed. Paths and prefix arguments may contain spaces
 and quotes. Selection is frozen per sandbox/fixture, before resource allocation.
 
 ```bash
-# Host CLI contracts; use a real native build only once it supports the subset.
+# Native public-process contracts require a built executable.
 TMT_TEST_CLI='{"executable":"/absolute/path/to/tmt","args":[]}' \
-  pnpm exec vitest run src/identity-cli-contract.test.ts
+  pnpm exec vitest run --config test/native/vitest.config.ts test/native/identity.test.ts
 
 # Docker paths refer to files INSIDE the image, not host executable paths.
-TMT_TEST_CLI='{"executable":"/workspace/bin/tmux-team","args":[]}' pnpm test:e2e
+TMT_TEST_CLI='{"executable":"/opt/tmt-tests/tmt","args":[]}' pnpm test:e2e
 
-# Explicit Node+wrapper is also a descriptor, not a special runtime mode.
+# The selector can address the historical wrapper, but the maintained shared
+# scenarios now assert native lifetime/listing/receipt contracts, not TS parity.
 TMT_TEST_CLI='{"executable":"/usr/local/bin/node","args":["/workspace/bin/tmux-team"]}' \
 TMT_TEST_PEER_CLI='{"executable":"/workspace/bin/tmux-team","args":[]}' pnpm test:e2e
 ```

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -180,16 +180,16 @@ execute original TS-generated v1 receipts against migrated frozen schema-8
 fixtures, including in-flight and orphan finals. This proves service handoff,
 not simultaneous TS/schema-8 access to native/schema-9 state.
 
-Installed TypeScript still emits v1. #122 enables public native preview
+The transitional npm/TypeScript reference emits v1. #122 enables public native
 `reply`/`result`, using this codec and the existing service with complete bounded
 input before storage. Both v1 and v2 receipts work without tmux or current config.
 The same submitted/completed/unavailable output and exit contracts apply; a
 stopped schema-8 fixture can migrate through native reply while retaining its v1
 instruction. This is not permission to mix writers after schema-9 migration.
 Native talk (#129) emits compact instructions through the same codec and proves
-the public flow with private-tmux/native mock replies. Parent #106 still owns
-canonical installed guidance before cutover; installed skill/README instructions
-remain unchanged for now.
+the public flow with private-tmux/native mock replies. The published native
+alpha and its embedded skill use this compact instruction contract (#106);
+the retained TypeScript source is not the advertised native installation path.
 
 ### TMT-39 live durable completion
 

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -1,20 +1,13 @@
-# Rust rewrite preparation
+# Rust rewrite and closeout
 
-Status: native grammar (#96), storage lifecycle (#97) with native identity schema 9 (#108), configuration (#103)
-and bounded tmux evidence (#105), shared identity records (#111), and
-storage-only identity commands (#113), and pane identity lifecycle (#109)
-are implemented in the development preview, not a shipped Rust runtime.
-#118 adds the internal transactional request/final foundation; #120 adds compact
-receipt encoding and old-v1 decoding through that same service. #122 adds public
-native reply/result with bounded input. #129 adds native talk; the full #106
-installed short-receipt instruction transition remains pending.
-#124 adds the bounded native send/capture adapter and isolated real-tmux
-acceptance. #125 adds shared current-server target resolution and public
-diagnostic check/read. #127 adds native role/preamble and shared bounded profile
-text/file acquisition. #129 adds public talk composition and bounded observation.
-#131 adds identity-scoped X attention; #133 adds exclusive local initialization,
-embedded guidance and managed provider/custom skill installation. Native network
-installation/self-update and runtime cutover remain separate delivery gates.
+Status: native `v5.0.0-alpha.2` is published with verified installation and
+self-update assets (#149). Rust owns the advertised runtime. Paired performance
+acceptance (#151) and retained test-harness separation (#152) are delivered.
+#153 moves the maintained Docker scenarios to native by default and records
+the source-retirement evidence below. Transitional TypeScript source, npm
+entrypoints and their artifact gates still require explicit retirement; they
+are not the native installer. Earlier slice descriptions retain implementation
+provenance, not a claim that the shipped native features remain previews.
 Owner: [#93](https://github.com/wkh237/tmux-team/issues/93);
 preparation: [#94](https://github.com/wkh237/tmux-team/issues/94).
 The compatibility reference is TypeScript main `cb53533f3a9f19a1a2ab95af59dda20df419200b`
@@ -38,7 +31,7 @@ start a daemon, implement MCP, publish artifacts, or restore v4 compatibility.
 Keep `this`, exact durable replies, `!` shell-mode protection, and default-off,
 non-invasive pane badges. Native installation and self-update belong to
 [#82](https://github.com/wkh237/tmux-team/issues/82), including its explicitly
-proposed `update` alias; that future alias is not current v5 behavior.
+approved `update` alias, implemented in the published native runtime.
 
 ## Decision: one reusable policy core, explicit adapters
 
@@ -63,7 +56,7 @@ coordination without a new boundary. A single package would be simpler initially
 but leaves IO-to-domain import restrictions solely to review. The proposed split
 is by responsibility, not a mechanical copy of every TypeScript file.
 
-### Implemented native preview
+### Implemented native runtime
 
 The `rust/` workspace contains `tmt-core` (numeric and settings policy),
 `tmt-cli` (grammar, typed invocation translation and output), and `tmt-adapters`
@@ -71,7 +64,7 @@ The `rust/` workspace contains `tmt-core` (numeric and settings policy),
 tmux evidence under #105). The npm entry points still execute TypeScript. No command silently
 delegates from native to Node.
 
-The preview implements help, version, Bash/Zsh completion and the existing
+The native runtime implements help, version, Bash/Zsh completion and the existing
 `config` command plus storage-only `identity create/show/list` (#113) and pane
 identity `name`/`this`/`add`/`whoami`/`unbind`/`rm`/`list` (#109), plus storage-only
 `reply`/`result` (#122), diagnostic `check`/`read` (#125), role/preamble (#127), and
@@ -79,7 +72,7 @@ durable `talk` (#129), identity-scoped `x list/show/ack/ackall` (#131), and
 `init`/`learn`/`install` (#133), and managed native `upgrade`/`update` (#142).
 Updates validate the executing installation before network and reuse the offline
 publisher; unmanaged package-manager executables are rejected without writes.
-Public release availability remains a separate gate. Text-only commands reject JSON. Native
+Public release availability was verified under #149. Text-only commands reject JSON. Native
 `name`/`this`/`add` create temporary bindings unless `-s`/`--save` promotes or
 creates a saved identity. `rm`/`remove` require explicit force for saved rows.
 
@@ -91,7 +84,7 @@ saved identities continue to reserve their names. Visibility does not silently
 expand current-server routing or justify unbounded per-identity tmux queries.
 The exact JSON and failure precedence are recorded in #109, with real SQLite
 service tests and public CLI/private-tmux lifecycle tests. These are native
-preview changes, not installed TypeScript behavior or a second identity registry.
+runtime changes, not transitional TypeScript behavior or a second identity registry.
 
 #103 makes settings an invocation-owned shared boundary rather than a rule set
 inside each CLI handler. Core owns typed defaults, scalar bounds, setting scope
@@ -237,7 +230,8 @@ final without attempt metadata. No current identity lookup authorizes a reply.
 Real SQLite tests cover retirement/name reuse and late submission, but this is
 not old receipt execution or public CLI transport acceptance. #106 consumes this
 same owner for compact correlation; it must not add a token-specific final store.
-Native command adapters and transport remain explicit follow-on slices under #93.
+At the #118 boundary, command adapters and transport were follow-on slices;
+#122/#124/#125/#129 have since delivered them. Source retirement remains under #93.
 
 #120 adds one typed proof to the existing submission input, not a second final
 API. Compact receipts are derived from the full immutable recorded association
@@ -376,7 +370,12 @@ Bundled rusqlite 0.40.2 is documented as compiling its own SQLite; platform
 artifact verification still has to establish the actual features and linkage.
 [Published rusqlite documentation](https://docs.rs/crate/rusqlite/0.40.2).
 
-## Compatibility matrix
+## Historical TypeScript compatibility baseline
+
+This is the rewrite's original reference contract, not current native command
+documentation. The approved temporary/save/remove/global-list amendments above
+and published native update/receipt behavior supersede its durable-only and
+retired-command assumptions. The current native evidence is recorded below.
 
 Examples below are essential fields, not complete JSON schemas. Dynamic UUIDs,
 timestamps and pane IDs are correlated, not hard-coded. Unmentioned existing
@@ -430,13 +429,54 @@ switch. Production TypeScript removal and replacement of transitional npm artifa
 gates still follow that evidence. Earlier delivery-gate notes below describe their
 original sequencing, not a claim that the published native installer is unfinished.
 
+### Native default acceptance (#153)
+
+The shared Docker suite now exercises the built native CLI and its inherited
+reply peer. It keeps the existing harness, private tmux servers, independent SQL,
+mock event logs and cleanup assertions; it is not a copied second scenario suite.
+Human formatting differences do not relax exact final bytes or identity provenance.
+
+| Boundary                              | Native evidence and accepted input/output difference                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pane identity lifecycle               | `identity-lifecycle`, `caller-context`, `grouped-session`, `multi-server`, `publication-race` E2E: plain `name`/`add` is temporary; `-s` preserves identity across unbind/death. JSON includes UUID/lifetime and unbind retirement. Global `list` includes saved offline and verified foreign rows; `talk`/`check` routing stays current-server-only. |
+| Caller preflight                      | `test/native/identity-context.test.ts`: role and X without an explicit identity or recoverable caller fail `IDENTITY_REQUIRED` before database creation/migration. Both commands reuse one selector owner; explicit offline access does not probe tmux.                                                                                               |
+| Capture bounds and endpoint death     | `capture-limits` and `multi-server` E2E plus parser/adapter tests: validate both supplied line operands before applying precedence. A malformed fresh-server marker is not death by itself; only conclusive recorded-PID death releases the old endpoint. Live/unknown PID evidence stays fail-closed.                                                |
+| Request transport and exact finals    | Shared `request-context`, `exchange-retention`, `response-integrity`, `durable-talk`, `transport-safety` and native-talk E2E retain original prompts, UUID attribution, late finals, virtualized terminal output, summary ordering, no replay and waiter cleanup. Completion comes from SQLite, not terminal boundaries.                              |
+| Receipt authorization and expiry      | `test/native/response.test.ts` independently encodes all request/attempt/six endpoint mismatches for v1 and v2, compares unchanged SQL, verifies a valid control and prevents expired retained-body resurrection. V2 is a fixed 25-character local proof, not a remote credential.                                                                    |
+| CLI/settings/profile process boundary | `test/native/cli.test.ts`, `config.test.ts`, `profile.test.ts`: ignored/invalid option placement and text-only JSON rejection before effects; exact default/zero/precedence projections, targeted repair and preserved opaque keys; large multibyte role output and future-history rejection.                                                         |
+| X human and machine output            | `test/native/exchange.test.ts` and shared attention E2E: acknowledgment is distinct from final completion, late finals reopen attention, human output preserves exact response bytes, and ackall advances only the observed revision.                                                                                                                 |
+| Migration/test infrastructure         | `test/native/storage.test.ts` and `storage-fixture.test.ts`: frozen historical prefixes and independent schema/data oracles, rollback, history rejection and contention. Test-only helpers stay outside `src/`; no current native migration generates its own expected results.                                                                       |
+
+This matrix is not permission to delete every TS unit test. The worker audit
+maps cadence reservation to
+`concurrent_prepare_connections_serialize_cadence_and_preserve_both_attempts`,
+final writers to `identical_and_conflicting_final_writers_keep_one_body_marker_and_revision`,
+and cleanup/late submission to `cleanup_and_late_submission_serialize_without_refund_or_lost_final`
+in the existing Rust request service concurrency suite. Attention races and
+rollback reuse that suite plus the service's `attention.rs` tests; waiter release
+uses `waiter_release_is_idempotent_isolated_and_does_not_cancel_delivery`.
+
+[#156](https://github.com/wkh237/tmux-team/issues/156) blocks deletion of the
+remaining unmatched protections: concurrent binding, process-death transaction
+rollback, final/failure and equal-expiry races, human talk output, and interactive
+passive reminder output. Existing drift/eligibility unit tests are not a terminal
+process assertion; a returned-error rollback is not a SIGKILL assertion. These
+are explicit follow-on acceptance gates, not claims of complete rewrite parity.
+Developer artifact/selector guards also remain until relocated during source retirement.
+Node wrapper/npm-upgrade implementation details are not native runtime features;
+their retirement must be explicit rather than silently counted as covered.
+Native startup performs local skill inspection only, not npm release discovery;
+managed upgrades remain explicit commands.
+
 Keep Vitest, Docker, private tmux sockets and deterministic mock agents.
 [#95](https://github.com/wkh237/tmux-team/issues/95) adds the shared test-only
 executable descriptor (absolute binary plus argv prefix), validated before fixture
 allocation and used by CLI contracts, E2E, mock replies, real descendants and the
 resource probe. Missing/non-executable selection fails without TS fallback.
-Default remains TS until explicit cutover; an explicit peer descriptor supports
-future mixed-runtime cases. See [selector usage](DEVELOPMENT.md#selecting-the-cli-under-test).
+Docker defaults to its built native CLI under #153, including inherited mock
+replies. Host TS unit tests retain their reference default until source retirement.
+An explicit peer descriptor is a test seam, not mixed-schema compatibility.
+See [selector usage](DEVELOPMENT.md#selecting-the-cli-under-test).
 The seam itself proves neither native behavior nor mixed-runtime compatibility.
 
 Keep SQL oracles independent and read-only. Existing TS unit tests importing
@@ -545,6 +585,7 @@ integrations with partial-effect reporting. #142 wires it to native upgrade/upda
 with bounded canonical HTTPS discovery and compare-before-activation fencing.
 #144 adds a release-generated curl bootstrap over that same offline installer,
 with manifest-derived sizes/digests and fresh npm replacement guidance. Actual
-matching-host archives are tested without Node/Rust on runtime PATH. Public
-immutable publication, remaining target execution and installed-runtime cutover
-remain #82/#93 gates; a local generated installer is not a live download.
+matching-host archives are tested without Node/Rust on runtime PATH. #149
+completed immutable alpha2 publication, all supported target execution and live
+download verification. Source/npm-gate retirement remains under #93; a local
+generated installer alone is still not live-download evidence for a future release.

--- a/rust/crates/tmt-adapters/src/tmux/io_tests.rs
+++ b/rust/crates/tmt-adapters/src/tmux/io_tests.rs
@@ -109,6 +109,21 @@ fn unavailable_observations_do_not_hide_failed_cleanup() {
 }
 
 #[test]
+fn malformed_probe_does_not_retire_a_live_recorded_process() {
+    let tmux = Tmux::new(ScriptedRunner::new([Ok("malformed endpoint snapshot")]));
+    assert_eq!(
+        tmux.probe(
+            "/tmp/private.sock",
+            u64::from(std::process::id()),
+            OperationOptions::default()
+        )
+        .unwrap(),
+        EndpointProbe::Unknown
+    );
+    assert_eq!(tmux.runner.calls.borrow().len(), 1);
+}
+
+#[test]
 fn ancestry_requires_one_coherent_candidate_after_grouped_row_deduplication() {
     const MATCH: &str = "%9__TMT_CALLER_PANE_4f1c__700__TMT_CALLER_PANE_4f1c__/tmp/private.sock__TMT_CALLER_PANE_4f1c__321";
     const OTHER: &str = "%10__TMT_CALLER_PANE_4f1c__900__TMT_CALLER_PANE_4f1c__/tmp/private.sock__TMT_CALLER_PANE_4f1c__321";

--- a/rust/crates/tmt-adapters/src/tmux/mod.rs
+++ b/rust/crates/tmt-adapters/src/tmux/mod.rs
@@ -329,6 +329,11 @@ impl<R: CommandRunner> Tmux<R> {
                 Ok(EndpointProbe::Live(snapshot))
             }
             Err(error) if error.cleanup_failed() => Err(error),
+            // A fresh server at a reused socket has no TMT server marker yet.
+            // Malformed output alone is not death, but ESRCH for the recorded
+            // process is independent, conclusive evidence. Never initialize the
+            // foreign server merely to reconcile the old binding.
+            Err(_) => Ok(probe_death(recorded_pid)),
             _ => Ok(EndpointProbe::Unknown),
         }
     }

--- a/rust/crates/tmt-cli/src/exchange_command.rs
+++ b/rust/crates/tmt-cli/src/exchange_command.rs
@@ -54,17 +54,17 @@ fn request_failure(error: RequestError<StorageError>) -> Failure {
 }
 
 fn run(identity: Option<String>, operation: ExchangeOperation) -> Result<Report, Failure> {
+    let selector = identity_context::required(identity.as_deref())?;
     let paths = ConfigPaths::discover().map_err(unavailable)?;
     let mut storage = Storage::open(paths.database).map_err(unavailable)?;
     let pending = (|| {
-        let identity =
-            identity_context::resolve(&mut storage, identity.as_deref()).map_err(|error| {
-                if error.code == "IDENTITY_ERROR" {
-                    unavailable(error)
-                } else {
-                    error
-                }
-            })?;
+        let identity = identity_context::resolve(&mut storage, selector).map_err(|error| {
+            if error.code == "IDENTITY_ERROR" {
+                unavailable(error)
+            } else {
+                error
+            }
+        })?;
         let mut service = RequestService::new(&mut storage, wall_time_ms);
         let result = match operation {
             ExchangeOperation::List { limit, after } => service

--- a/rust/crates/tmt-cli/src/identity_context.rs
+++ b/rust/crates/tmt-cli/src/identity_context.rs
@@ -22,14 +22,26 @@ pub fn missing(name: &str) -> Failure {
     )
 }
 
-pub fn resolve(storage: &mut Storage, explicit: Option<&str>) -> Result<Identity, Failure> {
-    optional(storage, &Tmux::default(), explicit)?.ok_or_else(|| {
-        Failure::new(
-            "IDENTITY_REQUIRED",
-            "An identity is required; use --identity or run from a verified bound pane.",
-            1,
-        )
-    })
+pub enum Selector {
+    Explicit(String),
+    Pane(String),
+}
+
+fn required_failure() -> Failure {
+    Failure::new(
+        "IDENTITY_REQUIRED",
+        "An identity is required; use --identity or run from a verified bound pane.",
+        1,
+    )
+}
+
+/// Reject an unavailable implicit caller before opening or migrating storage.
+pub fn required(explicit: Option<&str>) -> Result<Selector, Failure> {
+    select(&Tmux::default(), explicit)?.ok_or_else(required_failure)
+}
+
+pub fn resolve(storage: &mut Storage, selector: Selector) -> Result<Identity, Failure> {
+    selected(storage, &Tmux::default(), selector)?.ok_or_else(required_failure)
 }
 
 pub fn optional(
@@ -37,25 +49,39 @@ pub fn optional(
     tmux: &Tmux,
     explicit: Option<&str>,
 ) -> Result<Option<Identity>, Failure> {
+    match select(tmux, explicit)? {
+        Some(selector) => selected(storage, tmux, selector),
+        None => Ok(None),
+    }
+}
+
+fn select(tmux: &Tmux, explicit: Option<&str>) -> Result<Option<Selector>, Failure> {
     if let Some(name) = explicit {
-        return storage
-            .find_identity(&normalize_name(name))
+        return Ok(Some(Selector::Explicit(name.to_owned())));
+    }
+    tmux.caller_pane(&CallerEnvironment::current())
+        .map(|pane| pane.map(Selector::Pane))
+        .map_err(endpoint_failure)
+}
+
+fn selected(
+    storage: &mut Storage,
+    tmux: &Tmux,
+    selector: Selector,
+) -> Result<Option<Identity>, Failure> {
+    match selector {
+        Selector::Explicit(name) => storage
+            .find_identity(&normalize_name(&name))
             .map_err(|error| {
                 Failure::new("IDENTITY_ERROR", "Could not read identity storage.", 1)
                     .caused_by(error)
             })?
-            .ok_or_else(|| missing(name))
-            .map(Some);
-    }
-    let pane = tmux
-        .caller_pane(&CallerEnvironment::current())
-        .map_err(endpoint_failure)?;
-    if let Some(pane) = pane {
-        let observed = binding::pane_presence(storage, &mut BindingSession::new(tmux), &pane)
-            .map_err(binding_failure)?;
-        if let Some(identity) = observed.identity {
-            return Ok(Some(identity));
+            .ok_or_else(|| missing(&name))
+            .map(Some),
+        Selector::Pane(pane) => {
+            let observed = binding::pane_presence(storage, &mut BindingSession::new(tmux), &pane)
+                .map_err(binding_failure)?;
+            Ok(observed.identity)
         }
     }
-    Ok(None)
 }

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -205,13 +205,18 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
                 },
             }
         }
-        ["check"] => Invocation::Check {
-            target: required(m, "target"),
-            lines: text(m, "capture-lines")
-                .or_else(|| text(m, "lines"))
+        ["check"] => {
+            let positional = text(m, "capture-lines")
                 .map(|value| integer(&value, "lines", 0, MAX_CAPTURE_LINES))
-                .transpose()?,
-        },
+                .transpose()?;
+            let flagged = text(m, "lines")
+                .map(|value| integer(&value, "lines", 0, MAX_CAPTURE_LINES))
+                .transpose()?;
+            Invocation::Check {
+                target: required(m, "target"),
+                lines: positional.or(flagged),
+            }
+        }
         ["config"] | ["config", "show"] => Invocation::Config(ConfigRequest::Show),
         ["config", "set"] => Invocation::Config(ConfigRequest::Set {
             key: required(m, "key"),

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -578,11 +578,21 @@ fn capture_and_exchange_integers_accept_exact_boundaries() {
         &["check", "peer", "--lines", "2147483648"][..],
         &["check", "peer", "--lines", "1.5"][..],
         &["check", "peer", "--lines", "-1"][..],
+        &["--lines", "2147483648", "check", "peer", "0"][..],
+        &["check", "peer", "0", "--lines", "1.5"][..],
+        &["check", "peer", "2147483648", "--lines", "0"][..],
         &["x", "list", "--after", "9007199254740992"][..],
         &["x", "ack", "request-1", "--revision", "0"][..],
     ] {
         assert_eq!(parse_error(argv).code, "USAGE_ERROR", "arguments: {argv:?}");
     }
+    assert_eq!(
+        parsed(&["--lines", "12", "check", "peer", "0"]).invocation,
+        Invocation::Check {
+            target: "peer".into(),
+            lines: Some(0)
+        }
+    );
 }
 
 #[test]

--- a/rust/crates/tmt-cli/src/profile_command.rs
+++ b/rust/crates/tmt-cli/src/profile_command.rs
@@ -134,6 +134,10 @@ fn run(request: Invocation) -> Result<Report, Failure> {
     let unavailable = |error| {
         Failure::new(error_code(kind), "Could not access profile storage.", 1).caused_by(error)
     };
+    let selector = action
+        .as_ref()
+        .map(|_| identity_context::required(name.as_deref()))
+        .transpose()?;
     let paths = ConfigPaths::discover().map_err(|error| {
         Failure::new(error_code(kind), "Could not discover profile storage.", 1).caused_by(error)
     })?;
@@ -145,15 +149,18 @@ fn run(request: Invocation) -> Result<Report, Failure> {
                 .map(Report::List)
                 .map_err(unavailable);
         };
-        let identity =
-            identity_context::resolve(&mut storage, name.as_deref()).map_err(|error| {
-                if error.code == "IDENTITY_ERROR" {
-                    Failure::new(error_code(kind), "Could not access profile identity.", 1)
-                        .caused_by(error)
-                } else {
-                    error
-                }
-            })?;
+        let identity = identity_context::resolve(
+            &mut storage,
+            selector.expect("profile action selects identity"),
+        )
+        .map_err(|error| {
+            if error.code == "IDENTITY_ERROR" {
+                Failure::new(error_code(kind), "Could not access profile identity.", 1)
+                    .caused_by(error)
+            } else {
+                error
+            }
+        })?;
         let (value, change) = match action {
             Action::Show => (
                 storage

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -30,6 +30,7 @@ COPY . .
 COPY --from=native-tests /native-artifacts/ /opt/tmt-tests/
 ENV TMT_TEST_TMUX_PROBE='{"executable":"/opt/tmt-tests/tmux-probe","args":[]}'
 ENV TMT_TEST_NATIVE_CLI='{"executable":"/opt/tmt-tests/tmt","args":[]}'
+ENV TMT_TEST_CLI='{"executable":"/opt/tmt-tests/tmt","args":[]}'
 
 # Run process lifecycle tests under the wrapper's --init, not a build-stage
 # shell that may retain orphan zombies. Both suites share network isolation.

--- a/test/e2e/caller-context.e2e.test.ts
+++ b/test/e2e/caller-context.e2e.test.ts
@@ -1,3 +1,4 @@
+import { durableIdentity } from './identity-state-oracle.js';
 import Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
@@ -79,10 +80,23 @@ describe.sequential('strict caller context', () => {
         fixture.tmux(['select-pane', '-t', peer.pane]);
         await releaseRealTmuxCli(fixture, real);
 
-        const result = readRealTmuxCli<{ bound: boolean; name: string; pane: string }>(real);
+        const identity = durableIdentity(fixture, 'RealCaller');
+        const result = readRealTmuxCli<{
+          bound: boolean;
+          id: string;
+          name: string;
+          pane: string;
+          lifetime: 'temporary' | 'saved';
+        }>(real);
         expect(result).toEqual({
           code: 0,
-          stdout: { bound: true, name: 'RealCaller', pane: real.pane },
+          stdout: {
+            bound: true,
+            id: identity.id,
+            name: 'RealCaller',
+            pane: real.pane,
+            lifetime: 'temporary',
+          },
           stderr: '',
         });
         const binding = durableState(fixture).bindings.find(
@@ -114,10 +128,23 @@ describe.sequential('strict caller context', () => {
       fixture.tmux(['select-pane', '-t', peer.pane]);
       await releaseRealTmuxCli(fixture, real);
 
-      const result = readRealTmuxCli<{ bound: boolean; name: string; pane: string }>(real);
+      const identity = durableIdentity(fixture, 'AliasCaller');
+      const result = readRealTmuxCli<{
+        bound: boolean;
+        id: string;
+        name: string;
+        pane: string;
+        lifetime: 'temporary' | 'saved';
+      }>(real);
       expect(result).toEqual({
         code: 0,
-        stdout: { bound: true, name: 'AliasCaller', pane: real.pane },
+        stdout: {
+          bound: true,
+          id: identity.id,
+          name: 'AliasCaller',
+          pane: real.pane,
+          lifetime: 'temporary',
+        },
         stderr: '',
       });
       expect(fixture.paneMetadata(peer.pane)).toBe('');
@@ -143,7 +170,7 @@ describe.sequential('strict caller context', () => {
       const result = readRealTmuxCli<string>(real);
       expect(result.code).toBe(0);
       expect(result.stderr).toBe('');
-      expect(result.stdout).toContain("Bound identity 'HumanCaller'");
+      expect(result.stdout).toContain("Bound temporary identity 'HumanCaller'");
       expect(result.stdout).not.toContain('Not running inside tmux. Some features may not work.');
     });
   }, 20_000);
@@ -152,9 +179,22 @@ describe.sequential('strict caller context', () => {
     await withE2EFixture(async (fixture) => {
       await seedIdentity(fixture, 'Current', 'initial caller profile');
 
-      const whoami = await fixture.runJsonCli<{ bound: boolean; name: string }>(['whoami']);
+      const current = durableIdentity(fixture, 'Current');
+      const whoami = await fixture.runJsonCli<{
+        bound: boolean;
+        id: string;
+        name: string;
+        pane: string;
+        lifetime: 'temporary' | 'saved';
+      }>(['whoami']);
       expect(whoami.code).toBe(0);
-      expect(json(whoami)).toMatchObject({ bound: true, name: 'Current', pane: fixture.pane });
+      expect(json(whoami)).toEqual({
+        bound: true,
+        id: current.id,
+        name: 'Current',
+        pane: fixture.pane,
+        lifetime: 'temporary',
+      });
 
       const shown = await fixture.runJsonCli<{
         identity: { name: string };
@@ -182,11 +222,22 @@ describe.sequential('strict caller context', () => {
       const peer = await fixture.createMockPane('peer');
       const peerBound = await fixture.runJsonCli(['add', peer.pane, 'Peer']);
       expect(peerBound.code).toBe(0);
-      const peerWhoami = await fixture.runJsonCli<{ bound: boolean; name: string }>(['whoami'], {
-        pane: peer.pane,
-      });
+      const peerIdentity = durableIdentity(fixture, 'Peer');
+      const peerWhoami = await fixture.runJsonCli<{
+        bound: boolean;
+        id: string;
+        name: string;
+        pane: string;
+        lifetime: 'temporary' | 'saved';
+      }>(['whoami'], { pane: peer.pane });
       expect(peerWhoami.code).toBe(0);
-      expect(json(peerWhoami)).toMatchObject({ bound: true, name: 'Peer', pane: peer.pane });
+      expect(json(peerWhoami)).toEqual({
+        bound: true,
+        id: peerIdentity.id,
+        name: 'Peer',
+        pane: peer.pane,
+        lifetime: 'temporary',
+      });
       const peerRole = await fixture.runJsonCli<{ identity: { name: string } }>(['role', 'show'], {
         pane: peer.pane,
       });
@@ -310,7 +361,14 @@ describe.sequential('strict caller context', () => {
         outsideTmux: true,
       });
       expect(added.code).toBe(0);
-      expect(added.json).toMatchObject({ bound: true, name: 'Peer', pane: peer.pane });
+      const peerIdentity = durableIdentity(fixture, 'Peer');
+      expect(added.json).toEqual({
+        bound: true,
+        id: peerIdentity.id,
+        name: 'Peer',
+        pane: peer.pane,
+        lifetime: 'temporary',
+      });
 
       const message = 'explicit outside caller';
       const talk = await fixture.runJsonCli<{ response: string }>(

--- a/test/e2e/durable-identity.e2e.test.ts
+++ b/test/e2e/durable-identity.e2e.test.ts
@@ -6,11 +6,18 @@ interface PublicIdentity {
   id: string;
   name: string;
   canonicalName: string;
+  lifetime: 'temporary' | 'saved';
 }
 
 interface IdentityResult {
   identity: PublicIdentity;
   created?: boolean;
+}
+
+interface ListedIdentity extends PublicIdentity {
+  presence: 'active' | 'offline' | 'unknown';
+  pane: string | null;
+  command: string;
 }
 
 function success<T>(result: CliResult<T>): T {
@@ -46,7 +53,11 @@ describe.sequential('durable identity lifecycle', () => {
         })
       );
       expect(created.created).toBe(true);
-      expect(created.identity).toMatchObject({ name, canonicalName: 'alice' });
+      expect(created.identity).toMatchObject({
+        name,
+        canonicalName: 'alice',
+        lifetime: 'saved',
+      });
       expect(created.identity.id).toMatch(/^[0-9a-f-]{36}$/);
 
       expect(
@@ -78,10 +89,20 @@ describe.sequential('durable identity lifecycle', () => {
         )
       ).toEqual({ agent: name, preamble, status: 'set' });
 
-      const firstBinding = success<{ bound: true; name: string; pane: string }>(
-        await fixture.runJsonCli(['name', name])
-      );
-      expect(firstBinding).toEqual({ bound: true, name, pane: fixture.pane });
+      const firstBinding = success<{
+        bound: true;
+        id: string;
+        name: string;
+        pane: string;
+        lifetime: 'temporary' | 'saved';
+      }>(await fixture.runJsonCli(['name', name]));
+      expect(firstBinding).toEqual({
+        bound: true,
+        id: created.identity.id,
+        name,
+        pane: fixture.pane,
+        lifetime: 'saved',
+      });
       const stateBeforeRepeat = durableState(fixture);
       expect(stateBeforeRepeat.identities).toHaveLength(1);
       expect(stateBeforeRepeat.identities[0]?.id).toBe(created.identity.id);
@@ -100,10 +121,17 @@ describe.sequential('durable identity lifecycle', () => {
       expect(durableState(fixture)).toEqual(stateBeforeRepeat);
 
       const activeBeforeRestart = success<{
-        identities: Array<Omit<PublicIdentity, 'id'> & { pane: string }>;
+        identities: ListedIdentity[];
       }>(await fixture.runJsonCli(['list']));
       expect(activeBeforeRestart.identities).toEqual([
-        expect.objectContaining({ name, canonicalName: 'alice', pane: fixture.pane }),
+        expect.objectContaining({
+          id: created.identity.id,
+          name,
+          canonicalName: 'alice',
+          lifetime: 'saved',
+          presence: 'active',
+          pane: fixture.pane,
+        }),
       ]);
 
       const preambleBeforeRestart = success<{ agent: string; preamble: string }>(
@@ -113,16 +141,31 @@ describe.sequential('durable identity lifecycle', () => {
 
       expect(success(await fixture.runJsonCli(['unbind']))).toEqual({
         unbound: true,
+        id: created.identity.id,
         name,
         pane: fixture.pane,
+        lifetime: 'saved',
+        retired: false,
       });
-      expect(success(await fixture.runJsonCli(['list']))).toEqual({ identities: [] });
+      expect(success(await fixture.runJsonCli(['list']))).toEqual({
+        identities: [{ ...created.identity, presence: 'offline', pane: null, command: '' }],
+      });
 
       const restarted = await fixture.restartServer();
-      const rebound = success<{ bound: true; name: string; pane: string }>(
-        await fixture.runJsonCli(['name', equivalentName])
-      );
-      expect(rebound).toEqual({ bound: true, name, pane: restarted.pane });
+      const rebound = success<{
+        bound: true;
+        id: string;
+        name: string;
+        pane: string;
+        lifetime: 'temporary' | 'saved';
+      }>(await fixture.runJsonCli(['name', equivalentName]));
+      expect(rebound).toEqual({
+        bound: true,
+        id: created.identity.id,
+        name,
+        pane: restarted.pane,
+        lifetime: 'saved',
+      });
       expect(await showStoredProfile(fixture, name)).toBe(profile);
       expect(
         success(
@@ -132,15 +175,20 @@ describe.sequential('durable identity lifecycle', () => {
           )
         )
       ).toEqual({ agent: name, preamble });
-      expect(
-        success<{ identities: Array<Omit<PublicIdentity, 'id'> & { pane: string }> }>(
-          await fixture.runJsonCli(['list'])
-        )
-      ).toEqual({
-        identities: [
-          expect.objectContaining({ name, canonicalName: 'alice', pane: restarted.pane }),
-        ],
-      });
+      expect(success<{ identities: ListedIdentity[] }>(await fixture.runJsonCli(['list']))).toEqual(
+        {
+          identities: [
+            expect.objectContaining({
+              id: created.identity.id,
+              name,
+              canonicalName: 'alice',
+              lifetime: 'saved',
+              presence: 'active',
+              pane: restarted.pane,
+            }),
+          ],
+        }
+      );
       const finalState = durableState(fixture);
       expect(finalState.identities).toEqual(stateBeforeRepeat.identities);
       expect(finalState.profiles).toEqual(stateBeforeRepeat.profiles);

--- a/test/e2e/durable-talk.e2e.test.ts
+++ b/test/e2e/durable-talk.e2e.test.ts
@@ -347,7 +347,7 @@ describe.sequential('TMT-39 durable talk contract', () => {
         const failure = await fixture.waitForEvent(
           (event) => event.event === 'failure' && event.stage === 'reply'
         );
-        expect(failure.error).toMatchObject({ code: 'RESPONSE_RECEIPT_MISMATCH' });
+        expect(failure.error).toMatchObject({ code: 'RESPONSE_REQUEST_NOT_FOUND' });
         const result = await process.result;
         expect(result.code).toBe(4);
         expect(fixture.events().some((event) => event.event === 'summary')).toBe(false);

--- a/test/e2e/exchange-attention.e2e.test.ts
+++ b/test/e2e/exchange-attention.e2e.test.ts
@@ -31,8 +31,9 @@ function malformedConfig(fixture: E2EFixture): { global: string; local: string }
 }
 
 async function calibrateOfflineTmuxGuard(fixture: E2EFixture): Promise<void> {
-  const calibration = await fixture.runJsonCli(['list'], { withoutTmux: true });
-  expect(calibration.code).toBe(1);
+  const calibration = await fixture.runJsonCli(['check', fixture.pane], { withoutTmux: true });
+  expect(calibration.code).toBe(3);
+  expect(calibration.json).toMatchObject({ error: { code: 'PANE_NOT_FOUND' } });
   expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(true);
   fs.rmSync(fixture.forbiddenTmuxLogPath, { force: true });
 }
@@ -143,6 +144,8 @@ describe.sequential('Exchange attention through the real Docker/tmux fixture', (
           fs.writeFileSync(path.join(fixture.workspace, 'tmux-team.json'), '{}');
           expect(success(await fixture.runJsonCli(['name', name]))).toEqual({
             bound: true,
+            id: created.identity.id,
+            lifetime: 'saved',
             name: 'Alice',
             pane,
           });

--- a/test/e2e/grouped-session.e2e.test.ts
+++ b/test/e2e/grouped-session.e2e.test.ts
@@ -1,25 +1,31 @@
 import fs from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { durableState } from './identity-state-oracle.js';
+import { durableIdentity, durableState } from './identity-state-oracle.js';
 import { withE2EFixture, type CliResult, type E2EFixture } from './harness.js';
 import { readRealTmuxCli, releaseRealTmuxCli, spawnRealTmuxCli } from './real-tmux-caller.js';
 import { installTmuxTrace } from './tmux-trace.js';
 
 interface BindingResult {
   bound: true;
+  id: string;
   name: string;
   pane: string;
+  lifetime: 'temporary' | 'saved';
 }
 
 interface WhoamiResult {
   bound: boolean;
+  id?: string;
   name?: string;
   pane: string;
+  lifetime?: 'temporary' | 'saved';
 }
 
 interface IdentityListItem {
+  id: string;
   name: string;
   canonicalName: string;
+  lifetime: 'temporary' | 'saved';
   pane: string;
   target?: string;
   cwd?: string;
@@ -32,7 +38,12 @@ interface ListResult {
 
 interface FocusedListResult {
   target: string;
-  identity: { name: string; canonicalName: string } | null;
+  identity: {
+    id: string;
+    name: string;
+    canonicalName: string;
+    lifetime: 'temporary' | 'saved';
+  } | null;
   pane: { id: string; target?: string; cwd?: string; command: string };
 }
 
@@ -130,9 +141,16 @@ async function runRealName(
   }
   expectRepeatedPaneTargets(fixture, real.pane);
   await releaseRealTmuxCli(fixture, real);
+  const identity = durableIdentity(fixture, name);
   expect(readRealTmuxCli<BindingResult>(real)).toEqual({
     code: 0,
-    stdout: { bound: true, name, pane: real.pane },
+    stdout: {
+      bound: true,
+      id: identity.id,
+      name,
+      pane: real.pane,
+      lifetime: 'temporary',
+    },
     stderr: '',
   });
   return { pane: real.pane, pid: real.panePid };
@@ -162,13 +180,27 @@ async function exerciseBoundMockPane(
   const peerMetadataBeforeConflict = fixture.paneMetadata(peer.pane);
 
   const added = await fixture.runJsonCli<BindingResult>(['add', pane.pane, identityName]);
-  expect(json(added)).toEqual({ bound: true, name: identityName, pane: pane.pane });
+  const identity = durableIdentity(fixture, identityName);
+  const peerIdentity = durableIdentity(fixture, peer.name);
+  expect(json(added)).toEqual({
+    bound: true,
+    id: identity.id,
+    name: identityName,
+    pane: pane.pane,
+    lifetime: 'temporary',
+  });
   const metadataAfterAdd = fixture.paneMetadata(pane.pane);
   expect(JSON.parse(metadataAfterAdd)).toMatchObject(opaqueMetadata);
 
   trace.clear();
   const whoami = await fixture.runJsonCli<WhoamiResult>(['whoami'], { pane: pane.pane });
-  expect(json(whoami)).toEqual({ bound: true, name: identityName, pane: pane.pane });
+  expect(json(whoami)).toEqual({
+    bound: true,
+    id: identity.id,
+    name: identityName,
+    pane: pane.pane,
+    lifetime: 'temporary',
+  });
   const scopedInvocations = trace.invocations();
   const paneQueries = scopedInvocations.filter((invocation) =>
     invocation.startsWith('list-panes\t')
@@ -189,11 +221,18 @@ async function exerciseBoundMockPane(
   expect(listed.identities).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
+        id: identity.id,
         name: identityName,
         canonicalName: identityName.toLowerCase(),
+        lifetime: 'temporary',
         pane: pane.pane,
       }),
-      expect.objectContaining({ name: peer.name, pane: peer.pane }),
+      expect.objectContaining({
+        id: peerIdentity.id,
+        name: peer.name,
+        lifetime: 'temporary',
+        pane: peer.pane,
+      }),
     ])
   );
 
@@ -206,7 +245,12 @@ async function exerciseBoundMockPane(
   );
   expect(focused).toMatchObject({
     target,
-    identity: { name: identityName, canonicalName: identityName.toLowerCase() },
+    identity: {
+      id: identity.id,
+      name: identityName,
+      canonicalName: identityName.toLowerCase(),
+      lifetime: 'temporary',
+    },
     pane: { id: pane.pane },
   });
   expect(focused.pane.target).toBeDefined();

--- a/test/e2e/identity-lifecycle.e2e.test.ts
+++ b/test/e2e/identity-lifecycle.e2e.test.ts
@@ -3,7 +3,11 @@ import Database from 'better-sqlite3';
 import fs from 'node:fs';
 import path from 'node:path';
 import { E2EFixture, withE2EFixture, type CliResult, type MockPane } from './harness.js';
-import { durableState } from './identity-state-oracle.js';
+import {
+  durableIdentity,
+  durableState,
+  withoutVerificationTimestamp,
+} from './identity-state-oracle.js';
 
 interface Identity {
   name: string;
@@ -35,16 +39,15 @@ async function listIdentities(fixture: E2EFixture): Promise<IdentityListItem[]> 
   return json(result).identities;
 }
 
-function metadata(fixture: E2EFixture, pane: MockPane): Record<string, unknown> {
-  return JSON.parse(fixture.paneMetadata(pane.pane)) as Record<string, unknown>;
+function boundProjection(fixture: E2EFixture, name: string, pane: string, lifetime = 'temporary') {
+  const row = durableIdentity(fixture, name);
+  expect(row.id).toMatch(/^[0-9a-f-]{36}$/);
+  expect(row.lifetime).toBe(lifetime);
+  return { bound: true, id: row.id, name, pane, lifetime };
 }
 
-function withoutVerificationTimestamp(
-  bindings: Array<Record<string, unknown>>
-): Array<Record<string, unknown>> {
-  return bindings
-    .map(({ last_verified_at: _lastVerifiedAt, ...binding }) => binding)
-    .sort((left, right) => String(left.id).localeCompare(String(right.id)));
+function metadata(fixture: E2EFixture, pane: MockPane): Record<string, unknown> {
+  return JSON.parse(fixture.paneMetadata(pane.pane)) as Record<string, unknown>;
 }
 
 function eventCount(
@@ -127,41 +130,51 @@ describe.sequential('global identity lifecycle', () => {
         'Lifecycle',
       ]);
       expect(namedJson.code).toBe(0);
-      expect(json(namedJson)).toEqual({ bound: true, name: 'Lifecycle', pane });
+      const initialBinding = boundProjection(fixture, 'Lifecycle', pane);
+      expect(json(namedJson)).toEqual(initialBinding);
 
       const namedHuman = await fixture.runCli(['name', 'Lifecycle']);
       expect(namedHuman.code).toBe(0);
-      expect(namedHuman.stdout).toContain(`Bound 'Lifecycle' to pane ${pane}`);
+      expect(namedHuman.stdout).toContain(`Bound temporary identity 'Lifecycle' on pane ${pane}`);
       expect(namedHuman.stderr).toBe('');
 
       const whoamiHuman = await fixture.runCli(['whoami']);
       expect(whoamiHuman.code).toBe(0);
-      expect(whoamiHuman.stdout).toContain(`Bound identity 'Lifecycle' on pane ${pane}`);
+      expect(whoamiHuman.stdout).toContain(`Bound temporary identity 'Lifecycle' on pane ${pane}`);
       expect(whoamiHuman.stderr).toBe('');
 
       const whoamiJson = await fixture.runJsonCli<{ bound: true; name: string; pane: string }>([
         'whoami',
       ]);
       expect(whoamiJson.code).toBe(0);
-      expect(json(whoamiJson)).toEqual({ bound: true, name: 'Lifecycle', pane });
+      expect(json(whoamiJson)).toEqual(initialBinding);
 
       const unboundJson = await fixture.runJsonCli<{ unbound: true; name: string; pane: string }>([
         'unbind',
       ]);
       expect(unboundJson.code).toBe(0);
-      expect(json(unboundJson)).toEqual({ unbound: true, name: 'Lifecycle', pane });
+      expect(json(unboundJson)).toEqual({
+        unbound: true,
+        id: initialBinding.id,
+        name: 'Lifecycle',
+        pane,
+        lifetime: 'temporary',
+        retired: true,
+      });
 
       const rebound = await fixture.runJsonCli<{ bound: true; name: string; pane: string }>([
         'this',
         'Lifecycle',
       ]);
       expect(rebound.code).toBe(0);
-      expect(json(rebound)).toEqual(json(namedJson));
+      const reboundBinding = boundProjection(fixture, 'Lifecycle', pane);
+      expect(json(rebound)).toEqual(reboundBinding);
+      expect(reboundBinding.id).not.toBe(initialBinding.id);
       expect(rebound.stderr).toBe('');
 
       const reboundHuman = await fixture.runCli(['this', 'Lifecycle']);
       expect(reboundHuman.code).toBe(0);
-      expect(reboundHuman.stdout).toContain(`Bound 'Lifecycle' to pane ${pane}`);
+      expect(reboundHuman.stdout).toContain(`Bound temporary identity 'Lifecycle' on pane ${pane}`);
       expect(reboundHuman.stderr).toBe('');
 
       const beforeConflictList = await listIdentities(fixture);
@@ -175,11 +188,20 @@ describe.sequential('global identity lifecycle', () => {
       });
       expect(json(thisConflict)).toEqual(json(nameConflict));
       expect(fixture.paneMetadata(pane)).toBe(beforeConflictMetadata);
-      expect(await listIdentities(fixture)).toEqual(beforeConflictList);
+      const retainedConflict = {
+        id: durableIdentity(fixture, 'Conflict').id,
+        name: 'Conflict',
+        canonicalName: 'conflict',
+        lifetime: 'temporary',
+        presence: 'offline',
+        pane: null,
+        command: '',
+      };
+      expect(await listIdentities(fixture)).toEqual([retainedConflict, ...beforeConflictList]);
 
       const unboundHuman = await fixture.runCli(['unbind']);
       expect(unboundHuman.code).toBe(0);
-      expect(unboundHuman.stdout).toContain(`Unbound pane ${pane}`);
+      expect(unboundHuman.stdout).toContain(`Unbound 'Lifecycle' from pane ${pane}`);
       expect(unboundHuman.stderr).toBe('');
 
       const repeated = await fixture.runJsonCli<CommandError>(['unbind']);
@@ -188,7 +210,7 @@ describe.sequential('global identity lifecycle', () => {
         error: { code: 'UNBOUND_PANE', message: 'Pane has no active global name.' },
       });
       expect(fixture.paneMetadata(peer.pane)).toBe(peerMetadata);
-      expect(await listIdentities(fixture)).toEqual(peerList);
+      expect(await listIdentities(fixture)).toEqual([retainedConflict, ...peerList]);
 
       const finalWhoami = await fixture.runJsonCli<{ bound: false; pane: string }>(['whoami']);
       expect(finalWhoami.code).toBe(0);
@@ -210,7 +232,7 @@ describe.sequential('global identity lifecycle', () => {
         '  Alpha  ',
       ]);
       expect(alphaAdd.code).toBe(0);
-      expect(json(alphaAdd)).toEqual({ bound: true, name: 'Alpha', pane: alpha.pane });
+      expect(json(alphaAdd)).toEqual(boundProjection(fixture, 'Alpha', alpha.pane));
 
       const betaAdd = await fixture.runJsonCli<{ bound: true; name: string; pane: string }>([
         'add',
@@ -218,7 +240,7 @@ describe.sequential('global identity lifecycle', () => {
         'Beta',
       ]);
       expect(betaAdd.code).toBe(0);
-      expect(json(betaAdd)).toEqual({ bound: true, name: 'Beta', pane: beta.pane });
+      expect(json(betaAdd)).toEqual(boundProjection(fixture, 'Beta', beta.pane));
 
       const gammaAdd = await fixture.runJsonCli<{ bound: true; name: string; pane: string }>([
         'add',
@@ -226,7 +248,7 @@ describe.sequential('global identity lifecycle', () => {
         'Gamma',
       ]);
       expect(gammaAdd.code).toBe(0);
-      expect(json(gammaAdd)).toEqual({ bound: true, name: 'Gamma', pane: gamma.pane });
+      expect(json(gammaAdd)).toEqual(boundProjection(fixture, 'Gamma', gamma.pane));
 
       expect(metadata(fixture, alpha)).toMatchObject({
         version: 1,
@@ -245,7 +267,7 @@ describe.sequential('global identity lifecycle', () => {
       const beforeMetadata = fixture.paneMetadata(alpha.pane);
       const idempotent = await fixture.runJsonCli(['add', alpha.pane, ' ＡＬＰＨＡ ']);
       expect(idempotent.code).toBe(0);
-      expect(json(idempotent)).toEqual({ bound: true, name: 'Alpha', pane: alpha.pane });
+      expect(json(idempotent)).toEqual(json(alphaAdd));
       expect(fixture.paneMetadata(alpha.pane)).toBe(beforeMetadata);
       expect(await listIdentities(fixture)).toEqual(beforeIdempotent);
 
@@ -270,7 +292,18 @@ describe.sequential('global identity lifecycle', () => {
       expect(json(nameConflict)).toEqual({
         error: { code: 'NAME_ALREADY_ACTIVE', message: 'Name is already active on another pane.' },
       });
-      expect(await listIdentities(fixture)).toEqual(beforeConflictList);
+      expect(await listIdentities(fixture)).toEqual([
+        ...beforeConflictList,
+        {
+          id: durableIdentity(fixture, 'Other').id,
+          name: 'Other',
+          canonicalName: 'other',
+          lifetime: 'temporary',
+          presence: 'offline',
+          pane: null,
+          command: '',
+        },
+      ]);
       expect([
         fixture.paneMetadata(alpha.pane),
         fixture.paneMetadata(beta.pane),
@@ -374,6 +407,9 @@ describe.sequential('global identity lifecycle', () => {
       expect(await listIdentities(fixture)).toEqual([
         {
           name: 'Peer',
+          id: boundProjection(fixture, 'Peer', peer.pane).id,
+          lifetime: 'temporary',
+          presence: 'active',
           canonicalName: 'peer',
           pane: peer.pane,
           target: fixture.paneTarget(peer.pane),
@@ -453,6 +489,9 @@ describe.sequential('global identity lifecycle', () => {
       expect(await listIdentities(fixture)).toEqual([
         {
           name: 'AfterRestart',
+          id: boundProjection(fixture, 'AfterRestart', restarted.pane).id,
+          lifetime: 'temporary',
+          presence: 'active',
           canonicalName: 'afterrestart',
           pane: restarted.pane,
           target: fixture.paneTarget(restarted.pane),
@@ -466,7 +505,7 @@ describe.sequential('global identity lifecycle', () => {
   it('preserves a durable identity across pane death and a later rebind', async () => {
     await withE2EFixture(async (fixture) => {
       const gone = await fixture.createMockPane('durable');
-      const original = await fixture.runJsonCli(['add', gone.pane, 'Durable']);
+      const original = await fixture.runJsonCli(['add', gone.pane, 'Durable', '-s']);
       expect(original.code).toBe(0);
       const database = new Database(path.join(fixture.globalDir, 'tmux-team.db'), {
         readonly: true,
@@ -489,7 +528,19 @@ describe.sequential('global identity lifecycle', () => {
         2_000,
         'durable pane to disappear'
       );
-      expect((await fixture.runJsonCli(['list'])).json).toEqual({ identities: [] });
+      expect((await fixture.runJsonCli(['list'])).json).toEqual({
+        identities: [
+          {
+            id: identity.id,
+            name: 'Durable',
+            canonicalName: 'durable',
+            lifetime: 'saved',
+            presence: 'offline',
+            pane: null,
+            command: '',
+          },
+        ],
+      });
 
       const afterDeath = new Database(path.join(fixture.globalDir, 'tmux-team.db'), {
         readonly: true,
@@ -626,7 +677,7 @@ describe.sequential('global identity lifecycle', () => {
         'FreshExplicit',
       ]);
       expect(explicit.code).toBe(0);
-      expect(json(explicit)).toEqual({ bound: true, name: 'FreshExplicit', pane: oldPane.pane });
+      expect(json(explicit)).toEqual(boundProjection(fixture, 'FreshExplicit', oldPane.pane));
       expect(fixture.paneMetadata(collidingOldPane.pane)).toBe(collidingOldMarkerBytes);
       expect(fixture.paneMetadata(malformedPane.pane)).toBe(malformedMarkerBytes);
       expect(fs.readFileSync(legacyPath, 'utf8')).toBe(legacyBytes);
@@ -701,7 +752,20 @@ describe.sequential('global identity lifecycle', () => {
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
         const listed = await listIdentities(fixture);
-        expect(listed.map(({ name }) => name)).toEqual(['HealthyCurrent', 'HealthyPeer']);
+        expect(listed.map(({ name }) => name)).toEqual([
+          'HealthyCurrent',
+          'HealthyPeer',
+          'MalformedCurrent',
+        ]);
+        expect(listed.find(({ name }) => name === 'MalformedCurrent')).toEqual({
+          id: affectedIdentityId,
+          name: 'MalformedCurrent',
+          canonicalName: 'malformedcurrent',
+          lifetime: 'temporary',
+          presence: 'offline',
+          pane: null,
+          command: '',
+        });
         expect(fixture.paneMetadata(fixture.pane)).toBe(healthyMetadata);
         expect(fixture.paneMetadata(affectedPane.pane)).toBe(affectedMetadata);
         expect(fixture.paneMetadata(peerPane.pane)).toBe(peerMetadata);

--- a/test/e2e/identity-retention.e2e.test.ts
+++ b/test/e2e/identity-retention.e2e.test.ts
@@ -74,9 +74,14 @@ describe.sequential('committed identity retention', () => {
       expect(fixture.paneTitle()).toBe(originalTitle);
 
       const list = success(
-        await fixture.runJsonCli<{ identities: Array<{ name: string }> }>(['list'])
+        await fixture.runJsonCli<{ identities: Array<{ name: string; presence: string }> }>([
+          'list',
+        ])
       );
-      expect(list.identities.map((identity) => identity.name)).toEqual(['Occupied']);
+      expect(list.identities.map(({ name, presence }) => ({ name, presence }))).toEqual([
+        { name: 'Occupied', presence: 'active' },
+        { name: 'Retained', presence: 'offline' },
+      ]);
       const beforeEvents = fixture.events();
       const inactive = await fixture.runJsonCli(['talk', 'Retained', 'must not be delivered']);
       expect(inactive.code).toBe(3);

--- a/test/e2e/identity-state-oracle.ts
+++ b/test/e2e/identity-state-oracle.ts
@@ -2,8 +2,15 @@ import Database from 'better-sqlite3';
 import path from 'node:path';
 import type { E2EFixture } from './harness.js';
 
+export interface DurableIdentityRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  lifetime: 'temporary' | 'saved';
+  retired_at_ms: number | null;
+}
+
 export interface DurableState {
-  identities: Array<Record<string, unknown>>;
+  identities: DurableIdentityRow[];
   bindings: Array<Record<string, unknown>>;
   profiles: Array<Record<string, unknown>>;
 }
@@ -15,7 +22,7 @@ export function durableState(fixture: E2EFixture): DurableState {
     return {
       identities: database
         .prepare('SELECT * FROM identities ORDER BY canonical_name')
-        .all() as Array<Record<string, unknown>>,
+        .all() as DurableIdentityRow[],
       bindings: database.prepare('SELECT * FROM bindings ORDER BY identity_id').all() as Array<
         Record<string, unknown>
       >,
@@ -26,4 +33,22 @@ export function durableState(fixture: E2EFixture): DurableState {
   } finally {
     database.close();
   }
+}
+
+/** Correlate public identity projections with an independent, unretired SQL row. */
+export function durableIdentity(fixture: E2EFixture, name: string): DurableIdentityRow {
+  const row = durableState(fixture).identities.find(
+    (identity) => identity.name === name && identity.retired_at_ms === null
+  );
+  if (!row) throw new Error(`Missing unretired fixture identity: ${name}`);
+  return row;
+}
+
+/** Ignore only the verification clock; retain every other durable binding field. */
+export function withoutVerificationTimestamp(
+  bindings: Array<Record<string, unknown>>
+): Array<Record<string, unknown>> {
+  return bindings
+    .map(({ last_verified_at: _lastVerifiedAt, ...binding }) => binding)
+    .sort((left, right) => String(left.id).localeCompare(String(right.id)));
 }

--- a/test/e2e/large-session.e2e.test.ts
+++ b/test/e2e/large-session.e2e.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { performance } from 'node:perf_hooks';
 import { describe, expect, it } from 'vitest';
-import { durableState } from './identity-state-oracle.js';
+import { durableIdentity, durableState } from './identity-state-oracle.js';
 import { withE2EFixture, type CliResult, type E2EFixture, type MockEvent } from './harness.js';
 import { readRealTmuxCli, releaseRealTmuxCli, spawnRealTmuxCli } from './real-tmux-caller.js';
 import { installTmuxTrace } from './tmux-trace.js';
@@ -14,8 +14,10 @@ interface CommandError {
 
 interface WhoamiResult {
   bound: boolean;
+  id?: string;
   name?: string;
   pane: string;
+  lifetime?: 'temporary' | 'saved';
 }
 
 interface CheckResult {
@@ -36,8 +38,10 @@ interface TalkResult {
 
 interface BindingResult {
   bound: true;
+  id: string;
   name: string;
   pane: string;
+  lifetime: 'temporary' | 'saved';
 }
 
 function json<T>(result: CliResult<T>): T {
@@ -185,7 +189,15 @@ describe.sequential('scoped identity operations in a large tmux session', () => 
           'LargeSession',
         ]);
         expect(named.code).toBe(0);
-        expect(json(named)).toEqual({ bound: true, name: 'LargeSession', pane: fixture.pane });
+        const namedIdentity = durableIdentity(fixture, 'LargeSession');
+        expect(namedIdentity.lifetime).toBe('temporary');
+        expect(json(named)).toEqual({
+          bound: true,
+          id: namedIdentity.id,
+          name: 'LargeSession',
+          pane: fixture.pane,
+          lifetime: 'temporary',
+        });
         const addListInvocations = trace
           .invocations()
           .map(invocationArgs)
@@ -209,15 +221,29 @@ describe.sequential('scoped identity operations in a large tmux session', () => 
         });
         await releaseRealTmuxCli(fixture, realName);
         const realNameResult = readRealTmuxCli<BindingResult>(realName);
-        expect(realNameResult).toMatchObject({
+        const descendantIdentity = durableIdentity(fixture, 'DescendantAlias');
+        expect(descendantIdentity.lifetime).toBe('temporary');
+        expect(realNameResult).toEqual({
           code: 0,
-          stdout: { bound: true, name: 'DescendantAlias', pane: realName.pane },
+          stdout: {
+            bound: true,
+            id: descendantIdentity.id,
+            name: 'DescendantAlias',
+            pane: realName.pane,
+            lifetime: 'temporary',
+          },
           stderr: '',
         });
 
         const whoami = await fixture.runJsonCli<WhoamiResult>(['whoami']);
         expect(whoami.code).toBe(0);
-        expect(json(whoami)).toEqual({ bound: true, name: 'LargeSession', pane: fixture.pane });
+        expect(json(whoami)).toEqual({
+          bound: true,
+          id: namedIdentity.id,
+          name: 'LargeSession',
+          pane: fixture.pane,
+          lifetime: 'temporary',
+        });
 
         const namedCheck = await fixture.runJsonCli<CheckResult>([
           'check',

--- a/test/e2e/multi-server.e2e.test.ts
+++ b/test/e2e/multi-server.e2e.test.ts
@@ -1,8 +1,11 @@
-import Database from 'better-sqlite3';
 import fs from 'node:fs';
-import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { withE2EFixture, type E2EFixture, type CliResult } from './harness.js';
+import {
+  durableIdentity,
+  durableState,
+  withoutVerificationTimestamp,
+} from './identity-state-oracle.js';
 
 function successful<T>(result: CliResult<T>): T {
   expect(result.code, result.stderr || result.stdout).toBe(0);
@@ -11,16 +14,43 @@ function successful<T>(result: CliResult<T>): T {
   return result.json as T;
 }
 
-function durableState(fixture: E2EFixture) {
-  const database = new Database(path.join(fixture.globalDir, 'tmux-team.db'), { readonly: true });
-  try {
-    return {
-      identities: database.prepare('SELECT * FROM identities ORDER BY id').all(),
-      bindings: database.prepare('SELECT * FROM bindings ORDER BY id').all(),
-      profiles: database.prepare('SELECT * FROM role_profiles ORDER BY identity_id').all(),
-    };
-  } finally {
-    database.close();
+interface DurableIdentity {
+  id: string;
+  name: string;
+  lifetime: 'temporary' | 'saved';
+}
+
+interface BoundResult extends DurableIdentity {
+  bound: true;
+  pane: string;
+}
+
+interface ListedIdentity extends DurableIdentity {
+  canonicalName: string;
+  presence: 'active' | 'offline' | 'unknown';
+  pane: string | null;
+  command: string;
+  target?: string;
+  cwd?: string;
+}
+
+interface Listing {
+  identities: ListedIdentity[];
+}
+
+function expectVerificationTimestampsNondecreasing(
+  before: Array<Record<string, unknown>>,
+  after: Array<Record<string, unknown>>
+): void {
+  const beforeById = new Map(before.map((binding) => [String(binding.id), binding]));
+  for (const binding of after) {
+    const prior = beforeById.get(String(binding.id));
+    expect(prior).toBeDefined();
+    const priorTimestamp = Date.parse(String(prior!.last_verified_at));
+    const currentTimestamp = Date.parse(String(binding.last_verified_at));
+    expect(Number.isNaN(priorTimestamp)).toBe(false);
+    expect(Number.isNaN(currentTimestamp)).toBe(false);
+    expect(currentTimestamp).toBeGreaterThanOrEqual(priorTimestamp);
   }
 }
 
@@ -72,28 +102,95 @@ describe.sequential('global identities across isolated tmux servers', () => {
       successful(await b.runJsonCli(['name', 'Remote']));
       successful(await b.runJsonCli(['role', 'set', 'Keep the remote profile.']));
       const before = durableState(b);
+      const remoteIdentity = durableIdentity(b, 'Remote');
       const remoteMetadata = b.paneMetadata();
+      // Neither grouped session is attached: inventory retains the first linked
+      // presentation, while display-message may choose the other session.
+      const remoteTarget = b
+        .tmux([
+          'list-panes',
+          '-a',
+          '-F',
+          '#{pane_id}|#{session_name}:#{window_index}.#{pane_index}',
+        ])
+        .trim()
+        .split('\n')
+        .find((row) => row.startsWith(`${b.pane}|`))!
+        .split('|')[1];
 
-      expect(successful(await a.runJsonCli(['list']))).toEqual({ identities: [] });
-      expect(durableState(a)).toEqual(before);
+      expect(successful(await a.runJsonCli<Listing>(['list']))).toEqual({
+        identities: [
+          {
+            id: remoteIdentity.id,
+            name: 'Remote',
+            canonicalName: 'remote',
+            lifetime: 'temporary',
+            presence: 'active',
+            pane: b.pane,
+            command: 'node',
+            target: remoteTarget,
+            cwd: b.workspace,
+          },
+        ],
+      });
+      const afterList = durableState(a);
+      expect(afterList.identities).toEqual(before.identities);
+      expect(withoutVerificationTimestamp(afterList.bindings)).toEqual(
+        withoutVerificationTimestamp(before.bindings)
+      );
+      expectVerificationTimestampsNondecreasing(before.bindings, afterList.bindings);
+      expect(afterList.profiles).toEqual(before.profiles);
       const collision = await a.runJsonCli(['name', 'REMOTE']);
       expect(collision.code).toBe(5);
       expect(collision.json).toMatchObject({ error: { code: 'NAME_ALREADY_ACTIVE' } });
-      expect(durableState(a)).toEqual(before);
+      const afterCollision = durableState(a);
+      expect(afterCollision.identities).toEqual(before.identities);
+      expect(withoutVerificationTimestamp(afterCollision.bindings)).toEqual(
+        withoutVerificationTimestamp(before.bindings)
+      );
+      expectVerificationTimestampsNondecreasing(before.bindings, afterCollision.bindings);
+      expect(afterCollision.profiles).toEqual(before.profiles);
       expect(a.paneMetadata()).toBe('');
       expect(b.paneMetadata()).toBe(remoteMetadata);
 
       successful(await a.runJsonCli(['name', 'Local']));
+      const localIdentity = durableIdentity(a, 'Local');
       const local = durableState(a).bindings.filter(
         (row) => (row as { socket_path: string }).socket_path === a.socketPath
       );
-      const listB = successful(await b.runJsonCli<{ identities: { name: string }[] }>(['list']));
-      expect(listB.identities.map((entry) => entry.name)).toEqual(['Remote']);
       expect(
         durableState(a).bindings.filter(
           (row) => (row as { socket_path: string }).socket_path === a.socketPath
         )
       ).toEqual(local);
+
+      const listB = successful(await b.runJsonCli<Listing>(['list']));
+      expect(listB).toEqual({
+        identities: [
+          {
+            id: localIdentity.id,
+            name: 'Local',
+            canonicalName: 'local',
+            lifetime: 'temporary',
+            presence: 'active',
+            pane: a.pane,
+            command: 'node',
+            target: a.paneTarget(a.pane),
+            cwd: a.workspace,
+          },
+          {
+            id: remoteIdentity.id,
+            name: 'Remote',
+            canonicalName: 'remote',
+            lifetime: 'temporary',
+            presence: 'active',
+            pane: b.pane,
+            command: 'node',
+            target: remoteTarget,
+            cwd: b.workspace,
+          },
+        ],
+      });
 
       const foreignTalk = await a.runJsonCli(['talk', 'Remote', 'must-not-cross-servers']);
       expect(foreignTalk.code).toBe(3);
@@ -125,13 +222,26 @@ describe.sequential('global identities across isolated tmux servers', () => {
         successful(await b.runJsonCli(['name', 'Remote']));
         successful(await b.runJsonCli(['role', 'set', 'Preserve on uncertain evidence.']));
         const before = durableState(b);
+        const remoteIdentity = durableIdentity(b, 'Remote');
         const metadata = b.paneMetadata();
         const hiddenSocket = `${b.socketPath}.unreachable`;
         if (failure === 'hidden socket') fs.renameSync(b.socketPath, hiddenSocket);
         else process.kill(b.serverPid, 'SIGSTOP');
         try {
           expect(b.serverProcessIsRunning()).toBe(true);
-          expect(successful(await a.runJsonCli(['list']))).toEqual({ identities: [] });
+          expect(successful(await a.runJsonCli<Listing>(['list']))).toEqual({
+            identities: [
+              {
+                id: remoteIdentity.id,
+                name: 'Remote',
+                canonicalName: 'remote',
+                lifetime: 'temporary',
+                presence: 'unknown',
+                pane: null,
+                command: '',
+              },
+            ],
+          });
           expect(successful(await a.runJsonCli(['whoami']))).toMatchObject({ bound: false });
           expect(durableState(a)).toEqual(before);
           const started = Date.now();
@@ -146,9 +256,12 @@ describe.sequential('global identities across isolated tmux servers', () => {
           else process.kill(b.serverPid, 'SIGCONT');
         }
         expect(b.paneMetadata()).toBe(metadata);
-        expect(successful(await b.runJsonCli(['whoami']))).toMatchObject({
+        expect(successful(await b.runJsonCli(['whoami']))).toEqual({
           bound: true,
+          id: remoteIdentity.id,
           name: 'Remote',
+          pane: b.pane,
+          lifetime: 'temporary',
         });
       });
     },
@@ -157,12 +270,20 @@ describe.sequential('global identities across isolated tmux servers', () => {
 
   it('reclaims a proven-dead foreign endpoint without replacing the identity or profile', async () => {
     await withTwoServers(async (a, b) => {
-      successful(await b.runJsonCli(['name', 'Remote']));
+      successful(await b.runJsonCli(['name', 'Remote', '-s']));
       const profile = successful(await b.runJsonCli(['role', 'set', 'Survive endpoint death.']));
       const before = durableState(b);
+      const remoteIdentity = durableIdentity(b, 'Remote');
+      expect(remoteIdentity.lifetime).toBe('saved');
       b.tmux(['kill-server']);
       await b.waitFor(() => !b.serverProcessIsRunning(), 2_000, 'foreign server process exit');
-      successful(await a.runJsonCli(['name', 'Remote']));
+      expect(successful(await a.runJsonCli<BoundResult>(['name', 'Remote']))).toEqual({
+        bound: true,
+        id: remoteIdentity.id,
+        name: 'Remote',
+        pane: a.pane,
+        lifetime: 'saved',
+      });
       const after = durableState(a);
       expect(after.identities).toEqual(before.identities);
       expect(after.profiles).toEqual(before.profiles);
@@ -175,10 +296,13 @@ describe.sequential('global identities across isolated tmux servers', () => {
 
   it('prunes only the restarted socket while retaining another live server and both durable identities', async () => {
     await withTwoServers(async (a, b) => {
-      successful(await a.runJsonCli(['name', 'Local']));
+      successful(await a.runJsonCli(['name', 'Local', '-s']));
       successful(await a.runJsonCli(['role', 'set', 'Survive local restart.']));
       successful(await b.runJsonCli(['name', 'Remote']));
       const before = durableState(a);
+      const localIdentity = durableIdentity(a, 'Local');
+      const remoteIdentity = durableIdentity(a, 'Remote');
+      expect(localIdentity.lifetime).toBe('saved');
       const foreign = before.bindings.filter(
         (row) => (row as { socket_path: string }).socket_path === b.socketPath
       );
@@ -186,27 +310,65 @@ describe.sequential('global identities across isolated tmux servers', () => {
       const oldSocket = a.socketPath;
       await a.restartServer();
       expect(a.socketPath).toBe(oldSocket);
-      expect(successful(await a.runJsonCli(['list']))).toEqual({ identities: [] });
+      expect(successful(await a.runJsonCli<Listing>(['list']))).toEqual({
+        identities: [
+          {
+            id: localIdentity.id,
+            name: 'Local',
+            canonicalName: 'local',
+            lifetime: 'saved',
+            presence: 'offline',
+            pane: null,
+            command: '',
+          },
+          {
+            id: remoteIdentity.id,
+            name: 'Remote',
+            canonicalName: 'remote',
+            lifetime: 'temporary',
+            presence: 'active',
+            pane: b.pane,
+            command: 'node',
+            target: b.paneTarget(b.pane),
+            cwd: b.workspace,
+          },
+        ],
+      });
       const after = durableState(a);
-      expect(after.bindings).toEqual(foreign);
+      expect(withoutVerificationTimestamp(after.bindings)).toEqual(
+        withoutVerificationTimestamp(foreign)
+      );
+      expectVerificationTimestampsNondecreasing(foreign, after.bindings);
       expect(after.identities).toEqual(before.identities);
       expect(after.profiles).toEqual(before.profiles);
-      successful(await a.runJsonCli(['name', 'Local']));
-      expect(durableState(a).identities).toEqual(before.identities);
-      expect(successful(await b.runJsonCli(['whoami']))).toMatchObject({
+      expect(successful(await a.runJsonCli<BoundResult>(['name', 'Local']))).toEqual({
         bound: true,
+        id: localIdentity.id,
+        name: 'Local',
+        pane: a.pane,
+        lifetime: 'saved',
+      });
+      expect(durableState(a).identities).toEqual(before.identities);
+      expect(successful(await b.runJsonCli(['whoami']))).toEqual({
+        bound: true,
+        id: remoteIdentity.id,
         name: 'Remote',
+        pane: b.pane,
+        lifetime: 'temporary',
       });
     });
   }, 30_000);
 
   it('reclaims a dead foreign pane while its original server and another identity remain alive', async () => {
     await withTwoServers(async (a, b) => {
-      successful(await b.runJsonCli(['name', 'Remote']));
+      successful(await b.runJsonCli(['name', 'Remote', '-s']));
       const profile = successful(await b.runJsonCli(['role', 'set', 'Survive pane death.']));
       const peer = await b.createMockPane('survivor');
       successful(await b.runJsonCli(['add', peer.pane, 'Survivor']));
       const before = durableState(b);
+      const remoteIdentity = durableIdentity(b, 'Remote');
+      const survivorIdentity = durableIdentity(b, 'Survivor');
+      expect(remoteIdentity.lifetime).toBe('saved');
       const survivor = before.bindings.filter(
         (row) => (row as { pane_id: string }).pane_id === peer.pane
       );
@@ -215,18 +377,67 @@ describe.sequential('global identities across isolated tmux servers', () => {
       await b.waitFor(() => !b.mockProcessIsRunning(), 2_000, 'foreign pane process exit');
       expect(b.serverProcessIsRunning()).toBe(true);
 
-      expect(successful(await a.runJsonCli(['list']))).toEqual({ identities: [] });
-      expect(durableState(a)).toEqual(before);
-      successful(await a.runJsonCli(['name', 'Remote']));
+      expect(successful(await a.runJsonCli<Listing>(['list']))).toEqual({
+        identities: [
+          {
+            id: remoteIdentity.id,
+            name: 'Remote',
+            canonicalName: 'remote',
+            lifetime: 'saved',
+            presence: 'offline',
+            pane: null,
+            command: '',
+          },
+          {
+            id: survivorIdentity.id,
+            name: 'Survivor',
+            canonicalName: 'survivor',
+            lifetime: 'temporary',
+            presence: 'active',
+            pane: peer.pane,
+            command: 'node',
+            target: b.paneTarget(peer.pane),
+            cwd: peer.workspace,
+          },
+        ],
+      });
+      const observed = durableState(a);
+      expect(observed.identities).toEqual(before.identities);
+      expect(observed.profiles).toEqual(before.profiles);
+      const observedSurvivor = observed.bindings.filter(
+        (binding) => binding.identity_id === survivorIdentity.id
+      );
+      expect(observedSurvivor).toHaveLength(1);
+      expect(withoutVerificationTimestamp(observedSurvivor)).toEqual(
+        withoutVerificationTimestamp(survivor)
+      );
+      expectVerificationTimestampsNondecreasing(survivor, observedSurvivor);
+      expect(successful(await a.runJsonCli<BoundResult>(['name', 'Remote']))).toEqual({
+        bound: true,
+        id: remoteIdentity.id,
+        name: 'Remote',
+        pane: a.pane,
+        lifetime: 'saved',
+      });
       const after = durableState(a);
       expect(after.identities).toEqual(before.identities);
       expect(after.profiles).toEqual(before.profiles);
       expect(after.bindings).toHaveLength(2);
-      expect(after.bindings).toContainEqual(survivor[0]);
+      const afterSurvivor = after.bindings.filter(
+        (binding) => binding.identity_id === survivorIdentity.id
+      );
+      expect(afterSurvivor).toHaveLength(1);
+      expect(withoutVerificationTimestamp(afterSurvivor)).toEqual(
+        withoutVerificationTimestamp(survivor)
+      );
+      expectVerificationTimestampsNondecreasing(survivor, afterSurvivor);
       expect(successful(await a.runJsonCli(['role', 'show']))).toEqual(profile);
-      expect(successful(await b.runJsonCli(['whoami'], { pane: peer.pane }))).toMatchObject({
+      expect(successful(await b.runJsonCli(['whoami'], { pane: peer.pane }))).toEqual({
         bound: true,
+        id: survivorIdentity.id,
         name: 'Survivor',
+        pane: peer.pane,
+        lifetime: 'temporary',
       });
     });
   }, 30_000);

--- a/test/e2e/pane-badge.e2e.test.ts
+++ b/test/e2e/pane-badge.e2e.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { withE2EFixture, type CliResult, type E2EFixture } from './harness.js';
-import { durableState } from './identity-state-oracle.js';
+import { durableIdentity, durableState } from './identity-state-oracle.js';
 
 const BADGE_OPTION = '@tmux-team.badge';
 const USER_FORMAT = '#[align=left]#{window_index}.#{pane_index}#[align=right]repo/branch';
@@ -117,6 +117,8 @@ describe.sequential('non-invasive pane badge presentation', () => {
       successful(await fixture.runJsonCli(['config', 'set', 'ui.paneBadge', 'on', '--global']));
       const name = '#[fg=red]#{pane_title}#(false)';
       successful(await fixture.runJsonCli(['name', name]));
+      const identity = durableIdentity(fixture, name);
+      expect(identity.lifetime).toBe('temporary');
       const label = '＃[fg=red]＃{pane_title}＃(false) (tmt)';
       expect(badge(fixture)).toBe(label);
       expect(
@@ -124,8 +126,10 @@ describe.sequential('non-invasive pane badge presentation', () => {
       ).toBe(`[${label}]`);
       expect(successful(await fixture.runJsonCli(['whoami']))).toEqual({
         bound: true,
+        id: identity.id,
         name,
         pane: fixture.pane,
+        lifetime: 'temporary',
       });
     });
   });
@@ -168,10 +172,14 @@ describe.sequential('non-invasive pane badge presentation', () => {
           )
       );
       successful(await fixture.runJsonCli(['name', 'alice']));
+      const identity = durableIdentity(fixture, 'alice');
+      expect(identity.lifetime).toBe('temporary');
       expect(successful(await fixture.runJsonCli(['whoami']))).toEqual({
         bound: true,
+        id: identity.id,
         name: 'alice',
         pane: fixture.pane,
+        lifetime: 'temporary',
       });
       expect(durableState(fixture).bindings).toHaveLength(1);
       successful(await fixture.runJsonCli(['unbind']));

--- a/test/e2e/preamble-lifecycle.e2e.test.ts
+++ b/test/e2e/preamble-lifecycle.e2e.test.ts
@@ -16,7 +16,12 @@ interface PreambleValue {
 }
 
 interface RoleValue {
-  identity: { id: string; name: string; canonicalName: string };
+  identity: {
+    id: string;
+    name: string;
+    canonicalName: string;
+    lifetime: 'temporary' | 'saved';
+  };
   role: { content: string; updatedAt: string } | null;
 }
 
@@ -102,7 +107,7 @@ async function causalTalk(
 describe.sequential('durable identity preambles', () => {
   it('stores by durable identity, stays offline, and survives legacy files and rebinding', async () => {
     await withE2EFixture(async (fixture) => {
-      const bound = await fixture.runJsonCli(['name', 'Durable']);
+      const bound = await fixture.runJsonCli(['name', 'Durable', '-s']);
       expect(bound.code).toBe(0);
       const roleText = 'Role remains separate from the preamble.';
       expect((await fixture.runJsonCli(['role', 'set', roleText])).code).toBe(0);

--- a/test/e2e/publication-race.e2e.test.ts
+++ b/test/e2e/publication-race.e2e.test.ts
@@ -245,7 +245,7 @@ describe.sequential('crash-safe identity publication', () => {
 
   it('rolls back a killed post-metadata publication while retaining profile state for rebind', async () => {
     await withE2EFixture(async (fixture) => {
-      expect((await fixture.runJsonCli(['name', 'Preserved'])).code).toBe(0);
+      expect((await fixture.runJsonCli(['name', 'Preserved', '-s'])).code).toBe(0);
       const profile = await fixture.runJsonCli(['role', 'set', 'Keep this profile']);
       expect(profile.code).toBe(0);
       expect((await fixture.runJsonCli(['unbind'])).code).toBe(0);
@@ -270,9 +270,17 @@ describe.sequential('crash-safe identity publication', () => {
       expect(json(whoami)).toEqual({ bound: false, pane: fixture.pane });
       const listAfterKill = await fixture.runJsonCli<IdentityList>(['list']);
       expect(listAfterKill.code).toBe(0);
-      expect(json(listAfterKill).identities).not.toEqual(
-        expect.arrayContaining([expect.objectContaining({ name: 'Preserved' })])
-      );
+      expect(json(listAfterKill).identities).toEqual([
+        {
+          id: identityBefore.id,
+          name: 'Preserved',
+          canonicalName: 'preserved',
+          lifetime: 'saved',
+          presence: 'offline',
+          pane: null,
+          command: '',
+        },
+      ]);
       expect(durableCounts(fixture)).toMatchObject({ identities: 1, bindings: 0, profiles: 1 });
       expect(durableIdentity(fixture, 'preserved')).toEqual(identityBefore);
       expect(durableProfile(fixture, identityBefore.id)).toEqual(profileBefore);

--- a/test/e2e/request-context.e2e.test.ts
+++ b/test/e2e/request-context.e2e.test.ts
@@ -40,7 +40,7 @@ describe.sequential('TMT-55 request context and provenance', () => {
     await withE2EFixture(
       async (fixture) => {
         const peer = await fixture.createMockPane('peer');
-        expect((await fixture.runJsonCli(['name', 'Caller'])).code).toBe(0);
+        expect((await fixture.runJsonCli(['name', 'Caller', '-s'])).code).toBe(0);
         expect((await fixture.runJsonCli(['add', peer.pane, 'Peer'])).code).toBe(0);
         const callerId = await identityId(fixture, 'Caller');
         const peerId = await identityId(fixture, 'Peer');
@@ -169,7 +169,7 @@ describe.sequential('TMT-55 request context and provenance', () => {
 
         const previousRows = requestAttempts(fixture);
         expect((await fixture.runJsonCli(['unbind'])).code).toBe(0);
-        expect((await fixture.runJsonCli(['name', 'Caller'])).code).toBe(0);
+        expect((await fixture.runJsonCli(['name', 'Caller', '-s'])).code).toBe(0);
         expect(await identityId(fixture, 'Caller')).toBe(callerId);
         const rebound = await fixture.runJsonCli<TalkOutput>([
           'talk',
@@ -212,7 +212,7 @@ describe.sequential('TMT-55 request context and provenance', () => {
     await withE2EFixture(async (fixture) => {
       const peer = await fixture.createMockPane('peer');
       const anonymous = await fixture.createMockPane('anonymous');
-      expect((await fixture.runJsonCli(['name', 'Caller'])).code).toBe(0);
+      expect((await fixture.runJsonCli(['name', 'Caller', '-s'])).code).toBe(0);
       expect((await fixture.runJsonCli(['add', peer.pane, 'Peer'])).code).toBe(0);
       const callerId = await identityId(fixture, 'Caller');
       const peerId = await identityId(fixture, 'Peer');

--- a/test/e2e/retired-commands.e2e.test.ts
+++ b/test/e2e/retired-commands.e2e.test.ts
@@ -5,33 +5,38 @@ import { describe, expect, it } from 'vitest';
 import { withE2EFixture, type E2EFixture } from './harness.js';
 
 const RETIRED_COMMANDS = [
-  ['update', 'SharedIdentity', '--pane', '%999', '--remark', 'must not update'],
-  ['remove', 'SharedIdentity'],
-  ['rm', 'SharedIdentity'],
   ['migrate'],
   ['migrate', '--dry-run'],
   ['migrate', '--cleanup'],
   ['migrate', '--dry-run', '--cleanup'],
 ] as const;
 
+const LEGACY_UPDATE_ARGUMENTS = [
+  ['update', 'SharedIdentity', '--pane', '%999', '--remark', 'must not update'],
+] as const;
+
 const HELP_NEIGHBORS = [
-  'talk',
-  'check',
+  'help',
+  'init',
   'list',
   'add',
   'name',
-  'this',
+  'rm',
+  'talk',
+  'check',
   'whoami',
   'unbind',
-  'install',
-  'upgrade',
-  'init',
-  'completion',
   'config',
   'preamble',
+  'x',
+  'identity',
   'role',
+  'reply',
+  'result',
+  'install',
+  'completion',
+  'upgrade',
   'learn',
-  'help',
 ] as const;
 
 interface DurableSnapshot {
@@ -66,14 +71,34 @@ function durableSnapshot(fixture: E2EFixture): DurableSnapshot {
 function expectUnknownCommandHuman(result: { code: number; stdout: string; stderr: string }): void {
   expect(result.code).toBe(1);
   expect(result.stdout).toBe('');
-  expect(result.stderr).toMatch(/unknown command/i);
+  expect(result.stderr).toMatch(/(?:unknown command|unrecognized subcommand)/i);
 }
 
 function expectUnknownCommandJson(result: { code: number; stdout: string; stderr: string }): void {
   expect(result.code).toBe(1);
   expect(result.stderr).toBe('');
   expect(JSON.parse(result.stdout)).toEqual({
-    error: { code: 'USAGE_ERROR', message: expect.stringMatching(/unknown command/i) },
+    error: {
+      code: 'USAGE_ERROR',
+      message: expect.stringMatching(/(?:unknown command|unrecognized subcommand)/i),
+    },
+  });
+}
+
+function expectLegacyArgumentHuman(result: { code: number; stdout: string; stderr: string }): void {
+  expect(result.code).toBe(1);
+  expect(result.stdout).toBe('');
+  expect(result.stderr).toMatch(/(?:unexpected argument|unknown option)/i);
+}
+
+function expectLegacyArgumentJson(result: { code: number; stdout: string; stderr: string }): void {
+  expect(result.code).toBe(1);
+  expect(result.stderr).toBe('');
+  expect(JSON.parse(result.stdout)).toEqual({
+    error: {
+      code: 'USAGE_ERROR',
+      message: expect.stringMatching(/(?:unexpected argument|unknown option)/i),
+    },
   });
 }
 
@@ -82,26 +107,47 @@ function expectRetiredNamesAndFlagsAbsent(output: string, shell?: 'bash' | 'zsh'
     expect(output).not.toContain(flag);
   }
   if (!shell) {
-    expect(output).not.toMatch(/^\s+(?:update|remove|rm|migrate)\b/m);
+    expect(output).not.toMatch(/^\s+migrate\b/m);
     return;
   }
   if (shell === 'zsh') {
-    expect(output).not.toMatch(/'(?:update|remove|rm|migrate):/);
-    expect(output).not.toMatch(/(?:update|remove|rm|migrate)\)/);
+    expect(output).not.toMatch(/'migrate:/);
+    expect(output).not.toMatch(/migrate\)/);
     return;
   }
-  expect(output).not.toMatch(/commands="[^"]*\b(?:update|remove|rm|migrate)\b/);
-  expect(output).not.toMatch(/(?:update|remove|rm|migrate)\|/);
+  expect(output).not.toMatch(/^\s+opts="[^"]*\bmigrate\b/m);
+  expect(output).not.toMatch(/migrate\|/);
+}
+
+const HELP_ALIASES = [
+  ['list', 'ls'],
+  ['name', 'this'],
+  ['rm', 'remove'],
+  ['talk', 'send'],
+  ['check', 'read'],
+  ['upgrade', 'update'],
+] as const;
+
+function expectHelpAliasesPresent(output: string): void {
+  for (const [command, alias] of HELP_ALIASES) {
+    expect(output).toMatch(new RegExp(`^\\s+${command}\\b[^\\n]*\\[alias: ${alias}\\]`, 'm'));
+  }
 }
 
 function expectNeighborsPresent(output: string, shell?: 'bash' | 'zsh'): void {
-  for (const neighbor of HELP_NEIGHBORS) {
+  const names = [...HELP_NEIGHBORS, ...(shell ? HELP_ALIASES.map(([, alias]) => alias) : [])];
+  const bashCommands =
+    shell === 'bash'
+      ? output.match(/^\s+tmt\)\n\s+opts="([^"\n]+)"/m)?.[1].split(/\s+/)
+      : undefined;
+  if (shell === 'bash') expect(bashCommands).toBeDefined();
+  for (const neighbor of names) {
     if (!shell) {
       expect(output).toMatch(new RegExp(`^\\s+${neighbor}\\b`, 'm'));
     } else if (shell === 'zsh') {
       expect(output).toContain(`'${neighbor}:`);
     } else {
-      expect(output).toMatch(new RegExp(`commands="[^\\"]*\\b${neighbor}\\b`));
+      expect(bashCommands).toContain(neighbor);
     }
   }
 }
@@ -114,6 +160,10 @@ describe.sequential('retired legacy registry commands', () => {
       for (const args of RETIRED_COMMANDS) {
         const human = await fixture.runCli([...args], { withoutTmux: true });
         expectUnknownCommandHuman(human);
+      }
+      for (const args of LEGACY_UPDATE_ARGUMENTS) {
+        const human = await fixture.runCli([...args], { withoutTmux: true });
+        expectLegacyArgumentHuman(human);
       }
 
       expect(fs.existsSync(databasePath(fixture))).toBe(false);
@@ -166,6 +216,12 @@ describe.sequential('retired legacy registry commands', () => {
         const json = await fixture.runJsonCli([...args]);
         expectUnknownCommandJson(json);
       }
+      for (const args of LEGACY_UPDATE_ARGUMENTS) {
+        const human = await fixture.runCli([...args]);
+        expectLegacyArgumentHuman(human);
+        const json = await fixture.runJsonCli([...args]);
+        expectLegacyArgumentJson(json);
+      }
 
       expect(fs.readFileSync(legacyPath, 'utf8')).toBe(legacyBytes);
       expect(fixture.paneMetadata(fixture.pane)).toBe(metadataBefore.get(fixture.pane));
@@ -214,6 +270,7 @@ describe.sequential('retired legacy registry commands', () => {
       const help = await fixture.runCli(['help'], { withoutTmux: true });
       expect(help.code).toBe(0);
       expectNeighborsPresent(help.stdout);
+      expectHelpAliasesPresent(help.stdout);
       expectRetiredNamesAndFlagsAbsent(help.stdout);
 
       for (const shell of ['bash', 'zsh']) {

--- a/test/e2e/role-lifecycle.e2e.test.ts
+++ b/test/e2e/role-lifecycle.e2e.test.ts
@@ -5,7 +5,12 @@ import { describe, expect, it } from 'vitest';
 import { withE2EFixture, type E2EFixture, type CliResult } from './harness.js';
 
 interface RoleResult {
-  identity: { id: string; name: string; canonicalName: string };
+  identity: {
+    id: string;
+    name: string;
+    canonicalName: string;
+    lifetime: 'temporary' | 'saved';
+  };
   role: { content: string; updatedAt: string } | null;
 }
 
@@ -37,7 +42,7 @@ async function showOffline(fixture: E2EFixture, identity: string): Promise<RoleR
 describe.sequential('durable role profiles', () => {
   it('preserves one identity profile through unbind, pane death, restart, and rebind', async () => {
     await withE2EFixture(async (fixture) => {
-      expect((await fixture.runJsonCli(['name', 'Alice'])).code).toBe(0);
+      expect((await fixture.runJsonCli(['name', 'Alice', '-s'])).code).toBe(0);
       const empty = successful(await fixture.runJsonCli<RoleResult>(['role', 'show']));
       expect(empty.role).toBeNull();
       const content = '# Reviewer\n\tPreserve evidence.\n';
@@ -95,9 +100,12 @@ describe.sequential('durable role profiles', () => {
           updated_at: bob.role!.updatedAt,
         },
       ]);
-      expect((await fixture.runJsonCli(['whoami'])).json).toMatchObject({
+      expect((await fixture.runJsonCli(['whoami'])).json).toEqual({
         bound: true,
+        id: assigned.identity.id,
         name: 'Alice',
+        pane: fixture.pane,
+        lifetime: 'saved',
       });
       expect(await showOffline(fixture, 'Bob')).toEqual(bob);
       expect(fs.existsSync(fixture.forbiddenTmuxLogPath)).toBe(false);

--- a/test/e2e/routing.e2e.test.ts
+++ b/test/e2e/routing.e2e.test.ts
@@ -7,6 +7,9 @@ interface IdentitySummary {
 }
 
 interface IdentityListItem extends IdentitySummary {
+  id: string;
+  lifetime: 'temporary' | 'saved';
+  presence: 'active' | 'offline' | 'unknown';
   pane: string;
   target?: string;
   cwd?: string;
@@ -21,6 +24,14 @@ interface CommandError {
   };
 }
 
+interface BoundResult {
+  bound: true;
+  id: string;
+  name: string;
+  pane: string;
+  lifetime: 'temporary' | 'saved';
+}
+
 describe.sequential('global identity and runtime routing', () => {
   it('routes names, an ordinary all identity, and direct pane targets across workspaces', async () => {
     await withE2EFixture(async (fixture) => {
@@ -30,28 +41,34 @@ describe.sequential('global identity and runtime routing', () => {
       const alpha = await fixture.createMockPane('alpha', alphaWorkspace);
       const all = await fixture.createMockPane('all', allWorkspace);
 
-      const alphaBinding = await fixture.runJsonCli<{
-        bound: boolean;
-        name: string;
-        pane: string;
-      }>(['add', alpha.pane, 'Alpha'], { cwd: alphaWorkspace });
-      expect(alphaBinding).toMatchObject({
-        code: 0,
-        json: { bound: true, name: 'Alpha', pane: alpha.pane },
+      const alphaBinding = await fixture.runJsonCli<BoundResult>(['add', alpha.pane, 'Alpha'], {
+        cwd: alphaWorkspace,
       });
+      expect(alphaBinding.code).toBe(0);
+      expect(alphaBinding.json).toEqual({
+        bound: true,
+        id: expect.any(String),
+        name: 'Alpha',
+        pane: alpha.pane,
+        lifetime: 'temporary',
+      });
+      const alphaId = alphaBinding.json!.id;
       expect(JSON.parse(fixture.paneMetadata(alpha.pane))).toMatchObject({
         globalIdentity: { name: 'Alpha', canonicalName: 'alpha' },
       });
 
-      const allBinding = await fixture.runJsonCli<{
-        bound: boolean;
-        name: string;
-        pane: string;
-      }>(['add', all.pane, 'all'], { cwd: allWorkspace });
-      expect(allBinding).toMatchObject({
-        code: 0,
-        json: { bound: true, name: 'all', pane: all.pane },
+      const allBinding = await fixture.runJsonCli<BoundResult>(['add', all.pane, 'all'], {
+        cwd: allWorkspace,
       });
+      expect(allBinding.code).toBe(0);
+      expect(allBinding.json).toEqual({
+        bound: true,
+        id: expect.any(String),
+        name: 'all',
+        pane: all.pane,
+        lifetime: 'temporary',
+      });
+      const allId = allBinding.json!.id;
       expect(JSON.parse(fixture.paneMetadata(all.pane))).toMatchObject({
         globalIdentity: { name: 'all', canonicalName: 'all' },
       });
@@ -63,16 +80,22 @@ describe.sequential('global identity and runtime routing', () => {
       expect(listed.json).toEqual({
         identities: [
           {
+            id: allId,
             name: 'all',
             canonicalName: 'all',
+            lifetime: 'temporary',
+            presence: 'active',
             pane: all.pane,
             target: fixture.paneTarget(all.pane),
             cwd: allWorkspace,
             command: 'node',
           },
           {
+            id: alphaId,
             name: 'Alpha',
             canonicalName: 'alpha',
+            lifetime: 'temporary',
+            presence: 'active',
             pane: alpha.pane,
             target: fixture.paneTarget(alpha.pane),
             cwd: alphaWorkspace,
@@ -96,7 +119,10 @@ describe.sequential('global identity and runtime routing', () => {
       expect(alphaTalk.json).toMatchObject({
         target: normalizedTarget,
         pane: alpha.pane,
-        identity: { name: 'Alpha', canonicalName: 'alpha' },
+        identity: {
+          name: 'Alpha',
+          canonicalName: 'alpha',
+        },
         status: 'completed',
       });
       expect(alphaTalk.json?.response).toContain(`mock-agent response: ${alphaMessage}`);
@@ -125,7 +151,10 @@ describe.sequential('global identity and runtime routing', () => {
         json: {
           target: 'all',
           pane: all.pane,
-          identity: { name: 'all', canonicalName: 'all' },
+          identity: {
+            name: 'all',
+            canonicalName: 'all',
+          },
           status: 'completed',
         },
       });
@@ -175,7 +204,10 @@ describe.sequential('global identity and runtime routing', () => {
         json: {
           target: normalizedTarget,
           pane: alpha.pane,
-          identity: { name: 'Alpha', canonicalName: 'alpha' },
+          identity: {
+            name: 'Alpha',
+            canonicalName: 'alpha',
+          },
           lines: 25,
         },
       });
@@ -247,7 +279,7 @@ describe.sequential('global identity and runtime routing', () => {
       expect(teamCommand.json).toEqual({
         error: {
           code: 'UNSUPPORTED_TEAM',
-          message: 'Team-scoped commands and --team are not supported in tmt v5.',
+          message: 'Team workflows are not supported.',
         },
       });
 
@@ -262,7 +294,7 @@ describe.sequential('global identity and runtime routing', () => {
       expect(teamFlag.json).toEqual({
         error: {
           code: 'UNSUPPORTED_TEAM',
-          message: 'Team-scoped commands and --team are not supported in tmt v5.',
+          message: 'Team workflows are not supported.',
         },
       });
 

--- a/test/e2e/smoke.e2e.test.ts
+++ b/test/e2e/smoke.e2e.test.ts
@@ -18,11 +18,11 @@ describe.sequential('Docker/Vitest tmux foundation smoke scenarios', () => {
 
       const help = await fixture.runCli(['--help']);
       expect(help.code).toBe(0);
-      expect(help.stdout.toLowerCase()).toContain('tmux-team');
+      expect(help.stdout).toContain('TMT native alpha');
 
       const invalid = await fixture.runCli(['definitely-not-a-command']);
       expect(invalid.code).not.toBe(0);
-      expect(invalid.stderr.toLowerCase()).toContain('unknown command');
+      expect(invalid.stderr.toLowerCase()).toContain('unrecognized subcommand');
     });
   });
 

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -1,8 +1,9 @@
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 import { expectError, fileSnapshot, runCli, withSandbox } from '../support/cli-process.js';
+import { calibrateTmuxTripwire } from './tmux-tripwire.js';
 
 // This suite is deliberately native-specific. Requiring the shared
 // descriptor prevents an omitted build from silently exercising TypeScript.
@@ -76,6 +77,75 @@ describe('native grammar process contract', () => {
       expect(help.stdout).toContain('keep pane/exchanges');
       expect(help.stdout).not.toContain('--wait');
       expect(fileSnapshot(sandbox.root)).toEqual(before);
+    });
+  });
+
+  it('rejects invalid options before root help or version with JSON diagnostics', async () => {
+    await withSandbox(async (sandbox) => {
+      const tripwire = await calibrateTmuxTripwire(sandbox);
+      const before = fileSnapshot(sandbox.root);
+      const tmuxBaseline = readFileSync(tripwire, 'utf8');
+      for (const args of [
+        ['--json', 'help', '--timeout', '1s'],
+        ['--json', '--help', '--timeout', '1s'],
+        ['--json', '--version', '--timeout', '1s'],
+      ]) {
+        const result = await runCli(sandbox, args);
+        expect(result.status).toBe(1);
+        expectError(result, 'USAGE_ERROR');
+        expect(result.stderr).toBe('');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+        expect(existsSync(sandbox.database)).toBe(false);
+        expect(readFileSync(tripwire, 'utf8')).toBe(tmuxBaseline);
+      }
+    });
+  });
+
+  it('rejects ignored options in every placement before storage or tmux effects', async () => {
+    await withSandbox(async (sandbox) => {
+      const tripwire = await calibrateTmuxTripwire(sandbox);
+      const before = fileSnapshot(sandbox.root);
+      const tmuxBaseline = readFileSync(tripwire, 'utf8');
+      for (const args of [
+        ['list', '--config', '/tmp/ignored.json', '--json'],
+        ['--config', '/tmp/ignored.json', 'list', '--json'],
+        ['list', '--timeout', '1s', '--json'],
+        ['--timeout', '1s', 'list', '--json'],
+        ['role', 'show', '--timeout', '1s', '--json'],
+        ['--timeout', '1s', 'role', 'show', '--json'],
+      ]) {
+        const result = await runCli(sandbox, args);
+        expect(result.status).toBe(1);
+        expectError(result, 'USAGE_ERROR');
+        expect(result.stderr).toBe('');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+        expect(existsSync(sandbox.database)).toBe(false);
+        expect(readFileSync(tripwire, 'utf8')).toBe(tmuxBaseline);
+      }
+    });
+  });
+
+  it('rejects JSON mode for text-only commands before side effects', async () => {
+    await withSandbox(async (sandbox) => {
+      const tripwire = await calibrateTmuxTripwire(sandbox);
+      const before = fileSnapshot(sandbox.root);
+      const tmuxBaseline = readFileSync(tripwire, 'utf8');
+      for (const args of [
+        ['help', '--json'],
+        ['--json', '--help'],
+        ['--version', '--json'],
+        ['--json', '--version'],
+        ['completion', 'bash', '--json'],
+        ['learn', '--json'],
+      ]) {
+        const result = await runCli(sandbox, args);
+        expect(result.status).toBe(1);
+        expectError(result, 'JSON_UNSUPPORTED');
+        expect(result.stderr).toBe('');
+        expect(fileSnapshot(sandbox.root)).toEqual(before);
+        expect(existsSync(sandbox.database)).toBe(false);
+        expect(readFileSync(tripwire, 'utf8')).toBe(tmuxBaseline);
+      }
     });
   });
 

--- a/test/native/config.test.ts
+++ b/test/native/config.test.ts
@@ -12,6 +12,47 @@ import {
 if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
 
 describe('native configuration process boundary', () => {
+  it('renders resolved configuration values with their sources in human mode', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.mkdirSync(sandbox.globalDir, { recursive: true });
+      fs.writeFileSync(
+        sandbox.globalConfig,
+        JSON.stringify({
+          preambleMode: 'disabled',
+          defaults: { preambleEvery: 7 },
+          exchange: { retentionDays: 365 },
+          ui: { paneBadge: 'on' },
+        })
+      );
+      fs.writeFileSync(sandbox.localConfig, JSON.stringify({ $config: { preambleEvery: 0 } }));
+      const before = fileSnapshot(sandbox.root);
+
+      const result = await runCli(sandbox, ['config', 'show']);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('ℹ Current configuration:\n');
+      for (const [key, value, source] of [
+        ['preambleMode', 'disabled', 'global'],
+        ['preambleEvery', '0', 'local'],
+        ['pasteEnterDelayMs', '500', 'default'],
+        ['defaults.timeout', '180', 'global'],
+        ['defaults.pollInterval', '1', 'global'],
+        ['defaults.captureLines', '100', 'global'],
+        ['exchange.retentionDays', '365', 'global'],
+        ['ui.paneBadge', 'on', 'global'],
+      ]) {
+        expect(result.stdout).toMatch(
+          new RegExp(`^  ${key.replace('.', '\\.')}\\s+${value}\\s+\\(${source}\\)[ \\t]*$`, 'm')
+        );
+      }
+      expect(result.stdout).toContain('ℹ \nPaths:\n');
+      expect(result.stdout).toContain(`ℹ   Global: ${sandbox.globalConfig}\n`);
+      expect(result.stdout).toContain(`ℹ   Local:  ${fs.realpathSync(sandbox.localConfig)}\n`);
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect(fs.existsSync(sandbox.database)).toBe(false);
+    });
+  });
+
   it('retains JavaScript numeric semantics and insertion order in opaque fields', async () => {
     await withSandbox(async (sandbox) => {
       fs.mkdirSync(sandbox.globalDir, { recursive: true });
@@ -42,6 +83,137 @@ describe('native configuration process boundary', () => {
       expect(expectError(invalid, 'CONFIG_ERROR').error).toMatchObject({
         message: expect.stringContaining('(defaults.timeout)'),
       });
+    });
+  });
+
+  it('projects exact built-in defaults when config sections are omitted', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.mkdirSync(sandbox.globalDir, { recursive: true });
+      const globalBytes = JSON.stringify({ futureGlobal: { keep: true } });
+      const localBytes = JSON.stringify({ keep: true });
+      fs.writeFileSync(sandbox.globalConfig, globalBytes);
+      fs.writeFileSync(sandbox.localConfig, localBytes);
+      const before = fileSnapshot(sandbox.root);
+
+      const result = await runCli(sandbox, ['config', 'show', '--json']);
+      expect(result.status).toBe(0);
+      const document = parseWholeStdout(result) as {
+        resolved: Record<string, unknown>;
+        sources: Record<string, unknown>;
+      };
+      expect(document.resolved).toEqual({
+        preambleMode: 'always',
+        preambleEvery: 3,
+        pasteEnterDelayMs: 500,
+        defaults: {
+          timeout: 180,
+          pollInterval: 1,
+          captureLines: 100,
+          preambleEvery: 3,
+          pasteEnterDelayMs: 500,
+        },
+        exchange: { retentionDays: 90 },
+        ui: { paneBadge: 'off' },
+      });
+      expect(document.sources).toEqual({
+        preambleMode: 'default',
+        preambleEvery: 'default',
+        pasteEnterDelayMs: 'default',
+        exchange: { retentionDays: 'default' },
+        ui: { paneBadge: 'default' },
+      });
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalBytes);
+      expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(localBytes);
+      expect(fs.existsSync(sandbox.database)).toBe(false);
+    });
+  });
+
+  it('accepts a safe preamble frequency above the timer delay bound', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.mkdirSync(sandbox.globalDir, { recursive: true });
+      const globalBytes = JSON.stringify({ defaults: { preambleEvery: 2_147_483_648 } });
+      fs.writeFileSync(sandbox.globalConfig, globalBytes);
+
+      const result = await runCli(sandbox, ['config', 'show', '--json']);
+      expect(result.status).toBe(0);
+      const document = parseWholeStdout(result) as {
+        resolved: { preambleEvery: number; defaults: { preambleEvery: number } };
+        sources: { preambleEvery: string };
+      };
+      expect(document.resolved).toMatchObject({
+        preambleEvery: 2_147_483_648,
+        defaults: { preambleEvery: 2_147_483_648 },
+      });
+      expect(document.sources).toMatchObject({ preambleEvery: 'global' });
+      expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalBytes);
+      expect(fs.existsSync(sandbox.database)).toBe(false);
+    });
+  });
+
+  it('projects zero values with local precedence while omitting opaque keys', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.mkdirSync(sandbox.globalDir, { recursive: true });
+      const globalValue = {
+        preambleMode: 'disabled',
+        mode: 'retired-global-mode',
+        futureGlobal: { keep: true },
+        defaults: {
+          timeout: 86_400,
+          pollInterval: 0.25,
+          captureLines: 0,
+          preambleEvery: 7,
+          pasteEnterDelayMs: 1.5,
+          maxCaptureLines: 999,
+          futureDefault: 'opaque',
+        },
+      };
+      const localValue = {
+        keep: { value: true },
+        $config: {
+          mode: 'retired-local-mode',
+          preambleMode: 'always',
+          preambleEvery: 0,
+          futureLocal: ['opaque'],
+        },
+      };
+      const globalBytes = JSON.stringify(globalValue);
+      const localBytes = JSON.stringify(localValue);
+      fs.writeFileSync(sandbox.globalConfig, globalBytes);
+      fs.writeFileSync(sandbox.localConfig, localBytes);
+      const before = fileSnapshot(sandbox.root);
+
+      const result = await runCli(sandbox, ['config', 'show', '--json']);
+      expect(result.status).toBe(0);
+      const document = parseWholeStdout(result) as {
+        resolved: Record<string, unknown>;
+        sources: Record<string, unknown>;
+      };
+      expect(document.resolved).toEqual({
+        preambleMode: 'always',
+        preambleEvery: 0,
+        pasteEnterDelayMs: 1.5,
+        defaults: {
+          timeout: 86_400,
+          pollInterval: 0.25,
+          captureLines: 0,
+          preambleEvery: 0,
+          pasteEnterDelayMs: 1.5,
+        },
+        exchange: { retentionDays: 90 },
+        ui: { paneBadge: 'off' },
+      });
+      expect(document.sources).toEqual({
+        preambleMode: 'local',
+        preambleEvery: 'local',
+        pasteEnterDelayMs: 'global',
+        exchange: { retentionDays: 'default' },
+        ui: { paneBadge: 'default' },
+      });
+      expect(fileSnapshot(sandbox.root)).toEqual(before);
+      expect(fs.readFileSync(sandbox.globalConfig, 'utf8')).toBe(globalBytes);
+      expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(localBytes);
+      expect(fs.existsSync(sandbox.database)).toBe(false);
     });
   });
 
@@ -169,6 +341,156 @@ describe('native configuration process boundary', () => {
       expect(fileSnapshot(sandbox.root)).toEqual(before);
     });
   });
+
+  it('rejects invalid global and local setter values without rewriting files', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.mkdirSync(sandbox.globalDir, { recursive: true });
+      fs.writeFileSync(
+        sandbox.globalConfig,
+        JSON.stringify({ defaults: { preambleEvery: 3, pasteEnterDelayMs: 500 } })
+      );
+      fs.writeFileSync(
+        sandbox.localConfig,
+        JSON.stringify({ $config: { preambleEvery: 3, pasteEnterDelayMs: 500 } })
+      );
+      const before = fileSnapshot(sandbox.root);
+      const invalidCases: Array<{
+        key: string;
+        value: string;
+        global?: boolean;
+      }> = [
+        { key: 'preambleEvery', value: '1.5' },
+        { key: 'preambleEvery', value: '12junk' },
+        { key: 'preambleEvery', value: ' 12' },
+        { key: 'preambleEvery', value: '+12' },
+        { key: 'preambleEvery', value: '9007199254740992' },
+        { key: 'preambleEvery', value: '-1' },
+        { key: 'pasteEnterDelayMs', value: '1.5' },
+        { key: 'pasteEnterDelayMs', value: '12junk' },
+        { key: 'pasteEnterDelayMs', value: '12\n' },
+        { key: 'pasteEnterDelayMs', value: ' 12' },
+        { key: 'pasteEnterDelayMs', value: '+12' },
+        { key: 'pasteEnterDelayMs', value: '2147483648' },
+        { key: 'pasteEnterDelayMs', value: '-1' },
+        { key: 'preambleEvery', value: '1.5', global: true },
+        { key: 'preambleEvery', value: '9007199254740992', global: true },
+        { key: 'pasteEnterDelayMs', value: '2147483648', global: true },
+        { key: 'exchange.retentionDays', value: '0', global: true },
+        { key: 'exchange.retentionDays', value: '3651', global: true },
+        { key: 'futureKey', value: '1' },
+        { key: 'futureKey', value: '1', global: true },
+      ];
+
+      for (const invalid of invalidCases) {
+        const args = ['config', 'set', invalid.key, invalid.value];
+        if (invalid.global) args.push('--global');
+        args.push('--json');
+        const result = await runCli(sandbox, args);
+        expect(result.status, `${invalid.key}=${invalid.value}`).toBe(1);
+        expectError(result, 'ERROR');
+        expect(fileSnapshot(sandbox.root), `${invalid.key}=${invalid.value}`).toEqual(before);
+      }
+      expect(fs.existsSync(sandbox.database)).toBe(false);
+    });
+  }, 30_000);
+
+  it('repairs only targeted settings while preserving opaque siblings and zero values', async () => {
+    await withSandbox(async (sandbox) => {
+      fs.mkdirSync(sandbox.globalDir, { recursive: true });
+      fs.writeFileSync(
+        sandbox.globalConfig,
+        JSON.stringify({ defaults: { timeout: 240, futureDefault: { keep: true } } })
+      );
+      fs.writeFileSync(
+        sandbox.localConfig,
+        JSON.stringify({
+          keep: 'opaque',
+          $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 500 },
+        })
+      );
+
+      const repaired = await runCli(sandbox, ['config', 'set', 'preambleEvery', '4', '--json']);
+      expect(repaired.status).toBe(0);
+      expect(parseWholeStdout(repaired)).toEqual({ ok: true });
+      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+        keep: 'opaque',
+        $config: { preambleEvery: 4, pasteEnterDelayMs: 500 },
+      });
+
+      const globalSet = await runCli(sandbox, [
+        'config',
+        'set',
+        'preambleEvery',
+        '0',
+        '--global',
+        '--json',
+      ]);
+      expect(globalSet.status).toBe(0);
+      expect(parseWholeStdout(globalSet)).toEqual({ ok: true });
+      expect(JSON.parse(fs.readFileSync(sandbox.globalConfig, 'utf8'))).toEqual({
+        defaults: {
+          timeout: 240,
+          preambleEvery: 0,
+          futureDefault: { keep: true },
+        },
+      });
+
+      const zeroPaste = await runCli(sandbox, [
+        'config',
+        'set',
+        'pasteEnterDelayMs',
+        '0',
+        '--json',
+      ]);
+      expect(zeroPaste.status).toBe(0);
+      expect(parseWholeStdout(zeroPaste)).toEqual({ ok: true });
+      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+        keep: 'opaque',
+        $config: { preambleEvery: 4, pasteEnterDelayMs: 0 },
+      });
+      fs.writeFileSync(
+        sandbox.localConfig,
+        JSON.stringify({
+          keep: 'opaque',
+          $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 0 },
+        })
+      );
+      const cleared = await runCli(sandbox, ['config', 'clear', 'preambleEvery', '--json']);
+      expect(cleared.status).toBe(0);
+      expect(parseWholeStdout(cleared)).toEqual({ ok: true });
+      expect(JSON.parse(fs.readFileSync(sandbox.localConfig, 'utf8'))).toEqual({
+        keep: 'opaque',
+        $config: { pasteEnterDelayMs: 0 },
+      });
+
+      const shown = await runCli(sandbox, ['config', 'show', '--json']);
+      expect(shown.status).toBe(0);
+      const document = parseWholeStdout(shown) as {
+        resolved: Record<string, unknown>;
+        sources: Record<string, unknown>;
+      };
+      expect(document.resolved).toMatchObject({
+        preambleEvery: 0,
+        pasteEnterDelayMs: 0,
+        defaults: { timeout: 240, preambleEvery: 0, pasteEnterDelayMs: 0 },
+      });
+      expect(document.sources).toMatchObject({
+        preambleEvery: 'global',
+        pasteEnterDelayMs: 'local',
+      });
+
+      const invalidRemainder = JSON.stringify({
+        keep: 'opaque',
+        $config: { preambleEvery: 'invalid', pasteEnterDelayMs: 'invalid' },
+      });
+      fs.writeFileSync(sandbox.localConfig, invalidRemainder);
+      const rejected = await runCli(sandbox, ['config', 'clear', 'preambleEvery', '--json']);
+      expect(rejected.status).toBe(1);
+      expectError(rejected, 'CONFIG_ERROR');
+      expect(fs.readFileSync(sandbox.localConfig, 'utf8')).toBe(invalidRemainder);
+      expect(fs.existsSync(sandbox.database)).toBe(false);
+    });
+  }, 30_000);
 
   it('distinguishes absent-container clear, clear-all and obsolete-key repair', async () => {
     await withSandbox(async (sandbox) => {

--- a/test/native/exchange.test.ts
+++ b/test/native/exchange.test.ts
@@ -40,6 +40,84 @@ function attentionFixture(sandbox: Sandbox, owner: string, requestId: string) {
 }
 
 describe('native exchange attention process contract', () => {
+  it('renders human attention and reply results without confusing acknowledgment with completion', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      const owner = (await json(sandbox, ['identity', 'create', 'Reader'])).identity as {
+        id: string;
+      };
+      const seeded = attentionFixture(sandbox, owner.id, 'human-exchange');
+      const before = responseSnapshot(sandbox.database, seeded.requestId);
+      const listed = await runCli(sandbox, ['x', '--identity', 'Reader']);
+      expect(listed.status).toBe(0);
+      expect(listed.stderr).toBe('');
+      expect(listed.stdout).toBe(
+        'REQUEST\tRECIPIENT\tDELIVERY\tFINAL\tREVISION\n' +
+          'human-exchange\t-\tsent\tnot_submitted\t1\n'
+      );
+      expect(responseSnapshot(sandbox.database, seeded.requestId)).toEqual(before);
+      const acknowledged = await runCli(sandbox, [
+        'x',
+        'ack',
+        seeded.requestId,
+        '--revision',
+        '1',
+        '--identity',
+        'Reader',
+      ]);
+      expect(acknowledged.status).toBe(0);
+      expect(acknowledged.stdout).toBe('Acknowledged human-exchange at revision 1.\n');
+      const pending = await json(sandbox, ['x', 'show', seeded.requestId, '--identity', 'Reader']);
+      expect(pending.exchange).toMatchObject({
+        acknowledged: true,
+        settled: false,
+        final: { status: 'not_submitted' },
+      });
+      const empty = await runCli(sandbox, ['x', '--identity', 'Reader']);
+      expect(empty.status).toBe(0);
+      expect(empty.stdout).toBe('No unacknowledged exchanges.\n');
+
+      const body = '  final result\r\nsecond line  ';
+      const submitted = await runCli(sandbox, [
+        'reply',
+        seeded.requestId,
+        '--receipt',
+        seeded.compactReceipt,
+        '--message',
+        body,
+      ]);
+      expect(submitted.status).toBe(0);
+      expect(submitted.stderr).toBe('');
+      expect(submitted.stdout).toBe(
+        `Submitted response for request 'human-exchange' (${Buffer.byteLength(body)} bytes).\n`
+      );
+      expect(responseSnapshot(sandbox.database, seeded.requestId).response).toMatchObject({
+        body,
+        body_bytes: Buffer.byteLength(body),
+      });
+      const result = await runCli(sandbox, ['result', seeded.requestId]);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toBe(`Response for request 'human-exchange':\n${body}\n`);
+      const shown = await runCli(sandbox, ['x', 'show', seeded.requestId, '--identity', 'Reader']);
+      expect(shown.status).toBe(0);
+      expect(shown.stdout).toBe(
+        'REQUEST\tDELIVERY\tFINAL\tREVISION\tACKNOWLEDGED\tSETTLED\n' +
+          'human-exchange\tsent\tretained\t2\tfalse\tfalse\n' +
+          `Prompt (retained):\nprompt for human-exchange\nFinal:\n${body}\n`
+      );
+      const all = await runCli(sandbox, ['x', 'ackall', '--identity', 'Reader']);
+      expect(all.status).toBe(0);
+      expect(all.stdout).toBe(
+        "Acknowledged identity 'Reader' through revision 2. Later revisions remain unacknowledged.\n"
+      );
+      expect(
+        (await json(sandbox, ['x', 'show', seeded.requestId, '--identity', 'Reader'])).exchange
+      ).toMatchObject({ acknowledged: true, settled: true });
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+    });
+  });
+
   it('keeps retired-name history with its original UUID rather than the replacement identity', async () => {
     await withSandbox(async (sandbox) => {
       await calibrateTmuxTripwire(sandbox);

--- a/test/native/identity-context.test.ts
+++ b/test/native/identity-context.test.ts
@@ -1,0 +1,29 @@
+import { existsSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { expectError, runCli, withSandbox } from '../support/cli-process.js';
+import { installTmuxTripwire } from './tmux-tripwire.js';
+
+describe('required identity preflight', () => {
+  it.each(
+    [
+      ['role', 'show'],
+      ['role', 'set', 'must not write'],
+      ['role', 'clear'],
+      ['x', 'list'],
+      ['x', 'show', 'missing-request'],
+      ['x', 'ack', 'missing-request', '--revision', '1'],
+      ['x', 'ackall'],
+    ].map((args) => ({ label: args.join(' '), args }))
+  )('rejects $label without initializing storage for an outside caller', async ({ args }) => {
+    await withSandbox(async (sandbox) => {
+      installTmuxTripwire(sandbox);
+      expect(existsSync(sandbox.database)).toBe(false);
+      const result = await runCli(sandbox, [...args, '--json']);
+      expect(result.status).toBe(1);
+      expectError(result, 'IDENTITY_REQUIRED');
+      expect(existsSync(sandbox.database)).toBe(false);
+      expect(existsSync(`${sandbox.database}-wal`)).toBe(false);
+      expect(existsSync(`${sandbox.database}-shm`)).toBe(false);
+    });
+  });
+});

--- a/test/native/profile.test.ts
+++ b/test/native/profile.test.ts
@@ -20,6 +20,132 @@ async function json(sandbox: Sandbox, args: string[]): Promise<unknown> {
 }
 
 describe('native role and preamble process contracts', () => {
+  it('prints the role lifecycle in human mode and retains the durable profile', async () => {
+    await withSandbox(async (sandbox) => {
+      await json(sandbox, ['identity', 'create', 'Alice']);
+
+      const set = await runCli(sandbox, ['role', 'set', 'Review code', '--identity', 'Alice']);
+      expect(set.status).toBe(0);
+      expect(set.stdout).toBe("Set role profile for 'Alice'.\n");
+      expect(set.stderr).toBe('');
+
+      const shown = await runCli(sandbox, ['role', 'show', '--identity', 'Alice']);
+      expect(shown.status).toBe(0);
+      expect(shown.stdout).toBe("Identity 'Alice'\nReview code\n");
+      expect(shown.stderr).toBe('');
+
+      const cleared = await runCli(sandbox, ['role', 'clear', '--identity', 'Alice']);
+      expect(cleared.status).toBe(0);
+      expect(cleared.stdout).toBe("Cleared role profile for 'Alice'.\n");
+      expect(cleared.stderr).toBe('');
+      expect(await json(sandbox, ['role', 'show', '--identity', 'Alice'])).toMatchObject({
+        identity: { name: 'Alice', lifetime: 'saved' },
+        role: null,
+      });
+    });
+  });
+
+  it('reports human role file failures without changing the stored profile', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      await json(sandbox, ['identity', 'create', 'Alice']);
+      const original = await json(sandbox, ['role', 'set', 'Review code', '--identity', 'Alice']);
+      const result = await runCli(sandbox, [
+        'role',
+        'set',
+        '--file',
+        path.join(sandbox.root, 'missing-role.txt'),
+        '--identity',
+        'Alice',
+      ]);
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toBe('Could not read a regular role file.\n');
+      expect(await json(sandbox, ['role', 'show', '--identity', 'Alice'])).toEqual(original);
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+    });
+  });
+
+  it('prints the preamble show/set/clear lifecycle and preserves the paired JSON state', async () => {
+    await withSandbox(async (sandbox) => {
+      await json(sandbox, ['identity', 'create', 'Alice']);
+
+      const set = await runCli(sandbox, ['preamble', 'set', 'Alice', 'Be helpful']);
+      expect(set.status).toBe(0);
+      expect(set.stdout).toBe('Set preamble for Alice\n');
+      expect(set.stderr).toBe('');
+
+      const shown = await runCli(sandbox, ['preamble', 'show', 'Alice']);
+      expect(shown.status).toBe(0);
+      expect(shown.stdout).toBe('Preamble for Alice:\nBe helpful\n');
+      expect(shown.stderr).toBe('');
+      expect(await json(sandbox, ['preamble', 'show', 'Alice'])).toEqual({
+        agent: 'Alice',
+        preamble: 'Be helpful',
+      });
+
+      const cleared = await runCli(sandbox, ['preamble', 'clear', 'Alice']);
+      expect(cleared.status).toBe(0);
+      expect(cleared.stdout).toBe('Cleared preamble for Alice\n');
+      expect(cleared.stderr).toBe('');
+      expect(await json(sandbox, ['preamble', 'show', 'Alice'])).toEqual({
+        agent: 'Alice',
+        preamble: null,
+      });
+    });
+  });
+
+  it('transports a large multibyte role as one complete JSON document', async () => {
+    await withSandbox(async (sandbox) => {
+      const log = await calibrateTmuxTripwire(sandbox);
+      const created = (await json(sandbox, ['identity', 'create', 'LargeRole'])) as {
+        identity: unknown;
+      };
+      // Non-English fixture bytes exercise multibyte JSON transport, not UI copy.
+      const content = 'role-content-日本語-🚀-' + 'x'.repeat(48 * 1024);
+      const file = path.join(sandbox.root, 'large-role.txt');
+      writeFileSync(file, content);
+      await json(sandbox, ['role', 'set', '--file', file, '--identity', 'LargeRole']);
+      const result = await runCli(sandbox, ['role', 'show', '--identity', 'LargeRole', '--json']);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(Buffer.byteLength(result.stdout)).toBeGreaterThan(32 * 1024);
+      expect(parseWholeStdout(result)).toEqual({
+        identity: created.identity,
+        role: { content, updatedAt: expect.any(String) },
+      });
+      expect(readFileSync(log, 'utf8')).toBe('\n');
+    });
+  });
+
+  it('maps a future schema to one role error without mutating history or identities', async () => {
+    await withSandbox(async (sandbox) => {
+      await json(sandbox, ['identity', 'create', 'Preserved']);
+      const writer = new Database(sandbox.database);
+      let history: unknown[];
+      let identities: unknown[];
+      try {
+        writer.exec(
+          "INSERT INTO _migrations VALUES (10, 'future migration', '2026-01-01T00:00:00.000Z')"
+        );
+        history = writer.prepare('SELECT * FROM _migrations ORDER BY version').all();
+        identities = writer.prepare('SELECT * FROM identities ORDER BY id').all();
+      } finally {
+        writer.close();
+      }
+      const result = await runCli(sandbox, ['role', 'show', '--identity', 'Preserved', '--json']);
+      expect(result.status).toBe(1);
+      expectError(result, 'ROLE_ERROR');
+      const reader = new Database(sandbox.database, { readonly: true });
+      try {
+        expect(reader.prepare('SELECT * FROM _migrations ORDER BY version').all()).toEqual(history);
+        expect(reader.prepare('SELECT * FROM identities ORDER BY id').all()).toEqual(identities);
+      } finally {
+        reader.close();
+      }
+    });
+  });
+
   it('persists independent offline profiles across processes without config or tmux', async () => {
     await withSandbox(async (sandbox) => {
       const log = await calibrateTmuxTripwire(sandbox);

--- a/test/native/response-fixture.ts
+++ b/test/native/response-fixture.ts
@@ -2,6 +2,14 @@ import crypto from 'node:crypto';
 import Database from 'better-sqlite3';
 
 export const MAX_RESPONSE_BYTES = 1_048_576;
+export interface ResponseEndpoint {
+  serverId: string;
+  socketPath: string;
+  serverPid: number;
+  serverStartTime: string;
+  paneId: string;
+  panePid: number;
+}
 export const RESPONSE_SERVER = {
   serverId: 'native-response-server',
   socketPath: '/tmp/native-response.sock',
@@ -38,7 +46,7 @@ function appendString(parts: Buffer[], value: string): void {
 export function compactReceipt(
   requestId: string,
   attemptId: string,
-  endpoint: typeof RESPONSE_SERVER = RESPONSE_SERVER
+  endpoint: ResponseEndpoint = RESPONSE_SERVER
 ): string {
   const parts = [Buffer.from('tmux-team/reply-receipt/v2\0', 'utf8')];
   appendString(parts, requestId);
@@ -60,7 +68,7 @@ export function compactReceipt(
 export function v1Receipt(
   requestId: string,
   attemptId: string,
-  endpoint: typeof RESPONSE_SERVER = RESPONSE_SERVER
+  endpoint: ResponseEndpoint = RESPONSE_SERVER
 ): string {
   return Buffer.from(
     JSON.stringify({

--- a/test/native/response.test.ts
+++ b/test/native/response.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import Database from 'better-sqlite3';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { initializeHistoricalDatabase } from './storage-fixture.js';
@@ -14,15 +15,143 @@ import {
 } from '../support/cli-process.js';
 import {
   MAX_RESPONSE_BYTES,
+  RESPONSE_SERVER,
+  compactReceipt,
   responseSnapshot,
   removeAttempt,
   seedResponse,
   schemaVersion,
   v1Receipt,
   type SeededResponse,
+  type ResponseEndpoint,
 } from './response-fixture.js';
 
 if (!process.env.TMT_TEST_CLI) throw new Error('Select the native build with TMT_TEST_CLI.');
+
+describe('native response authorization and retention boundaries', () => {
+  it.each(['v1', 'v2'] as const)(
+    'rejects every %s request/attempt/endpoint mismatch without mutation',
+    async (version) => {
+      await withSandbox(async (sandbox) => {
+        await initializeSchema(sandbox);
+        const seeded = seedResponse(sandbox.database, 'all-fences');
+        const before = responseSnapshot(sandbox.database, seeded.requestId);
+        const encode = version === 'v1' ? v1Receipt : compactReceipt;
+        const cases: Array<{
+          field: string;
+          request?: string;
+          attempt?: string;
+          endpoint?: Partial<ResponseEndpoint>;
+          v1Error: string;
+        }> = [
+          { field: 'request', request: 'other-request', v1Error: 'RESPONSE_RECEIPT_MISMATCH' },
+          { field: 'attempt', attempt: 'other-attempt', v1Error: 'RESPONSE_ATTEMPT_MISMATCH' },
+          ...Object.entries({
+            serverId: 'other-server',
+            socketPath: '/tmp/other.sock',
+            serverPid: 1235,
+            serverStartTime: 'other-start',
+            paneId: '%2',
+            panePid: 5679,
+          }).map(([field, value]) => ({
+            field,
+            endpoint: { [field]: value },
+            v1Error: 'RESPONSE_RECIPIENT_MISMATCH',
+          })),
+        ];
+        for (const candidate of cases) {
+          const receipt = encode(
+            candidate.request ?? seeded.requestId,
+            candidate.attempt ?? seeded.attemptId,
+            { ...RESPONSE_SERVER, ...candidate.endpoint }
+          );
+          const result = await runCli(sandbox, [
+            'reply',
+            seeded.requestId,
+            '--receipt',
+            receipt,
+            '--message',
+            'must not commit',
+            '--json',
+          ]);
+          expect(result.status, candidate.field).toBe(1);
+          expectError(result, version === 'v1' ? candidate.v1Error : 'RESPONSE_RECEIPT_MISMATCH');
+          expect(responseSnapshot(sandbox.database, seeded.requestId), candidate.field).toEqual(
+            before
+          );
+        }
+        const accepted = await runCli(sandbox, [
+          'reply',
+          seeded.requestId,
+          '--receipt',
+          encode(seeded.requestId, seeded.attemptId),
+          '--message',
+          'authorized',
+          '--json',
+        ]);
+        expect(accepted.status).toBe(0);
+        expect(responseSnapshot(sandbox.database, seeded.requestId).response).toMatchObject({
+          body: 'authorized',
+          body_bytes: 10,
+        });
+      });
+    }
+  );
+
+  it('prunes an expired retained body while keeping the acceptance marker against resurrection', async () => {
+    await withSandbox(async (sandbox) => {
+      await initializeSchema(sandbox);
+      const prepared = Date.now() - 2 * 86_400_000;
+      const seeded = seedResponse(sandbox.database, 'expired-retained-body', { nowMs: prepared });
+      const submitted = await runCli(sandbox, [
+        'reply',
+        seeded.requestId,
+        '--receipt',
+        seeded.compactReceipt,
+        '--message',
+        'retained but expired',
+        '--json',
+      ]);
+      expect(submitted.status).toBe(0);
+      const writer = new Database(sandbox.database);
+      try {
+        writer.transaction(() => {
+          writer
+            .prepare(
+              'UPDATE request_attempts SET retention_days = 1, response_submitted_at_ms = ?, message_expires_at_ms = ? WHERE request_id = ?'
+            )
+            .run(prepared + 1, prepared + 86_400_000, seeded.requestId);
+          writer
+            .prepare(
+              'UPDATE request_responses SET submitted_at_ms = ?, response_expires_at_ms = ? WHERE request_id = ?'
+            )
+            .run(prepared + 1, prepared + 86_400_001, seeded.requestId);
+        })();
+      } finally {
+        writer.close();
+      }
+      const before = responseSnapshot(sandbox.database, seeded.requestId);
+      const result = await runCli(sandbox, ['result', seeded.requestId, '--json']);
+      expect(result.status).toBe(3);
+      expectError(result, 'RESPONSE_NOT_AVAILABLE');
+      expect(result.stdout).not.toContain('retained but expired');
+      const after = responseSnapshot(sandbox.database, seeded.requestId);
+      expect(after).toEqual({
+        ...before,
+        attempt: { ...before.attempt, message_text: null, message_bytes: null },
+        response: undefined,
+      });
+      const retry = await runCli(
+        sandbox,
+        ['reply', seeded.requestId, '--receipt', seeded.compactReceipt, '--stdin', '--json'],
+        { stdin: Buffer.from('retained but expired') }
+      );
+      expect(retry.status).toBe(1);
+      expectError(retry, 'RESPONSE_EXPIRED');
+      expect(responseSnapshot(sandbox.database, seeded.requestId)).toEqual(after);
+    });
+  });
+});
 
 async function initializeSchema(sandbox: Sandbox): Promise<void> {
   expectJsonSuccess(await runCli(sandbox, ['identity', 'list', '--json']), { identities: [] });


### PR DESCRIPTION
## Summary

- Select the Docker-built Rust CLI and inherited mock reply peer by default, reusing all maintained shared scenarios.
- Preserve the approved temporary/save/global-list/remove/update/compact-receipt contracts with independent SQL identity and binding assertions.
- Fix three real gaps exposed by the native run: required identity preflight before storage bootstrap, validation of both capture-line operands before precedence, and conclusive old-PID death after a tmux socket restart.
- Add independent native parser/config/profile/response/attention process coverage, including human output and all receipt association fences.
- Reconcile published-alpha documentation and E2E skill rules. Record unmatched source-retirement protections in #156; no TS runtime or unmatched tests are deleted here.

Closes #153. Refs #93, #106, #83, #156.

## Primary architecture review

Reviewed head: `894e476b5813f51ceef63b1b0375c3dd08952541`.

The primary personally reviewed every changed diff, runtime callers, selected-command behavior, independent fixture/state oracles, and output expectations. Identity selection stays in one CLI composition owner and binding verification uses the existing service; no second identity registry or database connection is added. Endpoint death still requires conclusive recorded-process evidence; malformed output alone and live/unknown processes cannot retire names. Both capture operands are validated without changing valid precedence.

Review corrected repeated test identity lookups into the existing SQL oracle, consolidated timestamp normalization, retained every non-clock binding field, and strengthened config zero-write verification before fixture replacement. Grouped-session tests now observe inventory presentation rather than assuming display-message chooses the same linked session. Global listing does not broaden cross-server routing. Public talk/check identity summaries retain their intentionally narrower schema.

The source-retirement inventory found unmatched concurrent binding, process-death rollback, final/settlement and equal-expiry races, human talk and interactive reminder coverage. #156 explicitly blocks deletion of those old assertions. Npm network startup checking is historical package-manager behavior; native startup remains local-only and upgrade remains explicit.

## Verification

- [x] `pnpm check` (Node 24.20.0): type, lint, formatting and documentation gates pass.
- [x] Full existing unit suite: 1,156 tests / 74 files; statements/lines 95.68%, branches 89.49%, functions 97.55%. Local workers bounded to two without changed assertions/deadlines.
- [x] Full native process suite: 149 tests / 15 files, with explicit task-built CLI and storage probe.
- [x] Rust fmt, all-target Clippy `-D warnings`, locked tests, normal build and MSRV 1.88 build pass. Local TLS fixture tests require the local network permission; the approved full run passed.
- [x] Seven new outside-caller preflight cases all fail against the pre-fix native binary (unwanted database creation), then pass with the shared preflight fix.
- [x] Complete explicit-native Docker suite passes before switching the default.
- [x] Two complete native-default Docker runs: each 284 adapter tests + 160 E2E scenarios; one intentional archive-fixture ignore and one opt-in benchmark skip. Vitest durations 116.62s and 116.28s. Private sockets, mock peers, no network, image cleanup and failure propagation retained.
- [x] Rebase onto current main preserves the verified tree exactly.
- [x] All eleven required CI checks pass on this reviewed head in run 34242803521, the first and only CI candidate.

Local refinement was evidence-driven: the first unchanged shared native run passed 121/160 scenarios; approved lifetime/output expectation changes and the three demonstrated runtime fixes brought the complete suite green. No failed scenario was skipped, no deadline increased, no production TS was removed, and no CI rerun was used as a substitute for diagnosis.

No release, tag, npm publication, user-state migration/deletion, host tmux operation, MCP or memory feature is included. Version stays alpha2.
