### PR TITLE
Simplify native onboarding and remove redundant tooling aliases

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,6 +9,13 @@ Use this guide for reproducible commands and evidence.
 
 ## Setup
 
+This section is for contributors, not end users. Rust/Cargo builds the product.
+Node and pinned pnpm run Vitest/native-process/Docker orchestration, formatting,
+type checks and release verification. `better-sqlite3` is an independent test
+oracle; `tar` builds test archives. These are retained developer dependencies,
+not reasons to install TMT through npm. npm is not a separate required workflow;
+use the pinned pnpm lockfile rather than introducing another package manager.
+
 Requirements are Node.js 22.12 or newer, the pinned pnpm toolchain, and the
 Rust toolchain declared by `rust/rust-toolchain.toml`. The workspace MSRV is
 Rust 1.88; CI also runs the current pinned release toolchain.
@@ -131,6 +138,11 @@ For ordinary developer checks, run:
 pnpm check
 pnpm test:run
 ```
+
+`pnpm check` is the common quality entrypoint for all retained tooling, including
+E2E. For focused work use `pnpm type:check`, `pnpm lint` or
+`pnpm format:check`; the old duplicate `e2e:*` quality aliases are removed.
+`pnpm test:e2e` remains the actual Docker scenario runner.
 
 The first command checks TypeScript types and lint/format for retained tooling
 and docs; the second runs tooling behavior and source-boundary tests. Neither

--- a/NATIVE-INSTALL.md
+++ b/NATIVE-INSTALL.md
@@ -1,8 +1,11 @@
 # TMT native alpha installation
 
 This archive contains the standalone Rust native alpha runtime. It needs no
-Node.js, Rust toolchain or source checkout to run. tmux is still required for
-pane operations. Use the installer asset from a published release; the README
+Node.js, npm, pnpm, Rust toolchain or source checkout to run. tmux and socket
+access are required for binding, sending and capturing live panes, not for
+storage-only identity/profile/reply/result/X operations with explicit selection
+where required. A sender can run outside tmux; recipients still need live panes.
+Use the installer asset from a published release; the README
 supplies the verified version URL when one is available.
 
 Native schema 9 is forward-only: the TypeScript runtime cannot reopen it.
@@ -60,13 +63,17 @@ for tested host OS versions; a deployment target is not testing on every OS.
 
 ## Curl bootstrap
 
-Use the exact `tmt-installer.sh` asset URL from a published release. The README
-supplies the verified version URL when one is available. Set that URL as
-`TMT_INSTALLER_URL` after checking the release asset before running:
+Download the published native `5.0.0-alpha.2` installer:
 
 ```sh
-curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
-  --output tmt-installer.sh "$TMT_INSTALLER_URL" &&
+curl -fsSL --proto '=https' --proto-redir '=https' \
+  -o tmt-installer.sh \
+  https://github.com/wkh237/tmux-team/releases/download/v5.0.0-alpha.2/tmt-installer.sh
+```
+
+Only after a successful download, inspect it if desired and run:
+
+```sh
 sh tmt-installer.sh
 ```
 
@@ -89,6 +96,32 @@ and archive sizes/digests before executing the temporary binary, then delegates
 permanent writes to the native installer. It does not edit shell profiles or
 touch SQLite. Initial receipts record local-archive verification, not independent
 attestation provenance. HTTPS and hashes do not protect a compromised origin.
+
+## One-time PATH setup
+
+If `command -v tmt` already selects `~/.local/bin/tmt`, no setup is needed.
+Otherwise, for Bash or Zsh, add this block **once** to the startup file you
+actually use (`~/.bashrc` or `~/.zshrc` for interactive shells):
+
+```sh
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+```
+
+Open a new terminal, then check `command -v tmt` and `tmt --version`.
+The block avoids adding the directory again when a shell inherits it. Do not
+append it on every installation/update or blindly edit both startup files.
+Other shells use their own persistent PATH configuration. For a custom prefix,
+substitute its absolute `bin` directory.
+
+Running `export` in a terminal changes only that shell; `curl ... | sh` cannot
+change its parent's PATH. The installer therefore reports path problems and
+does not modify shell profiles. You can immediately run `~/.local/bin/tmt`
+directly without changing PATH. If PATH already contains that directory but
+another installation wins, follow the replacement guidance below rather than
+repeatedly adding directories.
 
 ## Replacing npm or pnpm
 

--- a/README.md
+++ b/README.md
@@ -6,30 +6,32 @@ history. A standalone native CLI—no Node.js, Rust toolchain, or daemon require
 
 ## Install
 
-Native `5.0.0-alpha.2` for macOS and Linux, arm64 and x64. tmux is required for
-pane operations.
+Native alpha for macOS and Linux, arm64 and x64. No Node, npm, pnpm or Rust
+toolchain needed.
 
-```bash
-curl -fsSL --proto '=https' --proto-redir '=https' https://github.com/wkh237/tmux-team/releases/download/v5.0.0-alpha.2/tmt-installer.sh | sh
-export PATH="$HOME/.local/bin:$PATH"
-tmt --version
+[Download the installer](https://github.com/wkh237/tmux-team/releases/download/v5.0.0-alpha.2/tmt-installer.sh),
+then run it from the download folder:
+
+```sh
+sh tmt-installer.sh
 ```
 
 Installs into `~/.local/bin` and sets up the agent skill non-interactively.
-Keep that directory in your shell's PATH and reload your agent's skills.
-Update later with `tmt upgrade` (`tmt update` works too).
+If `tmt` is not found, complete the [one-time PATH setup](NATIVE-INSTALL.md#one-time-path-setup).
+Reload your agent's skills. Update later with `tmt upgrade`—no reinstall or
+repeated PATH setup.
 
-Already using npm or pnpm? Read [replacement and PATH guidance](NATIVE-INSTALL.md#replacing-npm-or-pnpm)
-first. The installer does not uninstall old packages or transfer/delete data.
-Old TypeScript writers must not use native SQLite state.
+Prefer curl, a custom location, or replacing an older installation? See
+[installation options](NATIVE-INSTALL.md). The installer never uninstalls old
+packages or deletes application data.
 
-For custom prefixes, pinning, binary-only installation, or inspecting the
-installer before running it, see [native installation](NATIVE-INSTALL.md).
-Downloads and integrity evidence are in the [alpha release](https://github.com/wkh237/tmux-team/releases/tag/v5.0.0-alpha.2).
+tmux is needed for live pane operations: binding, messaging and inspection.
+Explicit local identity/profile access and stored results work without it. There is no
+non-tmux receiving agent transport yet.
 
 ## Quick start
 
-Start a tmux session if needed:
+For the receiving agent, start a tmux session if needed:
 
 ```bash
 tmux new -s tmt
@@ -42,7 +44,8 @@ tmt name reviewer
 gemini
 ```
 
-From another terminal or tmux pane:
+From another terminal or tmux pane on the same machine (the sender need not be
+inside tmux):
 
 ```bash
 tmt talk reviewer "Review the current changes and report concrete risks."
@@ -103,10 +106,8 @@ failure handling, or `tmt help` for command options.
 
 ## Development
 
-`rust/` is the only runtime. Node and pnpm are developer test tools, not an
-installation path: use the native installer above, not an npm/GitHub source URI.
-See [development](DEVELOPMENT.md),
-[architecture](ARCHITECTURE.md) and the [rewrite tracker](https://github.com/wkh237/tmux-team/issues/93).
+Contributor-only requirements and checks are in [development](DEVELOPMENT.md).
+See [architecture](ARCHITECTURE.md) for runtime and test ownership.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "test:native": "vitest run --config test/native/vitest.config.ts",
     "test:run": "vitest run",
     "lint": "oxlint test/ scripts/*.mjs",
-    "e2e:typecheck": "pnpm type:check",
-    "e2e:lint": "pnpm lint",
-    "e2e:format:check": "pnpm format:check",
     "docs:format:check": "prettier --check --ignore-path .gitignore AGENTS.md ARCHITECTURE.md CONVENTIONS.md DEVELOPMENT.md RUST-REWRITE.md PERFORMANCE-BASELINE.md \".agents/skills/**/SKILL.md\" .github/pull_request_template.md",
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --write test/ scripts/*.mjs tsconfig.json tsconfig.e2e.json vitest.config.ts package.json .github/workflows/ci.yml",
@@ -21,14 +18,6 @@
     "type:check": "tsc --noEmit",
     "check": "pnpm type:check && pnpm lint && pnpm format:check && pnpm docs:format:check"
   },
-  "keywords": [
-    "tmux",
-    "cli",
-    "ai",
-    "agent",
-    "collaboration",
-    "multi-agent"
-  ],
   "author": "Ben Hsieh",
   "license": "MIT",
   "repository": {

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -19,6 +19,10 @@ do not fall back to TypeScript on native state. Native schema 9 is forward-only
 and TypeScript cannot reopen it. Switching installations does not migrate or
 delete old data. Stop old writers before switching.
 
+The native CLI needs no Node/npm/pnpm or Rust toolchain. tmux is needed for
+live pane operations, not local storage-only work. A sender may run outside
+tmux; there is no non-tmux recipient transport yet.
+
 Native talk supplies a compact `v2_` receipt; use it unchanged. Native reply
 also accepts retained legacy receipts, but TypeScript cannot consume native
 receipts or schema 9. Do not mix runtimes for an active exchange.
@@ -372,10 +376,12 @@ name `all` is an ordinary identity; it is not a special destination. The
 current `add` order is `tmt add <pane-target> <global-name>`; the older
 name-first order is rejected with a usage error.
 
-Names are unique across servers sharing the same local TMT database, but
-`list`, `talk`, and `check` discover and address only the current tmux server.
-A `%pane_id` is stable within a server, not unique across servers. Routine
-reads preserve bindings on other sockets. Binding a foreign live name fails
+Names are unique across servers sharing the same local TMT database.
+Global `list` can observe recorded bindings on other servers; `talk` and
+`check` route only to the current tmux server. Listing is not routing permission.
+A `%pane_id` is stable within a server, not unique across servers. Uncertain
+observations preserve bindings; conclusive pane/server death follows the
+temporary/saved lifetime rules, including on other sockets. Binding a foreign live name fails
 with `NAME_ALREADY_ACTIVE` (exit 5); an unverifiable foreign endpoint fails
 with `RECONCILIATION_FAILED` (exit 1). Do not delete the binding to bypass an
 uncertain check. Rebinding a proven stale endpoint retains its identity and
@@ -530,6 +536,11 @@ Old npm skill links can conflict: inspect first, then explicitly use the new
 absolute `tmt install --force` if replacement is intended. A skill failure can
 leave the native binary installed; do not report rollback or silently force.
 Read this skill again through the new executable before using remembered syntax.
+
+The installer does not edit shell profiles or change the parent shell's PATH.
+If `tmt` is missing, use the installed absolute path and complete one-time shell
+PATH setup; do not repeatedly append exports on every upgrade. If another
+installation is selected, inspect its owner before changing or removing it.
 
 The selected Rust executable embeds this exact skill; viewing and installation
 work after moving the binary, without Node or a checkout. Native installs link

--- a/test/tooling/onboarding.test.ts
+++ b/test/tooling/onboarding.test.ts
@@ -1,0 +1,49 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withSandbox } from '../support/cli-process.js';
+
+const guide = readFileSync(new URL('../../NATIVE-INSTALL.md', import.meta.url), 'utf8');
+const setup = guide.split('## One-time PATH setup\n')[1]?.match(/```sh\n([\s\S]*?)\n```/)?.[1];
+
+describe('documented one-time PATH setup', () => {
+  it.each(['bash', 'zsh'])(
+    'selects the new command without duplicating inherited PATH in %s',
+    async (shell) => {
+      expect(
+        setup,
+        'The installation guide must contain its executable PATH example.'
+      ).toBeDefined();
+      await withSandbox(async (sandbox) => {
+        const home = path.join(sandbox.root, 'home with spaces');
+        const bin = path.join(home, '.local', 'bin');
+        const command = path.join(bin, 'tmt');
+        const original = path.join(sandbox.root, 'original-bin');
+        mkdirSync(bin, { recursive: true });
+        mkdirSync(original);
+        // A lookup target only; this fixture never pretends to run the product.
+        writeFileSync(command, '#!/bin/sh\nexit 0\n', { mode: 0o700 });
+        for (const [initial, expected] of [
+          [original, `${bin}:${original}`],
+          [`${bin}:${original}`, `${bin}:${original}`],
+          [`${original}:${bin}`, `${original}:${bin}`],
+          [`${bin}-other:${original}`, `${bin}:${bin}-other:${original}`],
+        ]) {
+          const output = execFileSync(
+            `/bin/${shell}`,
+            ['-c', `${setup}\n${setup}\nprintf '%s\\n' "$PATH"\ncommand -v tmt`],
+            {
+              cwd: sandbox.cwd,
+              env: { HOME: home, PATH: initial },
+              encoding: 'utf8',
+              timeout: 5000,
+              maxBuffer: 64 * 1024,
+            }
+          );
+          expect(output).toBe(`${expected}\n${command}\n`);
+        }
+      });
+    }
+  );
+});


### PR DESCRIPTION
## Scope

- Closes #168; follows merged #166 / #169.
- Shorten README onboarding to the published installer download and one execution command. Move curl and one-time PATH configuration to the installation guide.
- Clarify optional tmux boundaries and separate native end-user requirements from retained contributor tooling.
- Remove three unused E2E quality aliases and private npm keywords. Preserve every dependency, canonical check, lockfile and release owner.

## Architecture and review

- No runtime module, persistence, transport or installer ownership changes; therefore no ARCHITECTURE.md change is needed. DEVELOPMENT.md documents retained tooling ownership.
- Reuse the existing release installer, runtime verifier, canonical embedded skill and `withSandbox` test fixture. No alternate downloader or shell-profile writer.
- New tests execute the actual documented PATH snippet in Bash and Zsh with isolated lookup directories, a home containing spaces, repeated sourcing, existing entries and prefix collisions.
- Primary reviewer: Codex. Reviewed all six files and relevant shell, routing and tooling callers. Corrected skill drift: global presence reporting is not cross-server routing permission; uncertain observations differ from confirmed endpoint death.
- Reviewed commit: c497bf4ecbd74c4853e43045084cb868fcd3dd5b.
- A fixed short curl endpoint remains pending the user's choice. No new domain, launcher, release, host installation or MCP support is included.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge: all 15 checks passed on reviewed head c497bf4ecbd74c4853e43045084cb868fcd3dd5b, run 34295922046, attempt 1 (no retries).

Commands and results (local):

- `pnpm install --frozen-lockfile`: passed, no lockfile changes.
- `pnpm check`: types, lint, tooling/docs formatting passed.
- `pnpm test:run --maxWorkers 2 --minWorkers 2`: 89 tests / 10 files passed.
- `pnpm test:native --maxWorkers 2 --minWorkers 2` with the task-built storage probe: 152 tests / 15 files passed.
- `pnpm test:e2e`: Docker adapter suite 292 passed; E2E 168 passed, one existing opt-in scenario skipped. Private tmux/mock agents only.
- `cargo test --workspace --manifest-path rust/Cargo.toml`: 292 adapter, 42 CLI, 20 architecture and 56 core tests passed; one existing actual-release-archive test ignored.
- `cargo clippy --workspace --all-targets --manifest-path rust/Cargo.toml -- -D warnings`: passed.
- Rust 1.88 MSRV workspace check: passed.
- `node scripts/verify-native-runtime.mjs --executable /Users/benhsieh/dev/tmux-team/rust/target/debug/tmt --target aarch64-apple-darwin --version 5.0.0-alpha.2 --skill skills/tmux-team/SKILL.md`: linkage, version, exact embedded/installed skill, managed installation and SQLite persistence passed.
- Canonical skill `quick_validate.py`: passed. `git diff --check`: passed.
- Public README installer smoke: downloaded immutable published v5.0.0-alpha.2 asset, verified SHA-256 `d4167bfc7fe8fd66aaf2e6509aab252b4ddc319e2796149b25f09127ed1da4fe`, installed with an allowlisted environment into a disposable prefix, verified version, pinned upgrade and exact published embedded/installed skill. No shell profiles or SQLite state created. This checks the existing published release, not a new release of this commit.

## Project lifecycle

- README, NATIVE-INSTALL.md, DEVELOPMENT.md and canonical user skill updated together.
- Issue #168 tracks scope, implementation and deliberately deferred short-URL choice.
- Single-stream branch `docs/168-native-onboarding` uses the main checkout; no additional worktree. Merge only after exact-head required CI succeeds. No publication or host tmux changes.
