### PR TITLE
feat: show sender in XML-style reply instructions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -132,6 +132,13 @@ schema, connection or alternate final-submission path. Input is bounded and
 validated before storage effects. A malformed receipt, a stale revision, an
 unknown identity and an uncertain transport outcome remain distinct failures.
 
+Talk preparation renders `<tmt-reply from="…">` using the same resolved
+originator's display name (explicit identity before verified caller), or
+`unknown`. The attribute is XML-escaped presentation, not authentication,
+routing or a strict XML document. It introduces no extra identity lookup or
+stored field; original message bytes, originator UUID/kind and reply correlation
+remain owned by the existing request contract.
+
 ### Tmux and process effects
 
 `tmt-adapters::process` is the shared bounded subprocess owner. It enforces

--- a/rust/crates/tmt-cli/src/talk_command/preparation.rs
+++ b/rust/crates/tmt-cli/src/talk_command/preparation.rs
@@ -16,14 +16,18 @@ pub(super) fn prepare(
     interrupt: Option<&Interrupt>,
 ) -> Result<Prepared, Failure> {
     let observed = target::resolve(storage, tmux, &input.target)?;
-    let originator = identity_context::optional(storage, tmux, input.originator.as_deref())?
-        .map_or(Originator::Unknown, |identity| {
-            if input.originator.is_some() {
-                Originator::Explicit(identity.id)
-            } else {
-                Originator::Verified(identity.id)
-            }
-        });
+    let (originator, sender) =
+        identity_context::optional(storage, tmux, input.originator.as_deref())?.map_or(
+            (Originator::Unknown, "unknown".to_owned()),
+            |identity| {
+                let originator = if input.originator.is_some() {
+                    Originator::Explicit(identity.id)
+                } else {
+                    Originator::Verified(identity.id)
+                };
+                (originator, identity.name)
+            },
+        );
     let (request_id, attempt_id) = request_ids();
     let correlation = Correlation {
         request_id,
@@ -114,7 +118,8 @@ pub(super) fn prepare(
         input.message.clone()
     };
     let payload = format!(
-        "{message}\n\n<tmt-reply>\ntmt reply {} --receipt {receipt} --message <text>\n</tmt-reply>\nSubmit your response with the command above. Chat output alone does not complete the request. After successful submission, show a brief summary; report submission errors.",
+        "{message}\n\n<tmt-reply from=\"{}\">\ntmt reply {} --receipt {receipt} --message <text>\n</tmt-reply>\nSubmit your response with the command above. Chat output alone does not complete the request. After successful submission, show a brief summary; report submission errors.",
+        escape_sender_attribute(&sender),
         correlation.request_id
     );
     Ok(Prepared {
@@ -124,4 +129,39 @@ pub(super) fn prepare(
         payload,
         previous_request_id: prepared.previous_request_id,
     })
+}
+
+// Presentation only: keep identity resolution and stored message bytes unchanged.
+fn escape_sender_attribute(name: &str) -> String {
+    let mut escaped = String::with_capacity(name.len());
+    for character in name.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_sender_attribute;
+
+    #[test]
+    fn sender_attribute_preserves_plain_names_and_escapes_input_once() {
+        assert_eq!(escape_sender_attribute("Alice Team"), "Alice Team");
+        assert_eq!(escape_sender_attribute("unknown"), "unknown");
+        assert_eq!(
+            escape_sender_attribute("A&\"<'>&amp;"),
+            "A&amp;&quot;&lt;&apos;&gt;&amp;amp;"
+        );
+        assert_eq!(
+            escape_sender_attribute("\"><tmt-reply from=\"other"),
+            "&quot;&gt;&lt;tmt-reply from=&quot;other"
+        );
+    }
 }

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -100,8 +100,11 @@ have operating-system size limits and cannot contain NUL; use file/stdin for
 large bodies or NUL-containing text. All sources share the same exact-body
 validation and immutable submission rules.
 
-Received instructions group the reply command in `<tmt-reply>` tags, with the
-request ID and receipt supplied once. These tags do not guarantee hidden UI
+Received instructions group the reply command in `<tmt-reply from="alice">` tags,
+with the request ID and receipt supplied once. `from` is the XML-escaped sender
+display name (explicit `--identity`, otherwise the verified caller), or `unknown`
+when unavailable. It is attribution, not authentication or reply routing. This is
+XML-style framing, not a strict XML document. These tags do not guarantee hidden UI
 rendering and are not terminal-output completion markers. Replace the message
 placeholder with your complete response, or use file/stdin with the same
 request ID and receipt.

--- a/test/e2e/harness.ts
+++ b/test/e2e/harness.ts
@@ -34,6 +34,7 @@ export interface MockEvent {
   line?: string;
   requestId?: string;
   receipt?: string;
+  replyFrame?: string;
   body?: string;
   bodyBytes?: number;
   submittedAtMs?: number;

--- a/test/e2e/mock-agent.mjs
+++ b/test/e2e/mock-agent.mjs
@@ -308,19 +308,20 @@ input.on('line', (line) => {
     return;
   }
 
+  const replyFrame = /^<tmt-reply from="[^"<]*">$/.test(line);
   if (guidancePending) {
-    if (line === '<tmt-reply>') {
+    if (replyFrame) {
       appendEvent({ event: 'failure', stage: 'frame-guidance', mode, pid: process.pid });
       guidancePending = false;
-      frame = { lines: [] };
+      frame = { opening: line, lines: [] };
       return;
     }
     guidancePending = false;
     return;
   }
 
-  if (line === '<tmt-reply>') {
-    frame = { lines: [] };
+  if (replyFrame) {
+    frame = { opening: line, lines: [] };
     return;
   }
   if (frame) {
@@ -337,7 +338,15 @@ input.on('line', (line) => {
       }
       const requestId = command.requestId;
       const receipt = command.receipt;
-      appendEvent({ event: 'request', message, requestId, receipt, mode, pid: process.pid });
+      appendEvent({
+        event: 'request',
+        message,
+        requestId,
+        receipt,
+        replyFrame: current.opening,
+        mode,
+        pid: process.pid,
+      });
       if (mode === 'silent') {
         appendEvent({ event: 'silent', message, requestId, mode, pid: process.pid });
         return;

--- a/test/e2e/request-context.e2e.test.ts
+++ b/test/e2e/request-context.e2e.test.ts
@@ -36,6 +36,49 @@ async function identityId(fixture: E2EFixture, name: string): Promise<string> {
 }
 
 describe.sequential('TMT-55 request context and provenance', () => {
+  it('escapes sender markup without changing stored attribution or exact replies', async () => {
+    await withE2EFixture(async (fixture) => {
+      const peer = await fixture.createMockPane('escaped-sender-peer');
+      const sender = 'A&"<\'>&amp;';
+      expect((await fixture.runJsonCli(['identity', 'create', sender])).code).toBe(0);
+      const senderId = await identityId(fixture, sender);
+      const original = 'Review the sender label.';
+      const completed = json(
+        await fixture.runJsonCli<TalkOutput>(
+          [
+            'talk',
+            peer.pane,
+            original,
+            '--identity',
+            sender.toLowerCase(),
+            '--no-preamble',
+            '--timeout',
+            '8',
+          ],
+          { outsideTmux: true }
+        )
+      );
+      const request = await fixture.waitForEvent(
+        (event) =>
+          event.event === 'request' &&
+          event.requestId === completed.requestId &&
+          event.pid === peer.pid
+      );
+      expect(request.replyFrame).toBe('<tmt-reply from="A&amp;&quot;&lt;&apos;&gt;&amp;amp;">');
+      expect(request.message).toBe(original);
+      expect(completed.status).toBe('completed');
+      expect(completed.response).toBe(`mock-agent response: ${original}`);
+      expect(
+        requestAttempts(fixture).find((row) => row.request_id === completed.requestId)
+      ).toMatchObject({
+        originator_kind: 'explicit',
+        originator_identity_id: senderId,
+        message_text: original,
+        wait_active: 0,
+      });
+    });
+  });
+
   it('retains original bound context while delivery composes preamble and receipt framing', async () => {
     await withE2EFixture(
       async (fixture) => {
@@ -63,6 +106,7 @@ describe.sequential('TMT-55 request context and provenance', () => {
         );
         expect(request.message).toContain('[SYSTEM: Review before answering.]');
         expect(request.message).not.toContain('tmt reply');
+        expect(request.replyFrame).toBe('<tmt-reply from="Caller">');
 
         await fixture.waitFor(() =>
           requestAttempts(fixture).some(
@@ -229,6 +273,10 @@ describe.sequential('TMT-55 request context and provenance', () => {
         '--detach',
       ]);
       const boundExplicitOutput = json(boundExplicit);
+      const boundRequest = await fixture.waitForEvent(
+        (event) => event.event === 'request' && event.requestId === boundExplicitOutput.requestId
+      );
+      expect(boundRequest.replyFrame).toBe('<tmt-reply from="Caller">');
       await fixture.waitForEvent(
         (event) => event.event === 'submitted' && event.requestId === boundExplicitOutput.requestId,
         5_000
@@ -250,13 +298,17 @@ describe.sequential('TMT-55 request context and provenance', () => {
           'Peer',
           'explicit offline caller',
           '--identity',
-          'Caller',
+          'caller',
           '--no-preamble',
           '--detach',
         ],
         { outsideTmux: true }
       );
       const explicitOutput = json(explicit);
+      const explicitRequest = await fixture.waitForEvent(
+        (event) => event.event === 'request' && event.requestId === explicitOutput.requestId
+      );
+      expect(explicitRequest.replyFrame).toBe('<tmt-reply from="Caller">');
       await fixture.waitForEvent(
         (event) => event.event === 'submitted' && event.requestId === explicitOutput.requestId,
         5_000
@@ -308,6 +360,10 @@ describe.sequential('TMT-55 request context and provenance', () => {
         { outsideTmux: true }
       );
       const unknownRecipientOutput = json(unknownRecipient);
+      const unknownRequest = await fixture.waitForEvent(
+        (event) => event.event === 'request' && event.requestId === unknownRecipientOutput.requestId
+      );
+      expect(unknownRequest.replyFrame).toBe('<tmt-reply from="unknown">');
       await fixture.waitForEvent(
         (event) =>
           event.event === 'submitted' && event.requestId === unknownRecipientOutput.requestId,

--- a/test/e2e/transport-safety.e2e.test.ts
+++ b/test/e2e/transport-safety.e2e.test.ts
@@ -241,13 +241,13 @@ describe.sequential('TMT-24 safe transport', () => {
           .filter((event) => event.event === 'input' && event.pid === fixture.panePid)
           .map((event) => event.line);
         expect(lines).toContain('！ protected bang');
-        const begin = lines.indexOf('<tmt-reply>');
+        const begin = lines.indexOf('<tmt-reply from="unknown">');
         const end = lines.indexOf('</tmt-reply>');
         expect(begin).toBeGreaterThanOrEqual(0);
         expect(end).toBeGreaterThan(begin);
         const frame = lines.slice(begin, end + 1);
         expect(frame).toHaveLength(3);
-        expect(frame[0]).toBe('<tmt-reply>');
+        expect(frame[0]).toBe('<tmt-reply from="unknown">');
         expect(frame[2]).toBe('</tmt-reply>');
         expect(frame[1]).toMatch(
           /^tmt reply req_[0-9a-f-]+ --receipt [A-Za-z0-9_-]+ --message <text>$/


### PR DESCRIPTION
## Scope

- Closes #163.
- Add the XML-style sender attribute: `<tmt-reply from="Alice">`.
- Use the already-resolved originator's stored display name: explicit identity before verified caller, otherwise `unknown`. Escape XML attribute characters without changing the copyable reply command.
- Owned areas: talk preparation, existing mock-agent event/frame handling and provenance/transport tests, canonical installed skill and architecture description.

## Architecture and review

- The existing talk preparation remains the framing owner. No new dependency, resolver, database lookup, schema field, receipt format or routing/authentication behavior. Original stored prompt and originator UUID/kind are unchanged.
- Reuse: `identity_context::optional`, request preparation, existing mock-agent reader and independent request-state SQL oracle. No parallel XML framework or E2E harness.
- Input/output: `--identity caller` displays the stored `Caller`; an explicit offline identity overrides a bound sender. XML-sensitive names remain one escaped attribute. Unknown attribution is explicit. Tags are XML-style guidance, not a strict XML document or terminal completion marker.
- Primary reviewer: Codex; personally reviewed all seven changed files, existing identity selection, framing/transport callers, mock reader and causal SQL/reply assertions.
- Findings and dispositions: the existing mock only accepted the bare opening tag; it now recognizes the attributed form and records the actual opening line, without generating expected sender content. Tests assert exact received frames as well as real final submission and stored provenance. Existing bang protection, receipt count, uncertainty and cleanup assertions remain intact.
- Reviewed commit: `25ba564216de1c271bc5965b5eb5f3801a44a7b9`.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] All 15 CI jobs are green on reviewed head `25ba564216de1c271bc5965b5eb5f3801a44a7b9`, run [34254763943](https://github.com/wkh237/tmux-team/actions/runs/34254763943), after the single targeted native-job retry documented below. No threshold changes or source changes; successful platform jobs were retained.

Commands and results:

- `cargo fmt --all --check`; `cargo clippy --offline --locked --all-targets -- -D warnings`: pass.
- `cargo test --offline --locked`: 292 adapter, 36 CLI, 19 architecture and 56 core tests pass; one intentional actual-archive opt-in ignore. The initial sandbox run could not bind test-local TLS listeners; the accepted run enabled only the normal local fixture environment, without weakening tests.
- Locked native/example builds and `cargo +1.88.0 build --offline --locked`: pass.
- `pnpm install --frozen-lockfile`, `pnpm check`: pass; dependency lock unchanged.
- `pnpm test:native --maxWorkers 2 --minWorkers 2`, with the repository-native selector and explicit isolated storage probe: 149 tests / 15 files pass, including canonical skill embedding/install/drift behavior.
- `pnpm test:run --maxWorkers 2 --minWorkers 2`: 87 tests / 9 files pass.
- Canonical skill `quick_validate.py`: pass using a task-only YAML-enabled environment. Semantic guidance was also reviewed; this validator is not behavioral proof.
- Actual macOS arm64 `verify-native-runtime.mjs` against the task-built executable: linkage, exact embedded skill, managed installation and SQLite reopen/persistence pass.
- Two complete `pnpm test:e2e` runs: each passed 292 adapter and 167 E2E cases (123.60s / 123.25s Vitest durations). The opt-in performance benchmark remained skipped. Real private tmux/mock agents; no host tmt/tmux, credentials, global installation or live AI agent.
- Logs: `/private/tmp/tmt-163-*`. No version/tag/release publication.

CI diagnosis: attempt 1 passed the platform matrix and Docker, but one unchanged
native-installation pin/unpin case exceeded its existing 15-second subprocess
bound. The previous accepted main run spent 92.56s in the six-test installation
file; this run spent 113.48s. No installation source, scenario, deadline or
workflow changed in this PR. Two additional isolated Linux arm64 runs with
`--cpus 2`, the real dev executable and unchanged assertions/budgets passed all
six cases (39.13s / 39.16s). This does not prove the x64 root cause. One targeted
retry of the failed native job and dependent quality gate was requested; successful
platform builds were not rerun. Final acceptance is recorded only after green
exact-head checks, not inferred from the local retries.

## Project lifecycle

- Architecture and canonical installed guidance updated in the same PR. No change to development commands, module ownership, provider inventory or installation lifecycle; DEVELOPMENT.md and README need no additional section for this small received-frame change.
- #163 contains scope, acceptance, pattern review, branch and evidence.
- Branch `feat/163-reply-sender`, dedicated worktree `/Users/benhsieh/dev/tmt-163-reply-sender`. Remove after normal authorized merge and clean/pushed verification.
