### PR TITLE
fix: align human CLI tables and consolidate presentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,6 +58,14 @@ The grammar owns option placement and rejection. Handlers do not search raw
 argv, create competing option parsers, or reinterpret payload text as flags.
 JSON and human output use the same typed result and status contracts.
 
+`output::table` is the single plain human-table renderer for binding, identity,
+exchange and configuration reports. Callers own columns and typed projections;
+the renderer owns control-character escaping, Unicode display-width measurement
+and spacing. The CLI-only `unicode-width` dependency does not enter domain or
+adapter policy. Tables preserve complete values without terminal probing,
+truncation or color; narrow terminals may wrap. JSON and exact prompt, final,
+profile and diagnostic bodies bypass table rendering.
+
 ## Domain and state ownership
 
 ### Identity, names and bindings

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -52,6 +52,11 @@ tmt list reviewer
 tmt whoami
 ```
 
+Human tables align columns using Unicode display widths and show complete values.
+Long rows may wrap in narrow terminals. Control characters in table metadata are
+shown as escapes, not executed. Use `--json` for scripts and exact metadata;
+human spacing is presentation, not a machine-readable format.
+
 `name` and `whoami` need a live caller pane. `add` accepts `%pane_id`,
 `window.pane`, or `session:window.pane`; the current order is pane target first,
 global name second. `tmt unbind` retires a temporary identity; a saved identity
@@ -183,13 +188,13 @@ tmt config set preambleEvery 3
 tmt config set exchange.retentionDays 90 --global
 ```
 
-| Setting | Default | Scope |
-| --- | --- | --- |
-| `preambleMode` | `always` | Local override or `--global`; `always` / `disabled` |
-| `preambleEvery` | `3` | Local override or `--global`; `0` disables injection |
-| `pasteEnterDelayMs` | `500` | Local override or `--global`; `0` removes the delay |
-| `exchange.retentionDays` | `90` | Global only; new requests, integer days `1..3650` |
-| `ui.paneBadge` | `off` | Global only; `on` / `off` |
+| Setting                  | Default  | Scope                                                |
+| ------------------------ | -------- | ---------------------------------------------------- |
+| `preambleMode`           | `always` | Local override or `--global`; `always` / `disabled`  |
+| `preambleEvery`          | `3`      | Local override or `--global`; `0` disables injection |
+| `pasteEnterDelayMs`      | `500`    | Local override or `--global`; `0` removes the delay  |
+| `exchange.retentionDays` | `90`     | Global only; new requests, integer days `1..3650`    |
+| `ui.paneBadge`           | `off`    | Global only; `on` / `off`                            |
 
 `config show --json` reports resolved values, sources, and actual file paths.
 Global settings normally live in `~/.config/tmux-team/config.json`; local

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
  "syn 2.0.119",
  "tmt-adapters",
  "tmt-core",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1278,6 +1279,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 repository = "https://github.com/wkh237/tmux-team"
 
 [workspace.dependencies]
+unicode-width = { version = "=0.2.2", default-features = false }
 ureq = { version = "=3.4.0", default-features = false, features = ["rustls", "platform-verifier"] }
 rustls = { version = "=0.23.44", default-features = false, features = ["std", "ring", "tls12"] }
 rcgen = { version = "=0.14.10", default-features = false, features = ["crypto", "ring"] }

--- a/rust/crates/tmt-cli/Cargo.toml
+++ b/rust/crates/tmt-cli/Cargo.toml
@@ -20,6 +20,7 @@ tmt-adapters.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 serde_json.workspace = true
+unicode-width.workspace = true
 
 [dev-dependencies]
 syn = { version = "=2.0.119", default-features = false, features = ["full", "parsing", "visit"] }

--- a/rust/crates/tmt-cli/src/binding_command/presentation.rs
+++ b/rust/crates/tmt-cli/src/binding_command/presentation.rs
@@ -1,7 +1,7 @@
 //! Public projections deliberately omit binding markers and process evidence.
 
 use super::Report;
-use crate::output::identity_document;
+use crate::output::{identity_document, table};
 use serde_json::{Value, json};
 use std::io::{self, Write};
 use tmt_core::{binding::IdentityPresence, endpoint::PaneObservation, identity::Identity};
@@ -73,23 +73,21 @@ pub(super) fn document(report: &Report) -> Value {
     }
 }
 
-fn identity_row(
-    output: &mut impl Write,
-    identity: &Identity,
-    status: &str,
-    pane: Option<&PaneObservation>,
-) -> io::Result<()> {
-    writeln!(
-        output,
-        "{}\t{}\t{}\t{}\t{}\t{}\t{}",
-        identity.name,
+const HEADERS: [&str; 7] = [
+    "NAME", "LIFETIME", "STATUS", "PANE", "TARGET", "CWD", "COMMAND",
+];
+
+fn identity_row(identity: &Identity, status: &str, pane: Option<&PaneObservation>) -> [String; 7] {
+    [
+        identity.name.as_str(),
         identity.lifetime.as_str(),
         status,
         pane.map_or("-", |pane| pane.id.as_str()),
         pane.and_then(|pane| pane.target.as_deref()).unwrap_or("-"),
         pane.and_then(|pane| pane.cwd.as_deref()).unwrap_or("-"),
-        pane.map_or("", |pane| pane.command.as_str())
-    )
+        pane.map_or("", |pane| pane.command.as_str()),
+    ]
+    .map(str::to_owned)
 }
 
 pub(super) fn text(output: &mut impl Write, report: &Report) -> io::Result<()> {
@@ -130,27 +128,21 @@ pub(super) fn text(output: &mut impl Write, report: &Report) -> io::Result<()> {
             entry.identity.name
         ),
         Report::Listed(rows) if rows.is_empty() => writeln!(output, "No identities found."),
-        Report::Listed(rows) => {
-            writeln!(output, "NAME\tLIFETIME\tSTATUS\tPANE\tTARGET\tCWD\tCOMMAND")?;
-            for row in rows {
-                identity_row(
-                    output,
-                    &row.identity,
-                    row.presence.as_str(),
-                    row.pane.as_ref(),
-                )?;
-            }
-            Ok(())
-        }
-        Report::Named { row, .. } => {
-            writeln!(output, "NAME\tLIFETIME\tSTATUS\tPANE\tTARGET\tCWD\tCOMMAND")?;
-            identity_row(
-                output,
+        Report::Listed(rows) => table::write(
+            output,
+            HEADERS,
+            rows.iter()
+                .map(|row| identity_row(&row.identity, row.presence.as_str(), row.pane.as_ref())),
+        ),
+        Report::Named { row, .. } => table::write(
+            output,
+            HEADERS,
+            [identity_row(
                 &row.identity,
                 row.presence.as_str(),
                 row.pane.as_ref(),
-            )
-        }
+            )],
+        ),
         Report::Pane { pane, identity, .. } => {
             writeln!(
                 output,
@@ -160,8 +152,11 @@ pub(super) fn text(output: &mut impl Write, report: &Report) -> io::Result<()> {
                 pane.command
             )?;
             if let Some(identity) = identity {
-                writeln!(output, "NAME\tLIFETIME\tSTATUS\tPANE\tTARGET\tCWD\tCOMMAND")?;
-                identity_row(output, identity, "active", Some(pane))
+                table::write(
+                    output,
+                    HEADERS,
+                    [identity_row(identity, "active", Some(pane))],
+                )
             } else {
                 writeln!(output, "Pane has no active global identity.")
             }

--- a/rust/crates/tmt-cli/src/config_command.rs
+++ b/rust/crates/tmt-cli/src/config_command.rs
@@ -157,34 +157,13 @@ fn show_text(
             loaded.source(SettingKey::PaneBadge),
         ),
     ];
-    let key_width = rows.iter().map(|row| row.0.len()).max().unwrap_or(3).max(3);
-    let value_width = rows.iter().map(|row| row.1.len()).max().unwrap_or(5).max(5);
-    let source_width = rows
-        .iter()
-        .map(|row| row.2.len() + 2)
-        .max()
-        .unwrap_or(6)
-        .max(6);
     writeln!(output, "ℹ Current configuration:\n")?;
-    writeln!(
+    crate::output::table::write(
         output,
-        "  {:key_width$} {:value_width$} {:source_width$}",
-        "Key", "Value", "Source"
+        ["Key", "Value", "Source"],
+        rows.into_iter()
+            .map(|(key, value, source)| [key.to_owned(), value, format!("({source})")]),
     )?;
-    writeln!(
-        output,
-        "  {} {} {}",
-        "─".repeat(key_width),
-        "─".repeat(value_width),
-        "─".repeat(source_width)
-    )?;
-    for (key, value, source) in rows {
-        writeln!(
-            output,
-            "  {key:key_width$} {value:value_width$} {:source_width$}",
-            format!("({source})")
-        )?;
-    }
     writeln!(output, "ℹ \nPaths:")?;
     writeln!(output, "ℹ   Global: {}", paths.global_config.display())?;
     writeln!(output, "ℹ   Local:  {}", paths.local_config.display())

--- a/rust/crates/tmt-cli/src/exchange_command/presentation.rs
+++ b/rust/crates/tmt-cli/src/exchange_command/presentation.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::output::identity_document;
+use crate::output::{identity_document, table};
 use serde_json::{Value, json};
 use std::io::Write;
 use tmt_core::request::{
@@ -111,18 +111,22 @@ pub(super) fn publish(report: Report, mode: OutputMode) -> io::Result<u8> {
                 if page.items.is_empty() {
                     writeln!(stdout, "No unacknowledged exchanges.")?;
                 } else {
-                    writeln!(stdout, "REQUEST\tRECIPIENT\tDELIVERY\tFINAL\tREVISION")?;
-                    for item in &page.items {
-                        writeln!(
-                            stdout,
-                            "{}\t{}\t{}\t{}\t{}",
-                            item.request_id,
-                            item.recipient_identity_id.as_deref().unwrap_or("-"),
-                            item.delivery.as_str(),
-                            item.final_state.as_str(),
-                            item.revision
-                        )?;
-                    }
+                    table::write(
+                        &mut stdout,
+                        ["REQUEST", "RECIPIENT", "DELIVERY", "FINAL", "REVISION"],
+                        page.items.iter().map(|item| {
+                            [
+                                item.request_id.clone(),
+                                item.recipient_identity_id
+                                    .as_deref()
+                                    .unwrap_or("-")
+                                    .to_owned(),
+                                item.delivery.as_str().to_owned(),
+                                item.final_state.as_str().to_owned(),
+                                item.revision.to_string(),
+                            ]
+                        }),
+                    )?;
                 }
                 if let Some(after) = page.next_after {
                     writeln!(
@@ -133,19 +137,24 @@ pub(super) fn publish(report: Report, mode: OutputMode) -> io::Result<u8> {
             }
             ResultKind::Show(detail) => {
                 let item = &detail.exchange;
-                writeln!(
-                    stdout,
-                    "REQUEST\tDELIVERY\tFINAL\tREVISION\tACKNOWLEDGED\tSETTLED"
-                )?;
-                writeln!(
-                    stdout,
-                    "{}\t{}\t{}\t{}\t{}\t{}",
-                    item.request_id,
-                    item.delivery.as_str(),
-                    item.final_state.as_str(),
-                    item.revision,
-                    item.acknowledged,
-                    item.settled
+                table::write(
+                    &mut stdout,
+                    [
+                        "REQUEST",
+                        "DELIVERY",
+                        "FINAL",
+                        "REVISION",
+                        "ACKNOWLEDGED",
+                        "SETTLED",
+                    ],
+                    [[
+                        item.request_id.clone(),
+                        item.delivery.as_str().to_owned(),
+                        item.final_state.as_str().to_owned(),
+                        item.revision.to_string(),
+                        item.acknowledged.to_string(),
+                        item.settled.to_string(),
+                    ]],
                 )?;
                 writeln!(stdout, "Prompt ({}):", prompt_status(&detail.prompt))?;
                 if let RequestPrompt::Retained(prompt) = &detail.prompt {

--- a/rust/crates/tmt-cli/src/identity_command.rs
+++ b/rust/crates/tmt-cli/src/identity_command.rs
@@ -105,30 +105,32 @@ pub fn execute(request: IdentityRequest, mode: OutputMode) -> io::Result<u8> {
                 )?;
             }
             Report::Shown(identity) => {
-                writeln!(stdout, "NAME\tLIFETIME\tCANONICAL NAME\tID")?;
-                writeln!(
-                    stdout,
-                    "{}\t{}\t{}\t{}",
-                    identity.name,
-                    identity.lifetime.as_str(),
-                    identity.canonical_name,
-                    identity.id
+                crate::output::table::write(
+                    &mut stdout,
+                    ["NAME", "LIFETIME", "CANONICAL NAME", "ID"],
+                    [[
+                        identity.name,
+                        identity.lifetime.as_str().to_owned(),
+                        identity.canonical_name,
+                        identity.id,
+                    ]],
                 )?;
             }
             Report::Listed(identities) if identities.is_empty() => {
                 writeln!(stdout, "No identities found.")?
             }
             Report::Listed(identities) => {
-                writeln!(stdout, "NAME\tLIFETIME\tID")?;
-                for identity in identities {
-                    writeln!(
-                        stdout,
-                        "{}\t{}\t{}",
-                        identity.name,
-                        identity.lifetime.as_str(),
-                        identity.id
-                    )?;
-                }
+                crate::output::table::write(
+                    &mut stdout,
+                    ["NAME", "LIFETIME", "ID"],
+                    identities.into_iter().map(|identity| {
+                        [
+                            identity.name,
+                            identity.lifetime.as_str().to_owned(),
+                            identity.id,
+                        ]
+                    }),
+                )?;
             }
         }
     }

--- a/rust/crates/tmt-cli/src/output.rs
+++ b/rust/crates/tmt-cli/src/output.rs
@@ -1,5 +1,7 @@
 //! Shared failure presentation and close-before-publication ordering.
 
+pub(crate) mod table;
+
 use crate::invocation::OutputMode;
 use std::{
     error::Error,

--- a/rust/crates/tmt-cli/src/output/table.rs
+++ b/rust/crates/tmt-cli/src/output/table.rs
@@ -1,0 +1,52 @@
+//! Plain human tables only; structured output and exact bodies bypass this owner.
+
+use std::io::{self, Write};
+use unicode_width::UnicodeWidthStr;
+
+fn cell(value: &str) -> String {
+    let mut rendered = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch.is_control() || matches!(ch, '\u{2028}' | '\u{2029}') {
+            rendered.extend(ch.escape_default());
+        } else {
+            rendered.push(ch);
+        }
+    }
+    rendered
+}
+
+/// Preserve full values and align by displayed columns, not bytes or tab stops.
+/// Const-sized rows prevent silently missing or extra cells at call sites.
+pub(crate) fn write<const N: usize>(
+    output: &mut impl Write,
+    headers: [&str; N],
+    rows: impl IntoIterator<Item = [String; N]>,
+) -> io::Result<()> {
+    let rows: Vec<_> = std::iter::once(headers.map(str::to_owned))
+        .chain(rows)
+        .map(|row| row.map(|value| cell(&value)))
+        .collect();
+    let widths: [usize; N] =
+        std::array::from_fn(|index| rows.iter().map(|row| row[index].width()).max().unwrap_or(0));
+    for row in rows {
+        // Empty final cells must not leave trailing padding on a line.
+        let end = row.iter().rposition(|value| !value.is_empty());
+        if let Some(end) = end {
+            for index in 0..=end {
+                write!(output, "{}", row[index])?;
+                if index < end {
+                    write!(
+                        output,
+                        "{}",
+                        " ".repeat(widths[index] - row[index].width() + 2)
+                    )?;
+                }
+            }
+        }
+        writeln!(output)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-cli/src/output/table/tests.rs
+++ b/rust/crates/tmt-cli/src/output/table/tests.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+fn render<const N: usize>(headers: [&str; N], rows: Vec<[&str; N]>) -> String {
+    let mut output = Vec::new();
+    write(
+        &mut output,
+        headers,
+        rows.into_iter().map(|row| row.map(str::to_owned)),
+    )
+    .unwrap();
+    String::from_utf8(output).unwrap()
+}
+
+#[test]
+fn aligns_long_ascii_values_without_truncation() {
+    assert_eq!(
+        render(
+            ["NAME", "STATE"],
+            vec![["a", "offline"], ["long-agent-name", "active"]]
+        ),
+        "NAME             STATE\na                offline\nlong-agent-name  active\n"
+    );
+}
+
+#[test]
+fn measures_wide_combining_and_emoji_sequences_as_display_columns() {
+    // Non-English fixture characters exercise terminal width, not translated UI.
+    assert_eq!(
+        render(
+            ["NAME", "STATE"],
+            vec![["測試", "wide"], ["e\u{301}", "combining"], ["👩‍💻", "emoji"]]
+        ),
+        "NAME  STATE\n測試  wide\ne\u{301}     combining\n👩‍💻    emoji\n"
+    );
+}
+
+#[test]
+fn escapes_controls_before_measuring_and_preserves_literal_backslashes() {
+    assert_eq!(
+        render(
+            ["KEY", "VALUE"],
+            vec![
+                ["a\tb", "\u{1b}[31m\n\r\0\u{7f}\u{85}\u{2028}"],
+                ["x", r"\n"]
+            ]
+        ),
+        "KEY   VALUE\na\\tb  \\u{1b}[31m\\n\\r\\u{0}\\u{7f}\\u{85}\\u{2028}\nx     \\n\n"
+    );
+}
+
+#[test]
+fn retains_empty_middle_cells_without_trailing_padding() {
+    assert_eq!(
+        render(
+            ["A", "B", "C"],
+            vec![["x", "", "z"], ["y", "", ""], ["", "", ""]]
+        ),
+        "A  B  C\nx     z\ny\n\n"
+    );
+    assert_eq!(render(["A", "B"], vec![]), "A  B\n");
+}
+
+#[test]
+fn propagates_output_errors() {
+    struct Broken;
+    impl Write for Broken {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::ErrorKind::BrokenPipe.into())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    assert_eq!(
+        write(&mut Broken, ["NAME"], Vec::<[String; 1]>::new())
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::BrokenPipe
+    );
+}

--- a/rust/crates/tmt-cli/tests/architecture/cases.rs
+++ b/rust/crates/tmt-cli/tests/architecture/cases.rs
@@ -447,6 +447,20 @@ fn receipt_dependencies_stay_at_their_reviewed_layer() {
     }
 }
 
+#[test]
+fn display_width_dependency_stays_in_cli_presentation() {
+    for (owner, expected) in [("tmt-cli", 0), ("tmt-core", 1), ("tmt-adapters", 1)] {
+        assert_eq!(
+            policy::dependency_violations(&package(
+                owner,
+                vec![dependency("unicode-width", "normal", None, None)]
+            ))
+            .len(),
+            expected
+        );
+    }
+}
+
 struct FixtureDirectory {
     path: PathBuf,
 }

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -37,6 +37,7 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
             "sha2",
         ],
         "tmt-cli" => &[
+            "unicode-width",
             "tmt-core",
             "tmt-adapters",
             "clap",

--- a/test/e2e/native-identity.e2e.test.ts
+++ b/test/e2e/native-identity.e2e.test.ts
@@ -42,6 +42,56 @@ function success<T>(result: CliResult<T>): T {
 }
 
 describe.sequential('native identity CLI lifecycle', () => {
+  it('aligns human list columns for live Unicode identities and long pane paths without changing JSON', async () => {
+    await withE2EFixture(async (fixture) => {
+      // Fullwidth fixture data exposes byte/character-count padding bugs.
+      const wideName = 'Ａｌｉｃｅ';
+      const longName = 'long-reviewer-agent';
+      const workspace = fixture.createWorkspace('long-repository-folder-for-column-alignment');
+      const peer = await fixture.createMockPane('table-peer', workspace);
+      const wide = success(await fixture.runJsonCli<Bound>(['name', wideName]));
+      const long = success(await fixture.runJsonCli<Bound>(['add', peer.pane, longName]));
+      const before = success(await fixture.runJsonCli<Listing>(['ls']));
+      expect(before.identities).toEqual([
+        expect.objectContaining({
+          id: wide.id,
+          name: wideName,
+          cwd: fixture.workspace,
+          pane: fixture.pane,
+        }),
+        expect.objectContaining({ id: long.id, name: longName, cwd: workspace, pane: peer.pane }),
+      ]);
+      const human = await fixture.runCli(['ls']);
+      expect(human.code, human.stderr).toBe(0);
+      expect(human.stderr).toBe('');
+      expect(human.stdout).not.toContain('\t');
+      const lines = human.stdout.trimEnd().split('\n');
+      expect(lines).toHaveLength(3);
+      const header = lines[0]!;
+      const starts = ['LIFETIME', 'STATUS', 'PANE', 'TARGET', 'CWD', 'COMMAND'].map((label) =>
+        header.indexOf(label)
+      );
+      for (const [index, row] of before.identities.entries()) {
+        const line = lines[index + 1]!;
+        expect(line.startsWith(row.name)).toBe(true);
+        // This known five-fullwidth-character name occupies ten columns.
+        // Substitution is an independent fixture oracle, not a second renderer.
+        const columns = line.replace(wideName, '1234567890');
+        const values = [row.lifetime, row.presence, row.pane!, row.target!, row.cwd!, row.command];
+        for (const [column, value] of values.entries()) {
+          expect(columns.slice(starts[column], starts[column]! + value.length)).toBe(value);
+        }
+        expect(line).toBe(line.trimEnd());
+      }
+      expect(success(await fixture.runJsonCli<Listing>(['ls']))).toEqual(before);
+      expect(
+        durableState(fixture)
+          .bindings.map((row) => row.identity_id)
+          .sort()
+      ).toEqual([wide.id, long.id].sort());
+    }, options());
+  });
+
   it('coordinates a concurrent global observer with uncommitted publication and rechecks after lock acquisition', async () => {
     await withE2EFixture(async (fixture) => {
       fixture.enableMetadataBarrier({ phase: 'after' });

--- a/test/native/binding.test.ts
+++ b/test/native/binding.test.ts
@@ -180,9 +180,48 @@ describe('native identity binding process contract', () => {
       expect(human.status).toBe(0);
       expect(human.stderr).toBe('');
       expect(human.stdout).toBe(
-        'NAME\tLIFETIME\tSTATUS\tPANE\tTARGET\tCWD\tCOMMAND\n' +
-          'Offline Agent\tsaved\toffline\t-\t-\t-\t\n'
+        'NAME           LIFETIME  STATUS   PANE  TARGET  CWD  COMMAND\n' +
+          'Offline Agent  saved     offline  -     -       -\n'
       );
+    });
+  });
+
+  it('aligns Unicode and variable-length names in the human ls table', async () => {
+    await withSandbox(async (sandbox) => {
+      // Fullwidth and decomposed fixture names must retain their display bytes.
+      const names = ['A', 'ＡＢ', 'Longest identity name', 'e\u0301'];
+      const identities = new Map<string, Identity>();
+      for (const name of names) {
+        identities.set(
+          name,
+          documentIdentity(await runCli(sandbox, ['identity', 'create', name, '--json']))
+        );
+      }
+
+      const listed = await runCli(sandbox, ['ls']);
+      expect(listed.status).toBe(0);
+      expect(listed.stderr).toBe('');
+      expect(listed.stdout).toBe(
+        'NAME                   LIFETIME  STATUS   PANE  TARGET  CWD  COMMAND\n' +
+          `A                      saved     offline  -     -       -\n` +
+          `ＡＢ                   saved     offline  -     -       -\n` +
+          `Longest identity name  saved     offline  -     -       -\n` +
+          `é                      saved     offline  -     -       -\n`
+      );
+      const structured = await runCli(sandbox, ['ls', '--json']);
+      expect(structured.status).toBe(0);
+      expect(structured.stderr).toBe('');
+      expect(parseWholeStdout(structured)).toEqual({
+        identities: names.map((name, index) => ({
+          id: identities.get(name)!.id,
+          name,
+          canonicalName: ['a', 'ab', 'longest identity name', 'é'][index],
+          lifetime: 'saved',
+          presence: 'offline',
+          pane: null,
+          command: '',
+        })),
+      });
     });
   });
 

--- a/test/native/config.test.ts
+++ b/test/native/config.test.ts
@@ -29,6 +29,17 @@ describe('native configuration process boundary', () => {
       expect(result.status).toBe(0);
       expect(result.stderr).toBe('');
       expect(result.stdout).toContain('ℹ Current configuration:\n');
+      expect(result.stdout).toContain(
+        'Key                     Value     Source\n' +
+          'preambleMode            disabled  (global)\n' +
+          'preambleEvery           0         (local)\n' +
+          'pasteEnterDelayMs       500       (default)\n' +
+          'defaults.timeout        180       (global)\n' +
+          'defaults.pollInterval   1         (global)\n' +
+          'defaults.captureLines   100       (global)\n' +
+          'exchange.retentionDays  365       (global)\n' +
+          'ui.paneBadge            on        (global)\n'
+      );
       for (const [key, value, source] of [
         ['preambleMode', 'disabled', 'global'],
         ['preambleEvery', '0', 'local'],
@@ -40,7 +51,7 @@ describe('native configuration process boundary', () => {
         ['ui.paneBadge', 'on', 'global'],
       ]) {
         expect(result.stdout).toMatch(
-          new RegExp(`^  ${key.replace('.', '\\.')}\\s+${value}\\s+\\(${source}\\)[ \\t]*$`, 'm')
+          new RegExp(`^${key.replace('.', '\\.')}\\s+${value}\\s+\\(${source}\\)[ \\t]*$`, 'm')
         );
       }
       expect(result.stdout).toContain('ℹ \nPaths:\n');

--- a/test/native/exchange.test.ts
+++ b/test/native/exchange.test.ts
@@ -52,8 +52,8 @@ describe('native exchange attention process contract', () => {
       expect(listed.status).toBe(0);
       expect(listed.stderr).toBe('');
       expect(listed.stdout).toBe(
-        'REQUEST\tRECIPIENT\tDELIVERY\tFINAL\tREVISION\n' +
-          'human-exchange\t-\tsent\tnot_submitted\t1\n'
+        'REQUEST         RECIPIENT  DELIVERY  FINAL          REVISION\n' +
+          'human-exchange  -          sent      not_submitted  1\n'
       );
       expect(responseSnapshot(sandbox.database, seeded.requestId)).toEqual(before);
       const acknowledged = await runCli(sandbox, [
@@ -77,7 +77,7 @@ describe('native exchange attention process contract', () => {
       expect(empty.status).toBe(0);
       expect(empty.stdout).toBe('No unacknowledged exchanges.\n');
 
-      const body = '  final result\r\nsecond line  ';
+      const body = '  final\tresult\r\nsecond line \u001b[31mred\u001b[0m  ';
       const submitted = await runCli(sandbox, [
         'reply',
         seeded.requestId,
@@ -102,8 +102,8 @@ describe('native exchange attention process contract', () => {
       const shown = await runCli(sandbox, ['x', 'show', seeded.requestId, '--identity', 'Reader']);
       expect(shown.status).toBe(0);
       expect(shown.stdout).toBe(
-        'REQUEST\tDELIVERY\tFINAL\tREVISION\tACKNOWLEDGED\tSETTLED\n' +
-          'human-exchange\tsent\tretained\t2\tfalse\tfalse\n' +
+        'REQUEST         DELIVERY  FINAL     REVISION  ACKNOWLEDGED  SETTLED\n' +
+          'human-exchange  sent      retained  2         false         false\n' +
           `Prompt (retained):\nprompt for human-exchange\nFinal:\n${body}\n`
       );
       const all = await runCli(sandbox, ['x', 'ackall', '--identity', 'Reader']);

--- a/test/native/identity.test.ts
+++ b/test/native/identity.test.ts
@@ -467,8 +467,12 @@ describe('native durable identity process boundary', () => {
       expect(repeatedHuman.stderr).toBe('');
       const humanShow = await runCli(sandbox, ['identity', 'show', 'human']);
       expect(humanShow.status).toBe(0);
-      expect(humanShow.stdout).toContain('NAME\tLIFETIME\tCANONICAL NAME\tID');
-      expect(humanShow.stdout).toContain('Human\tsaved\thuman\t');
+      const shown = documentIdentity(
+        await runCli(sandbox, ['identity', 'show', 'human', '--json'])
+      );
+      expect(humanShow.stdout).toBe(
+        `NAME   LIFETIME  CANONICAL NAME  ID\n` + `Human  saved     human           ${shown.id}\n`
+      );
       expect(humanShow.stderr).toBe('');
       const missingHuman = await runCli(sandbox, ['identity', 'show', 'missing']);
       expect(missingHuman.status).toBe(3);
@@ -476,9 +480,44 @@ describe('native durable identity process boundary', () => {
       expect(missingHuman.stderr).toBe("Identity 'missing' was not found.\n");
       const humanList = await runCli(sandbox, ['identity', 'list']);
       expect(humanList.status).toBe(0);
-      expect(humanList.stdout).toContain('NAME\tLIFETIME\tID');
-      expect(humanList.stdout).toContain('Human\tsaved\t');
+      expect(humanList.stdout).toBe(`NAME   LIFETIME  ID\nHuman  saved     ${shown.id}\n`);
       expect(humanList.stderr).toBe('');
+    });
+  });
+
+  it('aligns Unicode and variable-length names in the human identity table', async () => {
+    await withSandbox(async (sandbox) => {
+      // Fullwidth and decomposed fixture names must retain their display bytes.
+      const names = ['A', 'ＡＢ', 'Longest identity name', 'e\u0301'];
+      const identities = new Map<string, Identity>();
+      for (const name of names) {
+        identities.set(
+          name,
+          documentIdentity(await runCli(sandbox, ['identity', 'create', name, '--json']))
+        );
+      }
+
+      const listed = await runCli(sandbox, ['identity', 'list']);
+      expect(listed.status).toBe(0);
+      expect(listed.stderr).toBe('');
+      expect(listed.stdout).toBe(
+        `NAME                   LIFETIME  ID\n` +
+          `A                      saved     ${identities.get('A')?.id}\n` +
+          `ＡＢ                   saved     ${identities.get('ＡＢ')?.id}\n` +
+          `Longest identity name  saved     ${identities.get('Longest identity name')?.id}\n` +
+          `é                      saved     ${identities.get('e\u0301')?.id}\n`
+      );
+      const structured = await runCli(sandbox, ['identity', 'list', '--json']);
+      expect(structured.status).toBe(0);
+      expect(structured.stderr).toBe('');
+      expect(parseWholeStdout(structured)).toEqual({
+        identities: names.map((name, index) => ({
+          id: identities.get(name)!.id,
+          name,
+          canonicalName: ['a', 'ab', 'longest identity name', 'é'][index],
+          lifetime: 'saved',
+        })),
+      });
     });
   });
 


### PR DESCRIPTION
## Scope

Closes #165.

- Replace tab-delimited human tables with one plain Unicode display-width-aware renderer used by binding list/detail, identity list/show, X list/show and config show.
- Preserve complete values, existing columns/order and empty states. Escape table control characters before measuring; no trailing padding, color, truncation or terminal probing. Config adopts the same plain style instead of maintaining a separate decorated padding implementation.
- Keep JSON, prompt/final/profile content, storage and tmux lifecycle unchanged.

## Architecture and review

- Owner: `tmt-cli::output::table`; const-sized rows keep column counts checked at compile time. Callers retain domain projections and table columns. No domain or adapter presentation dependency.
- Pinned `unicode-width` 0.2.2 without default features: no transitive dependencies, upstream MSRV 1.66, MIT/Apache-2.0. This avoids reimplementing Unicode widths without adding a styled-table/TTY framework. Workspace MSRV 1.88 passes; target-filtered cargo-about output includes its full MIT notice.
- Primary personally reviewed all 19 changed files, the four callers and their JSON/exact-body branches, existing output cleanup/identity projection owners, names normalization, SQL ordering, architecture policy and test setup/assertions.
- Existing `after_cleanup`, identity resolution and `RequestService` remain their SSOTs. Similar lifecycle operations are not interchangeable, so no generic command runner or speculative MCP façade was added.
- Audit finding: advertised verbose/debug options have no observable behavior; tracked separately in #166. Suspected parent JSON-placement problem was rejected after both real isolated invocations produced JSON.
- Reviewed commit: `09228cbe63e1d985666f97601c87730fd536412f`.

## Verification

- [x] Primary reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results recorded below.
- [x] CI checked on the current commit before authorized merge: all 15 checks passed on `09228cbe63e1d985666f97601c87730fd536412f`, run 34292121162, first attempt; no retries.

Local results (task-built native executables, isolated state, no host tmux/global installation):

- `cargo fmt --manifest-path rust/Cargo.toml --all --check`: passed.
- `cargo clippy --locked --manifest-path rust/Cargo.toml --all-targets -- -D warnings`: passed.
- `cargo test --locked --manifest-path rust/Cargo.toml`: 292 adapter, 41 CLI, 20 architecture, 56 core tests passed; one actual-release-archive fixture intentionally ignored, not claimed as release proof.
- `cargo build --locked --manifest-path rust/Cargo.toml`, `cargo build --locked --manifest-path rust/Cargo.toml --examples`, and `cargo +1.88.0 build --locked --manifest-path rust/Cargo.toml`: passed.
- `pnpm check`: passed (types, lint and formatting).
- `pnpm test:run --maxWorkers 2 --minWorkers 2`: 87 tests passed.
- `TMT_TEST_STORAGE_PROBE=<absolute repository storage-probe descriptor> pnpm test:native --maxWorkers 2 --minWorkers 2`: 151 tests passed.
- `pnpm test:e2e`: final complete Docker run passed, 292 adapter and 168 E2E cases; one opt-in performance case skipped. Real tmux and mock agents run under the existing network-isolated cleanup harness.
- `cargo-about generate --manifest-path crates/tmt-cli/Cargo.toml --config about.toml --target aarch64-apple-darwin --locked --offline --fail about.hbs --output-file /private/tmp/tmt-165-notices.txt`: passed; Unicode-width notice reviewed.
- `git diff --check`: passed.
- `node scripts/verify-native-runtime.mjs --executable /Users/benhsieh/dev/tmux-team/rust/target/debug/tmt --target aarch64-apple-darwin --version 5.0.0-alpha.2 --skill skills/tmux-team/SKILL.md`: passed with isolated HOME/PATH, system-only linkage, embedded skill, managed installation and SQLite persistence.

New tests independently specify ASCII/CJK/combining/emoji spacing, controls, missing cells and write failures; native tests verify original Unicode JSON values, and the exchange test preserves tab/CRLF/ESC-containing final bytes through SQLite and output. Private-tmux E2E verifies live names, pane targets, long working directories, JSON stability and binding UUIDs. No expected rows are generated using the production table renderer.

Local diagnosis before push: restored missing development `tar` using the frozen lockfile (no dependency-file drift); corrected the new E2E expectation to existing NFKC canonical ordering after inspecting names/SQL. No product sorting, assertions, timeouts or CI thresholds were weakened. One mistaken root Vitest invocation selected zero native files and is not counted as evidence; the proper native configuration passed. No remote CI retries have been used.

## Project lifecycle

- ARCHITECTURE and USER-GUIDE document the presentation owner and contract. Canonical installed skill remains accurate: command syntax/semantics and machine interfaces are unchanged, so no duplicated installation guidance was added.
- #165 holds scope/acceptance criteria; #166 records deferred CLI flag behavior. MCP remains paused and outside this PR.
- Work uses `fix/165-cli-tables` in the clean primary checkout, per the latest user instruction permitting single-stream feature branches without an extra worktree. No worktree to remove; no release/tag/global installation changes.
