### PR TITLE
feat(office): add isolated emulator sign-in and browser session proof

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,9 @@
 **/node_modules
 coverage
 **/dist
+**/dist-preview
+**/test-results
+**/playwright-report
 rust/target
 target/distrib
 .DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,23 +38,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.office == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22.23.2
-      - name: Activate pinned pnpm
-        run: corepack enable && corepack prepare pnpm@10.33.0 --activate
-      - name: Install Office dependencies
-        run: pnpm office:install
-      - name: Check, test and build the SPA
-        run: |
-          pnpm office:check
-          pnpm office:test
-          pnpm office:build
+      - name: Build isolated browser and emulator verification
+        run: docker build --target browser-tests -f services/office/Dockerfile -t tmt-office-browser:ci .
+      - name: Verify emulator sessions with restricted browser destinations
+        run: docker run --rm --init --shm-size=256m tmt-office-browser:ci
 
   code-quality:
     name: Code quality

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,6 +42,15 @@ excluded from Git and Docker; the image has no host credential/data mounts.
 `scripts/verify-office-emulators.mjs` proves emulator transport and fixture
 cleanup separately from native tmux E2E and future Office authorization tests.
 
+Office's explicit emulator-only login has one app-owned Firebase/session boundary
+under `apps/office/src/auth`, with memory-only persistence and no world authority.
+React subscribes to the observer-backed session rather than copying identity into
+Jotai. The opt-in `browser-tests` stage of the same emulator Dockerfile proves
+real browser session behavior with local auth and an explicit public Google
+script allowlist, not fully offline OAuth; its default stage remains
+the lightweight emulator environment. See Office architecture for lifecycle and
+failure ownership. No cloud membership service or connector is implemented.
+
 `scripts/ci-scope.mjs` owns conservative affected-area selection and final gate
 validation. Office-only source/docs avoid native matrices; native source/skill
 changes avoid Office. Shared or unknown paths (including lockfiles, security,

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,6 +77,11 @@ the app directory against the same root lockfile, without workspace recursion.
 With pinned pnpm 10.33, a plain Office `--filter` install still builds root
 SQLite; the explicit isolated install avoids that unrelated dependency. Do not
 create an app lockfile or remove `--frozen-lockfile` to work around a mismatch.
+The script resolves the lockfile directory through an absolute path: pinned pnpm
+can apply a relative path twice and place modules outside the checkout. The
+non-root browser image verifies dependencies stay in its workspace. Firebase's
+optional auto-configuration postinstall and protobufjs's version warning script
+remain unapproved; explicit app configuration and bundled SDK code need neither.
 
 The app's verification-only Dockerfile proves the isolated install has neither
 the root SQLite oracle nor a native TMT executable. It runs quality, DOM tests
@@ -113,6 +118,41 @@ Java and Firebase tooling with a demo project; no host Firebase login is require
 for emulator tests. Local real-project mappings and credentials must remain
 ignored by both Git and Docker. Never substitute this bootstrap smoke proof for
 future membership rules, invitation or browser tests.
+
+### Local browser sign-in
+
+Start the emulators as described above, then explicitly opt in:
+
+```sh
+pnpm office:dev --mode emulator
+```
+
+Open the loopback URL printed by Vite. Choose **Sign in with Google (emulator)**,
+add a local test account in the popup and observe its UID. No real Google login,
+Firebase owner alias or credentials are needed. Reload signs out; another tab
+does not inherit the session. Default `office:dev` / `office:build` stays a
+disconnected preview. Login does not create a world or grant membership.
+
+Run the real-browser suite with the same emulator owner:
+
+```sh
+docker build --target browser-tests -f services/office/Dockerfile -t tmt-office-browser:local .
+docker run --rm --init --shm-size=256m tmt-office-browser:local
+```
+
+The image installs pinned Chromium, checks the app, runs DOM/session tests and
+builds both preview and emulator variants. The container starts disposable
+Auth/Firestore emulators and two strict-port preview servers, then Playwright.
+It uses one worker, no retries, bounded waits and independent browser contexts.
+Auth responses are real and local. Google's official popup transport still loads
+public JavaScript from `apis.google.com`, even in emulator mode. The browser
+allowlist permits only those script GETs and loopback, blocks optional upstream
+CDN styling, and fails for any other destination. This suite requires Internet
+access for that library; it is not a fully offline OAuth test. No host
+credentials/volumes or published ports are used. A failed browser test must
+propagate through `emulators:exec`; do not count a skipped or empty suite as proof.
+The selected Office CI job runs this same target. Native tmux E2E remains
+separate. Remove the task-owned verification image when no longer needed.
 
 ## Rust checks
 

--- a/apps/office/.gitignore
+++ b/apps/office/.gitignore
@@ -1,0 +1,3 @@
+dist-preview/
+test-results/
+playwright-report/

--- a/apps/office/Dockerfile
+++ b/apps/office/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/office/package.json apps/office/package.json
 RUN pnpm office:install \
   && test ! -e node_modules/better-sqlite3 \
+  && test ! -e /node_modules \
   && test ! -e rust/target/debug/tmt
 COPY apps/office apps/office
 CMD ["sh", "-c", "pnpm office:check && pnpm office:test && pnpm office:build"]

--- a/apps/office/e2e/session.spec.ts
+++ b/apps/office/e2e/session.spec.ts
@@ -1,0 +1,155 @@
+import { test as base, expect } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
+
+interface BrowserSession {
+  context: BrowserContext;
+  page: Page;
+  requests: URL[];
+}
+const test = base.extend<{ openSession: (url?: string) => Promise<BrowserSession> }>({
+  openSession: async ({ browser }, use) => {
+    const sessions: BrowserSession[] = [];
+    const unexpected: string[] = [];
+    await use(async (url = 'http://127.0.0.1:4173') => {
+      const context = await browser.newContext();
+      const requests: URL[] = [];
+      context.on('request', (request) => {
+        requests.push(new URL(request.url()));
+      });
+      await context.route('**/*', async (route) => {
+        const target = new URL(route.request().url());
+        if (target.hostname === '127.0.0.1') return route.continue();
+        // The official popup transport requires Google's public iframe library even
+        // with Auth Emulator. No production auth/API endpoints are allowed.
+        if (
+          target.protocol === 'https:' &&
+          target.hostname === 'apis.google.com' &&
+          (target.pathname.startsWith('/js/') || target.pathname.startsWith('/_/scs/')) &&
+          route.request().method() === 'GET' &&
+          route.request().resourceType() === 'script'
+        )
+          return route.continue();
+        // Firebase's emulator widget requests optional CDN presentation assets.
+        // Block them, but do not stub its local authentication logic or responses.
+        if (!['unpkg.com', 'fonts.googleapis.com', 'fonts.gstatic.com'].includes(target.hostname)) {
+          unexpected.push(target.origin + target.pathname);
+        }
+        await route.abort();
+      });
+      const page = await context.newPage();
+      const session = { context, page, requests };
+      sessions.push(session);
+      await page.goto(url);
+      return session;
+    });
+    for (const session of sessions) await session.context.close();
+    expect(unexpected).toEqual([]);
+  },
+});
+
+async function openPopup(page: Page): Promise<Page> {
+  const opened = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'Sign in with Google (emulator)' }).click();
+  const popup = await opened;
+  await expect(popup.getByRole('button', { name: 'Add new account' })).toBeVisible();
+  return popup;
+}
+
+async function submitNewAccount(popup: Page, name: string): Promise<void> {
+  await popup.getByRole('button', { name: 'Add new account' }).click();
+  // The upstream emulator labels are not associated with inputs; use its stable IDs.
+  await popup
+    .locator('#email-input')
+    .fill(`${name.toLowerCase()}-${crypto.randomUUID()}@example.test`);
+  await popup.locator('#display-name-input').fill(name);
+  await popup.getByRole('button', { name: 'Sign in with Google.com', exact: true }).click();
+}
+
+async function signIn(page: Page, name: string): Promise<void> {
+  await submitNewAccount(await openPopup(page), name);
+  await expect(page.getByText(`Signed in as ${name}`, { exact: true })).toBeVisible();
+  await expect(page.getByText(/^UID: /)).toContainText(/UID: \S+/);
+}
+
+test('default build stays disconnected without Firebase requests', async ({ openSession }) => {
+  const { page, requests } = await openSession('http://127.0.0.1:4174');
+  await expect(page.getByRole('heading', { name: 'No world connected' })).toBeVisible();
+  await page.getByRole('link', { name: 'Setup', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'A private world' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Sign in/ })).toHaveCount(0);
+  expect(requests.every((request) => request.origin === 'http://127.0.0.1:4174')).toBe(true);
+});
+
+test('real popup login is memory-only, tab-isolated and never implies world membership', async ({
+  openSession,
+}) => {
+  const alice = await openSession();
+  const bob = await openSession();
+  await signIn(alice.page, 'Alice');
+  const aliceUid = await alice.page.getByText(/^UID: /).textContent();
+  await expect(bob.page.getByRole('button', { name: /Sign in/ })).toBeEnabled();
+  await signIn(bob.page, 'Bob');
+  expect(await bob.page.getByText(/^UID: /).textContent()).not.toBe(aliceUid);
+  const tab = await alice.context.newPage();
+  await tab.goto('http://127.0.0.1:4173');
+  await expect(tab.getByRole('button', { name: /Sign in/ })).toBeEnabled();
+  await alice.page.getByRole('button', { name: 'Sign out', exact: true }).click();
+  await expect(alice.page.getByRole('button', { name: /Sign in/ })).toBeEnabled();
+  await expect(bob.page.getByText('Signed in as Bob', { exact: true })).toBeVisible();
+  await bob.page.reload();
+  await expect(bob.page.getByRole('button', { name: /Sign in/ })).toBeEnabled();
+  await expect(bob.page.getByText(/^UID: /)).toHaveCount(0);
+  await expect(bob.page.getByRole('heading', { name: 'No world connected' })).toBeVisible();
+  expect(
+    alice.requests.some(
+      (request) => request.port === '9099' && request.pathname.includes('signInWithIdp')
+    )
+  ).toBe(true);
+});
+
+test('closing the real popup clears pending state and permits another login', async ({
+  openSession,
+}) => {
+  const { page } = await openSession();
+  const button = page.getByRole('button', { name: /Sign in/ });
+  const popup = await openPopup(page);
+  await expect(button).toBeDisabled();
+  await popup.close();
+  // Firebase waits eight seconds after its two-second desktop close poll.
+  await expect(page.getByRole('alert')).toHaveText('Sign-in cancelled. You can try again.', {
+    timeout: 15_000,
+  });
+  await expect(button).toBeEnabled();
+  await signIn(page, 'Retry');
+  await expect(page.getByRole('alert')).toHaveCount(0);
+});
+
+test('failed token exchange reports transport failure without inventing a session, then recovers', async ({
+  openSession,
+}) => {
+  const { page, context } = await openSession();
+  const exchange = '**/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp*';
+  await context.route(exchange, (route) => route.abort('connectionrefused'));
+  await submitNewAccount(await openPopup(page), 'Offline');
+  await expect(page.getByRole('alert')).toHaveText(
+    'Cannot reach the local Auth Emulator. Check that it is running, then try again.'
+  );
+  await expect(page.getByText(/^UID: /)).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /Sign in/ })).toBeEnabled();
+  await context.unroute(exchange);
+  await signIn(page, 'Recovered');
+});
+
+test('browser popup blocking produces an actionable error and releases the button', async ({
+  openSession,
+}) => {
+  const { page } = await openSession();
+  // Exercise the real SDK's blocked-window path, not a fabricated Firebase error.
+  await page.evaluate(() => {
+    window.open = () => null;
+  });
+  await page.getByRole('button', { name: /Sign in/ }).click();
+  await expect(page.getByRole('alert')).toHaveText('Allow popups for this page, then try again.');
+  await expect(page.getByRole('button', { name: /Sign in/ })).toBeEnabled();
+  await expect(page.getByText(/^UID: /)).toHaveCount(0);
+});

--- a/apps/office/package.json
+++ b/apps/office/package.json
@@ -8,19 +8,22 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview --host 127.0.0.1",
     "test": "vitest run",
+    "test:browser": "playwright test",
     "type:check": "tsc --noEmit",
-    "lint": "oxlint --deny-warnings --react-plugin src vite.config.ts",
+    "lint": "oxlint --deny-warnings --react-plugin src e2e vite.config.ts playwright.config.ts",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
     "check": "pnpm type:check && pnpm lint && pnpm format:check"
   },
   "dependencies": {
     "@tanstack/react-router": "1.170.33",
+    "firebase": "12.18.0",
     "jotai": "3.0.0",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
+    "@playwright/test": "1.63.0",
     "@testing-library/react": "16.3.3",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.0.3",

--- a/apps/office/playwright.config.ts
+++ b/apps/office/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  workers: 1,
+  retries: 0,
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  reporter: 'list',
+  use: { browserName: 'chromium', baseURL: 'http://127.0.0.1:4173' },
+  webServer: [
+    {
+      command: 'pnpm exec vite preview --host 127.0.0.1 --port 4173 --strictPort',
+      url: 'http://127.0.0.1:4173',
+      reuseExistingServer: false,
+    },
+    {
+      command:
+        'pnpm exec vite preview --host 127.0.0.1 --port 4174 --strictPort --outDir dist-preview',
+      url: 'http://127.0.0.1:4174',
+      reuseExistingServer: false,
+    },
+  ],
+});

--- a/apps/office/src/auth/firebase-session.test.ts
+++ b/apps/office/src/auth/firebase-session.test.ts
@@ -1,0 +1,20 @@
+import { getApps } from 'firebase/app';
+import { describe, expect, it } from 'vitest';
+import { startOfficeSession } from './firebase-session.js';
+
+describe('Firebase activation boundary', () => {
+  it('does not initialize Firebase for ordinary preview or unknown modes', () => {
+    for (const mode of ['development', 'production', 'preview', 'cloud']) {
+      expect(startOfficeSession(mode, 'localhost')).toBeUndefined();
+    }
+    expect(getApps()).toEqual([]);
+  });
+
+  it.each(['office.example', 'localhost.evil', '127.0.0.1.evil', '0.0.0.0', ''])(
+    'rejects non-loopback hostname %s before Firebase initialization',
+    (hostname) => {
+      expect(() => startOfficeSession('emulator', hostname)).toThrow('only available on loopback');
+      expect(getApps()).toEqual([]);
+    }
+  );
+});

--- a/apps/office/src/auth/firebase-session.ts
+++ b/apps/office/src/auth/firebase-session.ts
@@ -1,0 +1,45 @@
+import { deleteApp, initializeApp } from 'firebase/app';
+import {
+  browserPopupRedirectResolver,
+  connectAuthEmulator,
+  GoogleAuthProvider,
+  initializeAuth,
+  inMemoryPersistence,
+  onAuthStateChanged,
+  signInWithPopup,
+  signOut,
+} from 'firebase/auth';
+import { createSession } from './session.js';
+import type { OfficeSession } from './session.js';
+
+/** Called by the entry point, never during a React render or with cloud credentials. */
+export function startOfficeSession(mode: string, hostname: string): OfficeSession | undefined {
+  if (mode !== 'emulator') return undefined;
+  if (!['127.0.0.1', 'localhost', '[::1]'].includes(hostname)) {
+    throw new Error('Local sign-in is only available on loopback.');
+  }
+  const app = initializeApp(
+    {
+      apiKey: 'demo-tmt-office',
+      projectId: 'demo-tmt-office',
+      authDomain: 'demo-tmt-office.firebaseapp.com',
+    },
+    `office-${crypto.randomUUID()}`
+  );
+  const auth = initializeAuth(app, {
+    persistence: inMemoryPersistence,
+    popupRedirectResolver: browserPopupRedirectResolver,
+  });
+  connectAuthEmulator(auth, 'http://127.0.0.1:9099');
+  return createSession({
+    observe: (changed) =>
+      onAuthStateChanged(auth, (user) =>
+        changed(user ? { uid: user.uid, displayName: user.displayName } : null)
+      ),
+    signIn: async () => {
+      await signInWithPopup(auth, new GoogleAuthProvider());
+    },
+    signOut: () => signOut(auth),
+    dispose: () => deleteApp(app),
+  });
+}

--- a/apps/office/src/auth/session-view.tsx
+++ b/apps/office/src/auth/session-view.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useSyncExternalStore } from 'react';
+import type { ReactElement } from 'react';
+import type { OfficeSession } from './session.js';
+
+export const OfficeSessionContext = createContext<OfficeSession | undefined>(undefined);
+
+export function SessionPanel(): ReactElement | null {
+  const session = useContext(OfficeSessionContext);
+  return session ? <ConnectedSession session={session} /> : null;
+}
+
+function ConnectedSession({ session }: { session: OfficeSession }): ReactElement {
+  const { ready, user, pending, error } = useSyncExternalStore(
+    session.subscribe,
+    session.getSnapshot
+  );
+  return (
+    <section className="session-panel" aria-label="Local session">
+      <p>Auth Emulator only · Sign-in does not grant world access.</p>
+      {!ready ? (
+        <p role="status">Preparing local sign-in…</p>
+      ) : user ? (
+        <>
+          <p>Signed in as {user.displayName ?? 'Local user'}</p>
+          <p>
+            UID: <code>{user.uid}</code>
+          </p>
+          <button type="button" disabled={pending} onClick={() => void session.signOut()}>
+            Sign out
+          </button>
+        </>
+      ) : (
+        <button type="button" disabled={pending} onClick={() => void session.signIn()}>
+          Sign in with Google (emulator)
+        </button>
+      )}
+      {pending && <p role="status">Waiting for the session action…</p>}
+      {error && <p role="alert">{error}</p>}
+      <p>Session stays in memory. Reloading signs you out.</p>
+    </section>
+  );
+}

--- a/apps/office/src/auth/session.test.ts
+++ b/apps/office/src/auth/session.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSession } from './session.js';
+import type { SessionUser } from './session.js';
+
+function fixture() {
+  let changed: (user: SessionUser | null) => void = () => {};
+  const unsubscribe = vi.fn();
+  const adapter = {
+    observe: vi.fn((listener: typeof changed) => {
+      changed = listener;
+      return unsubscribe;
+    }),
+    signIn: vi.fn(async () => {}),
+    signOut: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {}),
+  };
+  const session = createSession(adapter);
+  return { session, adapter, unsubscribe, changed: (user: SessionUser | null) => changed(user) };
+}
+
+describe('App-owned session', () => {
+  it('waits for the observer and never invents identity from a successful action', async () => {
+    const { session, adapter, changed } = fixture();
+    await session.signIn();
+    expect(adapter.signIn).not.toHaveBeenCalled();
+    changed(null);
+    await session.signIn();
+    expect(adapter.signIn).toHaveBeenCalledOnce();
+    expect(session.getSnapshot()).toEqual({ ready: true, pending: false, user: null, error: null });
+    changed({ uid: 'alice', displayName: 'Alice' });
+    expect(session.getSnapshot().user?.uid).toBe('alice');
+    await session.signOut();
+    expect(session.getSnapshot().user?.uid).toBe('alice');
+    changed(null);
+    expect(session.getSnapshot().user).toBeNull();
+    await session.dispose();
+  });
+
+  it('serializes actions and prevents late completion or observers from reviving disposed state', async () => {
+    const { session, adapter, changed, unsubscribe } = fixture();
+    let finish!: () => void;
+    adapter.signIn.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        })
+    );
+    changed(null);
+    const listener = vi.fn();
+    session.subscribe(listener);
+    const action = session.signIn();
+    await session.signIn();
+    await session.signOut();
+    expect(adapter.signIn).toHaveBeenCalledOnce();
+    expect(adapter.signOut).not.toHaveBeenCalled();
+    expect(session.getSnapshot().pending).toBe(true);
+    await session.dispose();
+    await session.dispose();
+    listener.mockClear();
+    changed({ uid: 'late', displayName: null });
+    finish();
+    await action;
+    await session.signIn();
+    expect(listener).not.toHaveBeenCalled();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(adapter.dispose).toHaveBeenCalledOnce();
+    expect(session.getSnapshot()).toEqual({
+      ready: false,
+      pending: false,
+      user: null,
+      error: null,
+    });
+  });
+
+  it.each([
+    ['auth/popup-closed-by-user', 'Sign-in cancelled. You can try again.'],
+    ['auth/cancelled-popup-request', 'Sign-in cancelled. You can try again.'],
+    ['auth/popup-blocked', 'Allow popups for this page, then try again.'],
+    [
+      'auth/network-request-failed',
+      'Cannot reach the local Auth Emulator. Check that it is running, then try again.',
+    ],
+    ['secret-token-value', 'The session action failed. Please try again.'],
+  ])(
+    'sanitizes %s and allows recovery without changing observed identity',
+    async (code, message) => {
+      const { session, adapter, changed } = fixture();
+      changed({ uid: 'alice', displayName: null });
+      adapter.signOut.mockRejectedValueOnce({ code, message: 'private credential' });
+      await session.signOut();
+      expect(session.getSnapshot()).toEqual({
+        ready: true,
+        pending: false,
+        user: { uid: 'alice', displayName: null },
+        error: message,
+      });
+      await session.signOut();
+      expect(session.getSnapshot().error).toBeNull();
+      expect(adapter.signOut).toHaveBeenCalledTimes(2);
+      await session.dispose();
+    }
+  );
+
+  it('isolates sessions and releases view subscriptions independently', async () => {
+    const first = fixture();
+    const second = fixture();
+    const listener = vi.fn();
+    const stop = first.session.subscribe(listener);
+    first.changed({ uid: 'alice', displayName: null });
+    expect(listener).toHaveBeenCalledOnce();
+    stop();
+    first.changed(null);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(second.session.getSnapshot().ready).toBe(false);
+    await first.session.dispose();
+    await second.session.dispose();
+  });
+});

--- a/apps/office/src/auth/session.ts
+++ b/apps/office/src/auth/session.ts
@@ -1,0 +1,89 @@
+export interface SessionUser {
+  readonly uid: string;
+  readonly displayName: string | null;
+}
+
+export interface SessionSnapshot {
+  readonly ready: boolean;
+  readonly user: SessionUser | null;
+  readonly pending: boolean;
+  readonly error: string | null;
+}
+
+export interface SessionAdapter {
+  observe: (changed: (user: SessionUser | null) => void) => () => void;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+  dispose: () => Promise<void>;
+}
+
+export interface OfficeSession {
+  getSnapshot: () => SessionSnapshot;
+  subscribe: (listener: () => void) => () => void;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+  dispose: () => Promise<void>;
+}
+
+function actionError(error: unknown): string {
+  const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : null;
+  switch (code) {
+    case 'auth/popup-closed-by-user':
+    case 'auth/cancelled-popup-request':
+      return 'Sign-in cancelled. You can try again.';
+    case 'auth/popup-blocked':
+      return 'Allow popups for this page, then try again.';
+    case 'auth/network-request-failed':
+      return 'Cannot reach the local Auth Emulator. Check that it is running, then try again.';
+    default:
+      return 'The session action failed. Please try again.';
+  }
+}
+
+/** One observer owns identity; action completion never manufactures a signed-in user. */
+export function createSession(adapter: SessionAdapter): OfficeSession {
+  let snapshot: SessionSnapshot = { ready: false, user: null, pending: false, error: null };
+  const listeners = new Set<() => void>();
+  let disposed = false;
+  let disposal: Promise<void> | undefined;
+  function publish(next: SessionSnapshot): void {
+    if (disposed) return;
+    snapshot = next;
+    for (const listener of listeners) listener();
+  }
+  const unsubscribe = adapter.observe((user) => publish({ ...snapshot, ready: true, user }));
+
+  async function act(action: () => Promise<void>): Promise<void> {
+    if (disposed || !snapshot.ready || snapshot.pending) return;
+    publish({ ...snapshot, pending: true, error: null });
+    try {
+      await action();
+    } catch (error) {
+      publish({ ...snapshot, error: actionError(error) });
+    } finally {
+      publish({ ...snapshot, pending: false });
+    }
+  }
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener) {
+      if (disposed) return () => {};
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    signIn: () => act(adapter.signIn),
+    signOut: () => act(adapter.signOut),
+    dispose() {
+      if (disposal) return disposal;
+      disposed = true;
+      unsubscribe();
+      listeners.clear();
+      snapshot = { ready: false, user: null, pending: false, error: null };
+      disposal = adapter.dispose();
+      return disposal;
+    },
+  };
+}

--- a/apps/office/src/main.tsx
+++ b/apps/office/src/main.tsx
@@ -3,12 +3,42 @@ import { createRoot } from 'react-dom/client';
 import { OfficeApp } from './office-app.js';
 import { createOfficeRouter } from './router.js';
 import './styles.css';
+import type { OfficeSession } from './auth/session.js';
 
 const root = document.getElementById('root');
 if (!root) throw new Error('Office root element is missing.');
 
-createRoot(root).render(
-  <StrictMode>
-    <OfficeApp router={createOfficeRouter()} />
-  </StrictMode>
-);
+const app = createRoot(root);
+let session: OfficeSession | undefined;
+let active = true;
+import.meta.hot?.dispose(() => {
+  active = false;
+  app.unmount();
+  void session?.dispose();
+});
+
+async function mount(): Promise<void> {
+  try {
+    // Vite removes this branch (and the SDK chunk) from the default build.
+    if (import.meta.env.MODE === 'emulator') {
+      const { startOfficeSession } = await import('./auth/firebase-session.js');
+      if (!active) return;
+      session = startOfficeSession(import.meta.env.MODE, location.hostname);
+    }
+  } catch {
+    if (active)
+      app.render(
+        <p role="alert">
+          Office could not initialize local sign-in. Use a loopback hostname and reload.
+        </p>
+      );
+    return;
+  }
+  app.render(
+    <StrictMode>
+      <OfficeApp router={createOfficeRouter()} session={session} />
+    </StrictMode>
+  );
+}
+
+void mount();

--- a/apps/office/src/office-app.test.tsx
+++ b/apps/office/src/office-app.test.tsx
@@ -29,7 +29,7 @@ describe('Office foundation', () => {
     await user.click(within(screen.getByRole('navigation')).getByRole('link', { name: 'Setup' }));
     await screen.findByRole('heading', { name: 'Start small. Stay in control.' });
     expect(router.state.location.pathname).toBe('/setup');
-    expect(screen.getByText(/This shell does not sign in/)).toBeDefined();
+    expect(screen.getByText(/This shell does not create a world/)).toBeDefined();
     await user.click(within(screen.getByRole('navigation')).getByRole('link', { name: 'Office' }));
     await screen.findByRole('heading', { name: 'No world connected' });
     expect(router.state.location.pathname).toBe('/');
@@ -52,13 +52,13 @@ describe('Office foundation', () => {
     const first = renderOffice();
     await screen.findByRole('heading', { name: 'No world connected' });
     await user.click(screen.getByRole('button', { name: 'Preview details' }));
-    expect(screen.getByText(/This shell does not sign in/)).toBeDefined();
+    expect(screen.getByText(/This shell does not create a world/)).toBeDefined();
     first.unmount();
     renderOffice();
     await screen.findByRole('heading', { name: 'No world connected' });
     expect(
       screen.getByRole('button', { name: 'Preview details' }).getAttribute('aria-expanded')
     ).toBe('false');
-    expect(screen.queryByText(/This shell does not sign in/)).toBeNull();
+    expect(screen.queryByText(/This shell does not create a world/)).toBeNull();
   });
 });

--- a/apps/office/src/office-app.tsx
+++ b/apps/office/src/office-app.tsx
@@ -3,17 +3,23 @@ import { createStore, Provider } from 'jotai';
 import { useState } from 'react';
 import type { ReactElement } from 'react';
 import type { createOfficeRouter } from './router.js';
+import { OfficeSessionContext } from './auth/session-view.js';
+import type { OfficeSession } from './auth/session.js';
 
 export function OfficeApp({
   router,
+  session,
 }: {
   router: ReturnType<typeof createOfficeRouter>;
+  session?: OfficeSession;
 }): ReactElement {
   // A mounted app owns its UI state; tests and future embedded views cannot leak it.
   const [store] = useState(() => createStore());
   return (
     <Provider store={store}>
-      <RouterProvider router={router} />
+      <OfficeSessionContext value={session}>
+        <RouterProvider router={router} />
+      </OfficeSessionContext>
     </Provider>
   );
 }

--- a/apps/office/src/pages/setup.tsx
+++ b/apps/office/src/pages/setup.tsx
@@ -13,7 +13,10 @@ export function SetupPage(): ReactElement {
       <ol className="setup-steps">
         <li>
           <h2>A private world</h2>
-          <p>Sign-in and invitations will control who can visit. Not connected in this preview.</p>
+          <p>
+            Invitations will control who can visit. Local emulator sign-in alone grants no world
+            access.
+          </p>
         </li>
         <li>
           <h2>Your local team</h2>

--- a/apps/office/src/shell.tsx
+++ b/apps/office/src/shell.tsx
@@ -1,6 +1,7 @@
 import { Link, Outlet } from '@tanstack/react-router';
 import { atom, useAtom } from 'jotai';
 import type { ReactElement } from 'react';
+import { SessionPanel } from './auth/session-view.js';
 
 const showPreviewNotesAtom = atom(false);
 
@@ -24,6 +25,7 @@ export function OfficeShell(): ReactElement {
         <span className="preview-badge">Local preview</span>
       </header>
       <main id="main">
+        <SessionPanel />
         <Outlet />
       </main>
       <footer>
@@ -38,7 +40,8 @@ export function OfficeShell(): ReactElement {
         </button>
         {showNotes && (
           <p id="preview-notes">
-            This shell does not sign in, create a world, read local TMT data or send work to agents.
+            This shell does not create a world, read local TMT data or send work to agents. Local
+            sign-in is available only in explicit emulator mode.
           </p>
         )}
       </footer>

--- a/apps/office/src/styles.css
+++ b/apps/office/src/styles.css
@@ -150,6 +150,23 @@ footer p {
   flex-basis: 100%;
   margin: 0;
 }
+.session-panel {
+  border: 1px solid #d4dccf;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 24px;
+  background: #fff;
+  overflow-wrap: anywhere;
+}
+.session-panel p {
+  margin: 8px 0;
+}
+.session-panel button {
+  padding: 8px 12px;
+}
+.session-panel [role='alert'] {
+  color: #9b2c2c;
+}
 .skip-link {
   position: absolute;
   left: -10000px;

--- a/apps/office/tsconfig.json
+++ b/apps/office/tsconfig.json
@@ -12,5 +12,5 @@
     "verbatimModuleSyntax": true,
     "types": ["vite/client", "node"]
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "e2e", "vite.config.ts", "playwright.config.ts"]
 }

--- a/apps/office/vite.config.ts
+++ b/apps/office/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
-    include: ['src/**/*.test.tsx'],
+    include: ['src/**/*.test.{ts,tsx}'],
     setupFiles: ['./src/test-setup.ts'],
     passWithNoTests: false,
     restoreMocks: true,

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -3,7 +3,7 @@
 Tracking: [#175](https://github.com/wkh237/tmux-team/issues/175), under
 [#173](https://github.com/wkh237/tmux-team/issues/173).
 The owner approved workspace-first delivery. The full protocol and trust design
-in [#174](https://github.com/wkh237/tmux-team/issues/174) remains open; this
+in [#174](https://github.com/wkh237/tmux-team/issues/174) is merged; this
 document describes the implemented workspace. The
 [v1 design](design.md), [planned commands](commands.md) and
 [wire contracts](../../contracts/office/README.md) now record the design baseline;
@@ -13,8 +13,24 @@ they do not make the shell a connected Office.
 
 Office is an optional React SPA under `apps/office`. Its local shell has a home
 route, setup explanation, unknown-route recovery and provider-local presentation
-state. It does not authenticate, contact Firebase, load local identities, install
-an extension, open a listener or dispatch work. The native CLI remains unchanged.
+state. Default preview does not initialize Firebase. Explicit `emulator` mode
+on loopback enables local Google-provider popup sign-in, UID display and logout
+through the Auth Emulator, not real Google. It does not load local identities,
+install an extension, open a connector listener or dispatch work. The native CLI
+remains unchanged. Login does not grant world access; Firestore still denies all
+client access. This is #187, the first slice of #176, not a private-world implementation.
+
+`src/auth/firebase-session.ts` is the only Firebase initialization/adapter owner.
+The entry point creates one uniquely named app outside React rendering and
+disposes it on hot replacement. `session.ts` owns one observer, bounded public
+identity projection, action serialization, sanitized errors and teardown.
+`session-view.tsx` subscribes directly with React's external-store interface;
+Jotai and Query do not mirror identity. Only the observer changes identity;
+failed actions retain the observed state, and late completions cannot revive
+a disposed session. Auth uses explicit in-memory persistence from initialization:
+reload signs out and other tabs/contexts do not inherit the identity. No tokens
+are exposed in view snapshots. This memory policy is not a substitute for future
+server-side revocation or world authorization.
 
 | Owner              | Responsibility                                                              | Forbidden dependency                                                    |
 | ------------------ | --------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -78,6 +94,13 @@ or automatic federation. No cloud provisioning, billing or deployment occurs her
 | Expand preview details, then navigate | Disclosure stays open in this mounted app                     |
 | Unmount and start another app         | Disclosure resets; no global/persisted UI state               |
 
-The DOM tests use the real router and user interactions. They do not prove
-browser layout, hosting rewrites, Firebase rules, connector lifecycle or remote
-collaboration. Those need their own downstream evidence.
+DOM tests use the real router, with focused session lifecycle tests beside the
+owner. Playwright under `apps/office/e2e` proves real Chromium/SDK/Auth Emulator
+popup flow, cancellation, transport failure, memory isolation and default-preview
+network inactivity. Its opt-in Docker target extends the existing emulator image;
+it does not duplicate emulator pins or use the native tmux harness. Upstream
+emulator CDN presentation assets are blocked, not replaced with fake auth
+responses. Google's public popup/iframe library is still required: browser
+tests allow its script GETs on `apis.google.com`, keep all auth requests local,
+and reject other destinations. This is not a fully offline flow. These tests do not prove world rules,
+connector lifecycle, real Google login or remote collaboration.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check:tooling": "pnpm type:check && pnpm lint && pnpm format:check && pnpm docs:format:check",
     "check": "pnpm check:tooling && pnpm office:check",
     "office:dev": "pnpm --filter @tmt/office --fail-if-no-match dev",
-    "office:install": "cd apps/office && pnpm install --ignore-workspace --lockfile-dir ../.. --frozen-lockfile",
+    "office:install": "cd apps/office && pnpm install --ignore-workspace --lockfile-dir \"$PWD/../..\" --frozen-lockfile",
     "office:build": "pnpm --filter @tmt/office --fail-if-no-match build",
     "office:test": "pnpm --filter @tmt/office --fail-if-no-match test",
     "office:check": "pnpm --filter @tmt/office --fail-if-no-match check"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@tanstack/react-router':
         specifier: 1.170.33
         version: 1.170.33(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      firebase:
+        specifier: 12.18.0
+        version: 12.18.0
       jotai:
         specifier: 3.0.0
         version: 3.0.0(@types/react@19.2.18)(react@19.2.8)
@@ -51,6 +54,9 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
     devDependencies:
+      '@playwright/test':
+        specifier: 1.63.0
+        version: 1.63.0
       '@testing-library/react':
         specifier: 16.3.3
         version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.7(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -271,6 +277,243 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@firebase/ai@2.15.0':
+    resolution: {integrity: sha512-Aj7TbFdAIWZdkX8JfdDStERpR35g6WNs+7XhNPtFLFOizUotj6k4N/D8HJkR45165HhnMJBe4hjOeeaxnnn56Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-types': 0.x
+
+  '@firebase/analytics-compat@0.2.30':
+    resolution: {integrity: sha512-uVZEKlLaW4AHAhv8zoN9cTmveX6v86AVqcJ4LCaRCMTChTH8/NsjbisTq1lpBfWCLWS1spqwSHB4vol/YSCdMA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/analytics-types@0.8.5':
+    resolution: {integrity: sha512-kdnooE7Bis2jEnsqcerRwn/UQpH5D3uvHpku7OdUM9TJN3omlu6iYtbyAQ6XkAJRgJtO0aNf9OOkW8J6D59oCA==}
+
+  '@firebase/analytics@0.10.24':
+    resolution: {integrity: sha512-OfIAcIIwoqXjBzS+DnUQpOZ7i3ePaNFg83KPpDWjBZUKJmqMwzzAtLJqmKZOkQnW8im6vFR6f2I3M/9hxVd+QA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-check-compat@0.4.7':
+    resolution: {integrity: sha512-fBb/xSMyIKv1nDmccfzz3IAGBzx/cQOxmZai66rJzifb1hMMkztf824Xx7LhpTUe7HNUbXwY90IvJ66fi8q6yg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/app-check-interop-types@0.3.5':
+    resolution: {integrity: sha512-qId34pVZ2CXTmtu4ofW5leiI93DvnOvIcr/5GT7MZPw5WXAi6nZoU+g9cNRgl7K90UJSbK0cXxten4meYMPyZg==}
+
+  '@firebase/app-check-types@0.5.5':
+    resolution: {integrity: sha512-+DF4gzFrlwGFyky38o4T/YN/r51l70yCtJ2HTkwmRj8FCMwPjm4hLH4fQbj6BUvzkiFqliBkitFsRpf1/YZkWA==}
+
+  '@firebase/app-check@0.13.1':
+    resolution: {integrity: sha512-l8y3dmnhodXks/APAwx4tWqRl3tk8b9874KF1FJyKg1DIU+kMD0l52iz7S9/MW+eK8k6cjJg0G0iJ5KQAsQpow==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-compat@0.5.17':
+    resolution: {integrity: sha512-5GdJWobqs6jbNYOnaQiSa4Ng8gnFerhqr7nY+v5jlnT7o9QbEeIZRLPQpnLe0TxYSWfRV2lAMbyR0kbXeIos9Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/app-types@0.9.6':
+    resolution: {integrity: sha512-yPLahy7Esfu2w/yme3msVK4xTkDXQqq6szfQn8yVOQpCKiT5GVFjqNpLbuz6NkX0WuTwUidkmPewW3r4xkvpeg==}
+
+  '@firebase/app@0.16.1':
+    resolution: {integrity: sha512-tjUEorFyKrurH7PbLWv9zDHRuU4mLefgD/yY38D584ziorIRlQz/PVjx4c/SCGyCuUlmyzt72mK+Lh+COAywNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/auth-compat@0.6.10':
+    resolution: {integrity: sha512-Bvklg2nL7BrBFCAqdsleW8fse9Jh0fARqJPlJmA40uermfWx1bJiO7dnKyZN3J39d2TFVd4VJXtg3i6Wg92/YQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/auth-interop-types@0.2.6':
+    resolution: {integrity: sha512-FgwZqDrBqgK0BHI70QTv1v/5wmuDF9f8fsJFvKSxoRlK2PPfSQtZAk2jhXu4pe9BZzFi/e4UYusU/bEQHdf6Qg==}
+
+  '@firebase/auth-types@0.13.2':
+    resolution: {integrity: sha512-OU+miuoSxIWYN7GT291d2ylVJBL3k/OePo7/JDSoQtkFQoEiGBc4AHuMjj/seqFIsHrqnjrAfRCk4pfufoJolQ==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/auth@1.13.5':
+    resolution: {integrity: sha512-1AXoBJqBVD8WL8FZYo3S2GmJF9YUoom6Y6ngMxOSkzzhW5sT83pLchb6TGFgxes91dfXx8s/VYc5VrLDNqpLog==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@react-native-async-storage/async-storage': ^2.2.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+
+  '@firebase/component@0.7.5':
+    resolution: {integrity: sha512-vuFDcL91Q+2ZuBJkyOh86T4q0B4ffNTDjc/A38tybO56odQABxRTFLTIowCWqAKeIcgo37GowWMVgFF73gD8Qw==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/data-connect@0.7.4':
+    resolution: {integrity: sha512-su1aGWlzhxb+xtggCUSsufJn1FDa06SBDK71y+fpQ+g2zMhMExik6FUv/odkKzOF/xfWVjabCbWBcjJY3MceDA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/database-compat@2.1.7':
+    resolution: {integrity: sha512-lBq9sJm8MnJINKJnkAKSOj2MbC66xGoSVCcGkPtstl+lkoKEBtD46qHLbuDgW/WbLPoKVm17RIN8BxHj+Z2F2w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+    peerDependenciesMeta:
+      '@firebase/app':
+        optional: true
+      '@firebase/app-compat':
+        optional: true
+
+  '@firebase/database-types@1.0.22':
+    resolution: {integrity: sha512-YAZNXsjY9EQQ+pKw/3ax8n5FgolHC7Qew7EY5RceYdl0R2ZP+kCv1O0DkKlcceue8uQCOreHCNN7PWVFpY1Nug==}
+
+  '@firebase/database@1.1.5':
+    resolution: {integrity: sha512-/JGpvszLoNXNgzilRXocigGfFF4hbcPA9wN1i1kjJx6oKkXgkHteZYl3lQs1lJX3ETDf6bv7zI15lPMVUp4sAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/firestore-compat@0.4.13':
+    resolution: {integrity: sha512-l9dCewxMzzLOIhcwTjERCKxrWOn1kZ9JvwOQq9zZNq4I/Nbvb/B9njT230V61uvQ9qZ3/qpUG758D8DDTEFXnw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/firestore-types@3.0.5':
+    resolution: {integrity: sha512-dbdMAQkMd5dwWc48eupz/Y6/E9ruat3+gY5lhVKscvvT/HnDBEEMzJW38zdKhgdnglZHGk2vUsJMOHAphMHGMA==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/firestore@4.17.1':
+    resolution: {integrity: sha512-8lqPNf2w10CtYG+tayVjZO1pSyQpnhztQRudeD109VtXDzNbASTaYdO43sj5PMsDcWq0aOYY3RmJOUlXu9++jw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/functions-compat@0.5.0':
+    resolution: {integrity: sha512-T3BDIToESZUHt7438wyKYMkRjKg3m1xAIux5fVpNvTRQlDOFLukWniQWBDhJ2znpU9kxMTR6+e31TVo8P15PZw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/functions-types@0.6.5':
+    resolution: {integrity: sha512-Zc0pURjthHXzSj54ZivCkzKDSV1r/wIpnmHdhq82q2yFFPVoncG/ZJjnVMiANvQfeww/QnElhzODpfwUucVwdA==}
+
+  '@firebase/functions@0.14.0':
+    resolution: {integrity: sha512-DhuYFr0eMhp+s/PNEk6SiMsYkc00+XVOUeKbrl8MOzQNZI3SKQpqoDR1d+keNDAutwmHRWTUAdXBoVPD+xxVUw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/installations-compat@0.2.24':
+    resolution: {integrity: sha512-8M5nlcWwYt881x83COP2odq5vgf+NgwJh+RMd4LRSv8JI1pxwDfgrDJOERrjTgfC9J5Z0vnQX4b1pdN914e0Zw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/installations-types@0.5.5':
+    resolution: {integrity: sha512-e9UYcju3puDl1vdrcKIi5dExzHLameOT/Tc61Q48PYwxtsM1NzZh/ikGbdBQTsbRgg0EMZqdPr0/m5ODUBobrg==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+
+  '@firebase/installations@0.6.24':
+    resolution: {integrity: sha512-Ui52ey8wHoWqkBbXRKJEKYWylI0JZogZmoLS+o8Anh1bxWtK27ZYjLla1UJAAdC5DCKLJ2qAp0VpJOjg8VOX1g==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/logger@0.5.2':
+    resolution: {integrity: sha512-J2VO4NFTc0xQFrxV1B/lm5balicm9cwuX2acR9Yn41fN8KgUeQFo+VJV222IqW2FPSXKDu9uo5WdQFWf9TPbYg==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/messaging-compat@0.2.29':
+    resolution: {integrity: sha512-8Twe4CeYvAx8AzjBxyyQFKzinaMGGt13hPQBqaARQ2QZjagrEaqSVBe+Zy6F4L/vT8DV168yRgRu7W/RK7p+4w==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/messaging-interop-types@0.2.6':
+    resolution: {integrity: sha512-MVzvkKe2V4H2dHu5oOxRfeKQcfTwWmCgnzsC4V1q3ixun5iiL8riCZ2qI35rDhCL4glPGiu0jHxDbpVNuTKfow==}
+
+  '@firebase/messaging@0.13.2':
+    resolution: {integrity: sha512-KcZoqUu2ih4sLH91dW9tmyHjCR0IQyNzSLZunX5uq7cLeImXb4uO2I0wq5FACduO2I+FoTeWa2BtUv7Jpowqdw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/performance-compat@0.2.27':
+    resolution: {integrity: sha512-O/ozTf/EbChN94Pk7bd1eUC0PAC36726AwsaiJyC0bZzSBWfLGSWASGPH5pebUWXQPJtGxIJYRkkbX5l0Qa+Hw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/performance-types@0.2.5':
+    resolution: {integrity: sha512-PRzOgB+/M+6AKlEkY8a9xy5Ff5SfZPIh4iShXhn2WAcL/euSbK7bdLqWysHduunNJhGFsXa22Ag3ixqL6rQtYg==}
+
+  '@firebase/performance@0.7.14':
+    resolution: {integrity: sha512-9PH1XEZVHErxGdbXluvGz4Uyjw4W955H8v7Mv9rHIybRrg5F2Ac2tvf5+mSf5EtnxWNmxrD2WLnvMFaZP4sMrQ==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/remote-config-compat@0.2.29':
+    resolution: {integrity: sha512-mY7JtTISK6F4g4T0x3kVepr5cp0NXL7f5yjIUXXGaTrg4qUlFBWRbENaHaqZ78dwmNcLm24h/yPsOVRlDXEXhA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/remote-config-types@0.5.2':
+    resolution: {integrity: sha512-i8k1omVfoAnaT1ZPv2FFjxMZrATYsO/GnFgHEj5+7fAJLzi8wLnGGv1WK06oEAD6ltrWXSO1HzeNyajn/NjMWw==}
+
+  '@firebase/remote-config@0.9.2':
+    resolution: {integrity: sha512-Rii93DkXjM+RE/ytHdYa7EIiQLJbdBr+W8EEiqd/vbLCOC+1FdkDuRiumJBp6t3yewHGbdqbpjB3fk3z0cZ+8g==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/storage-compat@0.4.5':
+    resolution: {integrity: sha512-vO0tFPxXbKDKdlTu8tYT08S9t9ezUTJYEdLCULpWxWq2aq6zojwN1QmAB+1a50AI/g47GlWUJn1XPncm/PDZsw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+
+  '@firebase/storage-types@0.8.5':
+    resolution: {integrity: sha512-GEDs5P+rNUfNcS+wxIdOLAHficife2YXtvTJnyi3ssrX11AAtBg+nDUdbYh8vuBzWehVQZPmztGUUnud4L+4yg==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/storage@0.14.5':
+    resolution: {integrity: sha512-r2tozN/BlEewLi70tJNUQPzWwbex9GM7NgXZsamHKQrjKEfcR0i4jGgHBKAKA4hbwiPE9eNMb3hcxWnDpeJZwg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/util@1.15.3':
+    resolution: {integrity: sha512-c/z/gaIlaaLZEuGbE6sLUuJ61tskg1JghvhcNQzW948ASBinbVBBRnZTC4b4yt4LaEtJQkYlyzqLHcutFwEIvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/webchannel-wrapper@1.0.7':
+    resolution: {integrity: sha512-phBFwieDLvkZGYN9CE9ZFNEIoBVksprzsnCzQejCmCHtgwCXReeuRpoEGN9C4EbhONztv8NRV1tau6Rb9pONwQ==}
+
+  '@grpc/grpc-js@1.9.16':
+    resolution: {integrity: sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==}
+    engines: {node: ^8.13.0 || >=10.10.0}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -450,6 +693,38 @@ packages:
     resolution: {integrity: sha512-yPFcj6umrhusnG/kMS5wh96vblsqZ0kArQJS+7kEOSJDrH+DsFWaDCsSRF8U6gmSmZJ26KVMU3C3TMpqDN4M1g==}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.63.0':
+    resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@rolldown/binding-android-arm-eabi@1.2.8':
     resolution: {integrity: sha512-tN5aztYkKCte4i5SIrrz5yK/HMjEuCqCSCJa418jOV8tZ1cBY3YF2otxB1ktPxzsLA1BeTqwapK0bfjxNvHJVw==}
@@ -832,6 +1107,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
@@ -868,6 +1147,17 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -924,6 +1214,9 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -935,6 +1228,10 @@ packages:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -953,6 +1250,10 @@ packages:
   fast-uri@3.1.7:
     resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
+  faye-websocket@0.11.4:
+    resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
+    engines: {node: '>=0.8.0'}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -962,10 +1263,17 @@ packages:
       picomatch:
         optional: true
 
+  firebase@12.18.0:
+    resolution: {integrity: sha512-XaL6tlE5Xd20ZDhckqOMIw+JJTET+wTdeZPxQ7ihc42oxRb7kWUyn/j1LO5V9dH1xq8Rv5R71Pv1fBCdIkt9Rw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
@@ -977,6 +1285,9 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -993,6 +1304,13 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  idb@7.1.1:
+    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -1116,6 +1434,12 @@ packages:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
     engines: {node: '>=14'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
@@ -1236,6 +1560,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   postcss@8.5.28:
     resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1257,9 +1591,17 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  protobufjs@7.6.6:
+    resolution: {integrity: sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==}
+    engines: {node: '>=12.0.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  re2js@2.8.6:
+    resolution: {integrity: sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==}
+    engines: {node: '>=18.0.0'}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -1274,6 +1616,10 @@ packages:
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
@@ -1292,6 +1638,9 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1340,6 +1689,14 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -1396,6 +1753,9 @@ packages:
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
@@ -1566,9 +1926,20 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
+    engines: {node: '>=0.8.0'}
+
+  websocket-extensions@0.1.4:
+    resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
+    engines: {node: '>=0.8.0'}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -1593,6 +1964,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -1612,9 +1987,21 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
 
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
@@ -1729,6 +2116,336 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@firebase/ai@2.15.0(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-check-interop-types': 0.3.5
+      '@firebase/app-types': 0.9.6
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/analytics-compat@0.2.30(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/analytics': 0.10.24(@firebase/app@0.16.1)
+      '@firebase/analytics-types': 0.8.5
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+      '@firebase/component': 0.7.5
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/analytics-types@0.8.5': {}
+
+  '@firebase/analytics@0.10.24(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/installations': 0.6.24(@firebase/app@0.16.1)
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/app-check-compat@0.4.7(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-check': 0.13.1(@firebase/app@0.16.1)
+      '@firebase/app-check-types': 0.5.5
+      '@firebase/app-compat': 0.5.17
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/app-check-interop-types@0.3.5': {}
+
+  '@firebase/app-check-types@0.5.5': {}
+
+  '@firebase/app-check@0.13.1(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/app-compat@0.5.17':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/app-types@0.9.6':
+    dependencies:
+      '@firebase/logger': 0.5.2
+
+  '@firebase/app@0.16.1':
+    dependencies:
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/auth-compat@0.6.10(@firebase/app-compat@0.5.17)(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+      '@firebase/auth': 1.13.5(@firebase/app@0.16.1)
+      '@firebase/auth-types': 0.13.2(@firebase/app-types@0.9.6)(@firebase/util@1.15.3)
+      '@firebase/component': 0.7.5
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+      - '@react-native-async-storage/async-storage'
+
+  '@firebase/auth-interop-types@0.2.6': {}
+
+  '@firebase/auth-types@0.13.2(@firebase/app-types@0.9.6)(@firebase/util@1.15.3)':
+    dependencies:
+      '@firebase/app-types': 0.9.6
+      '@firebase/util': 1.15.3
+
+  '@firebase/auth@1.13.5(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/component@0.7.5':
+    dependencies:
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/data-connect@0.7.4(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/auth-interop-types': 0.2.6
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/database-compat@2.1.7(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/component': 0.7.5
+      '@firebase/database': 1.1.5
+      '@firebase/database-types': 1.0.22
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+
+  '@firebase/database-types@1.0.22':
+    dependencies:
+      '@firebase/app-types': 0.9.6
+      '@firebase/util': 1.15.3
+
+  '@firebase/database@1.1.5':
+    dependencies:
+      '@firebase/app-check-interop-types': 0.3.5
+      '@firebase/auth-interop-types': 0.2.6
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      faye-websocket: 0.11.4
+      tslib: 2.8.1
+
+  '@firebase/firestore-compat@0.4.13(@firebase/app-compat@0.5.17)(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+      '@firebase/component': 0.7.5
+      '@firebase/firestore': 4.17.1(@firebase/app@0.16.1)
+      '@firebase/firestore-types': 3.0.5(@firebase/app-types@0.9.6)(@firebase/util@1.15.3)
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+
+  '@firebase/firestore-types@3.0.5(@firebase/app-types@0.9.6)(@firebase/util@1.15.3)':
+    dependencies:
+      '@firebase/app-types': 0.9.6
+      '@firebase/util': 1.15.3
+
+  '@firebase/firestore@4.17.1(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      '@firebase/webchannel-wrapper': 1.0.7
+      '@grpc/grpc-js': 1.9.16
+      '@grpc/proto-loader': 0.7.15
+      re2js: 2.8.6
+      tslib: 2.8.1
+
+  '@firebase/functions-compat@0.5.0(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+      '@firebase/component': 0.7.5
+      '@firebase/functions': 0.14.0(@firebase/app@0.16.1)
+      '@firebase/functions-types': 0.6.5
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/functions-types@0.6.5': {}
+
+  '@firebase/functions@0.14.0(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-check-interop-types': 0.3.5
+      '@firebase/auth-interop-types': 0.2.6
+      '@firebase/component': 0.7.5
+      '@firebase/messaging-interop-types': 0.2.6
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/installations-compat@0.2.24(@firebase/app-compat@0.5.17)(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+      '@firebase/component': 0.7.5
+      '@firebase/installations': 0.6.24(@firebase/app@0.16.1)
+      '@firebase/installations-types': 0.5.5(@firebase/app-types@0.9.6)
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+
+  '@firebase/installations-types@0.5.5(@firebase/app-types@0.9.6)':
+    dependencies:
+      '@firebase/app-types': 0.9.6
+
+  '@firebase/installations@0.6.24(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/util': 1.15.3
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/logger@0.5.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/messaging-compat@0.2.29(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+      '@firebase/component': 0.7.5
+      '@firebase/messaging': 0.13.2(@firebase/app@0.16.1)
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/messaging-interop-types@0.2.6': {}
+
+  '@firebase/messaging@0.13.2(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/installations': 0.6.24(@firebase/app@0.16.1)
+      '@firebase/messaging-interop-types': 0.2.6
+      '@firebase/util': 1.15.3
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/performance-compat@0.2.27(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/performance': 0.7.14(@firebase/app@0.16.1)
+      '@firebase/performance-types': 0.2.5
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/performance-types@0.2.5': {}
+
+  '@firebase/performance@0.7.14(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/installations': 0.6.24(@firebase/app@0.16.1)
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+      web-vitals: 4.2.4
+
+  '@firebase/remote-config-compat@0.2.29(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+      '@firebase/component': 0.7.5
+      '@firebase/logger': 0.5.2
+      '@firebase/remote-config': 0.9.2(@firebase/app@0.16.1)
+      '@firebase/remote-config-types': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/remote-config-types@0.5.2': {}
+
+  '@firebase/remote-config@0.9.2(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/installations': 0.6.24(@firebase/app@0.16.1)
+      '@firebase/logger': 0.5.2
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/storage-compat@0.4.5(@firebase/app-compat@0.5.17)(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/app-compat': 0.5.17
+      '@firebase/component': 0.7.5
+      '@firebase/storage': 0.14.5(@firebase/app@0.16.1)
+      '@firebase/storage-types': 0.8.5(@firebase/app-types@0.9.6)(@firebase/util@1.15.3)
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app-types'
+
+  '@firebase/storage-types@0.8.5(@firebase/app-types@0.9.6)(@firebase/util@1.15.3)':
+    dependencies:
+      '@firebase/app-types': 0.9.6
+      '@firebase/util': 1.15.3
+
+  '@firebase/storage@0.14.5(@firebase/app@0.16.1)':
+    dependencies:
+      '@firebase/app': 0.16.1
+      '@firebase/component': 0.7.5
+      '@firebase/util': 1.15.3
+      tslib: 2.8.1
+
+  '@firebase/util@1.15.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/webchannel-wrapper@1.0.7': {}
+
+  '@grpc/grpc-js@1.9.16':
+    dependencies:
+      '@grpc/proto-loader': 0.7.15
+      '@types/node': 25.0.3
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.6
+      yargs: 17.7.3
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -1821,6 +2538,30 @@ snapshots:
 
   '@oxlint/win32-x64@1.35.0':
     optional: true
+
+  '@playwright/test@1.63.0':
+    dependencies:
+      playwright: 1.63.0
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@rolldown/binding-android-arm-eabi@1.2.8':
     optional: true
@@ -2110,6 +2851,10 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansi-styles@5.2.0: {}
 
   aria-query@5.3.0:
@@ -2143,6 +2888,18 @@ snapshots:
       get-func-name: 2.0.2
 
   chownr@3.0.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   confbox@0.1.8: {}
 
@@ -2186,6 +2943,8 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
+  emoji-regex@8.0.0: {}
+
   entities@6.0.1: {}
 
   es-module-lexer@2.3.2: {}
@@ -2216,6 +2975,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  escalade@3.2.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -2238,12 +2999,51 @@ snapshots:
 
   fast-uri@3.1.7: {}
 
+  faye-websocket@0.11.4:
+    dependencies:
+      websocket-driver: 0.7.5
+
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
       picomatch: 4.0.7
 
+  firebase@12.18.0:
+    dependencies:
+      '@firebase/ai': 2.15.0(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)
+      '@firebase/analytics': 0.10.24(@firebase/app@0.16.1)
+      '@firebase/analytics-compat': 0.2.30(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)
+      '@firebase/app': 0.16.1
+      '@firebase/app-check': 0.13.1(@firebase/app@0.16.1)
+      '@firebase/app-check-compat': 0.4.7(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)
+      '@firebase/app-compat': 0.5.17
+      '@firebase/app-types': 0.9.6
+      '@firebase/auth': 1.13.5(@firebase/app@0.16.1)
+      '@firebase/auth-compat': 0.6.10(@firebase/app-compat@0.5.17)(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)
+      '@firebase/data-connect': 0.7.4(@firebase/app@0.16.1)
+      '@firebase/database': 1.1.5
+      '@firebase/database-compat': 2.1.7(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)
+      '@firebase/firestore': 4.17.1(@firebase/app@0.16.1)
+      '@firebase/firestore-compat': 0.4.13(@firebase/app-compat@0.5.17)(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)
+      '@firebase/functions': 0.14.0(@firebase/app@0.16.1)
+      '@firebase/functions-compat': 0.5.0(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)
+      '@firebase/installations': 0.6.24(@firebase/app@0.16.1)
+      '@firebase/installations-compat': 0.2.24(@firebase/app-compat@0.5.17)(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)
+      '@firebase/messaging': 0.13.2(@firebase/app@0.16.1)
+      '@firebase/messaging-compat': 0.2.29(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)
+      '@firebase/performance': 0.7.14(@firebase/app@0.16.1)
+      '@firebase/performance-compat': 0.2.27(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)
+      '@firebase/remote-config': 0.9.2(@firebase/app@0.16.1)
+      '@firebase/remote-config-compat': 0.2.29(@firebase/app-compat@0.5.17)(@firebase/app@0.16.1)
+      '@firebase/storage': 0.14.5(@firebase/app@0.16.1)
+      '@firebase/storage-compat': 0.4.5(@firebase/app-compat@0.5.17)(@firebase/app-types@0.9.6)(@firebase/app@0.16.1)
+      '@firebase/util': 1.15.3
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+
   fsevents@2.3.3:
     optional: true
+
+  get-caller-file@2.0.5: {}
 
   get-func-name@2.0.2: {}
 
@@ -2252,6 +3052,8 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  http-parser-js@0.5.10: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -2272,6 +3074,10 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  idb@7.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -2372,6 +3178,10 @@ snapshots:
     dependencies:
       mlly: 1.8.0
       pkg-types: 1.3.1
+
+  lodash.camelcase@4.3.0: {}
+
+  long@5.3.2: {}
 
   loupe@2.3.7:
     dependencies:
@@ -2485,6 +3295,12 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  playwright-core@1.63.0: {}
+
+  playwright@1.63.0:
+    dependencies:
+      playwright-core: 1.63.0
+
   postcss@8.5.28:
     dependencies:
       nanoid: 3.3.18
@@ -2511,7 +3327,23 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  protobufjs@7.6.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 25.0.3
+      long: 5.3.2
+
   punycode@2.3.1: {}
+
+  re2js@2.8.6: {}
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -2523,6 +3355,8 @@ snapshots:
   react-is@18.3.1: {}
 
   react@19.2.8: {}
+
+  require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
@@ -2577,6 +3411,8 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -2608,6 +3444,16 @@ snapshots:
   std-env@3.10.0: {}
 
   std-env@4.2.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-final-newline@3.0.0: {}
 
@@ -2655,6 +3501,8 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  tslib@2.8.1: {}
 
   type-detect@4.1.0: {}
 
@@ -2774,7 +3622,17 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  web-vitals@4.2.4: {}
+
   webidl-conversions@7.0.0: {}
+
+  websocket-driver@0.7.5:
+    dependencies:
+      http-parser-js: 0.5.10
+      safe-buffer: 5.2.1
+      websocket-extensions: 0.1.4
+
+  websocket-extensions@0.1.4: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
@@ -2796,12 +3654,32 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   ws@8.21.3: {}
 
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@5.0.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@1.2.2: {}

--- a/services/office/Dockerfile
+++ b/services/office/Dockerfile
@@ -1,6 +1,6 @@
 # Local emulators only; never mount host Firebase credentials into this image.
 FROM eclipse-temurin:21-jre-jammy@sha256:54b382c9d790d3201004d4e3921f4eff7dc7d67e1ce21a2da8d8faaaf63c85fc AS java
-FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
+FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS emulators
 COPY --from=java /opt/java/openjdk /opt/java/openjdk
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="/opt/java/openjdk/bin:${PATH}"
@@ -13,3 +13,25 @@ COPY --chown=node:node services/office/firebase.json services/office/firestore.r
 COPY --chown=node:node scripts/verify-office-emulators.mjs ./
 ENV GCLOUD_PROJECT=demo-tmt-office
 CMD ["firebase", "emulators:start", "--only", "auth,firestore", "--project", "demo-tmt-office", "--config", "firebase.json", "--non-interactive"]
+
+# Opt-in browser proof reuses the emulator owner; no host credentials or volumes.
+FROM emulators AS browser-tests
+USER root
+RUN npm install --global pnpm@10.33.0 && mkdir -p /workspace/apps/office && chown -R node:node /workspace
+WORKDIR /workspace
+COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY --chown=node:node apps/office/package.json apps/office/package.json
+USER node
+RUN pnpm office:install && test ! -e node_modules/better-sqlite3 && test ! -e /node_modules
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
+USER root
+RUN pnpm --filter @tmt/office exec playwright install --with-deps chromium
+USER node
+COPY --chown=node:node apps/office apps/office
+RUN --network=none pnpm office:check && pnpm office:test \
+  && pnpm --filter @tmt/office exec vite build --outDir dist-preview \
+  && pnpm --filter @tmt/office exec vite build --mode emulator
+CMD ["firebase", "emulators:exec", "--only", "auth,firestore", "--project", "demo-tmt-office", "--config", "/home/node/office/firebase.json", "--non-interactive", "pnpm --filter @tmt/office test:browser"]
+
+# Keep the existing default build and compose behavior lightweight.
+FROM emulators AS default

--- a/services/office/README.md
+++ b/services/office/README.md
@@ -1,7 +1,8 @@
 # Office service boundary
 
-Local Firebase environment for #184, prerequisite of #176. Authentication,
-invitations, membership and presence UI are not implemented. The bootstrap
+Local Firebase environment for #184, prerequisite of #176. The SPA now offers
+explicit emulator-only sign-in (#187); real authentication deployment,
+invitations, membership and presence are not implemented. The bootstrap
 Firestore rules deny every client read/write; they are not production policy.
 
 See [the architecture](../../docs/office/architecture.md). Add functions only
@@ -28,6 +29,10 @@ docker compose -f services/office/compose.yaml down
 ```
 
 State is ephemeral: there are no mounted data volumes or automatic imports.
+
+For the optional local sign-in UI and the opt-in `browser-tests` Docker target,
+follow [Local browser sign-in](../../DEVELOPMENT.md#local-browser-sign-in).
+The default image/Compose service does not install Chromium or start the app.
 Do not mount credentials, host config or repository roots into this service.
 The first image build downloads tools and emulator binaries; later runs use the
 cached image. Rebuild deliberately to update pinned tools, not on every test.


### PR DESCRIPTION
## Scope

Closes #187; first implementation slice of #176 under the TMT Office project.

- Add explicit loopback-only Auth Emulator sign-in, UID display and logout. Default preview neither initializes nor loads Firebase; no world access is implied.
- Keep session persistence in memory, with one observer-backed owner, serialized actions, safe errors and disposal guards. Use the official modular Firebase SDK, not custom OAuth.
- Extend the existing emulator Docker owner with opt-in Chromium verification. Preserve the lightweight default, deny-all Firestore rules and credential isolation.
- Run app quality, DOM/session tests and both builds offline in the image, followed by real browser scenarios. The existing selected Office CI gate owns this proof without duplicate host installation/build steps.

## Architecture and primary review

Primary reviewer: Codex. Reviewed commit: `ff548afa12c2ee6d9e5c2fe4ff2a742b89622f2e`.

Inspected all changed owners and relevant callers: entry point and hot replacement, OfficeApp/router/shell, session adapter and observer lifecycle, tests/fixtures, lockfile changes, emulator stages, CI gates and maintained documentation. ARCHITECTURE.md and Office architecture describe the new boundary. Jotai remains presentation-only; no Query mirror, Firestore product policy, native state owner, connector or runtime package is introduced.

Findings and disposition:

1. Non-root verification exposed the existing relative lockfile-directory bug: pnpm tried to create modules outside the workspace. Resolve the same lockfile through an absolute path; assert no `/node_modules` and no root SQLite install. Do not relax permissions.
2. The official Firebase popup resolver and emulator iframe require public Google scripts even with local Auth. The fully disconnected attempt failed as expected. Preserve upstream transport; the browser allowlist permits only public script GETs under `apis.google.com/js/` and `apis.google.com/_/scs/`, plus loopback. Optional CDN presentation is blocked; unexpected destinations fail. All auth remains local. This is **not** fully offline OAuth and the spec/docs now say so.
3. Firebase's inspected cancellation policy waits eight seconds after a two-second desktop poll. The cancellation assertion alone allows 15 seconds; the suite keeps a 30-second case budget and zero retries. Assertions were not weakened.
4. Default preview initially bundled unused auth code. A compile-time mode branch with dynamic import now removes that SDK chunk from the default build (277.88 kB default JS; emulator adds a separate 89.18 kB auth chunk, uncompressed).

Firebase 12.18.0 and Playwright 1.63.0 are pinned in the one workspace lockfile. Firebase auto-config/protobuf postinstall scripts remain unapproved; no extra lifecycle permissions or cloud configuration are needed. Production dependency audit reported zero known advisories across 104 dependencies at verification time, not a guarantee of absence of vulnerabilities.

## Verification

- [x] Primary reviewed changed code, callers, contracts, tests and docs.
- [x] Local commands and results recorded below.
- [x] All 17 CI checks passed on the reviewed head in run 34372570758, first attempt, before merge.

Passing local evidence:

- `pnpm check`: root/app type, lint and formatting checks pass.
- `pnpm test:run`: 146 tests / 14 files pass.
- `pnpm office:test`: 18 tests / 3 files pass, including observer authority, duplicate actions, safe errors, unsubscribe, disposal/late completion and default/host activation guards.
- `docker build --target browser-tests -f services/office/Dockerfile -t tmt-office-browser:187-local .`: non-root isolated install, offline app checks/tests and default/emulator builds pass.
- `docker run --rm --init --shm-size=256m --name tmt-office-browser-187-proof tmt-office-browser:187-local`: **two fresh-container runs**, each 5/5 real Chromium scenarios pass (13.8s and 13.6s). Covers default network inactivity; real popup login/logout, two contexts, same-browser fresh tab and reload isolation; cancellation/retry; failed token exchange/recovery; browser popup blocking.
- Default `services/office/Dockerfile` image plus `firebase emulators:exec ... 'node verify-office-emulators.mjs'` under `--network none`: existing Auth, denied client read/write, fixture persistence and cleanup proof passes.
- `pnpm audit --prod --audit-level high --json`: zero reported advisories.
- `git diff --check`: passes. Owner alias and browser outputs remain ignored.

Native code/fixtures are unchanged; local native matrices were not rerun. Shared lockfile/workflow changes still select the unchanged native CI gates. No CI retries or protection changes are requested.

## Lifecycle and limitations

Issue #187 and parent #176 record scope, research, the network refinement and progress. Dedicated branch `feat/187-office-emulator-auth`; no extra worktree. No host credentials, owner config, build output or test artifacts are committed.

No real Google account flow, cloud deployment/API activation, membership/invitations/presence, world creation, agent dispatch, native release or publishing. Those remain future slices of #176 and its downstream issues.
