### PR TITLE
test: close native retirement race and terminal coverage gaps

### DIFF
--- a/.agents/skills/tmt-dev/SKILL.md
+++ b/.agents/skills/tmt-dev/SKILL.md
@@ -42,6 +42,12 @@ Read the repository guidance before planning work:
 6. Run the exact checks required by the changed layer and report their commands
    and results. Add behavioral tests for changed contracts, including relevant
    failure, cleanup, or lifecycle cases.
+   During runtime retirement, map assertions rather than file names or counts:
+   returned-error rollback is not crash recovery, and policy tests are not
+   terminal-output tests. Preserve a positive control when a fixture could pass
+   without executing its intended mutation. Review resource destruction order
+   when consolidating cleanup helpers; reuse the existing test-only child owner
+   and stop/reap children before their files are removed.
 7. Before an authorized merge, verify all required CI passed on the current
    reviewed commit. Review later edits and rerun affected checks. Keep
    GitHub issue status, branch/PR links, verification evidence, and deferred work

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -937,6 +937,21 @@ must remain auditable; never regenerate the expected results with the native
 implementation under test. The read-only SQL snapshot oracle still owns full
 structural/data comparisons, while schema 9 behavior has explicit assertions.
 
+Native adapter process fixtures share test-only `TestChild` alongside
+`TestDirectory`. Child status remains owned by `std::process::Child`; no parallel
+reaped flag is maintained. Declare an owned child before its directory so Rust's
+field-drop order stops/reaps it before deleting files. Panic/timeout tests check
+reaping directly, not merely an absent marker after a sleep. Existing interrupt,
+bounded-file and installer fixtures consume this same owner.
+
+The request crash test decorates only `RequestRepository`'s transaction callback:
+it pauses after actual service preparation writes, before the real SQLite commit.
+A task-owned subprocess is killed there; read-only snapshots and a commit-enabled
+control distinguish real rollback from a fixture that never wrote anything. No
+product test command, duplicate SQL mutation layer or nested transaction support
+is added. Ordered final/failure and equal-expiry tests use separately opened
+connections and both serialized orders, distinct from simultaneous writer tests.
+
 Identity, request and response concurrency suites share the bounded process
 harness in `src/test-support/request-workers.ts`. Each scenario owns its handles
 and stops workers in `finally` before deleting fixture files. Worker entrypoints

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -202,6 +202,18 @@ retired-name reuse, and implicit selection failure before housekeeping.
 gated mock replies with verified pane identity; reuse shared descriptors and
 oracles, and run the Docker lifecycle suite twice before delivery.
 
+#156 closes the remaining worker/output evidence gaps in existing owners.
+`storage::requests::service_tests::crash` proves SIGKILL rollback after actual
+prepare writes and uses a commit-enabled positive control. Its concurrency
+neighbor explicitly covers both final/failure and equal-expiry orders; do not
+label ordered connections as a simultaneous race. `publication-race` observes
+both the writer lock and the contender's open database before releasing it,
+then checks canonical UUID convergence and complete binding counts. Human talk
+tests retain exact bodies and request IDs across completion, detach, timeout and
+overlap-warning suppression. The shared real-tmux caller can preserve terminal
+streams for passive skill reminder tests; default redirected caller tests stay
+unchanged. Provider directories remain inside the private fixture.
+
 Keep Cargo workspace version synchronized with the package version while both
 runtimes coexist. Check the resolved dependency graph's licenses, MSRVs and
 current RustSec advisories when changing Cargo.lock. `tmt-core` must remain free

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -456,12 +456,17 @@ in the existing Rust request service concurrency suite. Attention races and
 rollback reuse that suite plus the service's `attention.rs` tests; waiter release
 uses `waiter_release_is_idempotent_isolated_and_does_not_cancel_delivery`.
 
-[#156](https://github.com/wkh237/tmux-team/issues/156) blocks deletion of the
-remaining unmatched protections: concurrent binding, process-death transaction
-rollback, final/failure and equal-expiry races, human talk output, and interactive
-passive reminder output. Existing drift/eligibility unit tests are not a terminal
-process assertion; a returned-error rollback is not a SIGKILL assertion. These
-are explicit follow-on acceptance gates, not claims of complete rewrite parity.
+[#156](https://github.com/wkh237/tmux-team/issues/156) supplies the remaining
+protections in the same owners: `sigkill_rolls_back_preparation_without_losing_committed_state`,
+`finalization_and_failure_orders_preserve_or_reject_exactly`, and
+`equal_expiry_finalization_is_rejected_before_or_after_cleanup` cover the actual
+request transaction boundaries. The existing same-canonical-name publication
+race now waits for the independent contender to open SQLite before commit and
+correlates both successful UUIDs with the sole durable identity/binding.
+Native-talk E2E covers human completion/detach/timeout and overlap warning versus
+force/JSON suppression; skill-reminder E2E uses a real private terminal and
+fixture-owned provider home. Unit-only drift eligibility or returned-error
+rollback would not establish those process guarantees.
 Developer artifact/selector guards also remain until relocated during source retirement.
 Node wrapper/npm-upgrade implementation details are not native runtime features;
 their retirement must be explicit rather than silently counted as covered.

--- a/rust/crates/tmt-adapters/src/bounded_file/tests.rs
+++ b/rust/crates/tmt-adapters/src/bounded_file/tests.rs
@@ -1,18 +1,16 @@
 use super::*;
-use crate::test_support::TestDirectory;
+use crate::test_support::{TestChild, TestDirectory};
 use nix::{sys::stat::Mode, unistd::mkfifo};
 use std::{
     env, fs,
     os::unix::fs::symlink,
-    process::{Child, Command, ExitStatus, Stdio},
-    thread,
-    time::{Duration, Instant},
+    process::{Command, Stdio},
+    time::Duration,
 };
 
 const FIFO_FIXTURE_TEST: &str = "bounded_file::tests::fifo_fixture";
 const FIFO_FIXTURE_PATH: &str = "TMT_BOUNDED_FILE_FIFO";
 const FIFO_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
-const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[test]
 fn bounded_reads_accept_regular_files_and_reject_oversized_content() {
@@ -57,7 +55,7 @@ fn no_follow_rejects_directories_without_waiting() {
     let fifo = directory.path.join("fifo");
     mkfifo(&fifo, Mode::S_IRUSR | Mode::S_IWUSR).unwrap();
     let mut fixture = FifoFixture::start(&fifo);
-    let status = wait_for_exit(&mut fixture.child, FIFO_EXIT_TIMEOUT);
+    let status = fixture.child.wait_for_exit(FIFO_EXIT_TIMEOUT);
     assert!(
         status.success(),
         "FIFO fixture rejected input unsuccessfully: {status}"
@@ -65,7 +63,7 @@ fn no_follow_rejects_directories_without_waiting() {
 }
 
 struct FifoFixture {
-    child: Child,
+    child: TestChild,
 }
 
 impl FifoFixture {
@@ -83,31 +81,9 @@ impl FifoFixture {
             .stderr(Stdio::null())
             .spawn()
             .expect("spawn task-owned FIFO fixture");
-        Self { child }
-    }
-}
-
-impl Drop for FifoFixture {
-    fn drop(&mut self) {
-        if matches!(self.child.try_wait(), Ok(None)) {
-            let _ = self.child.kill();
-            let _ = self.child.wait();
+        Self {
+            child: TestChild::new(child),
         }
-    }
-}
-
-fn wait_for_exit(child: &mut Child, timeout: Duration) -> ExitStatus {
-    let deadline = Instant::now() + timeout;
-    loop {
-        if let Some(status) = child.try_wait().expect("inspect FIFO fixture status") {
-            return status;
-        }
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let status = child.wait().expect("reap timed-out FIFO fixture");
-            panic!("FIFO fixture did not exit before deadline: {status}");
-        }
-        thread::sleep(POLL_INTERVAL);
     }
 }
 

--- a/rust/crates/tmt-adapters/src/interrupt/tests.rs
+++ b/rust/crates/tmt-adapters/src/interrupt/tests.rs
@@ -1,5 +1,5 @@
 use super::Interrupt;
-use crate::test_support::TestDirectory;
+use crate::test_support::{TestChild, TestDirectory};
 use nix::{
     sys::signal::{Signal, kill},
     unistd::Pid,
@@ -7,8 +7,7 @@ use nix::{
 use std::{
     env, fs,
     os::unix::process::ExitStatusExt,
-    path::Path,
-    process::{Child, Command, ExitStatus, Stdio},
+    process::{Command, Stdio},
     thread,
     time::{Duration, Instant},
 };
@@ -17,15 +16,15 @@ const FIXTURE_TEST: &str = "interrupt::tests::subprocess_fixture";
 const FIXTURE_MODE: &str = "TMT_INTERRUPT_TEST_MODE";
 const FIXTURE_READY: &str = "TMT_INTERRUPT_TEST_READY";
 const FIXTURE_EVENT: &str = "TMT_INTERRUPT_TEST_EVENT";
-const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(2);
 const EXIT_TIMEOUT: Duration = Duration::from_secs(3);
 
 struct Fixture {
+    // Drop the child before the directory removes its readiness/event paths.
+    child: TestChild,
     _directory: TestDirectory,
     ready: std::path::PathBuf,
     event: std::path::PathBuf,
-    child: Child,
 }
 
 impl Fixture {
@@ -47,62 +46,13 @@ impl Fixture {
             _directory: directory,
             ready,
             event,
-            child,
-        }
-    }
-
-    fn wait_for_content(&mut self, path: &Path, expected: &str, timeout: Duration) {
-        let deadline = Instant::now() + timeout;
-        loop {
-            if fs::read_to_string(path).ok().as_deref() == Some(expected) {
-                return;
-            }
-            if let Some(status) = self
-                .child
-                .try_wait()
-                .expect("inspect interrupt fixture status")
-            {
-                panic!(
-                    "interrupt fixture exited before {}: {status}",
-                    path.display()
-                );
-            }
-            assert!(
-                Instant::now() < deadline,
-                "interrupt fixture did not publish {expected:?} to {}",
-                path.display(),
-            );
-            thread::sleep(POLL_INTERVAL);
-        }
-    }
-
-    fn wait_for_exit(&mut self, timeout: Duration) -> ExitStatus {
-        let deadline = Instant::now() + timeout;
-        loop {
-            if let Some(status) = self
-                .child
-                .try_wait()
-                .expect("inspect interrupt fixture status")
-            {
-                return status;
-            }
-            assert!(Instant::now() < deadline, "interrupt fixture did not exit");
-            thread::sleep(POLL_INTERVAL);
-        }
-    }
-}
-
-impl Drop for Fixture {
-    fn drop(&mut self) {
-        if matches!(self.child.try_wait(), Ok(None)) {
-            let _ = self.child.kill();
-            let _ = self.child.wait();
+            child: TestChild::new(child),
         }
     }
 }
 
 fn fixture_pid(fixture: &Fixture) -> Pid {
-    Pid::from_raw(i32::try_from(fixture.child.id()).expect("fixture PID fits in pid_t"))
+    Pid::from_raw(i32::try_from(fixture.child.child.id()).expect("fixture PID fits in pid_t"))
 }
 
 fn event(fixture: &Fixture) -> String {
@@ -118,10 +68,12 @@ fn open_fd_count() -> usize {
 #[test]
 fn sigint_wakes_a_task_owned_wait() {
     let mut fixture = Fixture::start("wake");
-    fixture.wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
+    fixture
+        .child
+        .wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
     kill(fixture_pid(&fixture), Signal::SIGINT).expect("send SIGINT to fixture child");
 
-    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    let status = fixture.child.wait_for_exit(EXIT_TIMEOUT);
     assert!(status.success(), "fixture failed after SIGINT: {status}");
     assert_eq!(event(&fixture), "interrupted");
 }
@@ -129,13 +81,17 @@ fn sigint_wakes_a_task_owned_wait() {
 #[test]
 fn second_sigint_uses_the_emergency_default() {
     let mut fixture = Fixture::start("second");
-    fixture.wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
+    fixture
+        .child
+        .wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
     kill(fixture_pid(&fixture), Signal::SIGINT).expect("send first SIGINT to fixture child");
-    fixture.wait_for_content(&fixture.event.clone(), "first-interrupted", STARTUP_TIMEOUT);
+    fixture
+        .child
+        .wait_for_content(&fixture.event.clone(), "first-interrupted", STARTUP_TIMEOUT);
     assert_eq!(event(&fixture), "first-interrupted");
 
     kill(fixture_pid(&fixture), Signal::SIGINT).expect("send second SIGINT to fixture child");
-    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    let status = fixture.child.wait_for_exit(EXIT_TIMEOUT);
     assert_eq!(
         status.signal(),
         Some(Signal::SIGINT as i32),
@@ -146,9 +102,11 @@ fn second_sigint_uses_the_emergency_default() {
 #[test]
 fn deadline_returns_without_a_signal() {
     let mut fixture = Fixture::start("deadline");
-    fixture.wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
+    fixture
+        .child
+        .wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
 
-    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    let status = fixture.child.wait_for_exit(EXIT_TIMEOUT);
     assert!(status.success(), "deadline fixture failed: {status}");
     assert_eq!(event(&fixture), "deadline-no-signal");
 }
@@ -156,9 +114,11 @@ fn deadline_returns_without_a_signal() {
 #[test]
 fn guard_drop_releases_descriptors_and_allows_reinstallation() {
     let mut fixture = Fixture::start("drop");
-    fixture.wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
+    fixture
+        .child
+        .wait_for_content(&fixture.ready.clone(), "ready", STARTUP_TIMEOUT);
 
-    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    let status = fixture.child.wait_for_exit(EXIT_TIMEOUT);
     assert!(status.success(), "drop fixture failed: {status}");
     assert_eq!(event(&fixture), "reinstalled");
 }

--- a/rust/crates/tmt-adapters/src/native_install/interrupt_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/interrupt_tests.rs
@@ -3,16 +3,18 @@ use super::{
     receipt::Receipt,
     test_support::{artifact, state},
 };
-use crate::{interrupt::Interrupt, test_support::TestDirectory};
+use crate::{
+    interrupt::Interrupt,
+    test_support::{TestChild, TestDirectory},
+};
 use nix::{
     sys::signal::{Signal, kill},
     unistd::Pid,
 };
 use std::{
     env, fs, io,
-    path::{Path, PathBuf},
-    process::{Child, Command, ExitStatus, Stdio},
-    thread,
+    path::PathBuf,
+    process::{Command, Stdio},
     time::{Duration, Instant},
 };
 
@@ -20,15 +22,15 @@ const FIXTURE_TEST: &str = "native_install::interrupt_tests::subprocess_fixture"
 const FIXTURE_ROOT: &str = "TMT_NATIVE_INSTALL_INTERRUPT_ROOT";
 const FIXTURE_READY: &str = "TMT_NATIVE_INSTALL_INTERRUPT_READY";
 const FIXTURE_EVENT: &str = "TMT_NATIVE_INSTALL_INTERRUPT_EVENT";
-const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(2);
 const EXIT_TIMEOUT: Duration = Duration::from_secs(4);
 
 struct Fixture {
+    // Drop the child before the directory removes its readiness/event paths.
+    child: TestChild,
     _directory: TestDirectory,
     ready: PathBuf,
     event: PathBuf,
-    child: Child,
 }
 
 impl Fixture {
@@ -50,73 +52,24 @@ impl Fixture {
             _directory: directory,
             ready,
             event,
-            child,
-        }
-    }
-
-    fn wait_for_content(&mut self, path: &Path, expected: &str, timeout: Duration) {
-        let deadline = Instant::now() + timeout;
-        loop {
-            if fs::read_to_string(path).ok().as_deref() == Some(expected) {
-                return;
-            }
-            if let Some(status) = self
-                .child
-                .try_wait()
-                .expect("inspect native-install interrupt fixture")
-            {
-                panic!(
-                    "native-install interrupt fixture exited before {}: {status}",
-                    path.display()
-                );
-            }
-            assert!(
-                Instant::now() < deadline,
-                "native-install interrupt fixture did not publish {expected:?}"
-            );
-            thread::sleep(POLL_INTERVAL);
-        }
-    }
-
-    fn wait_for_exit(&mut self, timeout: Duration) -> ExitStatus {
-        let deadline = Instant::now() + timeout;
-        loop {
-            if let Some(status) = self
-                .child
-                .try_wait()
-                .expect("inspect native-install interrupt fixture")
-            {
-                return status;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "native-install interrupt fixture did not exit"
-            );
-            thread::sleep(POLL_INTERVAL);
-        }
-    }
-}
-
-impl Drop for Fixture {
-    fn drop(&mut self) {
-        if matches!(self.child.try_wait(), Ok(None)) {
-            let _ = self.child.kill();
-            let _ = self.child.wait();
+            child: TestChild::new(child),
         }
     }
 }
 
 fn fixture_pid(fixture: &Fixture) -> Pid {
-    Pid::from_raw(i32::try_from(fixture.child.id()).expect("fixture PID fits in pid_t"))
+    Pid::from_raw(i32::try_from(fixture.child.child.id()).expect("fixture PID fits in pid_t"))
 }
 
 #[test]
 fn sigint_cleans_staged_native_publication_and_allows_retry() {
     let mut fixture = Fixture::start();
-    fixture.wait_for_content(&fixture.ready.clone(), "staged", STARTUP_TIMEOUT);
+    fixture
+        .child
+        .wait_for_content(&fixture.ready.clone(), "staged", STARTUP_TIMEOUT);
     kill(fixture_pid(&fixture), Signal::SIGINT).expect("signal task-owned fixture child");
 
-    let status = fixture.wait_for_exit(EXIT_TIMEOUT);
+    let status = fixture.child.wait_for_exit(EXIT_TIMEOUT);
     assert!(
         status.success(),
         "native-install interrupt fixture failed: {status}"

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests.rs
@@ -1,6 +1,7 @@
 mod acceptance;
 mod attention;
 mod concurrency;
+mod crash;
 mod lifecycle;
 mod receipts;
 mod response;

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/concurrency.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/concurrency.rs
@@ -2,6 +2,7 @@ use super::support::{
     DAY_MS, Fixture, NOW_MS, count_rows, endpoint, preamble_count, prepare_input, service,
 };
 use crate::storage::{Storage, StorageError};
+use rusqlite::OptionalExtension;
 use std::{path::Path, sync::mpsc, thread, time::Duration};
 use tmt_core::request::{
     FinalResponse, Originator, PreambleReservation, PrepareRequest, PreparedRequest, RequestError,
@@ -54,6 +55,92 @@ fn concurrent_pair<T: Send>(database: &Path, operations: [Operation<T>; 2]) -> [
         }
         values.try_into().ok().expect("exactly two worker results")
     })
+}
+
+/// Run two operations in a chosen order on two connections that were opened
+/// before either operation started. These cases model the old worker tests,
+/// which deliberately released one independent process before releasing the
+/// other rather than asserting on an unstructured race.
+fn ordered_pair<T>(database: &Path, operations: [Operation<T>; 2], first: usize) -> [T; 2] {
+    assert!(first < 2, "ordered pair index must be 0 or 1");
+    let [mut first_storage, mut second_storage] = [
+        Storage::open(database).unwrap(),
+        Storage::open(database).unwrap(),
+    ];
+    let [operation_zero, operation_one] = operations;
+    let (first_operation, second_operation, first_index) = if first == 0 {
+        (operation_zero, operation_one, 0)
+    } else {
+        (operation_one, operation_zero, 1)
+    };
+    let first_result = first_operation(&mut first_storage);
+    first_storage.close().expect("close first ordered storage");
+    let second_result = second_operation(&mut second_storage);
+    second_storage
+        .close()
+        .expect("close second ordered storage");
+    if first_index == 0 {
+        [first_result, second_result]
+    } else {
+        [second_result, first_result]
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct RequestState {
+    status: String,
+    wait_active: i64,
+    cadence_reserved: i64,
+    response_submitted_at_ms: Option<i64>,
+    wait_released_at_ms: Option<i64>,
+    attention_revision: i64,
+    attention_acknowledged_revision: i64,
+    latest_attention_revision: i64,
+}
+
+fn request_state(database: &Path, request_id: &str) -> RequestState {
+    let oracle =
+        rusqlite::Connection::open_with_flags(database, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .unwrap();
+    oracle
+        .query_row(
+            "SELECT status, wait_active, cadence_reserved, response_submitted_at_ms,
+                    wait_released_at_ms, attention_revision,
+                    attention_acknowledged_revision,
+                    COALESCE((SELECT latest_revision
+                              FROM request_attention_identities
+                              WHERE identity_id = a.originator_identity_id), 0)
+             FROM request_attempts a WHERE request_id = ?",
+            [request_id],
+            |row| {
+                Ok(RequestState {
+                    status: row.get(0)?,
+                    wait_active: row.get(1)?,
+                    cadence_reserved: row.get(2)?,
+                    response_submitted_at_ms: row.get(3)?,
+                    wait_released_at_ms: row.get(4)?,
+                    attention_revision: row.get(5)?,
+                    attention_acknowledged_revision: row.get(6)?,
+                    latest_attention_revision: row.get(7)?,
+                })
+            },
+        )
+        .unwrap()
+}
+
+fn response_state(database: &Path, request_id: &str) -> Option<(String, i64, i64)> {
+    let oracle =
+        rusqlite::Connection::open_with_flags(database, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .unwrap();
+    oracle
+        .query_row(
+            "SELECT body, body_bytes, submitted_at_ms
+             FROM request_responses WHERE request_id = ?",
+            [request_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()
+        .unwrap()
 }
 
 #[test]
@@ -301,6 +388,197 @@ fn identical_and_conflicting_final_writers_keep_one_body_marker_and_revision() {
                 2
             )
         );
+    }
+}
+
+#[test]
+fn finalization_and_failure_orders_preserve_or_reject_exactly() {
+    for final_first in [true, false] {
+        let mut fixture = Fixture::new();
+        let request_id = if final_first {
+            "request-final-first"
+        } else {
+            "request-failure-first"
+        };
+        let attempt_id = if final_first {
+            "attempt-final-first"
+        } else {
+            "attempt-failure-first"
+        };
+        let target = endpoint("%63", 163);
+        let input = prepare_input(
+            &fixture,
+            request_id,
+            target.clone(),
+            true,
+            NOW_MS + 3_600_001,
+            Originator::Explicit(fixture.identity_id.clone()),
+            true,
+        );
+        service(&mut fixture)
+            .prepare(input, attempt_id.into(), 7)
+            .unwrap();
+        service(&mut fixture).begin_send(attempt_id).unwrap();
+
+        let race_now = NOW_MS + 10;
+        let final_request_id = request_id.to_owned();
+        let final_attempt_id = attempt_id.to_owned();
+        let final_target = target.clone();
+        let final_submission: Operation<Result<(), RequestError<StorageError>>> =
+            Box::new(move |storage| {
+                RequestService::new(storage, move || race_now)
+                    .submit_response(SubmitResponse {
+                        request_id: final_request_id,
+                        proof: ResponseProof::Recorded {
+                            attempt_id: final_attempt_id,
+                            endpoint: final_target,
+                        },
+                        body: "final body".into(),
+                    })
+                    .map(|_| ())
+            });
+        let failure_attempt_id = attempt_id.to_owned();
+        let definite_failure: Operation<Result<(), RequestError<StorageError>>> =
+            Box::new(move |storage| {
+                RequestService::new(storage, move || race_now).settle(
+                    &failure_attempt_id,
+                    tmt_core::request::Settlement::DefinitelyFailed,
+                )
+            });
+        let [submitted, settled] = if final_first {
+            ordered_pair(&fixture.database, [final_submission, definite_failure], 0)
+        } else {
+            ordered_pair(&fixture.database, [final_submission, definite_failure], 1)
+        };
+
+        if final_first {
+            assert!(
+                submitted.is_ok(),
+                "finalization should win when ordered first"
+            );
+            assert!(
+                settled.is_ok(),
+                "failure after finalization should settle uncertain"
+            );
+            assert_eq!(
+                request_state(&fixture.database, request_id),
+                RequestState {
+                    status: "uncertain".into(),
+                    wait_active: 1,
+                    cadence_reserved: 1,
+                    response_submitted_at_ms: Some(race_now as i64),
+                    wait_released_at_ms: None,
+                    attention_revision: 2,
+                    attention_acknowledged_revision: 0,
+                    latest_attention_revision: 2,
+                }
+            );
+            assert_eq!(
+                response_state(&fixture.database, request_id),
+                Some(("final body".into(), 10, race_now as i64))
+            );
+            assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 1);
+        } else {
+            assert!(settled.is_ok(), "definite failure should settle first");
+            assert!(matches!(
+                submitted,
+                Err(RequestError::Response(ResponseRejection::StateInvalid))
+            ));
+            assert_eq!(
+                request_state(&fixture.database, request_id),
+                RequestState {
+                    status: "definitely_failed".into(),
+                    wait_active: 1,
+                    cadence_reserved: 0,
+                    response_submitted_at_ms: None,
+                    wait_released_at_ms: None,
+                    attention_revision: 1,
+                    attention_acknowledged_revision: 0,
+                    latest_attention_revision: 1,
+                }
+            );
+            assert_eq!(response_state(&fixture.database, request_id), None);
+            assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+            assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 0);
+        }
+    }
+}
+
+#[test]
+fn equal_expiry_finalization_is_rejected_before_or_after_cleanup() {
+    for cleanup_first in [true, false] {
+        let mut fixture = Fixture::new();
+        let request_id = if cleanup_first {
+            "request-equal-expiry-cleanup-first"
+        } else {
+            "request-equal-expiry-final-first"
+        };
+        let attempt_id = if cleanup_first {
+            "attempt-equal-expiry-cleanup-first"
+        } else {
+            "attempt-equal-expiry-final-first"
+        };
+        let target = endpoint("%64", 164);
+        let expires_at = NOW_MS + 3_600_000;
+        let acceptance_expiry = NOW_MS + 7 * DAY_MS;
+        let input = prepare_input(
+            &fixture,
+            request_id,
+            target.clone(),
+            true,
+            expires_at,
+            Originator::Explicit(fixture.identity_id.clone()),
+            true,
+        );
+        service(&mut fixture)
+            .prepare(input, attempt_id.into(), 7)
+            .unwrap();
+        service(&mut fixture).begin_send(attempt_id).unwrap();
+
+        let cleanup: Operation<Result<(), RequestError<StorageError>>> =
+            Box::new(move |storage| RequestService::new(storage, || acceptance_expiry).cleanup());
+        let final_request_id = request_id.to_owned();
+        let final_attempt_id = attempt_id.to_owned();
+        let final_target = target.clone();
+        let final_submission: Operation<Result<(), RequestError<StorageError>>> =
+            Box::new(move |storage| {
+                RequestService::new(storage, || acceptance_expiry)
+                    .submit_response(SubmitResponse {
+                        request_id: final_request_id,
+                        proof: ResponseProof::Recorded {
+                            attempt_id: final_attempt_id,
+                            endpoint: final_target,
+                        },
+                        body: "expired body".into(),
+                    })
+                    .map(|_| ())
+            });
+        let [cleanup_result, submission_result] = ordered_pair(
+            &fixture.database,
+            [cleanup, final_submission],
+            usize::from(!cleanup_first),
+        );
+        assert!(cleanup_result.is_ok());
+        assert!(matches!(
+            submission_result,
+            Err(RequestError::Response(ResponseRejection::Expired))
+        ));
+        assert_eq!(
+            request_state(&fixture.database, request_id),
+            RequestState {
+                status: "uncertain".into(),
+                wait_active: 0,
+                cadence_reserved: 1,
+                response_submitted_at_ms: None,
+                wait_released_at_ms: Some(acceptance_expiry as i64),
+                attention_revision: 1,
+                attention_acknowledged_revision: 0,
+                latest_attention_revision: 1,
+            }
+        );
+        assert_eq!(response_state(&fixture.database, request_id), None);
+        assert_eq!(count_rows(&fixture.database, "request_responses"), 0);
+        assert_eq!(preamble_count(&fixture.database, &fixture.identity_id), 1);
     }
 }
 

--- a/rust/crates/tmt-adapters/src/storage/requests/service_tests/crash.rs
+++ b/rust/crates/tmt-adapters/src/storage/requests/service_tests/crash.rs
@@ -1,0 +1,210 @@
+//! Real process death while the shared preparation transaction is still open.
+
+use super::support::{Fixture, NOW_MS, endpoint, prepare_input, service};
+use crate::{
+    storage::{Storage, StorageError},
+    test_support::TestChild,
+};
+use rusqlite::{Connection, OpenFlags, types::Value};
+use std::{
+    env, fs,
+    os::unix::process::ExitStatusExt,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+use tmt_core::request::{
+    Originator, PreambleReservation, PrepareRequest, RequestRecords, RequestRepository,
+    RequestService,
+};
+
+const CHILD_TEST: &str = "storage::requests::service_tests::crash::preparation_child";
+const DATABASE_ENV: &str = "TMT_REQUEST_CRASH_DATABASE";
+const OWNER_ENV: &str = "TMT_REQUEST_CRASH_OWNER";
+const READY_ENV: &str = "TMT_REQUEST_CRASH_READY";
+const RELEASE_ENV: &str = "TMT_REQUEST_CRASH_RELEASE";
+
+fn snapshot(database: &Path) -> Vec<Vec<Vec<Value>>> {
+    let connection = Connection::open_with_flags(database, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .expect("open independent crash oracle");
+    [
+        "SELECT * FROM request_attempts ORDER BY attempt_id",
+        "SELECT * FROM request_responses ORDER BY request_id",
+        "SELECT * FROM preamble_counters ORDER BY identity_id",
+        "SELECT * FROM request_attention_identities ORDER BY identity_id",
+    ]
+    .into_iter()
+    .map(|query| {
+        connection
+            .prepare(query)
+            .unwrap()
+            .query_map([], |row| {
+                (0..row.as_ref().column_count())
+                    .map(|column| row.get(column))
+                    .collect::<rusqlite::Result<Vec<Value>>>()
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap()
+    })
+    .collect()
+}
+
+#[test]
+fn sigkill_rolls_back_preparation_without_losing_committed_state() {
+    for kill_before_commit in [true, false] {
+        let mut fixture = Fixture::new();
+        let baseline = prepare_input(
+            &fixture,
+            "committed-baseline",
+            endpoint("%11", 111),
+            false,
+            NOW_MS + 60_000,
+            Originator::Explicit(fixture.identity_id.clone()),
+            true,
+        );
+        service(&mut fixture)
+            .prepare(baseline, "baseline-attempt".into(), 7)
+            .unwrap();
+        fixture.storage.close().unwrap();
+        let before = snapshot(&fixture.database);
+        let ready = fixture._directory.path.join("transaction-ready");
+        let release = fixture._directory.path.join("release-commit");
+        let child = Command::new(env::current_exe().unwrap())
+            .args(["--exact", CHILD_TEST, "--nocapture", "--test-threads=1"])
+            .env(DATABASE_ENV, &fixture.database)
+            .env(OWNER_ENV, &fixture.identity_id)
+            .env(READY_ENV, &ready)
+            .env(RELEASE_ENV, &release)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut child = TestChild::new(child);
+        child.wait_for_content(&ready, "prepared-uncommitted", Duration::from_secs(5));
+        // WAL readers must see the committed baseline while the real service's
+        // attempt/cadence/attention writes are held inside its transaction.
+        assert_eq!(snapshot(&fixture.database), before);
+        if kill_before_commit {
+            assert!(child.child.try_wait().unwrap().is_none());
+            child.child.kill().unwrap();
+            assert_eq!(
+                child.wait_for_exit(Duration::from_secs(3)).signal(),
+                Some(9)
+            );
+        } else {
+            fs::write(&release, "commit").unwrap();
+            assert!(child.wait_for_exit(Duration::from_secs(3)).success());
+        }
+        let mut reopened = Storage::open(&fixture.database).unwrap();
+        assert_eq!(reopened.health().unwrap().journal_mode, "wal");
+        reopened.close().unwrap();
+        let after = snapshot(&fixture.database);
+        let oracle =
+            Connection::open_with_flags(&fixture.database, OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .unwrap();
+        assert_eq!(
+            oracle
+                .query_row("PRAGMA integrity_check", [], |row| row.get::<_, String>(0))
+                .unwrap(),
+            "ok"
+        );
+        if kill_before_commit {
+            assert_eq!(after, before);
+        } else {
+            // Positive control: readiness cannot be published without the
+            // mutation under test; allowing commit must expose all three writes.
+            assert_eq!(after[0].len(), 2);
+            assert_eq!(after[0][0], before[0][0]);
+            assert_ne!(after[0], before[0]);
+            assert_eq!(after[1], before[1]);
+            assert_ne!(after[2], before[2]);
+            assert_ne!(after[3], before[3]);
+            assert_eq!(
+                oracle
+                    .query_row("SELECT reserved_count FROM preamble_counters", [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap(),
+                2
+            );
+            assert_eq!(
+                oracle
+                    .query_row(
+                        "SELECT latest_revision FROM request_attention_identities",
+                        [],
+                        |row| row.get::<_, i64>(0)
+                    )
+                    .unwrap(),
+                2
+            );
+        }
+    }
+}
+
+/// Decorate only the repository's transaction callback, not its SQL or service
+/// policy. This pauses after actual prepare writes and before the actual commit.
+struct PauseBeforeCommit {
+    storage: Storage,
+    ready: PathBuf,
+    release: PathBuf,
+}
+
+impl RequestRepository for PauseBeforeCommit {
+    type Error = StorageError;
+
+    fn with_request_transaction<T, E: From<Self::Error>>(
+        &mut self,
+        operation: impl FnOnce(&mut dyn RequestRecords<Error = Self::Error>) -> Result<T, E>,
+    ) -> Result<T, E> {
+        let ready = &self.ready;
+        let release = &self.release;
+        self.storage.with_request_transaction(|records| {
+            let result = operation(records)?;
+            fs::write(ready, "prepared-uncommitted").unwrap();
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !release.exists() {
+                assert!(
+                    Instant::now() < deadline,
+                    "parent did not terminate or release crash fixture"
+                );
+                thread::sleep(Duration::from_millis(10));
+            }
+            Ok(result)
+        })
+    }
+}
+
+#[test]
+fn preparation_child() {
+    let Some(database) = env::var_os(DATABASE_ENV) else {
+        return;
+    };
+    let owner = env::var(OWNER_ENV).unwrap();
+    let mut repository = PauseBeforeCommit {
+        storage: Storage::open(PathBuf::from(database)).unwrap(),
+        ready: env::var_os(READY_ENV).unwrap().into(),
+        release: env::var_os(RELEASE_ENV).unwrap().into(),
+    };
+    RequestService::new(&mut repository, || NOW_MS)
+        .prepare(
+            PrepareRequest {
+                request_id: "uncommitted-request".into(),
+                message: "uncommitted prompt".into(),
+                endpoint: endpoint("%12", 112),
+                wait: false,
+                expires_at_ms: NOW_MS + 60_000,
+                originator: Originator::Explicit(owner.clone()),
+                recipient_identity_id: Some(owner.clone()),
+                preamble: Some(PreambleReservation {
+                    identity_id: owner,
+                    every: 3,
+                }),
+            },
+            "uncommitted-attempt".into(),
+            7,
+        )
+        .unwrap();
+    repository.storage.close().unwrap();
+}

--- a/rust/crates/tmt-adapters/src/test_support.rs
+++ b/rust/crates/tmt-adapters/src/test_support.rs
@@ -1,7 +1,11 @@
 use std::{
     fs,
+    path::Path,
     path::PathBuf,
+    process::{Child, ExitStatus},
     sync::atomic::{AtomicU64, Ordering},
+    thread,
+    time::{Duration, Instant},
 };
 
 /// One invocation-owned filesystem fixture shared by native adapter tests.
@@ -38,5 +42,200 @@ impl Drop for TestDirectory {
                 );
             }
         }
+    }
+}
+
+/// Owns a task-local child process and guarantees bounded cleanup on every test path.
+///
+/// `try_wait` marks the child as reaped before returning its status. Drop therefore
+/// never signals a child after observing that it has exited, avoiding a recycled-PID
+/// signal while still killing and reaping a live child after a panic or timeout.
+pub(crate) struct TestChild {
+    pub child: Child,
+}
+
+impl TestChild {
+    pub(crate) fn new(child: Child) -> Self {
+        Self { child }
+    }
+
+    pub(crate) fn wait_for_content(&mut self, path: &Path, expected: &str, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if fs::read_to_string(path).ok().as_deref() == Some(expected) {
+                return;
+            }
+            if let Some(status) = self
+                .child
+                .try_wait()
+                .expect("inspect task-owned test child status")
+            {
+                panic!("test child exited before {}: {status}", path.display());
+            }
+            assert!(
+                Instant::now() < deadline,
+                "test child did not publish {expected:?} to {}",
+                path.display(),
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    pub(crate) fn wait_for_exit(&mut self, timeout: Duration) -> ExitStatus {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = self
+                .child
+                .try_wait()
+                .expect("inspect task-owned test child status")
+            {
+                return status;
+            }
+            if Instant::now() >= deadline {
+                let _ = self.child.kill();
+                let status = self.child.wait().expect("reap timed-out test child");
+                panic!("test child did not exit before deadline: {status}");
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+impl Drop for TestChild {
+    fn drop(&mut self) {
+        match self.child.try_wait() {
+            Ok(Some(_)) | Err(_) => {}
+            Ok(None) => {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+    use nix::{
+        errno::Errno,
+        sys::wait::{WaitPidFlag, WaitStatus, waitpid},
+        unistd::Pid,
+    };
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        process::{Command, Stdio},
+    };
+
+    const READY_ENV: &str = "TMT_TEST_CHILD_READY";
+    const MARKER_ENV: &str = "TMT_TEST_CHILD_MARKER";
+    const RELEASE_ENV: &str = "TMT_TEST_CHILD_RELEASE";
+    const CHILD_TEST: &str = "test_support::tests::cleanup_child_process";
+    const CHILD_START_TIMEOUT: Duration = Duration::from_secs(2);
+
+    #[test]
+    fn cleanup_child_process() {
+        let Some(ready) = std::env::var_os(READY_ENV) else {
+            return;
+        };
+        let marker = std::env::var_os(MARKER_ENV).expect("cleanup marker environment");
+        let release = PathBuf::from(std::env::var_os(RELEASE_ENV).expect("cleanup release path"));
+        fs::write(ready, "ready").expect("publish cleanup child readiness");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !release.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "parent did not release or stop cleanup child"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        fs::write(marker, "survived").expect("publish cleanup child marker");
+    }
+
+    fn spawn_cleanup_child(directory: &TestDirectory) -> TestChild {
+        let ready = directory.path.join("ready");
+        let marker = directory.path.join("marker");
+        let child = Command::new(std::env::current_exe().expect("locate test executable"))
+            .args(["--exact", CHILD_TEST, "--nocapture"])
+            .env(READY_ENV, &ready)
+            .env(MARKER_ENV, &marker)
+            .env(RELEASE_ENV, directory.path.join("release"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn cleanup child");
+        let mut child = TestChild::new(child);
+        child.wait_for_content(&ready, "ready", CHILD_START_TIMEOUT);
+        child
+    }
+
+    fn assert_reaped(pid: u32) {
+        match waitpid(
+            Pid::from_raw(i32::try_from(pid).expect("child PID fits in pid_t")),
+            Some(WaitPidFlag::WNOHANG),
+        ) {
+            Err(Errno::ECHILD) => {}
+            Ok(WaitStatus::StillAlive) => panic!("test child {pid} was not reaped"),
+            Ok(status) => panic!("unexpected status for test child {pid}: {status:?}"),
+            Err(error) => panic!("inspect test child {pid}: {error}"),
+        }
+    }
+
+    fn assert_marker_absent(directory: &TestDirectory) {
+        assert!(!directory.path.join("marker").exists());
+    }
+
+    #[test]
+    fn drop_reaps_a_live_child_during_panic_unwind() {
+        let directory = TestDirectory::new();
+        let mut child = Some(spawn_cleanup_child(&directory));
+        let pid = child.as_ref().expect("cleanup child").child.id();
+        let started = Instant::now();
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _child = child.take().expect("take cleanup child");
+            panic!("force cleanup during panic unwind");
+        }));
+        assert!(result.is_err());
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "cleanup waited for the child's fallback deadline"
+        );
+        assert_reaped(pid);
+        assert_marker_absent(&directory);
+    }
+
+    #[test]
+    fn timeout_reaps_a_live_child_before_panicking() {
+        let directory = TestDirectory::new();
+        let mut pid = None;
+        let started = Instant::now();
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut child = spawn_cleanup_child(&directory);
+            pid = Some(child.child.id());
+            let _ = child.wait_for_exit(Duration::from_millis(20));
+        }));
+        assert!(result.is_err());
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "timeout did not stop its child promptly"
+        );
+        assert_reaped(pid.expect("cleanup child PID"));
+        assert_marker_absent(&directory);
+    }
+
+    #[test]
+    fn drop_does_not_signal_a_child_after_normal_exit() {
+        let directory = TestDirectory::new();
+        let mut child = spawn_cleanup_child(&directory);
+        let pid = child.child.id();
+        fs::write(directory.path.join("release"), "finish").unwrap();
+        let status = child.wait_for_exit(Duration::from_secs(2));
+        assert!(status.success());
+        assert_eq!(
+            fs::read_to_string(directory.path.join("marker")).expect("normal-exit marker"),
+            "survived"
+        );
+        drop(child);
+        assert_reaped(pid);
     }
 }

--- a/test/e2e/native-talk.e2e.test.ts
+++ b/test/e2e/native-talk.e2e.test.ts
@@ -68,6 +68,69 @@ async function submittedBody(
 }
 
 describe.sequential('native public talk/reply/result', () => {
+  it.each(['completed', 'detached', 'timeout'] as const)(
+    'keeps human %s output correlated with the durable request and exact final',
+    async (mode) => {
+      const body = '  human final\r\nsecond line  ';
+      await withE2EFixture(
+        async (fixture) => {
+          const args = [
+            'talk',
+            fixture.pane,
+            `human-${mode}`,
+            '--no-preamble',
+            ...(mode === 'detached' ? ['--detach'] : ['--timeout', mode === 'timeout' ? '1' : '8']),
+          ];
+          const result = await fixture.runCli(args);
+          expect(result.code, result.stderr || result.stdout).toBe(mode === 'timeout' ? 4 : 0);
+          const attempts = requestAttempts(fixture);
+          expect(attempts).toHaveLength(1);
+          const requestId = attempts[0]!.request_id;
+          expect(requestId).toMatch(/^req_[0-9a-f-]+$/);
+          expect(attempts[0]).toMatchObject({
+            message_text: `human-${mode}`,
+            status: 'sent',
+            wait_active: 0,
+          });
+          if (mode === 'timeout') {
+            expect(result.stdout).toBe('');
+            expect(result.stderr).toBe(
+              `Timed out waiting for ${fixture.pane} after 1s\nInspect with 'tmt result ${requestId}' and 'tmt check ${fixture.pane}' before deciding whether to retry.\n`
+            );
+          } else {
+            expect(result.stderr).toBe('');
+            expect(result.stdout).toBe(
+              (mode === 'completed'
+                ? `Completed request ${requestId} for ${fixture.pane} (${fixture.pane}).\n${body}\n`
+                : `Sent request ${requestId} to ${fixture.pane} (${fixture.pane}).\n`) +
+                `Retrieve later with 'tmt result ${requestId}'.\n`
+            );
+          }
+          if (mode !== 'completed') {
+            expect(fixture.events().filter((event) => event.event === 'submitted')).toEqual([]);
+            fixture.releaseReplyGate(requestId);
+          }
+          await submittedBody(fixture, requestId, body);
+          expect(
+            success(
+              await fixture.runJsonCli<TalkOutput>(['result', requestId], { withoutTmux: true })
+            )
+          ).toMatchObject({
+            requestId,
+            status: 'completed',
+            response: body,
+            bodyBytes: Buffer.byteLength(body),
+          });
+        },
+        options({
+          replyGate: mode !== 'completed',
+          responseBodyBase64: Buffer.from(body).toString('base64'),
+        })
+      );
+    },
+    15_000
+  );
+
   it.each([
     ['empty', ''],
     ['whitespace', ' \t  \n\r\n '],
@@ -522,107 +585,120 @@ describe.sequential('native public talk/reply/result', () => {
     }, options());
   }, 20_000);
 
-  it('keeps overlapping native requests independently gated and correlated', async () => {
-    await withE2EFixture(
-      async (fixture) => {
-        const slow = fixture.runCliProcess<TalkOutput>([
-          '--json',
-          'talk',
-          fixture.pane,
-          'native slow overlap',
-          '--no-preamble',
-          '--timeout',
-          '8',
-        ]);
-        const fast = fixture.runCliProcess<TalkOutput>([
-          '--json',
-          'talk',
-          fixture.pane,
-          'native fast overlap',
-          '--no-preamble',
-          '--timeout',
-          '8',
-        ]);
-        const slowRequest = await fixture.waitForEvent(
-          (event) => event.event === 'request' && event.message === 'native slow overlap',
-          5_000
-        );
-        const fastRequest = await fixture.waitForEvent(
-          (event) => event.event === 'request' && event.message === 'native fast overlap',
-          5_000
-        );
-        expect(slowRequest.requestId).toEqual(expect.stringMatching(/^req_[0-9a-f-]+$/));
-        expect(fastRequest.requestId).toEqual(expect.stringMatching(/^req_[0-9a-f-]+$/));
-        expect(slowRequest.requestId).not.toBe(fastRequest.requestId);
-        await fixture.waitFor(
-          () =>
-            requestAttempts(fixture).filter(
-              (row) =>
-                (row.request_id === slowRequest.requestId ||
-                  row.request_id === fastRequest.requestId) &&
-                row.status === 'sent' &&
-                row.wait_active === 1
-            ).length === 2,
-          5_000,
-          'overlapping native requests to settle independently'
-        );
+  it.each(['json', 'human', 'forced'] as const)(
+    'keeps %s overlapping requests correlated with appropriate warnings',
+    async (mode) => {
+      await withE2EFixture(
+        async (fixture) => {
+          const slow = fixture.runCliProcess<TalkOutput>([
+            '--json',
+            'talk',
+            fixture.pane,
+            'native slow overlap',
+            '--no-preamble',
+            '--timeout',
+            '8',
+          ]);
+          const slowRequest = await fixture.waitForEvent(
+            (event) => event.event === 'request' && event.message === 'native slow overlap',
+            5_000
+          );
+          const fast = fixture.runCliProcess<TalkOutput>([
+            ...(mode === 'json' ? ['--json'] : mode === 'forced' ? ['--force'] : []),
+            'talk',
+            fixture.pane,
+            'native fast overlap',
+            '--no-preamble',
+            '--timeout',
+            '8',
+          ]);
+          const fastRequest = await fixture.waitForEvent(
+            (event) => event.event === 'request' && event.message === 'native fast overlap',
+            5_000
+          );
+          expect(slowRequest.requestId).toEqual(expect.stringMatching(/^req_[0-9a-f-]+$/));
+          expect(fastRequest.requestId).toEqual(expect.stringMatching(/^req_[0-9a-f-]+$/));
+          expect(slowRequest.requestId).not.toBe(fastRequest.requestId);
+          await fixture.waitFor(
+            () =>
+              requestAttempts(fixture).filter(
+                (row) =>
+                  (row.request_id === slowRequest.requestId ||
+                    row.request_id === fastRequest.requestId) &&
+                  row.status === 'sent' &&
+                  row.wait_active === 1
+              ).length === 2,
+            5_000,
+            'overlapping native requests to settle independently'
+          );
 
-        fixture.releaseReplyGate(fastRequest.requestId);
-        await submittedBody(
-          fixture,
-          fastRequest.requestId ?? '',
-          'mock-agent response: native fast overlap'
-        );
-        expect(
-          fixture
-            .events()
-            .some(
-              (event) => event.event === 'submitted' && event.requestId === slowRequest.requestId
-            )
-        ).toBe(false);
-        const fastResult = await fast.result;
-        expect(fastResult).toMatchObject({
-          code: 0,
-          json: {
-            status: 'completed',
-            requestId: fastRequest.requestId,
-            response: 'mock-agent response: native fast overlap',
-          },
-        });
+          fixture.releaseReplyGate(fastRequest.requestId);
+          await submittedBody(
+            fixture,
+            fastRequest.requestId ?? '',
+            'mock-agent response: native fast overlap'
+          );
+          expect(
+            fixture
+              .events()
+              .some(
+                (event) => event.event === 'submitted' && event.requestId === slowRequest.requestId
+              )
+          ).toBe(false);
+          const fastResult = await fast.result;
+          expect(fastResult.code).toBe(0);
+          if (mode === 'json') {
+            expect(fastResult.json).toMatchObject({
+              status: 'completed',
+              requestId: fastRequest.requestId,
+              response: 'mock-agent response: native fast overlap',
+            });
+          } else {
+            expect(fastResult.stdout).toContain(
+              `Completed request ${fastRequest.requestId} for ${fixture.pane} (${fixture.pane}).\nmock-agent response: native fast overlap\n`
+            );
+          }
+          expect(fastResult.stderr).toBe(
+            mode === 'human'
+              ? `Another recent request exists for '${fixture.pane}' (id: ${slowRequest.requestId}). Input processing is not serialized; durable results remain associated by request ID.\n`
+              : ''
+          );
 
-        fixture.releaseReplyGate(slowRequest.requestId);
-        await submittedBody(
-          fixture,
-          slowRequest.requestId ?? '',
-          'mock-agent response: native slow overlap'
-        );
-        const slowResult = await slow.result;
-        expect(slowResult).toMatchObject({
-          code: 0,
-          json: {
-            status: 'completed',
-            requestId: slowRequest.requestId,
-            response: 'mock-agent response: native slow overlap',
-          },
-        });
-        expect(requestAttempts(fixture)).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              request_id: slowRequest.requestId,
-              status: 'sent',
-              wait_active: 0,
-            }),
-            expect.objectContaining({
-              request_id: fastRequest.requestId,
-              status: 'sent',
-              wait_active: 0,
-            }),
-          ])
-        );
-      },
-      options({ replyGate: true })
-    );
-  }, 25_000);
+          fixture.releaseReplyGate(slowRequest.requestId);
+          await submittedBody(
+            fixture,
+            slowRequest.requestId ?? '',
+            'mock-agent response: native slow overlap'
+          );
+          const slowResult = await slow.result;
+          expect(slowResult).toMatchObject({
+            code: 0,
+            json: {
+              status: 'completed',
+              requestId: slowRequest.requestId,
+              response: 'mock-agent response: native slow overlap',
+            },
+          });
+          expect(requestAttempts(fixture)).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                request_id: slowRequest.requestId,
+                status: 'sent',
+                wait_active: 0,
+              }),
+              expect.objectContaining({
+                request_id: fastRequest.requestId,
+                status: 'sent',
+                wait_active: 0,
+              }),
+            ])
+          );
+        },
+        options({ replyGate: true })
+      );
+    },
+    25_000
+  );
 
   it('reports ambiguous paste without replaying native talk input', async () => {
     const original = 'ambiguous! send';

--- a/test/e2e/publication-race.e2e.test.ts
+++ b/test/e2e/publication-race.e2e.test.ts
@@ -185,56 +185,65 @@ describe.sequential('crash-safe identity publication', () => {
       contender: (fixture: E2EFixture, pane: string) => ['--json', 'add', pane, 'Anchor'],
       expectedCode: 'NAME_ALREADY_ACTIVE',
       expectedBindings: 1,
+      expectedIdentities: 1,
     },
     {
       label: 'different name on the same pane',
       contender: (_fixture: E2EFixture, _pane: string) => ['--json', 'name', 'Challenger'],
       expectedCode: 'PANE_ALREADY_BOUND',
       expectedBindings: 1,
+      expectedIdentities: 2,
     },
     {
       label: 'same canonical name on the same pane',
       contender: (_fixture: E2EFixture, _pane: string) => ['--json', 'name', 'ａｎｃｈｏｒ'],
       expectedCode: undefined,
       expectedBindings: 1,
+      expectedIdentities: 1,
     },
     {
       label: 'different name on another pane',
       contender: (fixture: E2EFixture, pane: string) => ['--json', 'add', pane, 'Challenger'],
       expectedCode: undefined,
       expectedBindings: 2,
+      expectedIdentities: 2,
     },
   ])(
     'serializes $label without deleting the winner',
-    async ({ contender, expectedCode, expectedBindings }) => {
+    async ({ contender, expectedCode, expectedBindings, expectedIdentities }) => {
       await withE2EFixture(
         async (fixture) => {
           const peer = await fixture.createMockPane('peer');
-          const binder = fixture.runCliProcess(['--json', 'name', 'Anchor']);
+          const binder = fixture.runCliProcess<{ id: string }>(['--json', 'name', 'Anchor']);
           await fixture.waitForMetadataBarrier('entered');
           expect(writerIsLocked(fixture)).toBe(true);
 
-          const contenderProgress = path.join(fixture.root, 'contender-started');
-          const contenderProcess = fixture.runCliProcess(contender(fixture, peer.pane), {
-            progressFile: contenderProgress,
-          });
+          const contenderProcess = fixture.runCliProcess(contender(fixture, peer.pane));
           await fixture.waitFor(
-            () => fs.existsSync(contenderProgress),
+            () => processTreeHasOpenFile(contenderProcess.pid, databaseFile(fixture)),
             900,
-            'contender to invoke tmux'
+            'independent contender to open SQLite before publication commit'
           );
+          expect(writerIsLocked(fixture)).toBe(true);
 
           fixture.releaseMetadataBarrier();
-          await waitForSuccess(binder);
+          const winner = await waitForSuccess<{ id: string }>(binder);
           const contenderResult = await contenderProcess.result;
           if (expectedCode) {
             expect(contenderResult.code).toBe(5);
             expect(json(contenderResult)).toMatchObject({ error: { code: expectedCode } });
           } else {
             expect(contenderResult.code, contenderResult.stderr || contenderResult.stdout).toBe(0);
+            if (expectedIdentities === 1) {
+              expect(json(contenderResult)).toMatchObject({ id: winner.id });
+            }
           }
 
-          expect(durableCounts(fixture)).toMatchObject({ bindings: expectedBindings });
+          expect(durableCounts(fixture)).toMatchObject({
+            identities: expectedIdentities,
+            bindings: expectedBindings,
+          });
+          expect(durableIdentity(fixture, 'anchor').id).toBe(winner.id);
           await assertPublished(fixture, 'Anchor');
         },
         { metadataBarrier: { phase: 'before' } }

--- a/test/e2e/real-tmux-caller.ts
+++ b/test/e2e/real-tmux-caller.ts
@@ -28,6 +28,8 @@ export async function spawnRealTmuxCli(
     readonly stripTmux?: boolean;
     readonly stripPane?: boolean;
     readonly json?: boolean;
+    /** Keep all three standard streams on the pane's real terminal. */
+    readonly terminal?: boolean;
   }
 ): Promise<RealTmuxCli> {
   const workspace = fixture.createWorkspace(`real-${options.name}`);
@@ -45,7 +47,7 @@ export async function spawnRealTmuxCli(
   ];
   const command = [
     `while [ ! -f ${shellQuote(releasePath)} ]; do sleep 0.01; done`,
-    `env${options.stripTmux ? ' -u TMUX' : ''}${options.stripPane ? ' -u TMUX_PANE' : ''} ${invocation.map(shellQuote).join(' ')} >${shellQuote(outputPath)} 2>${shellQuote(errorPath)}`,
+    `env${options.stripTmux ? ' -u TMUX' : ''}${options.stripPane ? ' -u TMUX_PANE' : ''} ${invocation.map(shellQuote).join(' ')}${options.terminal ? '' : ` >${shellQuote(outputPath)} 2>${shellQuote(errorPath)}`}`,
     `printf '%s' "$?" >${shellQuote(exitPath)}`,
     `while [ ! -f ${shellQuote(holdPath)} ]; do sleep 0.05; done`,
   ].join('; ');

--- a/test/e2e/skill-reminder.e2e.test.ts
+++ b/test/e2e/skill-reminder.e2e.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture } from './harness.js';
+import { releaseRealTmuxCli, spawnRealTmuxCli } from './real-tmux-caller.js';
+
+describe('native passive skill guidance', () => {
+  it('warns only on an eligible terminal command without mutating stale guidance or storage', async () => {
+    await withE2EFixture(async (fixture) => {
+      const home = fixture.createWorkspace('isolated-provider-home');
+      for (const [key, value] of Object.entries({
+        HOME: home,
+        CODEX_HOME: path.join(home, '.codex'),
+        PI_CODING_AGENT_DIR: path.join(home, '.pi'),
+        OPENCODE_CONFIG_DIR: path.join(home, '.opencode'),
+        XDG_CONFIG_HOME: path.join(home, '.config'),
+      })) {
+        fixture.tmux(['set-environment', '-g', key, value]);
+      }
+      const stale = path.join(home, '.claude', 'skills', 'tmux-team');
+      fs.mkdirSync(stale, { recursive: true });
+      const staleFile = path.join(stale, 'SKILL.md');
+      fs.writeFileSync(staleFile, 'user-maintained stale guidance');
+
+      for (const scenario of [
+        { name: 'eligible', args: ['config', 'show'], terminal: true, json: false, warn: true },
+        { name: 'machine', args: ['config', 'show'], terminal: true, json: true, warn: false },
+        { name: 'redirected', args: ['config', 'show'], terminal: false, json: false, warn: false },
+        { name: 'help', args: ['help'], terminal: true, json: false, warn: false },
+      ]) {
+        const process = await spawnRealTmuxCli(fixture, scenario.args, scenario);
+        await releaseRealTmuxCli(fixture, process);
+        expect(fs.readFileSync(process.exitPath, 'utf8')).toBe('0');
+        const output = scenario.terminal
+          ? fixture.tmux(['capture-pane', '-p', '-J', '-S', '-', '-t', process.pane])
+          : fs.readFileSync(process.outputPath, 'utf8') +
+            fs.readFileSync(process.errorPath, 'utf8');
+        if (scenario.warn) {
+          expect(output).toContain(`Skill guidance needs inspection at ${stale} (1 location(s)).`);
+          expect(output).toContain(
+            'Run tmt install for the intended provider; inspect conflicts before using --force. Reload the agent afterward.'
+          );
+        } else {
+          expect(output).not.toContain('Skill guidance needs inspection');
+        }
+        if (scenario.json) {
+          expect(JSON.parse(output.trim())).toMatchObject({
+            resolved: { ui: { paneBadge: 'off' } },
+          });
+        } else if (scenario.name !== 'help') {
+          expect(output).toContain('Current configuration:');
+        }
+        expect(fs.readFileSync(staleFile, 'utf8')).toBe('user-maintained stale guidance');
+        expect(fs.existsSync(path.join(fixture.globalDir, 'tmux-team.db'))).toBe(false);
+      }
+    });
+  }, 15_000);
+});


### PR DESCRIPTION
## Scope

- Closes #156; follows #157 and advances #93 without retiring source prematurely.
- Close remaining request crash/order and terminal-output evidence gaps. No production command behavior or release changes.
- Owners: existing adapter request-service tests and test-only process owner; shared Docker E2E scenarios; maintained architecture/development guidance.

## Architecture and review

- Reuse the real request service and SQLite transaction port. A test decorator pauses the actual preparation transaction before commit; SIGKILL must preserve the independent committed snapshot. A release/commit positive control proves the paused writes really execute.
- Reuse one test-only child owner across interrupt, bounded-file and native-install fixtures. Child fields precede fixture directories so teardown reaps before removing files; cached Child exit state remains the only reaping state.
- Strengthen the existing concurrent publication scenario instead of duplicating it. Both canonical-name results must match the sole durable identity, after a contender demonstrably opens SQLite while the writer lock is held.
- Ordered independent connections explicitly test both final/failure and equal-expiry orderings; these are not represented as simultaneous races.
- Human completion/detach/timeout, overlap-warning suppression and real-terminal passive reminders use the existing private tmux/mock-agent harness. No host tmux or user installation is touched.
- Primary reviewer: Codex. Reviewed every changed file and relevant service, fixture, caller and output contract. Corrected redundant lifecycle state, field destruction order, weak cleanup timing assertions and invalid detached test arguments before acceptance.
- Reviewed commit: f2c3d5c373a71b9069397195c90fdee512fcd5f1. Rebase onto merged #157 preserved the tested tree exactly.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge. Run 34246003263 passed all 11 checks on f2c3d5c373a71b9069397195c90fdee512fcd5f1 on its first attempt.

Local commands and results (Node 24; isolated native builds):

- `pnpm check`: pass.
- `pnpm exec vitest run --coverage --maxWorkers=2 --minWorkers=1` and `node scripts/check-coverage.mjs --threshold 90 --branches 85`: 1,156 tests / 74 files; 95.68% statements/lines, 89.49% branches, 97.55% functions.
- `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked`: pass; adapter 292, CLI 35, architecture 19, core 56; one intentional archive-fixture ignore.
- `cargo +1.88.0 build --locked`: pass.
- `pnpm test:native` with explicit task-built CLI and storage probe: 149 tests / 15 files pass.
- `pnpm test:e2e` twice after final harness/lifecycle edits: each 292 adapter tests and 166 E2E tests pass. One opt-in performance scenario remains intentionally skipped. Vitest durations: 127.35s and 125.17s.
- `git diff --check`: pass. No CI rerun requested; one candidate will run all required gates.

## Project lifecycle

- Updated ARCHITECTURE.md, DEVELOPMENT.md, RUST-REWRITE.md and the repo development skill with owners, exact evidence and retirement review rules.
- Deferred: TypeScript product/npm-entrypoint retirement and relocation of retained Node tooling guards. No MCP, memory, release or tag changes.
- Branch: `test/156-native-race-closure`; worktree: `/Users/benhsieh/dev/tmt-156-native-race-closure`. Remove only after normal green merge and clean/pushed verification.
