### PR TITLE
fix: remove no-op verbose and debug flags

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,6 +57,9 @@ The maintained public surface is:
 The grammar owns option placement and rejection. Handlers do not search raw
 argv, create competing option parsers, or reinterpret payload text as flags.
 JSON and human output use the same typed result and status contracts.
+`OutputMode` contains only the supported JSON selection. Former no-op
+`--verbose`/`-v` and `--debug` flags are absent from the grammar and fail with
+`USAGE_ERROR` before effects; literal message/option-value text is unchanged.
 
 `output::table` is the single plain human-table renderer for binding, identity,
 exchange and configuration reports. Callers own columns and typed projections;

--- a/rust/crates/tmt-cli/src/diagnostics.rs
+++ b/rust/crates/tmt-cli/src/diagnostics.rs
@@ -82,10 +82,7 @@ fn find_option<'a>(commands: &[&'a Command], predicate: impl Fn(&Arg) -> bool) -
 }
 
 fn record(mode: &mut OutputMode, option: &Arg) {
-    match option.get_id().as_str() {
-        "json" => mode.json = true,
-        "verbose" => mode.verbose = true,
-        "debug" => mode.debug = true,
-        _ => {}
+    if option.get_id() == "json" {
+        mode.json = true;
     }
 }

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -11,8 +11,6 @@ pub fn grammar() -> Command {
         .args_override_self(true);
     for id in [
         "json",
-        "verbose",
-        "debug",
         "force",
         "config",
         "delay",
@@ -225,7 +223,7 @@ fn storage(name: &'static str, about: &'static str) -> Command {
 }
 
 fn general(name: &'static str, about: &'static str) -> Command {
-    with_options(storage(name, about), &["verbose", "debug", "wait", "team"])
+    with_options(storage(name, about), &["wait", "team"])
 }
 
 fn with_options(mut command: Command, ids: &[&'static str]) -> Command {
@@ -240,10 +238,7 @@ fn operand(id: &'static str, required: bool) -> Arg {
 }
 
 pub fn root_allowed(id: &str) -> bool {
-    matches!(
-        id,
-        "json" | "verbose" | "debug" | "help" | "version" | "team"
-    )
+    matches!(id, "json" | "help" | "version" | "team")
 }
 
 /// Completion generators include hidden and inherited arguments. Project only
@@ -290,8 +285,6 @@ fn option(id: &'static str) -> Arg {
     };
     match id {
         "json" => flag("Output one JSON document"),
-        "verbose" => flag("Show detailed output").short('v'),
-        "debug" => flag("Show diagnostics"),
         "force" => flag("Confirm saved-identity removal or skip advisory warnings").short('f'),
         "save" => flag("Preserve this identity after its pane is gone").short('s'),
         "help" => flag("Show help").short('h').hide(true),

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -137,8 +137,6 @@ pub enum ExchangeOperation {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct OutputMode {
     pub json: bool,
-    pub verbose: bool,
-    pub debug: bool,
 }
 
 #[derive(Debug, PartialEq)]

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -105,8 +105,6 @@ fn mode(matches: &ArgMatches) -> OutputMode {
     }
     OutputMode {
         json: flag(leaf, "json"),
-        verbose: flag(leaf, "verbose"),
-        debug: flag(leaf, "debug"),
     }
 }
 

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -297,22 +297,11 @@ fn literal_option_words_remain_data_when_the_grammar_requires_values() {
 #[test]
 fn root_and_command_local_options_work_before_and_after_the_command() {
     assert_eq!(
-        parsed(&["--json", "--debug", "talk", "peer", "hello", "--detach"]).mode,
-        OutputMode {
-            json: true,
-            verbose: false,
-            debug: true,
-        }
+        parsed(&["--json", "talk", "peer", "hello", "--detach"]).mode,
+        OutputMode { json: true }
     );
     assert_eq!(
-        parsed(&[
-            "talk",
-            "peer",
-            "hello",
-            "--json",
-            "--debug",
-            "--no-preamble"
-        ]),
+        parsed(&["talk", "peer", "hello", "--json", "--no-preamble"]),
         Parsed {
             invocation: Invocation::Talk {
                 target: "peer".into(),
@@ -326,11 +315,7 @@ fn root_and_command_local_options_work_before_and_after_the_command() {
                     no_preamble: true,
                 },
             },
-            mode: OutputMode {
-                json: true,
-                verbose: false,
-                debug: true,
-            },
+            mode: OutputMode { json: true },
         }
     );
     assert_eq!(
@@ -344,6 +329,35 @@ fn root_and_command_local_options_work_before_and_after_the_command() {
                 detach: false,
                 delay_seconds: None,
                 timeout_seconds: Some(2.0),
+                no_preamble: false,
+            },
+        }
+    );
+}
+
+#[test]
+fn removed_output_flags_are_rejected_but_remain_literal_payload_data() {
+    for option in ["--verbose", "-v", "--debug"] {
+        for argv in [
+            vec![option, "list", "--json"],
+            vec!["--json", "list", option],
+            vec!["identity", "create", "Agent", option, "--json"],
+            vec!["--json", "--version", option],
+        ] {
+            assert_usage_error(&argv, option, OutputMode { json: true });
+        }
+    }
+    assert_eq!(
+        parsed(&["talk", "peer", "--", "--verbose --debug -v"]).invocation,
+        Invocation::Talk {
+            target: "peer".into(),
+            message: "--verbose --debug -v".into(),
+            originator: None,
+            options: TalkOptions {
+                force: false,
+                detach: false,
+                delay_seconds: None,
+                timeout_seconds: None,
                 no_preamble: false,
             },
         }
@@ -386,15 +400,7 @@ fn missing_arguments_keep_json_mode_before_or_after_the_command() {
         &["--json", "talk", "peer"][..],
         &["talk", "peer", "--json"][..],
     ] {
-        assert_usage_error(
-            argv,
-            "required",
-            OutputMode {
-                json: true,
-                verbose: false,
-                debug: false,
-            },
-        );
+        assert_usage_error(argv, "required", OutputMode { json: true });
     }
 }
 
@@ -447,14 +453,7 @@ fn retired_wait_and_team_paths_have_distinct_errors() {
 
     let scoped = parse_error(&["--json", "--team", "legacy", "list"]);
     assert_eq!(scoped.code, "UNSUPPORTED_TEAM");
-    assert_eq!(
-        scoped.mode,
-        OutputMode {
-            json: true,
-            verbose: false,
-            debug: false,
-        }
-    );
+    assert_eq!(scoped.mode, OutputMode { json: true });
 }
 
 #[test]

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -494,8 +494,8 @@ such as reply `--receipt`, talk/send `--identity`, or install `--dir` after
 their command. Use `--`
 before a positional message beginning with a hyphen, or equals syntax for
 an option value, such as `--message='--json is literal text'`. Literal text
-does not enable diagnostic flags. Reply/result accept only their documented
-options; `--verbose` and `--debug` are not supported there.
+does not enable output flags. The former no-op `--verbose`/`-v` and `--debug`
+options are unsupported on every command; remove them from invocations.
 
 ## View and install the bundled skill
 

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -19,6 +19,8 @@ describe('native grammar process contract', () => {
         expect(completion.stdout).not.toContain('--wait');
         expect(completion.stdout).not.toContain('--team');
         expect(completion.stdout).not.toContain('--config');
+        expect(completion.stdout).not.toContain('--verbose');
+        expect(completion.stdout).not.toContain('--debug');
         execFileSync(shell, ['-n', '-c', completion.stdout], {
           env: sandbox.env,
           cwd: sandbox.cwd,
@@ -75,6 +77,8 @@ describe('native grammar process contract', () => {
       expect(help.stdout).toContain('remove role/preamble');
       expect(help.stdout).toContain('keep pane/exchanges');
       expect(help.stdout).not.toContain('--wait');
+      expect(help.stdout).not.toContain('--verbose');
+      expect(help.stdout).not.toContain('--debug');
       expect(fileSnapshot(sandbox.root)).toEqual(before);
     });
   });
@@ -121,6 +125,45 @@ describe('native grammar process contract', () => {
         expect(existsSync(sandbox.database)).toBe(false);
         expect(readFileSync(tripwire, 'utf8')).toBe(tmuxBaseline);
       }
+    });
+  });
+
+  it('rejects former no-op output flags before effects without confusing version or literal values', async () => {
+    await withSandbox(async (sandbox) => {
+      const tripwire = await calibrateTmuxTripwire(sandbox);
+      const before = fileSnapshot(sandbox.root);
+      const tmuxBaseline = readFileSync(tripwire, 'utf8');
+      for (const flag of ['--verbose', '-v', '--debug']) {
+        for (const args of [
+          [flag, 'ls'],
+          ['ls', flag],
+          ['help', flag],
+          ['--version', flag],
+          ['identity', 'create', 'Agent', flag],
+          ['send', 'peer', 'message', '--detach', flag],
+        ]) {
+          for (const argv of [args, ['--json', ...args], [...args, '--json']]) {
+            const result = await runCli(sandbox, argv);
+            expect(result.status).toBe(1);
+            if (argv.includes('--json')) {
+              expectError(result, 'USAGE_ERROR');
+              expect(result.stdout).toContain(flag);
+              expect(result.stderr).toBe('');
+            } else {
+              expect(result.stdout).toBe('');
+              expect(result.stderr).toContain(flag);
+            }
+            expect(fileSnapshot(sandbox.root)).toEqual(before);
+            expect(readFileSync(tripwire, 'utf8')).toBe(tmuxBaseline);
+          }
+        }
+      }
+      const literal = await runCli(sandbox, ['identity', 'create', '--json', '--', '--debug']);
+      expect(literal.status).toBe(0);
+      expect(JSON.parse(literal.stdout).identity.name).toBe('--debug');
+      const version = await runCli(sandbox, ['--version']);
+      expect(version.status).toBe(0);
+      expect(version.stdout).toBe('5.0.0-alpha.2\n');
     });
   });
 


### PR DESCRIPTION
## Scope

Closes #166. Remove the former no-op `--verbose` / `-v` and `--debug` options during alpha. They are no longer advertised or accepted; unknown-option errors occur before effects. `--version`, supported JSON behavior and literal payloads are preserved.

## Architecture and review

- The existing Clap grammar still owns recognition/help/completion. No retirement shim, secondary parser or diagnostics framework was added.
- `OutputMode` now contains only JSON selection; the existing grammar-driven error-mode recovery retains later `--json` without inspecting literal option values.
- Primary reviewed all eight changed files and relevant parser/dispatcher/output consumers. No storage, routing, lifecycle or dependency changes. Installed guidance and architecture now reflect the removed flags.
- Reviewed commit: `ec6b1b5d6e804905b4dbbe6ec7a824a7881f0a8e`.
- Tests cover root/leaf/nested/alias placements, human and JSON failures, no filesystem/tmux effects, literal `--debug` identity data and message contents, `--version`, and shell completion syntax. Existing positive supported-option and payload cases remain.

## Verification

- [x] Primary reviewed every changed file and relevant callers/tests.
- [x] Local commands/results recorded below.
- [x] All 15 required checks passed on reviewed head `ec6b1b5d6e804905b4dbbe6ec7a824a7881f0a8e`, CI run 34294446894, first attempt without retries.

All local checks passed using isolated task-built executables, never a host installation/tmux server:

- `cargo fmt --manifest-path rust/Cargo.toml --all --check`
- `cargo clippy --locked --manifest-path rust/Cargo.toml --all-targets -- -D warnings`
- `cargo test --locked --manifest-path rust/Cargo.toml`: 292 adapter + 42 CLI + 20 architecture + 56 core tests; one actual-archive fixture intentionally ignored, not claimed as release proof.
- `cargo build --locked --manifest-path rust/Cargo.toml` and `cargo +1.88.0 build --locked --manifest-path rust/Cargo.toml`
- `pnpm check`
- `pnpm test:run --maxWorkers 2 --minWorkers 2`: 87 passed.
- `TMT_TEST_STORAGE_PROBE=<absolute repository probe descriptor> pnpm test:native --maxWorkers 2 --minWorkers 2`: 152 passed.
- `pnpm test:e2e`: full isolated Docker suite, 292 adapter + 168 E2E cases; one opt-in performance skip.
- `node scripts/verify-native-runtime.mjs --executable /Users/benhsieh/dev/tmux-team/rust/target/debug/tmt --target aarch64-apple-darwin --version 5.0.0-alpha.2 --skill skills/tmux-team/SKILL.md`: system-only linkage, exact embedded skill, isolated managed installation and SQLite persistence passed.
- Canonical skill `quick_validate.py`: passed.
- `git diff --check`: passed.

One initial local test compile used a nonexistent TalkOptions default; corrected the test to the existing explicit typed fixture. No runtime policy/default/timeout or assertion was weakened.

## Project lifecycle

- ARCHITECTURE and canonical installed skill updated in this PR. README/toolchain work is separately tracked by #168 and follows this issue.
- Single feature branch `fix/166-remove-noop-flags` in the clean primary checkout; no extra worktree. No publication, version bump, host install, MCP work or package-manager changes.
