### PR TITLE
feat(office): add client-first private worlds and tester admission

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 coverage
 **/dist
 **/dist-preview
+**/dist-cloud
 **/test-results
 **/playwright-report
 rust/target

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,14 +36,20 @@ not CLI-output scraping or a competing exchange engine. Ordinary CLI operations
 remain independent of Office.
 
 `services/office` now contains the isolated Firebase emulator bootstrap (#184),
-not a deployed service. Its shared demo-project configuration and deny-all rules
-have no product membership semantics. Owner-local project aliases/secrets are
+not a deployed service. Its shared demo-project configuration and Firestore rules
+enforce owner-only private worlds and the Console-managed tester gate (#189).
+No HTTP/Admin product service is needed for direct client world creation/reads.
+Owner-local project aliases/secrets are
 excluded from Git and Docker; the image has no host credential/data mounts.
 `scripts/verify-office-emulators.mjs` proves emulator transport and fixture
 cleanup separately from native tmux E2E and future Office authorization tests.
 
-Office's explicit emulator-only login has one app-owned Firebase/session boundary
-under `apps/office/src/auth`, with memory-only persistence and no world authority.
+Office's explicit emulator/cloud modes share one app-owned Firebase/session boundary
+under `apps/office/src/auth`, with memory-only persistence. `src/worlds` owns
+the direct Firestore adapter and session-scoped admission/selected-world state.
+Its Firebase-free `world-contract.ts` is the single client port/value/validation
+owner; pure state does not depend on the concrete SDK adapter.
+Rules, not the UI, enforce tester admission and immutable owner authority.
 React subscribes to the observer-backed session rather than copying identity into
 Jotai. The opt-in `browser-tests` stage of the same emulator Dockerfile proves
 real browser session behavior with local auth and an explicit public Google

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -131,7 +131,11 @@ Open the loopback URL printed by Vite. Choose **Sign in with Google (emulator)**
 add a local test account in the popup and observe its UID. No real Google login,
 Firebase owner alias or credentials are needed. Reload signs out; another tab
 does not inherit the session. Default `office:dev` / `office:build` stays a
-disconnected preview. Login does not create a world or grant membership.
+disconnected preview. Login does not create a world or grant access. #189 adds
+Console-managed tester admission and direct Firestore world creation/read.
+For explicit real Google sign-in and owner-local configuration, see
+[the limited cloud pilot](services/office/README.md#limited-cloud-pilot).
+Do not point automated tests at a real project.
 
 Run the real-browser suite with the same emulator owner:
 
@@ -141,10 +145,16 @@ docker run --rm --init --shm-size=256m tmt-office-browser:local
 ```
 
 The image installs pinned Chromium, checks the app, runs DOM/session tests and
-builds both preview and emulator variants. The container starts disposable
-Auth/Firestore emulators and two strict-port preview servers, then Playwright.
+builds preview, emulator and unconfigured cloud variants. The container starts
+disposable Auth/Firestore emulators and three strict-port preview servers, then
+Playwright. The cloud build must fail closed without operator configuration;
+it never contacts a real project during automated tests.
 It uses one worker, no retries, bounded waits and independent browser contexts.
-Auth responses are real and local. Google's official popup transport still loads
+Auth responses are real and local. The suite also exercises the real Firestore
+SDK against Rules: immutable creation/retry, cross-user denial, self-grant denial,
+shape validation, and browser grant/create/revocation. Operator fixture writes
+use a hard-wired loopback demo-project bypass, never production credentials.
+Google's official popup transport still loads
 public JavaScript from `apis.google.com`, even in emulator mode. The browser
 allowlist permits only those script GETs and loopback, blocks optional upstream
 CDN styling, and fails for any other destination. This suite requires Internet

--- a/apps/office/.env.example
+++ b/apps/office/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env.cloud.local. These are public Firebase web app settings, not Admin credentials.
+# Cloud activation is explicit: pnpm office:dev --mode cloud
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_APP_ID=

--- a/apps/office/.gitignore
+++ b/apps/office/.gitignore
@@ -1,3 +1,4 @@
 dist-preview/
+dist-cloud/
 test-results/
 playwright-report/

--- a/apps/office/e2e/browser-session.ts
+++ b/apps/office/e2e/browser-session.ts
@@ -1,0 +1,77 @@
+import { test as base, expect } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
+
+interface BrowserSession {
+  context: BrowserContext;
+  page: Page;
+  requests: URL[];
+}
+export const test = base.extend<{ openSession: (url?: string) => Promise<BrowserSession> }>({
+  openSession: async ({ browser }, use) => {
+    const sessions: BrowserSession[] = [];
+    const unexpected: string[] = [];
+    await use(async (url = 'http://127.0.0.1:4173') => {
+      const context = await browser.newContext();
+      const requests: URL[] = [];
+      context.on('request', (request) => {
+        requests.push(new URL(request.url()));
+      });
+      await context.route('**/*', async (route) => {
+        const target = new URL(route.request().url());
+        if (target.hostname === '127.0.0.1') return route.continue();
+        // GAPI occasionally emits this optional telemetry beacon. Always block
+        // it; it is neither a required library nor a production auth request.
+        if (target.hostname === 'apis.google.com' && target.pathname === '/js/gen_204') {
+          return route.abort();
+        }
+        // The official popup transport requires Google's public iframe library even
+        // with Auth Emulator. No production auth/API endpoints are allowed.
+        if (
+          target.protocol === 'https:' &&
+          target.hostname === 'apis.google.com' &&
+          (target.pathname.startsWith('/js/') || target.pathname.startsWith('/_/scs/')) &&
+          route.request().method() === 'GET' &&
+          route.request().resourceType() === 'script'
+        )
+          return route.continue();
+        // Firebase's emulator widget requests optional CDN presentation assets.
+        // Block them, but do not stub its local authentication logic or responses.
+        if (!['unpkg.com', 'fonts.googleapis.com', 'fonts.gstatic.com'].includes(target.hostname)) {
+          unexpected.push(target.origin + target.pathname);
+        }
+        await route.abort();
+      });
+      const page = await context.newPage();
+      const session = { context, page, requests };
+      sessions.push(session);
+      await page.goto(url);
+      return session;
+    });
+    for (const session of sessions) await session.context.close();
+    expect(unexpected).toEqual([]);
+  },
+});
+
+export async function openPopup(page: Page): Promise<Page> {
+  const opened = page.waitForEvent('popup');
+  await page.getByRole('button', { name: 'Sign in with Google (emulator)' }).click();
+  const popup = await opened;
+  await expect(popup.getByRole('button', { name: 'Add new account' })).toBeVisible();
+  return popup;
+}
+
+export async function submitNewAccount(popup: Page, name: string): Promise<void> {
+  await popup.getByRole('button', { name: 'Add new account' }).click();
+  // The upstream emulator labels are not associated with inputs; use its stable IDs.
+  await popup
+    .locator('#email-input')
+    .fill(`${name.toLowerCase()}-${crypto.randomUUID()}@example.test`);
+  await popup.locator('#display-name-input').fill(name);
+  await popup.getByRole('button', { name: 'Sign in with Google.com', exact: true }).click();
+}
+
+export async function signIn(page: Page, name: string): Promise<void> {
+  await submitNewAccount(await openPopup(page), name);
+  await expect(page.getByText(`Signed in as ${name}`, { exact: true })).toBeVisible();
+  await expect(page.getByText(/^UID: /)).toContainText(/UID: \S+/);
+}

--- a/apps/office/e2e/firestore-fixture.ts
+++ b/apps/office/e2e/firestore-fixture.ts
@@ -1,0 +1,113 @@
+import { expect } from '@playwright/test';
+import { deleteApp, initializeApp } from 'firebase/app';
+import {
+  connectAuthEmulator,
+  GoogleAuthProvider,
+  initializeAuth,
+  signInWithCredential,
+  signInAnonymously,
+  signInWithCustomToken,
+} from 'firebase/auth';
+import { connectFirestoreEmulator, initializeFirestore, terminate } from 'firebase/firestore';
+
+const projectId = 'demo-tmt-office';
+const documents = `http://127.0.0.1:8080/v1/projects/${projectId}/databases/(default)/documents`;
+
+export async function ownedWorlds(uid: string): Promise<unknown[]> {
+  const response = await fetch(`${documents}:runQuery`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer owner', 'content-type': 'application/json' },
+    body: JSON.stringify({
+      structuredQuery: {
+        from: [{ collectionId: 'worlds' }],
+        where: {
+          fieldFilter: {
+            field: { fieldPath: 'ownerUid' },
+            op: 'EQUAL',
+            value: { stringValue: uid },
+          },
+        },
+        limit: 10,
+      },
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  expect(response.status).toBe(200);
+  const rows: Array<{ document?: unknown }> = await response.json();
+  return rows.flatMap((row) => (row.document ? [row.document] : []));
+}
+
+export async function updateWorldName(id: string, name: string): Promise<void> {
+  expect(id).toMatch(/^[a-zA-Z0-9]{20}$/);
+  const response = await fetch(`${documents}/worlds/${id}?updateMask.fieldPaths=name`, {
+    method: 'PATCH',
+    headers: { authorization: 'Bearer owner', 'content-type': 'application/json' },
+    body: JSON.stringify({ fields: { name: { stringValue: name } } }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  expect(response.status).toBe(200);
+}
+
+/** Operator fixture bypass is hard-wired to the disposable loopback emulator. */
+export async function setTester(uid: string, enabled: boolean): Promise<void> {
+  await writeTesterFields(uid, { enabled: { booleanValue: enabled } });
+}
+
+export async function writeTesterFields(
+  uid: string,
+  fields: Record<string, unknown>
+): Promise<void> {
+  const response = await fetch(`${documents}/testers/${encodeURIComponent(uid)}`, {
+    method: 'PATCH',
+    headers: { authorization: 'Bearer owner', 'content-type': 'application/json' },
+    body: JSON.stringify({ fields }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  expect(response.status).toBe(200);
+}
+
+export async function createFirestoreFixture() {
+  const clients: Array<() => Promise<void>> = [];
+  return {
+    async client(
+      approved = false,
+      provider: 'google' | 'unverified' | 'anonymous' | 'device' = 'google'
+    ) {
+      const app = initializeApp({ projectId, apiKey: 'demo-key' }, crypto.randomUUID());
+      const auth = initializeAuth(app);
+      connectAuthEmulator(auth, 'http://127.0.0.1:9099', { disableWarnings: true });
+      const db = initializeFirestore(app, {});
+      connectFirestoreEmulator(db, '127.0.0.1', 8080);
+      clients.push(async () => {
+        await terminate(db);
+        await deleteApp(app);
+      });
+      const identity = crypto.randomUUID();
+      const customToken = () => {
+        // Unsigned fixture credential is accepted only by the Auth Emulator.
+        const part = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64url');
+        return `${part({ alg: 'none', typ: 'JWT' })}.${part({ uid: identity, aud: 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit', iss: 'fixture@example.test', sub: 'fixture@example.test', iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 3600 })}.`;
+      };
+      const { user } =
+        provider === 'anonymous'
+          ? await signInAnonymously(auth)
+          : provider === 'device'
+            ? await signInWithCustomToken(auth, customToken())
+            : await signInWithCredential(
+                auth,
+                GoogleAuthProvider.credential(
+                  JSON.stringify({
+                    sub: identity,
+                    email: `${identity}@example.test`,
+                    email_verified: provider !== 'unverified',
+                  })
+                )
+              );
+      if (approved) await setTester(user.uid, true);
+      return { db, auth, uid: user.uid };
+    },
+    async dispose() {
+      for (const close of clients.reverse()) await close();
+    },
+  };
+}

--- a/apps/office/e2e/session.spec.ts
+++ b/apps/office/e2e/session.spec.ts
@@ -1,75 +1,15 @@
-import { test as base, expect } from '@playwright/test';
-import type { BrowserContext, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { test, signIn, openPopup, submitNewAccount } from './browser-session.js';
 
-interface BrowserSession {
-  context: BrowserContext;
-  page: Page;
-  requests: URL[];
-}
-const test = base.extend<{ openSession: (url?: string) => Promise<BrowserSession> }>({
-  openSession: async ({ browser }, use) => {
-    const sessions: BrowserSession[] = [];
-    const unexpected: string[] = [];
-    await use(async (url = 'http://127.0.0.1:4173') => {
-      const context = await browser.newContext();
-      const requests: URL[] = [];
-      context.on('request', (request) => {
-        requests.push(new URL(request.url()));
-      });
-      await context.route('**/*', async (route) => {
-        const target = new URL(route.request().url());
-        if (target.hostname === '127.0.0.1') return route.continue();
-        // The official popup transport requires Google's public iframe library even
-        // with Auth Emulator. No production auth/API endpoints are allowed.
-        if (
-          target.protocol === 'https:' &&
-          target.hostname === 'apis.google.com' &&
-          (target.pathname.startsWith('/js/') || target.pathname.startsWith('/_/scs/')) &&
-          route.request().method() === 'GET' &&
-          route.request().resourceType() === 'script'
-        )
-          return route.continue();
-        // Firebase's emulator widget requests optional CDN presentation assets.
-        // Block them, but do not stub its local authentication logic or responses.
-        if (!['unpkg.com', 'fonts.googleapis.com', 'fonts.gstatic.com'].includes(target.hostname)) {
-          unexpected.push(target.origin + target.pathname);
-        }
-        await route.abort();
-      });
-      const page = await context.newPage();
-      const session = { context, page, requests };
-      sessions.push(session);
-      await page.goto(url);
-      return session;
-    });
-    for (const session of sessions) await session.context.close();
-    expect(unexpected).toEqual([]);
-  },
+test('cloud build without operator configuration fails closed before Firebase traffic', async ({
+  openSession,
+}) => {
+  const { page, requests } = await openSession('http://127.0.0.1:4175');
+  await expect(page.getByRole('alert')).toContainText(
+    'Check the selected environment and Firebase configuration'
+  );
+  expect(requests.every((request) => request.origin === 'http://127.0.0.1:4175')).toBe(true);
 });
-
-async function openPopup(page: Page): Promise<Page> {
-  const opened = page.waitForEvent('popup');
-  await page.getByRole('button', { name: 'Sign in with Google (emulator)' }).click();
-  const popup = await opened;
-  await expect(popup.getByRole('button', { name: 'Add new account' })).toBeVisible();
-  return popup;
-}
-
-async function submitNewAccount(popup: Page, name: string): Promise<void> {
-  await popup.getByRole('button', { name: 'Add new account' }).click();
-  // The upstream emulator labels are not associated with inputs; use its stable IDs.
-  await popup
-    .locator('#email-input')
-    .fill(`${name.toLowerCase()}-${crypto.randomUUID()}@example.test`);
-  await popup.locator('#display-name-input').fill(name);
-  await popup.getByRole('button', { name: 'Sign in with Google.com', exact: true }).click();
-}
-
-async function signIn(page: Page, name: string): Promise<void> {
-  await submitNewAccount(await openPopup(page), name);
-  await expect(page.getByText(`Signed in as ${name}`, { exact: true })).toBeVisible();
-  await expect(page.getByText(/^UID: /)).toContainText(/UID: \S+/);
-}
 
 test('default build stays disconnected without Firebase requests', async ({ openSession }) => {
   const { page, requests } = await openSession('http://127.0.0.1:4174');
@@ -132,7 +72,7 @@ test('failed token exchange reports transport failure without inventing a sessio
   await context.route(exchange, (route) => route.abort('connectionrefused'));
   await submitNewAccount(await openPopup(page), 'Offline');
   await expect(page.getByRole('alert')).toHaveText(
-    'Cannot reach the local Auth Emulator. Check that it is running, then try again.'
+    'Cannot reach the sign-in service. Check your connection and try again.'
   );
   await expect(page.getByText(/^UID: /)).toHaveCount(0);
   await expect(page.getByRole('button', { name: /Sign in/ })).toBeEnabled();

--- a/apps/office/e2e/world-rules.spec.ts
+++ b/apps/office/e2e/world-rules.spec.ts
@@ -1,0 +1,229 @@
+import { test, expect } from '@playwright/test';
+import { signOut } from 'firebase/auth';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDocFromServer,
+  getDocsFromServer,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+  onSnapshot,
+} from 'firebase/firestore';
+import { createWorldPort } from '../src/worlds/firebase-worlds.js';
+import {
+  createFirestoreFixture,
+  setTester,
+  writeTesterFields,
+  updateWorldName,
+} from './firestore-fixture.js';
+
+test('missing, malformed and disabled tester grants deny access until repaired', async () => {
+  const fixture = await createFirestoreFixture();
+  try {
+    const alice = await fixture.client(true);
+    const port = createWorldPort(alice.db);
+    const draft = port.draft('Grant policy');
+    await port.create(draft, alice.uid);
+    const reference = doc(alice.db, 'worlds', draft.id);
+    for (const fields of [
+      {},
+      { enabled: { stringValue: 'true' } },
+      { enabled: { booleanValue: false } },
+      { enabled: { booleanValue: true }, extra: { booleanValue: true } },
+    ]) {
+      await writeTesterFields(alice.uid, fields);
+      await expect(getDocFromServer(reference)).rejects.toMatchObject({
+        code: 'permission-denied',
+      });
+    }
+    await setTester(alice.uid, true);
+    expect((await getDocFromServer(reference)).data()?.name).toBe('Grant policy');
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('server listeners reject cross-owner access and withhold updates after revocation without token refresh', async () => {
+  const fixture = await createFirestoreFixture();
+  const stops: Array<() => void> = [];
+  try {
+    const alice = await fixture.client(true);
+    const bob = await fixture.client(true);
+    const port = createWorldPort(alice.db);
+    const draft = port.draft('Stream policy');
+    await port.create(draft, alice.uid);
+    const seen: string[] = [];
+    const bobSeen: unknown[] = [];
+    let aliceError: string | undefined;
+    let bobError: string | undefined;
+    stops.push(
+      onSnapshot(
+        doc(alice.db, 'worlds', draft.id),
+        { includeMetadataChanges: true },
+        (snapshot) => {
+          if (!snapshot.metadata.fromCache && snapshot.exists()) seen.push(snapshot.data().name);
+        },
+        (error) => {
+          aliceError = error.code;
+        }
+      )
+    );
+    stops.push(
+      onSnapshot(
+        doc(bob.db, 'worlds', draft.id),
+        (snapshot) => {
+          if (snapshot.exists()) bobSeen.push(snapshot.data());
+        },
+        (error) => {
+          bobError = error.code;
+        }
+      )
+    );
+    await expect.poll(() => seen).toContain('Stream policy');
+    await expect.poll(() => bobError).toBe('permission-denied');
+    expect(bobSeen).toEqual([]);
+    await setTester(alice.uid, false);
+    // The emulator does not immediately close listeners on a dependent grant
+    // change. Prove it cannot disclose the next world update, independently of UI.
+    await updateWorldName(draft.id, 'Must remain private');
+    await expect.poll(() => aliceError).toBe('permission-denied');
+    expect(seen.every((name) => name === 'Stream policy')).toBe(true);
+  } finally {
+    for (const stop of stops) stop();
+    await fixture.dispose();
+  }
+});
+
+test('valid anonymous, custom-device and unverified Google sessions cannot become approved humans', async () => {
+  const fixture = await createFirestoreFixture();
+  try {
+    for (const provider of ['anonymous', 'device', 'unverified'] as const) {
+      const client = await fixture.client(true, provider);
+      expect(client.auth.currentUser?.uid).toBe(client.uid);
+      const token = await client.auth.currentUser!.getIdTokenResult();
+      expect(token.signInProvider).toBe(
+        provider === 'device' ? 'custom' : provider === 'anonymous' ? 'anonymous' : 'google.com'
+      );
+      await expect(getDocFromServer(doc(client.db, 'testers', client.uid))).rejects.toMatchObject({
+        code: 'permission-denied',
+      });
+      const port = createWorldPort(client.db);
+      await expect(port.create(port.draft('Denied'), client.uid)).rejects.toMatchObject({
+        code: 'permission-denied',
+      });
+    }
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('online creation is immutable and concurrent exact retries preserve one world', async () => {
+  const fixture = await createFirestoreFixture();
+  try {
+    const alice = await fixture.client(true);
+    const port = createWorldPort(alice.db);
+    const draft = port.draft('Alice office');
+    expect(
+      await Promise.all([port.create(draft, alice.uid), port.create(draft, alice.uid)])
+    ).toEqual([draft.id, draft.id]);
+    const reference = doc(alice.db, 'worlds', draft.id);
+    const original = (await getDocFromServer(reference)).data();
+    expect(original?.name).toBe('Alice office');
+    expect(original?.ownerUid).toBe(alice.uid);
+    expect(original?.createdAt.toMillis()).toBeGreaterThan(0);
+    await port.create(draft, alice.uid);
+    await expect(port.create({ ...draft, name: 'Conflict' }, alice.uid)).rejects.toThrow(
+      'conflicts'
+    );
+    expect((await getDocFromServer(reference)).data()).toEqual(original);
+    await expect(updateDoc(reference, { name: 'Overwritten' })).rejects.toMatchObject({
+      code: 'permission-denied',
+    });
+    await expect(deleteDoc(reference)).rejects.toMatchObject({ code: 'permission-denied' });
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('tester admission never grants another owner access or lets clients grant themselves', async () => {
+  const fixture = await createFirestoreFixture();
+  try {
+    const alice = await fixture.client(true);
+    const bob = await fixture.client(true);
+    const waiting = await fixture.client();
+    const port = createWorldPort(alice.db);
+    const draft = port.draft('Private');
+    await port.create(draft, alice.uid);
+    for (const client of [bob, waiting]) {
+      await expect(getDocFromServer(doc(client.db, 'worlds', draft.id))).rejects.toMatchObject({
+        code: 'permission-denied',
+      });
+      await expect(getDocsFromServer(collection(client.db, 'worlds'))).rejects.toMatchObject({
+        code: 'permission-denied',
+      });
+      await expect(
+        setDoc(doc(client.db, 'testers', client.uid), { enabled: true })
+      ).rejects.toMatchObject({ code: 'permission-denied' });
+      await expect(getDocFromServer(doc(client.db, 'testers', alice.uid))).rejects.toMatchObject({
+        code: 'permission-denied',
+      });
+    }
+    expect((await getDocFromServer(doc(waiting.db, 'testers', waiting.uid))).exists()).toBe(false);
+    await expect(
+      createWorldPort(waiting.db).create(port.draft('Denied'), waiting.uid)
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+    await setTester(alice.uid, false);
+    await expect(getDocFromServer(doc(alice.db, 'worlds', draft.id))).rejects.toMatchObject({
+      code: 'permission-denied',
+    });
+    await signOut(bob.auth);
+    await expect(getDocFromServer(doc(bob.db, 'worlds', draft.id))).rejects.toMatchObject({
+      code: 'permission-denied',
+    });
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('direct writes cannot bypass shape, ownership, name or server-time validation', async () => {
+  const fixture = await createFirestoreFixture();
+  try {
+    const alice = await fixture.client(true);
+    const valid = () => ({
+      version: 1,
+      name: 'Valid',
+      ownerUid: alice.uid,
+      createdAt: serverTimestamp(),
+    });
+    for (const changes of [
+      { ownerUid: 'forged' },
+      { version: 2 },
+      { extra: true },
+      { name: '' },
+      { name: '   ' },
+      { name: '\u00a0' },
+      { name: '\u3000' },
+      { name: 'x'.repeat(81) },
+      { name: 'a\nb' },
+      { name: 42 },
+      { createdAt: 0 },
+    ]) {
+      await expect(
+        setDoc(doc(collection(alice.db, 'worlds')), { ...valid(), ...changes })
+      ).rejects.toMatchObject({ code: 'permission-denied' });
+    }
+    const reference = doc(collection(alice.db, 'worlds'));
+    await setDoc(reference, { ...valid(), name: 'x'.repeat(80) });
+    expect((await getDocFromServer(reference)).data()?.name).toBe('x'.repeat(80));
+    const unicode = doc(collection(alice.db, 'worlds'));
+    await setDoc(unicode, { ...valid(), name: '😀'.repeat(80) });
+    expect((await getDocFromServer(unicode)).data()?.name).toBe('😀'.repeat(80));
+    await expect(
+      setDoc(doc(reference, 'blocks', 'agent'), { name: 'Agent' })
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+  } finally {
+    await fixture.dispose();
+  }
+});

--- a/apps/office/e2e/worlds.spec.ts
+++ b/apps/office/e2e/worlds.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from '@playwright/test';
+import { test, signIn } from './browser-session.js';
+import { setTester, ownedWorlds } from './firestore-fixture.js';
+
+test('transport failure cannot queue a create across reconnect; explicit retry creates exactly once', async ({
+  openSession,
+}) => {
+  const { page, context } = await openSession();
+  await signIn(page, 'Offline');
+  const uid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+  await setTester(uid, true);
+  await expect(page.getByRole('button', { name: 'Create world', exact: true })).toBeVisible();
+  expect(await ownedWorlds(uid)).toEqual([]);
+  const transport = 'http://127.0.0.1:8080/**';
+  await context.route(transport, (route) => route.abort('internetdisconnected'));
+  await page.getByLabel('World name').fill('Reconnect room');
+  await page.getByRole('button', { name: 'Create world', exact: true }).click();
+  await expect(page.getByRole('alert')).toContainText('could not be confirmed');
+  expect(await ownedWorlds(uid)).toEqual([]);
+  await context.unroute(transport);
+  expect(await ownedWorlds(uid)).toEqual([]);
+  await page.getByRole('button', { name: 'Retry creation', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Reconnect room' })).toBeVisible();
+  expect(await ownedWorlds(uid)).toHaveLength(1);
+});
+
+test('Console-style grant enables creation; another user is denied; revocation clears the live world', async ({
+  openSession,
+}) => {
+  const alice = await openSession();
+  const bob = await openSession();
+  await signIn(alice.page, 'Alice');
+  await expect(alice.page.getByRole('heading', { name: 'Waiting for access' })).toBeVisible();
+  const aliceUid = (await alice.page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+  await setTester(aliceUid, true);
+  await expect(
+    alice.page.getByRole('heading', { name: 'Create your private world' })
+  ).toBeVisible();
+  await alice.page.getByLabel('World name').fill('Alice private room');
+  await alice.page.getByRole('button', { name: 'Create world', exact: true }).click();
+  await expect(alice.page.getByRole('heading', { name: 'Alice private room' })).toBeVisible();
+  const address = alice.page.url();
+  await alice.page.getByRole('link', { name: 'Office', exact: true }).click();
+  await alice.page
+    .getByLabel('World ID', { exact: true })
+    .fill(new URL(address).pathname.split('/').at(-1)!);
+  await alice.page.getByRole('button', { name: 'Open world', exact: true }).click();
+  await expect(alice.page.getByRole('heading', { name: 'Alice private room' })).toBeVisible();
+  await signIn(bob.page, 'Bob');
+  const bobUid = (await bob.page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+  await setTester(bobUid, true);
+  await expect(bob.page.getByRole('heading', { name: 'Create your private world' })).toBeVisible();
+  await bob.page
+    .getByLabel('World ID', { exact: true })
+    .fill(new URL(address).pathname.split('/').at(-1)!);
+  await bob.page.getByRole('button', { name: 'Open world', exact: true }).click();
+  await expect(bob.page.getByRole('heading', { name: 'World unavailable' })).toBeVisible();
+  await expect(bob.page.getByText('Alice private room', { exact: true })).toHaveCount(0);
+  await setTester(aliceUid, false);
+  await expect(alice.page.getByRole('heading', { name: 'Waiting for access' })).toBeVisible();
+  await expect(alice.page.getByRole('heading', { name: 'Alice private room' })).toHaveCount(0);
+  await setTester(aliceUid, true);
+  await expect(alice.page.getByRole('heading', { name: 'Alice private room' })).toBeVisible();
+  await alice.page.getByRole('button', { name: 'Sign out', exact: true }).click();
+  await expect(alice.page.getByRole('heading', { name: 'Alice private room' })).toHaveCount(0);
+  await alice.page.reload();
+  await expect(alice.page.getByRole('button', { name: /Sign in/ })).toBeVisible();
+  await expect(alice.page.getByRole('heading', { name: 'Alice private room' })).toHaveCount(0);
+});

--- a/apps/office/playwright.config.ts
+++ b/apps/office/playwright.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
   use: { browserName: 'chromium', baseURL: 'http://127.0.0.1:4173' },
   webServer: [
     {
+      command:
+        'pnpm exec vite preview --host 127.0.0.1 --port 4175 --strictPort --outDir dist-cloud',
+      url: 'http://127.0.0.1:4175',
+      reuseExistingServer: false,
+    },
+    {
       command: 'pnpm exec vite preview --host 127.0.0.1 --port 4173 --strictPort',
       url: 'http://127.0.0.1:4173',
       reuseExistingServer: false,

--- a/apps/office/src/auth/firebase-config.test.ts
+++ b/apps/office/src/auth/firebase-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { officeFirebaseConfig } from './firebase-config.js';
+
+const settings = {
+  VITE_FIREBASE_API_KEY: 'public-key',
+  VITE_FIREBASE_PROJECT_ID: 'example-office',
+  VITE_FIREBASE_AUTH_DOMAIN: 'example-office.firebaseapp.com',
+  VITE_FIREBASE_APP_ID: 'public-app-id',
+};
+describe('explicit cloud configuration', () => {
+  it('uses only the supplied public configuration in cloud mode', () => {
+    expect(officeFirebaseConfig('cloud', 'localhost', settings)).toEqual({
+      apiKey: 'public-key',
+      projectId: 'example-office',
+      authDomain: 'example-office.firebaseapp.com',
+      appId: 'public-app-id',
+    });
+  });
+  it('never leaks cloud configuration into preview or emulator selection', () => {
+    expect(officeFirebaseConfig('production', 'localhost', settings)).toBeUndefined();
+    expect(officeFirebaseConfig('emulator', 'localhost', settings)?.projectId).toBe(
+      'demo-tmt-office'
+    );
+  });
+  it.each(Object.keys(settings))('rejects missing %s without fallback', (key) => {
+    expect(() => officeFirebaseConfig('cloud', 'localhost', { ...settings, [key]: '' })).toThrow(
+      'complete Firebase'
+    );
+  });
+  it('rejects a mismatched auth domain', () => {
+    expect(() =>
+      officeFirebaseConfig('cloud', 'localhost', {
+        ...settings,
+        VITE_FIREBASE_AUTH_DOMAIN: 'other.example',
+      })
+    ).toThrow('complete Firebase');
+  });
+});

--- a/apps/office/src/auth/firebase-config.ts
+++ b/apps/office/src/auth/firebase-config.ts
@@ -1,0 +1,38 @@
+import type { FirebaseOptions } from 'firebase/app';
+
+export function officeFirebaseConfig(
+  mode: string,
+  hostname: string,
+  settings: Record<string, unknown> = {}
+): FirebaseOptions | undefined {
+  if (mode === 'emulator') {
+    if (!['127.0.0.1', 'localhost', '[::1]'].includes(hostname))
+      throw new Error('Local sign-in is only available on loopback.');
+    return {
+      apiKey: 'demo-tmt-office',
+      projectId: 'demo-tmt-office',
+      authDomain: 'demo-tmt-office.firebaseapp.com',
+    };
+  }
+  if (mode !== 'cloud') return undefined;
+  const {
+    VITE_FIREBASE_API_KEY: apiKey,
+    VITE_FIREBASE_PROJECT_ID: projectId,
+    VITE_FIREBASE_AUTH_DOMAIN: authDomain,
+    VITE_FIREBASE_APP_ID: appId,
+  } = settings;
+  if (
+    typeof apiKey !== 'string' ||
+    !apiKey.trim() ||
+    typeof projectId !== 'string' ||
+    !/^[a-z][a-z0-9-]{4,28}[a-z0-9]$/.test(projectId) ||
+    projectId.startsWith('demo-') ||
+    typeof authDomain !== 'string' ||
+    authDomain !== `${projectId}.firebaseapp.com` ||
+    typeof appId !== 'string' ||
+    !appId.trim()
+  ) {
+    throw new Error('Cloud mode requires complete Firebase web app configuration.');
+  }
+  return { apiKey, projectId, authDomain, appId };
+}

--- a/apps/office/src/auth/firebase-session.test.ts
+++ b/apps/office/src/auth/firebase-session.test.ts
@@ -1,11 +1,11 @@
 import { getApps } from 'firebase/app';
 import { describe, expect, it } from 'vitest';
-import { startOfficeSession } from './firebase-session.js';
+import { startOfficeRuntime } from './firebase-session.js';
 
 describe('Firebase activation boundary', () => {
   it('does not initialize Firebase for ordinary preview or unknown modes', () => {
-    for (const mode of ['development', 'production', 'preview', 'cloud']) {
-      expect(startOfficeSession(mode, 'localhost')).toBeUndefined();
+    for (const mode of ['development', 'production', 'preview']) {
+      expect(startOfficeRuntime(mode, 'localhost')).toBeUndefined();
     }
     expect(getApps()).toEqual([]);
   });
@@ -13,8 +13,12 @@ describe('Firebase activation boundary', () => {
   it.each(['office.example', 'localhost.evil', '127.0.0.1.evil', '0.0.0.0', ''])(
     'rejects non-loopback hostname %s before Firebase initialization',
     (hostname) => {
-      expect(() => startOfficeSession('emulator', hostname)).toThrow('only available on loopback');
+      expect(() => startOfficeRuntime('emulator', hostname)).toThrow('only available on loopback');
       expect(getApps()).toEqual([]);
     }
   );
+  it('fails closed before SDK initialization for incomplete cloud settings', () => {
+    expect(() => startOfficeRuntime('cloud', 'localhost')).toThrow('complete Firebase');
+    expect(getApps()).toEqual([]);
+  });
 });

--- a/apps/office/src/auth/firebase-session.ts
+++ b/apps/office/src/auth/firebase-session.ts
@@ -10,28 +10,35 @@ import {
   signOut,
 } from 'firebase/auth';
 import { createSession } from './session.js';
-import type { OfficeSession } from './session.js';
+import {
+  connectFirestoreEmulator,
+  initializeFirestore,
+  memoryLocalCache,
+  terminate,
+} from 'firebase/firestore';
+import { officeFirebaseConfig } from './firebase-config.js';
+import { createWorldPort } from '../worlds/firebase-worlds.js';
+import { createWorldState } from '../worlds/world-state.js';
 
-/** Called by the entry point, never during a React render or with cloud credentials. */
-export function startOfficeSession(mode: string, hostname: string): OfficeSession | undefined {
-  if (mode !== 'emulator') return undefined;
-  if (!['127.0.0.1', 'localhost', '[::1]'].includes(hostname)) {
-    throw new Error('Local sign-in is only available on loopback.');
-  }
-  const app = initializeApp(
-    {
-      apiKey: 'demo-tmt-office',
-      projectId: 'demo-tmt-office',
-      authDomain: 'demo-tmt-office.firebaseapp.com',
-    },
-    `office-${crypto.randomUUID()}`
-  );
+/** One composition root for both explicit environments, outside React rendering. */
+export function startOfficeRuntime(
+  mode: string,
+  hostname: string,
+  settings: Record<string, unknown> = {}
+) {
+  const config = officeFirebaseConfig(mode, hostname, settings);
+  if (!config) return undefined;
+  const app = initializeApp(config, `office-${crypto.randomUUID()}`);
   const auth = initializeAuth(app, {
     persistence: inMemoryPersistence,
     popupRedirectResolver: browserPopupRedirectResolver,
   });
-  connectAuthEmulator(auth, 'http://127.0.0.1:9099');
-  return createSession({
+  const db = initializeFirestore(app, { localCache: memoryLocalCache() });
+  if (mode === 'emulator') {
+    connectAuthEmulator(auth, 'http://127.0.0.1:9099');
+    connectFirestoreEmulator(db, '127.0.0.1', 8080);
+  }
+  const session = createSession({
     observe: (changed) =>
       onAuthStateChanged(auth, (user) =>
         changed(user ? { uid: user.uid, displayName: user.displayName } : null)
@@ -40,6 +47,21 @@ export function startOfficeSession(mode: string, hostname: string): OfficeSessio
       await signInWithPopup(auth, new GoogleAuthProvider());
     },
     signOut: () => signOut(auth),
-    dispose: () => deleteApp(app),
+    dispose: async () => {
+      await terminate(db);
+      await deleteApp(app);
+    },
   });
+  const worlds = createWorldState(session, createWorldPort(db));
+  return {
+    session,
+    worlds,
+    mode,
+    dispose: async () => {
+      worlds.dispose();
+      await session.dispose();
+    },
+  };
 }
+
+export type OfficeRuntime = NonNullable<ReturnType<typeof startOfficeRuntime>>;

--- a/apps/office/src/auth/session-view.tsx
+++ b/apps/office/src/auth/session-view.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react';
 import type { OfficeSession } from './session.js';
 
 export const OfficeSessionContext = createContext<OfficeSession | undefined>(undefined);
+export const OfficeModeContext = createContext('emulator');
 
 export function SessionPanel(): ReactElement | null {
   const session = useContext(OfficeSessionContext);
@@ -10,13 +11,17 @@ export function SessionPanel(): ReactElement | null {
 }
 
 function ConnectedSession({ session }: { session: OfficeSession }): ReactElement {
+  const mode = useContext(OfficeModeContext);
   const { ready, user, pending, error } = useSyncExternalStore(
     session.subscribe,
     session.getSnapshot
   );
   return (
-    <section className="session-panel" aria-label="Local session">
-      <p>Auth Emulator only · Sign-in does not grant world access.</p>
+    <section className="session-panel" aria-label="Office session">
+      <p>
+        {mode === 'emulator' ? 'Auth Emulator only' : 'Private cloud pilot'} · Sign-in does not
+        grant world access.
+      </p>
       {!ready ? (
         <p role="status">Preparing local sign-in…</p>
       ) : user ? (
@@ -31,7 +36,7 @@ function ConnectedSession({ session }: { session: OfficeSession }): ReactElement
         </>
       ) : (
         <button type="button" disabled={pending} onClick={() => void session.signIn()}>
-          Sign in with Google (emulator)
+          {mode === 'emulator' ? 'Sign in with Google (emulator)' : 'Sign in with Google'}
         </button>
       )}
       {pending && <p role="status">Waiting for the session action…</p>}

--- a/apps/office/src/auth/session.test.ts
+++ b/apps/office/src/auth/session.test.ts
@@ -78,7 +78,7 @@ describe('App-owned session', () => {
     ['auth/popup-blocked', 'Allow popups for this page, then try again.'],
     [
       'auth/network-request-failed',
-      'Cannot reach the local Auth Emulator. Check that it is running, then try again.',
+      'Cannot reach the sign-in service. Check your connection and try again.',
     ],
     ['secret-token-value', 'The session action failed. Please try again.'],
   ])(

--- a/apps/office/src/auth/session.ts
+++ b/apps/office/src/auth/session.ts
@@ -34,7 +34,7 @@ function actionError(error: unknown): string {
     case 'auth/popup-blocked':
       return 'Allow popups for this page, then try again.';
     case 'auth/network-request-failed':
-      return 'Cannot reach the local Auth Emulator. Check that it is running, then try again.';
+      return 'Cannot reach the sign-in service. Check your connection and try again.';
     default:
       return 'The session action failed. Please try again.';
   }

--- a/apps/office/src/main.tsx
+++ b/apps/office/src/main.tsx
@@ -3,40 +3,46 @@ import { createRoot } from 'react-dom/client';
 import { OfficeApp } from './office-app.js';
 import { createOfficeRouter } from './router.js';
 import './styles.css';
-import type { OfficeSession } from './auth/session.js';
+import type { OfficeRuntime } from './auth/firebase-session.js';
 
 const root = document.getElementById('root');
 if (!root) throw new Error('Office root element is missing.');
 
 const app = createRoot(root);
-let session: OfficeSession | undefined;
+let runtime: OfficeRuntime | undefined;
 let active = true;
 import.meta.hot?.dispose(() => {
   active = false;
   app.unmount();
-  void session?.dispose();
+  void runtime?.dispose();
 });
 
 async function mount(): Promise<void> {
   try {
     // Vite removes this branch (and the SDK chunk) from the default build.
-    if (import.meta.env.MODE === 'emulator') {
-      const { startOfficeSession } = await import('./auth/firebase-session.js');
+    if (import.meta.env.MODE === 'emulator' || import.meta.env.MODE === 'cloud') {
+      const { startOfficeRuntime } = await import('./auth/firebase-session.js');
       if (!active) return;
-      session = startOfficeSession(import.meta.env.MODE, location.hostname);
+      runtime = startOfficeRuntime(import.meta.env.MODE, location.hostname, import.meta.env);
     }
   } catch {
     if (active)
       app.render(
         <p role="alert">
-          Office could not initialize local sign-in. Use a loopback hostname and reload.
+          Office could not initialize. Check the selected environment and Firebase configuration,
+          then reload.
         </p>
       );
     return;
   }
   app.render(
     <StrictMode>
-      <OfficeApp router={createOfficeRouter()} session={session} />
+      <OfficeApp
+        router={createOfficeRouter()}
+        session={runtime?.session}
+        worlds={runtime?.worlds}
+        mode={runtime?.mode}
+      />
     </StrictMode>
   );
 }

--- a/apps/office/src/office-app.tsx
+++ b/apps/office/src/office-app.tsx
@@ -3,22 +3,32 @@ import { createStore, Provider } from 'jotai';
 import { useState } from 'react';
 import type { ReactElement } from 'react';
 import type { createOfficeRouter } from './router.js';
-import { OfficeSessionContext } from './auth/session-view.js';
+import { OfficeSessionContext, OfficeModeContext } from './auth/session-view.js';
 import type { OfficeSession } from './auth/session.js';
+import { WorldContext } from './worlds/world-view.js';
+import type { WorldState } from './worlds/world-state.js';
 
 export function OfficeApp({
   router,
   session,
+  worlds,
+  mode = 'emulator',
 }: {
   router: ReturnType<typeof createOfficeRouter>;
   session?: OfficeSession;
+  worlds?: WorldState;
+  mode?: string;
 }): ReactElement {
   // A mounted app owns its UI state; tests and future embedded views cannot leak it.
   const [store] = useState(() => createStore());
   return (
     <Provider store={store}>
       <OfficeSessionContext value={session}>
-        <RouterProvider router={router} />
+        <OfficeModeContext value={mode}>
+          <WorldContext value={worlds}>
+            <RouterProvider router={router} />
+          </WorldContext>
+        </OfficeModeContext>
       </OfficeSessionContext>
     </Provider>
   );

--- a/apps/office/src/pages/home.tsx
+++ b/apps/office/src/pages/home.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import type { ReactElement } from 'react';
+import { CreateWorld, WorldGate } from '../worlds/world-view.js';
 
 export function HomePage(): ReactElement {
   return (
@@ -11,13 +12,15 @@ export function HomePage(): ReactElement {
         people and agents.
       </h1>
       <p className="intro">Private offices. Shared spaces. A team that can work together.</p>
+      <WorldGate>{(state) => <CreateWorld state={state} />}</WorldGate>
       <div className="empty-world">
         <span className="world-mark" aria-hidden="true">
           ＋
         </span>
         <h2>No world connected</h2>
         <p>
-          You're viewing the local foundation. World creation and invitations are not available yet.
+          Sign in in a connected environment to create a private world. Invitations are not
+          available yet.
         </p>
         <Link to="/setup">See what comes next</Link>
       </div>

--- a/apps/office/src/router.tsx
+++ b/apps/office/src/router.tsx
@@ -3,6 +3,7 @@ import type { RouterHistory } from '@tanstack/react-router';
 import { OfficeShell } from './shell.js';
 import { HomePage } from './pages/home.js';
 import { SetupPage } from './pages/setup.js';
+import { SelectedWorld, WorldGate } from './worlds/world-view.js';
 
 const rootRoute = createRootRoute({
   component: OfficeShell,
@@ -15,9 +16,20 @@ const rootRoute = createRootRoute({
   ),
 });
 
+const worldRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/worlds/$worldId',
+  component: WorldPage,
+});
+function WorldPage() {
+  const { worldId } = worldRoute.useParams();
+  return <WorldGate>{(state) => <SelectedWorld state={state} id={worldId} />}</WorldGate>;
+}
+
 const routeTree = rootRoute.addChildren([
   createRoute({ getParentRoute: () => rootRoute, path: '/', component: HomePage }),
   createRoute({ getParentRoute: () => rootRoute, path: '/setup', component: SetupPage }),
+  worldRoute,
 ]);
 
 export function createOfficeRouter(history?: RouterHistory) {

--- a/apps/office/src/shell.tsx
+++ b/apps/office/src/shell.tsx
@@ -1,12 +1,15 @@
 import { Link, Outlet } from '@tanstack/react-router';
 import { atom, useAtom } from 'jotai';
+import { useContext } from 'react';
 import type { ReactElement } from 'react';
-import { SessionPanel } from './auth/session-view.js';
+import { SessionPanel, OfficeModeContext, OfficeSessionContext } from './auth/session-view.js';
 
 const showPreviewNotesAtom = atom(false);
 
 export function OfficeShell(): ReactElement {
   const [showNotes, setShowNotes] = useAtom(showPreviewNotesAtom);
+  const session = useContext(OfficeSessionContext);
+  const mode = useContext(OfficeModeContext);
   return (
     <div className="office-shell">
       <a className="skip-link" href="#main">
@@ -22,14 +25,19 @@ export function OfficeShell(): ReactElement {
           </Link>
           <Link to="/setup">Setup</Link>
         </nav>
-        <span className="preview-badge">Local preview</span>
+        <span className="preview-badge">
+          {session ? (mode === 'cloud' ? 'Private pilot' : 'Local emulator') : 'Local preview'}
+        </span>
       </header>
       <main id="main">
         <SessionPanel />
         <Outlet />
       </main>
       <footer>
-        <span>No cloud connection · No agents connected</span>
+        <span>
+          {session && mode === 'cloud' ? 'Cloud pilot' : 'No cloud connection'} · No agents
+          connected
+        </span>
         <button
           type="button"
           aria-expanded={showNotes}
@@ -40,8 +48,9 @@ export function OfficeShell(): ReactElement {
         </button>
         {showNotes && (
           <p id="preview-notes">
-            This shell does not create a world, read local TMT data or send work to agents. Local
-            sign-in is available only in explicit emulator mode.
+            {session
+              ? 'Approved users can create private worlds. No local TMT data or agent execution is connected.'
+              : 'This shell does not create a world, read local TMT data or send work to agents. Choose an explicit connected mode to sign in.'}
           </p>
         )}
       </footer>

--- a/apps/office/src/worlds/firebase-worlds.ts
+++ b/apps/office/src/worlds/firebase-worlds.ts
@@ -1,0 +1,97 @@
+import {
+  collection,
+  doc,
+  onSnapshot,
+  runTransaction,
+  serverTimestamp,
+  Timestamp,
+} from 'firebase/firestore';
+import type { Firestore } from 'firebase/firestore';
+
+import { validWorldName } from './world-contract.js';
+import type { World, WorldDraft, WorldPort } from './world-contract.js';
+
+function readWorld(id: string, value: Record<string, unknown>): World {
+  if (
+    value.version !== 1 ||
+    typeof value.name !== 'string' ||
+    !validWorldName(value.name) ||
+    typeof value.ownerUid !== 'string' ||
+    !(value.createdAt instanceof Timestamp)
+  ) {
+    throw new Error('Unsupported world document.');
+  }
+  return {
+    id,
+    name: value.name,
+    ownerUid: value.ownerUid,
+    createdAtMs: value.createdAt.toMillis(),
+  };
+}
+
+export function createWorldPort(db: Firestore): WorldPort {
+  return {
+    draft(name: string): WorldDraft {
+      if (!validWorldName(name))
+        throw new Error('Use a nonblank name of at most 80 characters without control characters.');
+      return { id: doc(collection(db, 'worlds')).id, name };
+    },
+    async create(draft: WorldDraft, uid: string): Promise<string> {
+      if (!/^[a-zA-Z0-9]{20}$/.test(draft.id) || !validWorldName(draft.name)) {
+        throw new Error('Invalid world draft.');
+      }
+      const reference = doc(db, 'worlds', draft.id);
+      await runTransaction(db, async (transaction) => {
+        const snapshot = await transaction.get(reference);
+        if (snapshot.exists()) {
+          const world = readWorld(snapshot.id, snapshot.data());
+          if (world.ownerUid !== uid || world.name !== draft.name)
+            throw new Error('World creation conflicts with an existing document.');
+          return;
+        }
+        transaction.set(reference, {
+          version: 1,
+          name: draft.name,
+          ownerUid: uid,
+          createdAt: serverTimestamp(),
+        });
+      });
+      return draft.id;
+    },
+    watch(id: string, changed: (world: World | null) => void, failed: () => void): () => void {
+      if (!/^[a-zA-Z0-9]{20}$/.test(id)) {
+        failed();
+        return () => {};
+      }
+      return onSnapshot(
+        doc(db, 'worlds', id),
+        { includeMetadataChanges: true },
+        (snapshot) => {
+          if (snapshot.metadata.fromCache || snapshot.metadata.hasPendingWrites) return;
+          try {
+            changed(snapshot.exists() ? readWorld(snapshot.id, snapshot.data()) : null);
+          } catch {
+            failed();
+          }
+        },
+        failed
+      );
+    },
+    watchAdmission(
+      uid: string,
+      changed: (enabled: boolean) => void,
+      failed: () => void
+    ): () => void {
+      return onSnapshot(
+        doc(db, 'testers', uid),
+        { includeMetadataChanges: true },
+        (snapshot) => {
+          if (snapshot.metadata.fromCache || snapshot.metadata.hasPendingWrites) return;
+          const data = snapshot.data();
+          changed(data?.enabled === true && Object.keys(data).length === 1);
+        },
+        failed
+      );
+    },
+  };
+}

--- a/apps/office/src/worlds/world-contract.test.ts
+++ b/apps/office/src/worlds/world-contract.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { validWorldName } from './world-contract.js';
+
+describe('world name feedback', () => {
+  it.each(['', ' ', '\u00a0', '\u3000', '\ud800', 'line\nbreak', 'x'.repeat(81), '😀'.repeat(81)])(
+    'rejects invalid name %j',
+    (name) => {
+      expect(validWorldName(name)).toBe(false);
+    }
+  );
+  it.each(['My office', 'x'.repeat(80), '😀'.repeat(80)])('accepts valid name %j', (name) => {
+    expect(validWorldName(name)).toBe(true);
+  });
+});

--- a/apps/office/src/worlds/world-contract.ts
+++ b/apps/office/src/worlds/world-contract.ts
@@ -1,0 +1,32 @@
+export interface World {
+  id: string;
+  name: string;
+  ownerUid: string;
+  createdAtMs: number;
+}
+
+export interface WorldDraft {
+  id: string;
+  name: string;
+}
+
+/** Mirrors the feedback subset of contracts/office/private-world.md. Rules enforce it. */
+export function validWorldName(name: string): boolean {
+  const characters = [...name];
+  return (
+    characters.length > 0 &&
+    characters.length <= 80 &&
+    name.trim().length > 0 &&
+    characters.every((character) => {
+      const point = character.codePointAt(0)!;
+      return point >= 32 && point !== 127 && (point < 0xd800 || point > 0xdfff);
+    })
+  );
+}
+
+export interface WorldPort {
+  draft(name: string): WorldDraft;
+  create(draft: WorldDraft, uid: string): Promise<string>;
+  watch(id: string, changed: (world: World | null) => void, failed: () => void): () => void;
+  watchAdmission(uid: string, changed: (enabled: boolean) => void, failed: () => void): () => void;
+}

--- a/apps/office/src/worlds/world-state.test.ts
+++ b/apps/office/src/worlds/world-state.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSession } from '../auth/session.js';
+import type { SessionUser } from '../auth/session.js';
+import type { World, WorldPort } from './world-contract.js';
+import { createWorldState } from './world-state.js';
+
+function fixture() {
+  let changeUser: (user: SessionUser | null) => void = () => {};
+  const session = createSession({
+    observe: (changed) => {
+      changeUser = changed;
+      return vi.fn();
+    },
+    signIn: async () => {},
+    signOut: async () => {
+      changeUser(null);
+    },
+    dispose: async () => {},
+  });
+  const admissions: Array<(enabled: boolean) => void> = [];
+  const worlds: Array<(world: World | null) => void> = [];
+  const stopAdmission = vi.fn();
+  const stopWorld = vi.fn();
+  const port: WorldPort = {
+    draft: vi.fn((name) => ({ id: 'a'.repeat(20), name })),
+    create: vi.fn(async (draft) => draft.id),
+    watch: vi.fn((_id, changed) => {
+      worlds.push(changed);
+      return stopWorld;
+    }),
+    watchAdmission: vi.fn((_uid, changed) => {
+      admissions.push(changed);
+      return stopAdmission;
+    }),
+  };
+  const state = createWorldState(session, port);
+  changeUser({ uid: 'alice', displayName: 'Alice' });
+  return { state, port, admissions, worlds, stopAdmission, stopWorld, changeUser, session };
+}
+const world: World = { id: 'a'.repeat(20), name: 'Private', ownerUid: 'alice', createdAtMs: 1 };
+
+describe('private world lifetime', () => {
+  it('invalid local input reports validation feedback without a draft or transport', async () => {
+    const f = fixture();
+    f.admissions[0](true);
+    expect(await f.state.create('x'.repeat(81))).toBeNull();
+    expect(f.port.draft).not.toHaveBeenCalled();
+    expect(f.port.create).not.toHaveBeenCalled();
+    expect(f.state.getSnapshot()).toMatchObject({ draft: null, busy: false });
+    expect(f.state.getSnapshot().error).toContain('at most 80');
+    f.state.dispose();
+  });
+  it('waiting does not subscribe to worlds; approval and revocation update the same session', () => {
+    const f = fixture();
+    f.state.select(world.id);
+    f.admissions[0](false);
+    expect(f.port.watch).not.toHaveBeenCalled();
+    f.admissions[0](true);
+    f.worlds[0](world);
+    expect(f.state.getSnapshot().world).toEqual(world);
+    f.admissions[0](false);
+    expect(f.state.getSnapshot().world).toBeNull();
+    expect(f.stopWorld).toHaveBeenCalledOnce();
+    f.worlds[0](world);
+    expect(f.state.getSnapshot().world).toBeNull();
+    f.admissions[0](true);
+    expect(f.port.watch).toHaveBeenCalledTimes(2);
+    f.state.dispose();
+  });
+  it('account changes detach listeners and fence callbacks from the previous user', () => {
+    const f = fixture();
+    f.admissions[0](true);
+    f.state.select(world.id);
+    f.worlds[0](world);
+    f.changeUser({ uid: 'bob', displayName: 'Bob' });
+    expect(f.stopAdmission).toHaveBeenCalledOnce();
+    expect(f.state.getSnapshot().world).toBeNull();
+    f.worlds[0](world);
+    f.admissions[0](true);
+    expect(f.state.getSnapshot().admission).toBe('checking');
+    expect(f.state.getSnapshot().world).toBeNull();
+    f.admissions[1](true);
+    f.worlds[1](world);
+    expect(f.state.getSnapshot().world).toBeNull();
+    f.state.dispose();
+  });
+  it('uncertain creation retries preserve the same ID and name', async () => {
+    const f = fixture();
+    f.admissions[0](true);
+    vi.mocked(f.port.create).mockRejectedValueOnce(new Error('network'));
+    expect(await f.state.create('Original')).toBeNull();
+    const draft = f.state.getSnapshot().draft;
+    expect(await f.state.create('Changed')).toBe(world.id);
+    expect(f.port.create).toHaveBeenNthCalledWith(2, draft, 'alice');
+    expect(f.port.draft).toHaveBeenCalledOnce();
+    f.state.dispose();
+  });
+  it('a late successful create after revocation cannot navigate or restore private state', async () => {
+    const f = fixture();
+    f.admissions[0](true);
+    let complete: (id: string) => void = () => {};
+    vi.mocked(f.port.create).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          complete = resolve;
+        })
+    );
+    const result = f.state.create('Late');
+    expect(await f.state.create('Duplicate')).toBeNull();
+    f.admissions[0](false);
+    complete(world.id);
+    expect(await result).toBeNull();
+    expect(f.state.getSnapshot()).toMatchObject({ admission: 'waiting', busy: false, world: null });
+    f.state.dispose();
+  });
+  it('disposal fences every callback and clears private snapshots', () => {
+    const f = fixture();
+    f.admissions[0](true);
+    f.state.select(world.id);
+    f.worlds[0](world);
+    f.state.dispose();
+    f.worlds[0](world);
+    f.admissions[0](true);
+    expect(f.state.getSnapshot()).toMatchObject({ admission: 'signed-out', world: null });
+  });
+});

--- a/apps/office/src/worlds/world-state.ts
+++ b/apps/office/src/worlds/world-state.ts
@@ -1,0 +1,168 @@
+import type { OfficeSession } from '../auth/session.js';
+import type { World, WorldDraft, WorldPort } from './world-contract.js';
+import { validWorldName } from './world-contract.js';
+
+export interface WorldSnapshot {
+  admission: 'signed-out' | 'checking' | 'waiting' | 'approved' | 'error';
+  world: World | null;
+  loading: boolean;
+  busy: boolean;
+  error: string | null;
+  draft: WorldDraft | null;
+}
+
+/** One session-scoped owner for admission and the selected world's subscriptions. */
+export function createWorldState(session: OfficeSession, port: WorldPort) {
+  let snapshot: WorldSnapshot = {
+    admission: 'signed-out',
+    world: null,
+    loading: false,
+    busy: false,
+    error: null,
+    draft: null,
+  };
+  let uid: string | undefined;
+  let selected: string | undefined;
+  let generation = 0;
+  let admissionGeneration = 0;
+  let worldGeneration = 0;
+  let disposed = false;
+  let stopAdmission = () => {};
+  let stopWorld = () => {};
+  const listeners = new Set<() => void>();
+  function publish(next: Partial<WorldSnapshot>) {
+    if (disposed) return;
+    snapshot = { ...snapshot, ...next };
+    for (const listener of listeners) listener();
+  }
+  function clearWorld() {
+    worldGeneration++;
+    stopWorld();
+    stopWorld = () => {};
+    publish({ world: null, loading: false });
+  }
+  function observeWorld() {
+    clearWorld();
+    if (!uid || !selected || snapshot.admission !== 'approved') return;
+    const current = worldGeneration;
+    publish({ loading: true, error: null });
+    stopWorld = port.watch(
+      selected,
+      (world) => {
+        if (disposed || current !== worldGeneration) return;
+        if (world && world.ownerUid === uid) publish({ world, loading: false });
+        else publish({ world: null, loading: false, error: 'World unavailable.' });
+      },
+      () => {
+        if (disposed || current !== worldGeneration) return;
+        publish({ world: null, loading: false, error: 'World unavailable.' });
+      }
+    );
+  }
+  function observeAdmission() {
+    if (disposed) return;
+    generation++;
+    const current = ++admissionGeneration;
+    stopAdmission();
+    stopAdmission = () => {};
+    clearWorld();
+    publish({ admission: uid ? 'checking' : 'signed-out', draft: null, busy: false, error: null });
+    if (!uid) return;
+    stopAdmission = port.watchAdmission(
+      uid,
+      (enabled) => {
+        if (disposed || current !== admissionGeneration) return;
+        publish({ admission: enabled ? 'approved' : 'waiting', error: null });
+        if (!enabled) {
+          generation++;
+          publish({ busy: false, draft: null });
+          clearWorld();
+        } else observeWorld();
+      },
+      () => {
+        if (disposed || current !== admissionGeneration) return;
+        generation++;
+        clearWorld();
+        publish({
+          admission: 'error',
+          busy: false,
+          draft: null,
+          error: 'Could not verify access. Please retry.',
+        });
+      }
+    );
+  }
+  function changedSession() {
+    const state = session.getSnapshot();
+    const next = state.pending ? undefined : state.user?.uid;
+    if (next === uid) return;
+    uid = next;
+    observeAdmission();
+  }
+  const unsubscribe = session.subscribe(changedSession);
+  changedSession();
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener: () => void) {
+      if (disposed) return () => {};
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    select(id?: string) {
+      if (disposed) return;
+      if (selected === id) return;
+      selected = id;
+      observeWorld();
+    },
+    retryAccess: observeAdmission,
+    async create(name: string): Promise<string | null> {
+      if (disposed || !uid || snapshot.admission !== 'approved' || snapshot.busy) return null;
+      const current = generation;
+      if (!snapshot.draft && !validWorldName(name)) {
+        publish({
+          error: 'Use a nonblank name of at most 80 characters without control characters.',
+        });
+        return null;
+      }
+      try {
+        const draft = snapshot.draft ?? port.draft(name);
+        publish({ draft, busy: true, error: null });
+        const id = await port.create(draft, uid);
+        if (disposed || current !== generation) return null;
+        publish({ draft: null });
+        return id;
+      } catch {
+        if (current === generation)
+          publish({
+            error: 'World creation could not be confirmed. Retry the same creation when connected.',
+          });
+        return null;
+      } finally {
+        if (current === generation) publish({ busy: false });
+      }
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      generation++;
+      worldGeneration++;
+      admissionGeneration++;
+      unsubscribe();
+      stopAdmission();
+      stopWorld();
+      listeners.clear();
+      snapshot = {
+        admission: 'signed-out',
+        world: null,
+        loading: false,
+        busy: false,
+        error: null,
+        draft: null,
+      };
+    },
+  };
+}
+
+export type WorldState = ReturnType<typeof createWorldState>;

--- a/apps/office/src/worlds/world-view.tsx
+++ b/apps/office/src/worlds/world-view.tsx
@@ -1,0 +1,115 @@
+import { createContext, useContext, useEffect, useState, useSyncExternalStore } from 'react';
+import { Link, useNavigate } from '@tanstack/react-router';
+import type { ReactElement, ReactNode } from 'react';
+import type { WorldState } from './world-state.js';
+
+export const WorldContext = createContext<WorldState | undefined>(undefined);
+
+export function WorldGate({
+  children,
+}: {
+  children: (state: WorldState) => ReactNode;
+}): ReactElement | null {
+  const state = useContext(WorldContext);
+  return state ? <Admission state={state}>{children}</Admission> : null;
+}
+
+function Admission({
+  state,
+  children,
+}: {
+  state: WorldState;
+  children: (state: WorldState) => ReactNode;
+}): ReactElement | null {
+  const { admission, error } = useSyncExternalStore(state.subscribe, state.getSnapshot);
+  if (admission === 'signed-out') return null;
+  if (admission === 'checking') return <p role="status">Checking pilot access…</p>;
+  if (admission === 'waiting' || admission === 'error')
+    return (
+      <section aria-label="Pilot access">
+        <h2>Waiting for access</h2>
+        <p>Share your UID above with the operator to enable your test account.</p>
+        {error && <p role="alert">{error}</p>}
+        <button onClick={state.retryAccess}>Check access again</button>
+      </section>
+    );
+  return <>{children(state)}</>;
+}
+
+export function CreateWorld({ state }: { state: WorldState }): ReactElement {
+  const [name, setName] = useState('');
+  const [worldId, setWorldId] = useState('');
+  const { busy, error, draft } = useSyncExternalStore(state.subscribe, state.getSnapshot);
+  const navigate = useNavigate();
+  return (
+    <section aria-label="Create a world">
+      <h2>Create your private world</h2>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          void state.create(name).then((id) => {
+            if (id) void navigate({ to: '/worlds/$worldId', params: { worldId: id } });
+          });
+        }}
+      >
+        <label htmlFor="world-name">World name</label>
+        <input
+          id="world-name"
+          value={draft?.name ?? name}
+          disabled={busy || !!draft}
+          required
+          onChange={(event) => setName(event.target.value)}
+        />
+        <button disabled={busy || (!draft && !name.trim())}>
+          {busy ? 'Creating…' : draft ? 'Retry creation' : 'Create world'}
+        </button>
+      </form>
+      {error && <p role="alert">{error}</p>}
+      <p>Only your approved account can open this world. Invitations are not available yet.</p>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          void navigate({ to: '/worlds/$worldId', params: { worldId } });
+        }}
+      >
+        <label htmlFor="open-world-id">World ID</label>
+        <input
+          id="open-world-id"
+          value={worldId}
+          required
+          pattern="[a-zA-Z0-9]{20}"
+          onChange={(event) => setWorldId(event.target.value)}
+        />
+        <button>Open world</button>
+      </form>
+    </section>
+  );
+}
+
+export function SelectedWorld({ state, id }: { state: WorldState; id: string }): ReactElement {
+  const { world, loading, error } = useSyncExternalStore(state.subscribe, state.getSnapshot);
+  useEffect(() => {
+    state.select(id);
+    return () => state.select();
+  }, [state, id]);
+  // Route transitions cannot briefly display the previous route's private world.
+  if (loading || (world && world.id !== id)) return <p role="status">Opening world…</p>;
+  if (!world)
+    return (
+      <section>
+        <h1>World unavailable</h1>
+        <p>{error ?? 'No world is available at this address.'}</p>
+        <Link to="/">Return to Office</Link>
+      </section>
+    );
+  return (
+    <section>
+      <p className="eyebrow">Private world</p>
+      <h1>{world.name}</h1>
+      <p>
+        World ID: <code>{world.id}</code>
+      </p>
+      <p>Your space is ready. Agent blocks and invitations are coming next.</p>
+    </section>
+  );
+}

--- a/contracts/office/README.md
+++ b/contracts/office/README.md
@@ -2,6 +2,11 @@
 
 Design baseline for #174. There is no deployed API or production consumer yet.
 
+The separately versioned [private world document v1](private-world.md) is the
+#189 direct-Firestore contract. It uses native Firestore timestamps and Rules,
+not the work-handoff HTTP/JSON envelopes below. Its actual client adapter and
+Rules are exercised together in `apps/office/e2e/world-rules.spec.ts`.
+
 ## Single source of truth
 
 - `v1.schema.json` is JSON Schema 2020-12 for the initial work handoff ingress:

--- a/contracts/office/private-world.md
+++ b/contracts/office/private-world.md
@@ -1,0 +1,33 @@
+# Private world document v1
+
+Tracking: #189. This is a Firestore document contract, not an HTTP envelope or
+the work-dispatch protocol. Security Rules are the enforcement boundary; browser
+validation provides feedback, not authority.
+
+`worlds/{worldId}` uses a Firestore-generated 20-character alphanumeric ID and
+exactly these fields:
+
+| Field       | Value                                                                          |
+| ----------- | ------------------------------------------------------------------------------ |
+| `version`   | Number `1`                                                                     |
+| `name`      | Nonblank string, at most 80 Unicode scalar values, no ASCII control characters |
+| `ownerUid`  | Creating Google-authenticated human's Firebase UID                             |
+| `createdAt` | Firestore server timestamp at creation                                         |
+
+All fields are immutable in this slice. There is no delete or global listing.
+One online transaction reads the selected ID, creates if absent, or returns the
+same document when owner/name/version match. Conflicts never overwrite. The UI
+keeps the same ID and name for an uncertain retry. Deduplication lasts while the
+world exists; no offline write queue, expiring request record or second owner
+membership document is involved. An approved user may read an absent ID for the
+transaction; denied and absent worlds have the same user-facing unavailable view.
+
+`testers/{uid}` is an operator-managed document with exactly `{ enabled: true }`
+for admission. Missing, disabled or malformed documents deny world access.
+Verified Google users may get their own admission document, but cannot list or
+write tester documents. Admission does not grant access to other owners' worlds.
+The Firebase Console operator uses IAM, not a client-side administrator role.
+
+Future `worlds/{worldId}/blocks/{blockId}` and `messages/{messageId}` will store
+bounded independent objects. They are denied until their feature contracts are
+implemented. World data does not authorize native agent execution.

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -15,12 +15,27 @@ Office is an optional React SPA under `apps/office`. Its local shell has a home
 route, setup explanation, unknown-route recovery and provider-local presentation
 state. Default preview does not initialize Firebase. Explicit `emulator` mode
 on loopback enables local Google-provider popup sign-in, UID display and logout
-through the Auth Emulator, not real Google. It does not load local identities,
+through the Auth Emulator, not real Google. Explicit `cloud` mode requires
+owner-local Firebase web configuration and uses the same Google/session adapter.
+It does not load local identities,
 install an extension, open a connector listener or dispatch work. The native CLI
-remains unchanged. Login does not grant world access; Firestore still denies all
-client access. This is #187, the first slice of #176, not a private-world implementation.
+remains unchanged. Login alone does not grant world access. #189 adds a
+Console-managed tester gate and direct client create/read of owner-only worlds;
+Firestore Rules enforce both gates, immutable fields and default-deny paths.
+This is not an invitation, presence or connected-agent implementation.
 
-`src/auth/firebase-session.ts` is the only Firebase initialization/adapter owner.
+`src/auth/firebase-session.ts` is the only Firebase initialization/composition owner.
+`firebase-config.ts` validates explicit activation before SDK initialization.
+`src/worlds/firebase-worlds.ts` owns direct SDK operations; `world-state.ts`
+depends on the Firebase-free `world-contract.ts` port and value types, not the
+concrete adapter. The contract owns shared client validation and the adapter
+implements it; there is no second domain model or request layer. `world-state.ts`
+owns one admission listener and at most one selected-world listener. Session,
+admission and route generations fence late callbacks/creates. React subscribes
+directly, with no parallel Jotai/Query copy. Firestore cache-only snapshots never
+grant access or display world data; only server-confirmed observations do.
+The document contract is in `contracts/office/private-world.md`; Rules are the
+untrusted-write enforcement boundary. The client name check is feedback only.
 The entry point creates one uniquely named app outside React rendering and
 disposes it on hot replacement. `session.ts` owns one observer, bounded public
 identity projection, action serialization, sanitized errors and teardown.
@@ -29,16 +44,18 @@ Jotai and Query do not mirror identity. Only the observer changes identity;
 failed actions retain the observed state, and late completions cannot revive
 a disposed session. Auth uses explicit in-memory persistence from initialization:
 reload signs out and other tabs/contexts do not inherit the identity. No tokens
-are exposed in view snapshots. This memory policy is not a substitute for future
-server-side revocation or world authorization.
+are exposed in view snapshots. This memory policy is not a substitute for Rules
+authorization. Removing tester admission clears private UI and denies subsequent
+server operations; previously disclosed content cannot be recalled. No production
+Firebase setup is implied.
 
-| Owner              | Responsibility                                                              | Forbidden dependency                                                    |
-| ------------------ | --------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `apps/office`      | Browser routes, accessible views, UI state, app tests                       | Local SQLite, filesystem/process APIs, Rust source or test helpers      |
-| `services/office`  | Demo-project emulator bootstrap and deny-all rules; product policy deferred | Unrestricted local execution or implicit agent authority                |
-| `contracts/office` | Versioned design schema and structural conformance fixtures                 | Browser rendering, Firebase effects or duplicate domain policy          |
-| `rust/`            | Existing local CLI, domain and concrete adapters                            | Office assets, Node or a Firebase account required by ordinary commands |
-| `docs/office`      | Decisions, scenarios and operational guidance                               | Describing planned behavior as shipped                                  |
+| Owner              | Responsibility                                                   | Forbidden dependency                                                    |
+| ------------------ | ---------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `apps/office`      | Browser routes, accessible views, UI state, app tests            | Local SQLite, filesystem/process APIs, Rust source or test helpers      |
+| `services/office`  | Demo-project emulator bootstrap and private-world security rules | Unrestricted local execution or implicit agent authority                |
+| `contracts/office` | Versioned design schema and structural conformance fixtures      | Browser rendering, Firebase effects or duplicate domain policy          |
+| `rust/`            | Existing local CLI, domain and concrete adapters                 | Office assets, Node or a Firebase account required by ordinary commands |
+| `docs/office`      | Decisions, scenarios and operational guidance                    | Describing planned behavior as shipped                                  |
 
 There is no connector crate, deployable service or shared runtime package yet.
 Create each only with its first concrete consumer and reviewed contract.
@@ -102,5 +119,14 @@ it does not duplicate emulator pins or use the native tmux harness. Upstream
 emulator CDN presentation assets are blocked, not replaced with fake auth
 responses. Google's public popup/iframe library is still required: browser
 tests allow its script GETs on `apis.google.com`, keep all auth requests local,
-and reject other destinations. This is not a fully offline flow. These tests do not prove world rules,
-connector lifecycle, real Google login or remote collaboration.
+and reject other destinations. This is not a fully offline flow. Direct-SDK
+Rules scenarios additionally prove tester/owner isolation and immutable creation;
+the browser world scenario proves grant/create/read/revocation through the UI.
+They do not prove connector lifecycle, real Google login or remote collaboration.
+
+The emulator did not close an already authorized listener within the test budget
+when only its dependent tester grant changed. Tests separately prove denial of
+the next server read and next world update, while the app's own admission stream
+clears the view and detaches its world listener. Do not claim instantaneous
+server stream closure or recall of prior data. Real cloud revocation timing must
+be verified during the explicitly authorized pilot.

--- a/docs/office/design.md
+++ b/docs/office/design.md
@@ -1,7 +1,7 @@
 # Office v1 design
 
 Status: design baseline for #174, not implemented service behavior. The delivered
-SPA remains the disconnected shell described in [architecture](architecture.md).
+SPA implementation is described in [architecture](architecture.md).
 This document owns policy and user-visible semantics; the
 [wire schema](../../contracts/office/v1.schema.json) owns message shapes.
 
@@ -46,6 +46,23 @@ require a later authentication slice. A self-deployed operator supplies their
 own auth configuration; no project IDs or credentials ship in source.
 
 ## Authorization, not proximity
+
+### Private-world pilot refinement (#189)
+
+World creation and reads use the authenticated Firestore client directly, not
+an HTTP/Admin world service. `worlds/{worldId}` owns immutable world metadata
+and `ownerUid`; there is no redundant owner membership record. Rules require
+verified Google authentication, current operator-managed `testers/{uid}` admission
+and resource ownership. Client writes to tester grants are always denied.
+Operators edit `{ enabled: true }` in Firebase Console; missing/disabled/malformed
+grants deny world access. Authentication itself is not blocked by this gate.
+
+See [private world document v1](../../contracts/office/private-world.md) for
+the exact create/read and retry contract. Future blocks and messages live in
+world subcollections, not unbounded arrays on the root. Those paths currently
+deny all client access. Invitations and device/work operations below remain
+future design; they do not justify a generic backend for ordinary world storage.
+The initial owner-only world does not implement visitor memberships or presence.
 
 | Action             | Minimum authorization                                                                        | Explicitly does not grant                                                      |
 | ------------------ | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:native": "vitest run --config test/native/vitest.config.ts",
     "test:run": "vitest run",
     "lint": "oxlint test/ scripts/*.mjs",
-    "docs:format:check": "prettier --check --ignore-path .gitignore AGENTS.md ARCHITECTURE.md CONVENTIONS.md DEVELOPMENT.md RUST-REWRITE.md PERFORMANCE-BASELINE.md \".agents/skills/**/SKILL.md\" .github/pull_request_template.md \"docs/office/**/*.md\" services/office/README.md contracts/office/README.md",
+    "docs:format:check": "prettier --check --ignore-path .gitignore AGENTS.md ARCHITECTURE.md CONVENTIONS.md DEVELOPMENT.md RUST-REWRITE.md PERFORMANCE-BASELINE.md \".agents/skills/**/SKILL.md\" .github/pull_request_template.md \"docs/office/**/*.md\" services/office/README.md \"contracts/office/*.md\"",
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --write test/ scripts/*.mjs tsconfig.json tsconfig.e2e.json vitest.config.ts package.json .github/workflows/ci.yml services/office/firebase.json services/office/compose.yaml \"contracts/office/*.json\"",
     "format:check": "prettier --check test/ scripts/*.mjs tsconfig.json tsconfig.e2e.json vitest.config.ts package.json .github/workflows/ci.yml services/office/firebase.json services/office/compose.yaml \"contracts/office/*.json\"",

--- a/services/office/Dockerfile
+++ b/services/office/Dockerfile
@@ -1,6 +1,6 @@
 # Local emulators only; never mount host Firebase credentials into this image.
 FROM eclipse-temurin:21-jre-jammy@sha256:54b382c9d790d3201004d4e3921f4eff7dc7d67e1ce21a2da8d8faaaf63c85fc AS java
-FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS emulators
+FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS emulator-tools
 COPY --from=java /opt/java/openjdk /opt/java/openjdk
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="/opt/java/openjdk/bin:${PATH}"
@@ -9,13 +9,15 @@ RUN mkdir -p /home/node/office && chown node:node /home/node/office
 USER node
 WORKDIR /home/node/office
 RUN firebase setup:emulators:firestore --non-interactive
+ENV GCLOUD_PROJECT=demo-tmt-office
+
+FROM emulator-tools AS emulators
 COPY --chown=node:node services/office/firebase.json services/office/firestore.rules ./
 COPY --chown=node:node scripts/verify-office-emulators.mjs ./
-ENV GCLOUD_PROJECT=demo-tmt-office
 CMD ["firebase", "emulators:start", "--only", "auth,firestore", "--project", "demo-tmt-office", "--config", "firebase.json", "--non-interactive"]
 
 # Opt-in browser proof reuses the emulator owner; no host credentials or volumes.
-FROM emulators AS browser-tests
+FROM emulator-tools AS browser-tests
 USER root
 RUN npm install --global pnpm@10.33.0 && mkdir -p /workspace/apps/office && chown -R node:node /workspace
 WORKDIR /workspace
@@ -27,10 +29,12 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 USER root
 RUN pnpm --filter @tmt/office exec playwright install --with-deps chromium
 USER node
+COPY --from=emulators --chown=node:node /home/node/office/ /home/node/office/
 COPY --chown=node:node apps/office apps/office
 RUN --network=none pnpm office:check && pnpm office:test \
   && pnpm --filter @tmt/office exec vite build --outDir dist-preview \
-  && pnpm --filter @tmt/office exec vite build --mode emulator
+  && pnpm --filter @tmt/office exec vite build --mode emulator \
+  && pnpm --filter @tmt/office exec vite build --mode cloud --outDir dist-cloud
 CMD ["firebase", "emulators:exec", "--only", "auth,firestore", "--project", "demo-tmt-office", "--config", "/home/node/office/firebase.json", "--non-interactive", "pnpm --filter @tmt/office test:browser"]
 
 # Keep the existing default build and compose behavior lightweight.

--- a/services/office/README.md
+++ b/services/office/README.md
@@ -1,9 +1,10 @@
 # Office service boundary
 
-Local Firebase environment for #184, prerequisite of #176. The SPA now offers
-explicit emulator-only sign-in (#187); real authentication deployment,
-invitations, membership and presence are not implemented. The bootstrap
-Firestore rules deny every client read/write; they are not production policy.
+Local Firebase environment for #184 and private-world Rules for #189, under
+#176. The SPA offers explicit emulator/cloud Google sign-in and direct client
+creation/read of owner-only worlds. Rules require operator-managed tester
+admission. Cloud deployment, invitations, guest memberships and presence are
+not implied by this implementation. Unspecified paths remain denied.
 
 See [the architecture](../../docs/office/architecture.md). Add functions only
 when a trusted operation cannot be safely implemented with reviewed rules and
@@ -54,6 +55,38 @@ or a browser E2E test. The privileged `owner` fixture token is emulator-only.
 The verifier refuses non-loopback endpoints and any non-demo project.
 
 ## Owner-local project settings
+
+### Limited cloud pilot
+
+The operator must explicitly approve production setup before changing services,
+Rules or tester grants. In Firebase Console, register a Web app, enable Google
+in Authentication, and authorize the exact testing/hosting domain. If Firestore
+has not been created, choose its location deliberately and start locked; never
+use test-mode open rules. Billing changes are not part of this workflow.
+
+Copy `apps/office/.env.example` to `apps/office/.env.cloud.local`, then copy the
+four public web app values from Console. Run `pnpm office:dev --mode cloud`.
+For a build use `pnpm --filter @tmt/office build --mode cloud`; configure the
+SPA host to rewrite `/worlds/*` to `index.html`. Default builds stay disconnected.
+This pilot currently uses the project's standard `PROJECT.firebaseapp.com`
+Auth domain; custom auth domains need a separately reviewed configuration change.
+
+Deploy the reviewed `firestore.rules` only after explicit authorization, using
+the exact intended project rather than a default alias. A user can then sign
+in, see their UID and wait for access. Under Firestore Data in Console, create
+collection `testers`, document ID equal to that UID, and one Boolean field
+`enabled` set to `true`. Use Boolean, not a string. Set it to `false` to revoke.
+The UI observes changes and also provides **Check access again** for retry.
+No client can write this collection or list testers. Approval grants only
+access to the pilot; it does not grant access to another user's private world.
+
+Rules-dependent document lookups can incur reads, including denied requests.
+The app has one tester listener after login and at most one selected-world
+listener. A create transaction reads one world and writes it once; retries may
+repeat reads. No global directory, per-frame writes or polling is used. Logout
+and access loss detach private listeners and clear the view. Memory-only caches
+do not recall information already disclosed. No custom claims or Admin server
+are needed to manage the pilot allowlist.
 
 The shared configuration never selects a real project. If needed, copy
 `.firebaserc.example` to `.firebaserc` in this directory and replace the owner

--- a/services/office/firestore.rules
+++ b/services/office/firestore.rules
@@ -1,7 +1,44 @@
-// Bootstrap only: no product membership or invitation policy is implemented.
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function human() {
+      return request.auth != null
+        && request.auth.token.firebase.sign_in_provider == 'google.com'
+        && request.auth.token.email_verified == true;
+    }
+
+    function approved() {
+      return human()
+        && exists(/databases/$(database)/documents/testers/$(request.auth.uid))
+        && get(/databases/$(database)/documents/testers/$(request.auth.uid)).data.keys().hasOnly(['enabled'])
+        && get(/databases/$(database)/documents/testers/$(request.auth.uid)).data.enabled == true;
+    }
+
+    match /testers/{uid} {
+      // Waiting users can inspect their own admission, never enumerate or grant it.
+      allow get: if human() && request.auth.uid == uid;
+      allow list, write: if false;
+    }
+
+    match /worlds/{worldId} {
+      // Missing-document reads permit online create transactions. Existing world
+      // metadata remains owner-only; the UI does not distinguish denied/missing.
+      allow get: if approved() && (resource == null || resource.data.ownerUid == request.auth.uid);
+      allow create: if approved()
+        && worldId.matches('^[a-zA-Z0-9]{20}$')
+        && request.resource.data.keys().hasAll(['version', 'name', 'ownerUid', 'createdAt'])
+        && request.resource.data.keys().hasOnly(['version', 'name', 'ownerUid', 'createdAt'])
+        && request.resource.data.version == 1
+        && request.resource.data.name is string
+        && request.resource.data.name.matches('.{1,80}')
+        && request.resource.data.name.matches('.*[^\\s\\p{Z}\\x{feff}].*')
+        && !request.resource.data.name.matches('.*[\\x00-\\x1f\\x7f].*')
+        && request.resource.data.ownerUid == request.auth.uid
+        && request.resource.data.createdAt == request.time;
+      allow list, update, delete: if false;
+    }
+
+    // Blocks, messages, memberships and every unspecified path remain closed.
     match /{document=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## Scope

Closes #189. Parent #176 remains open in the TMT Office Connected Worlds project.

Approved Google users can explicitly create and reopen an owner-only world through the Firestore browser SDK. Operators manage admission with `testers/{uid}` and a Boolean `enabled` field in Firebase Console. Default preview remains disconnected; emulator and configured cloud modes share the same runtime.

No HTTP/Admin product service, new dependency, invitation, presence, agent execution, cloud deployment or billing change is included.

## Architecture and review

- Primary reviewer: Codex. Reviewed commit: `e3ab4d4` (all 37 changed files, relevant session/router callers, fixtures, Rules and documentation).
- Reused the existing Firebase/session composition, TanStack routing, observer subscriptions and Docker emulator owner. Pure world state depends on `world-contract.ts`, not the concrete Firestore adapter; React does not copy remote state into Jotai or another store.
- Rules enforce verified Google identity, current tester admission, immutable owner/schema/server time, and default denial of all undeveloped subcollections. A missing-document get allows online creation; existing non-owner data stays denied. The UI intentionally presents denied/missing worlds identically, not an API-level existence-concealment guarantee.
- Exact concurrent retries reuse one random ID and preserve the original timestamp. Uncertain creation keeps its draft for explicit retry. Memory-only persistence, server-confirmed projections and generation fences protect account changes, logout, revocation and late completions.
- Findings fixed: concrete-adapter dependency in pure state; retained admission unsubscribe closure; invalid local input misreported as transport failure; Unicode name-length mismatch between Rules and client; repeated browser dependency installation after Rules-only changes. Shared browser fixture extraction avoids copied popup/network/cleanup logic.
- Test validity refinement: SDK `disableNetwork` did not reliably simulate transaction transport loss, so the browser test blocks the actual Firestore transport and independently checks durable documents. The emulator did not immediately close a world listener on a dependent grant change; tests prove denial of its next update and separate UI admission-stream clearing. Real cloud timing remains unverified; no instantaneous recall claim.
- `ARCHITECTURE.md`, Office design/architecture, the private-world contract, development and operator guides updated together. Contract Markdown is now included in the existing documentation quality gate.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [x] CI was checked on the current commit before authorized merge. All 17 checks passed on reviewed head e3ab4d47361cdf71a853d861d56f1e251d73c288 (run 34384349504, attempt 3). Merged as 08936d4dd600d29b59e3c0777b88d8ae137e58dd.

Local results:

- `pnpm check` — passed, including root and Office type/lint/format and documentation checks.
- `pnpm office:test` — 43 tests in 6 files passed.
- `pnpm test:run` — 146 tooling tests in 14 files passed.
- `docker build --target browser-tests -f services/office/Dockerfile -t tmt-office-browser:189-local .` — passed, including offline app checks/tests and preview/emulator/unconfigured-cloud builds.
- `docker run --rm --init --shm-size=256m tmt-office-browser:189-local` — two fresh-container passes, 14 scenarios each (26.7s and 24.8s), no retries. The final subsequent change only expanded the docs-check glob and `pnpm check` passed again.
- `git diff --cached --check` — passed before commit.

The real Auth/Firestore emulator and Chromium scenarios cover grant/create/reopen/revoke/regrant, owner isolation, malformed grants, anonymous/custom/unverified users, immutable concurrent retries, direct-write validation, actual transport failure and explicit recovery, logout/reload, and all three build activation modes. Existing popup cancel/block/token-exchange and tab-isolation scenarios remain. Native Rust was not changed; native local E2E is not claimed for this slice.

## Project lifecycle

Branch: `feat/189-private-worlds`, main checkout, no additional worktree. One locally verified CI candidate. Required CI/protection is unchanged; no merge until current-head required checks pass.

No production Firebase setting, provider, Rules, database, tester grant or billing has been changed. The ignored owner configuration is preserved. Real Google/cloud pilot activation requires action-time authorization; invitations, blocks, presence and connector work remain separate slices under #176.
