### PR TITLE
feat(office): add revision-safe visual home block editor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,15 @@ the direct Firestore adapter and session-scoped admission/selected-world state.
 Its Firebase-free `world-contract.ts` is the single client port/value/validation
 owner; pure state does not depend on the concrete SDK adapter.
 Rules, not the UI, enforce tester admission and immutable owner authority.
+`src/blocks` adds one owner-only home block: pure catalog/geometry/validation,
+an SDK adapter and a mounted editor state owner. Remote snapshots and an explicit
+unsaved draft are separate, not duplicated caches. The view renders curated SVG
+primitives; it cannot execute stored markup. Block writes use expected revisions
+and online transactions, and reuse world ownership rather than adding another
+identity record. See `contracts/office/block-v1.md` for the bounded data contract.
+The same pure block owner encodes readable furniture into short storage tokens;
+Rules validate complete footprints within their expression budget. No parallel
+named-field copy is stored.
 React subscribes to the observer-backed session rather than copying identity into
 Jotai. The opt-in `browser-tests` stage of the same emulator Dockerfile proves
 real browser session behavior with local auth and an explicit public Google

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -152,7 +152,13 @@ it never contacts a real project during automated tests.
 It uses one worker, no retries, bounded waits and independent browser contexts.
 Auth responses are real and local. The suite also exercises the real Firestore
 SDK against Rules: immutable creation/retry, cross-user denial, self-grant denial,
-shape validation, and browser grant/create/revocation. Operator fixture writes
+shape validation, and browser grant/create/revocation. Operator fixtures
+also independently inspect saved block layouts. Home-block scenarios cover
+revision races, exact retries, Rules/client conformance vectors, bounded list
+validation, owner/device isolation and browser placement/save/reopen/revocation.
+Desktop and narrow editor screenshots are written to Playwright test results
+for primary visual review, not treated as automatic visual acceptance.
+Operator fixture writes
 use a hard-wired loopback demo-project bypass, never production credentials.
 Google's official popup transport still loads
 public JavaScript from `apis.google.com`, even in emulator mode. The browser

--- a/apps/office/Dockerfile
+++ b/apps/office/Dockerfile
@@ -9,4 +9,5 @@ RUN pnpm office:install \
   && test ! -e /node_modules \
   && test ! -e rust/target/debug/tmt
 COPY apps/office apps/office
+COPY contracts/office contracts/office
 CMD ["sh", "-c", "pnpm office:check && pnpm office:test && pnpm office:build"]

--- a/apps/office/e2e/block-rules.spec.ts
+++ b/apps/office/e2e/block-rules.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '@playwright/test';
+import { doc, getDocFromServer, setDoc, serverTimestamp, deleteDoc } from 'firebase/firestore';
+import vectors from '../../../contracts/office/block-v1.vectors.json' with { type: 'json' };
+import { createWorldPort } from '../src/worlds/firebase-worlds.js';
+import { createBlockPort } from '../src/blocks/firebase-blocks.js';
+import { createFirestoreFixture, setTester } from './firestore-fixture.js';
+
+test('direct block writes enforce contract vectors and every bounded slot', async () => {
+  const fixture = await createFirestoreFixture();
+  try {
+    const alice = await fixture.client(true);
+    const worlds = createWorldPort(alice.db);
+    const draft = worlds.draft('Rules workshop');
+    await worlds.create(draft, alice.uid);
+    const target = doc(alice.db, 'worlds', draft.id, 'blocks', 'home');
+    let revision = 0;
+    const valid = 'd000';
+    const cases = [
+      ...vectors.map((v) => ({ ...v, objects: [v.stored] })),
+      { name: 'empty', valid: true, objects: [] },
+      { name: 'full', valid: true, objects: Array(16).fill(valid) },
+      {
+        name: 'invalid final slot',
+        valid: false,
+        objects: [...Array(15).fill(valid), 'd0v0'],
+      },
+      { name: 'overflow', valid: false, objects: Array(17).fill(valid) },
+    ];
+    for (const vector of cases) {
+      const writing = setDoc(target, {
+        version: 1,
+        revision: revision + 1,
+        objects: vector.objects,
+        updatedAt: serverTimestamp(),
+      });
+      if (vector.valid) {
+        await writing;
+        revision++;
+        expect((await getDocFromServer(target)).data()?.objects, vector.name).toEqual(
+          vector.objects
+        );
+      } else
+        await expect(writing, vector.name).rejects.toMatchObject({ code: 'permission-denied' });
+    }
+    for (const changed of [
+      { revision },
+      { revision: revision + 2 },
+      { version: 2 },
+      { ownerUid: alice.uid },
+      { updatedAt: 0 },
+      { extra: true },
+    ]) {
+      await expect(
+        setDoc(target, {
+          version: 1,
+          revision: revision + 1,
+          objects: [],
+          updatedAt: serverTimestamp(),
+          ...changed,
+        })
+      ).rejects.toMatchObject({ code: 'permission-denied' });
+    }
+    await expect(deleteDoc(target)).rejects.toMatchObject({ code: 'permission-denied' });
+    // Creation must support the full budget too, not only incremental updates.
+    const full = worlds.draft('Full from the start');
+    await worlds.create(full, alice.uid);
+    const fullTarget = doc(alice.db, 'worlds', full.id, 'blocks', 'home');
+    await setDoc(fullTarget, {
+      version: 1,
+      revision: 1,
+      objects: Array(16).fill(valid),
+      updatedAt: serverTimestamp(),
+    });
+    expect((await getDocFromServer(fullTarget)).data()?.objects).toHaveLength(16);
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('block transactions preserve exact retries and reject concurrent revision conflicts', async () => {
+  const fixture = await createFirestoreFixture();
+  try {
+    const alice = await fixture.client(true);
+    const worlds = createWorldPort(alice.db);
+    const draft = worlds.draft('Concurrent studio');
+    await worlds.create(draft, alice.uid);
+    const port = createBlockPort(alice.db);
+    const first = await port.apply(draft.id, 0, []);
+    expect(first.revision).toBe(1);
+    expect(await port.apply(draft.id, 0, [])).toEqual(first);
+    const changes = [
+      [{ asset: 'desk' as const, x: 0, y: 0, rotation: 0 }],
+      [{ asset: 'plant' as const, x: 0, y: 0, rotation: 0 }],
+    ];
+    const results = await Promise.allSettled(
+      changes.map((objects) => port.apply(draft.id, 1, objects))
+    );
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    const failed = results.find((result) => result.status === 'rejected');
+    expect(failed?.status === 'rejected' && failed.reason.message).toContain('changed');
+    const stored = (
+      await getDocFromServer(doc(alice.db, 'worlds', draft.id, 'blocks', 'home'))
+    ).data();
+    expect(stored?.revision).toBe(2);
+    expect(stored?.objects).toEqual(results[0].status === 'fulfilled' ? ['d000'] : ['p000']);
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('only the approved owner can access the block, including after revocation', async () => {
+  const fixture = await createFirestoreFixture();
+  try {
+    const alice = await fixture.client(true);
+    const bob = await fixture.client(true);
+    const device = await fixture.client(true, 'device');
+    const waiting = await fixture.client();
+    const worlds = createWorldPort(alice.db);
+    const draft = worlds.draft('Private studio');
+    await worlds.create(draft, alice.uid);
+    await createBlockPort(alice.db).apply(draft.id, 0, []);
+    for (const actor of [bob, device, waiting]) {
+      await expect(
+        getDocFromServer(doc(actor.db, 'worlds', draft.id, 'blocks', 'home'))
+      ).rejects.toMatchObject({ code: 'permission-denied' });
+      await expect(createBlockPort(actor.db).apply(draft.id, 1, [])).rejects.toMatchObject({
+        code: 'permission-denied',
+      });
+    }
+    await setTester(alice.uid, false);
+    await expect(createBlockPort(alice.db).apply(draft.id, 1, [])).rejects.toMatchObject({
+      code: 'permission-denied',
+    });
+    await expect(
+      getDocFromServer(doc(alice.db, 'worlds', draft.id, 'blocks', 'home'))
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+  } finally {
+    await fixture.dispose();
+  }
+});

--- a/apps/office/e2e/blocks.spec.ts
+++ b/apps/office/e2e/blocks.spec.ts
@@ -1,0 +1,111 @@
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { test, signIn } from './browser-session.js';
+import { setTester, readBlockDocument } from './firestore-fixture.js';
+
+async function prepareStudio(page: Page) {
+  await signIn(page, 'Decorator');
+  const uid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+  await setTester(uid, true);
+  await page.getByLabel('World name').fill('The quiet studio');
+  await page.getByRole('button', { name: 'Create world', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'The quiet studio' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Add desk', exact: true })).toBeVisible();
+  const worldId = new URL(page.url()).pathname.split('/').at(-1)!;
+  return { uid, worldId };
+}
+
+test('owner arranges, explicitly saves, reopens and loses block access on revocation', async ({
+  openSession,
+}) => {
+  const { page } = await openSession();
+  const { uid, worldId } = await prepareStudio(page);
+  await page.getByRole('button', { name: 'Add rug', exact: true }).click();
+  await page.getByLabel('Tile X', { exact: true }).fill('12');
+  await page.getByLabel('Tile Y', { exact: true }).fill('12');
+  await page.getByRole('button', { name: 'Add desk', exact: true }).click();
+  await page.getByRole('button', { name: 'Rotate clockwise' }).click();
+  await page.getByRole('button', { name: 'Add chair', exact: true }).click();
+  await page.getByLabel('Tile X', { exact: true }).fill('17');
+  await page.getByRole('button', { name: 'Add plant', exact: true }).click();
+  await page.getByLabel('Tile X', { exact: true }).fill('21');
+  await expect(page.getByText('Unsaved changes', { exact: true })).toBeVisible();
+  expect(await readBlockDocument(worldId)).toBeNull();
+  await page.getByRole('button', { name: 'Save layout', exact: true }).click();
+  await expect(page.getByText('Saved · revision 1', { exact: true })).toBeVisible();
+  expect(await readBlockDocument(worldId)).toMatchObject({
+    fields: {
+      revision: { integerValue: '1' },
+      objects: {
+        arrayValue: {
+          values: [
+            { stringValue: 'r0cc' },
+            { stringValue: 'd1ee' },
+            { stringValue: 'c0he' },
+            { stringValue: 'p0le' },
+          ],
+        },
+      },
+    },
+  });
+  await page.getByRole('link', { name: 'Office', exact: true }).click();
+  await page.getByLabel('World ID', { exact: true }).fill(worldId);
+  await page.getByRole('button', { name: 'Open world', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Desk 2', exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Desk 2', exact: true }).click();
+  await expect(page.getByLabel('Tile X', { exact: true })).toHaveValue('14');
+  await page.getByLabel('Tile X', { exact: true }).focus();
+  await page.keyboard.press('ArrowUp');
+  await expect(page.getByLabel('Tile X', { exact: true })).toHaveValue('15');
+  const destination = await page.locator('.block-scene').evaluate((element) => {
+    const matrix = (element as SVGSVGElement).getScreenCTM()!;
+    const point = new DOMPoint(10.5, 10.5).matrixTransform(matrix);
+    return { x: point.x, y: point.y };
+  });
+  await page.mouse.click(destination.x, destination.y);
+  await expect(page.getByLabel('Tile X', { exact: true })).toHaveValue('10');
+  await expect(page.getByLabel('Tile Y', { exact: true })).toHaveValue('10');
+  await page.getByRole('button', { name: 'Save layout', exact: true }).click();
+  await expect(page.getByText('Saved · revision 2', { exact: true })).toBeVisible();
+  await page
+    .locator('.block-editor')
+    .screenshot({ path: test.info().outputPath('block-desktop.png') });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page
+    .locator('.block-editor')
+    .screenshot({ path: test.info().outputPath('block-mobile.png') });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
+    true
+  );
+  await page.getByRole('button', { name: 'Remove selected', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Desk 2', exact: true })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Save layout', exact: true }).click();
+  await expect(page.getByText('Saved · revision 3', { exact: true })).toBeVisible();
+  await setTester(uid, false);
+  await expect(page.getByRole('heading', { name: 'Waiting for access' })).toBeVisible();
+  await expect(page.getByRole('region', { name: 'Office block editor' })).toHaveCount(0);
+});
+
+test('a disconnected save keeps a local draft and reconnect cannot silently publish it', async ({
+  openSession,
+}) => {
+  const { page, context } = await openSession();
+  const { worldId } = await prepareStudio(page);
+  await page.getByRole('button', { name: 'Add desk', exact: true }).click();
+  const transport = 'http://127.0.0.1:8080/**';
+  await context.route(transport, (route) => route.abort('internetdisconnected'));
+  await page.getByRole('button', { name: 'Save layout', exact: true }).click();
+  await expect(page.getByRole('alert')).toContainText('Save could not be confirmed');
+  await expect(page.getByText('Unsaved changes', { exact: true })).toBeVisible();
+  expect(await readBlockDocument(worldId)).toBeNull();
+  await context.unroute(transport);
+  expect(await readBlockDocument(worldId)).toBeNull();
+  await page.getByRole('button', { name: 'Save layout', exact: true }).click();
+  await expect(page.getByText('Saved · revision 1', { exact: true })).toBeVisible();
+  expect(await readBlockDocument(worldId)).toMatchObject({
+    fields: {
+      revision: { integerValue: '1' },
+      objects: { arrayValue: { values: [{ stringValue: 'd0ee' }] } },
+    },
+  });
+});

--- a/apps/office/e2e/firestore-fixture.ts
+++ b/apps/office/e2e/firestore-fixture.ts
@@ -13,6 +13,17 @@ import { connectFirestoreEmulator, initializeFirestore, terminate } from 'fireba
 const projectId = 'demo-tmt-office';
 const documents = `http://127.0.0.1:8080/v1/projects/${projectId}/databases/(default)/documents`;
 
+export async function readBlockDocument(worldId: string): Promise<unknown> {
+  expect(worldId).toMatch(/^[a-zA-Z0-9]{20}$/);
+  const response = await fetch(`${documents}/worlds/${worldId}/blocks/home`, {
+    headers: { authorization: 'Bearer owner' },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (response.status === 404) return null;
+  expect(response.status).toBe(200);
+  return response.json();
+}
+
 export async function ownedWorlds(uid: string): Promise<unknown[]> {
   const response = await fetch(`${documents}:runQuery`, {
     method: 'POST',

--- a/apps/office/src/auth/firebase-session.ts
+++ b/apps/office/src/auth/firebase-session.ts
@@ -19,6 +19,7 @@ import {
 import { officeFirebaseConfig } from './firebase-config.js';
 import { createWorldPort } from '../worlds/firebase-worlds.js';
 import { createWorldState } from '../worlds/world-state.js';
+import { createBlockPort } from '../blocks/firebase-blocks.js';
 
 /** One composition root for both explicit environments, outside React rendering. */
 export function startOfficeRuntime(
@@ -56,6 +57,7 @@ export function startOfficeRuntime(
   return {
     session,
     worlds,
+    blocks: createBlockPort(db),
     mode,
     dispose: async () => {
       worlds.dispose();

--- a/apps/office/src/blocks/block-contract.test.ts
+++ b/apps/office/src/blocks/block-contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import vectors from '../../../../contracts/office/block-v1.vectors.json' with { type: 'json' };
+import {
+  footprint,
+  sameLayout,
+  validFurniture,
+  validLayout,
+  encodeLayout,
+  decodeLayout,
+} from './block-contract.js';
+
+describe('bounded decoration contract', () => {
+  it.each(vectors)('$name', ({ valid, item, stored }) => {
+    expect(validFurniture(item)).toBe(valid);
+    expect(validLayout([item])).toBe(valid);
+    if (validFurniture(item)) {
+      expect(encodeLayout([item])).toEqual([stored]);
+      expect(decodeLayout([stored])).toEqual([item]);
+    } else expect(() => decodeLayout([stored])).toThrow();
+  });
+  it('checks the last slot, the budget and empty layouts', () => {
+    const item = { asset: 'desk', x: 0, y: 0, rotation: 0 };
+    expect(validLayout([])).toBe(true);
+    expect(validLayout(Array(16).fill(item))).toBe(true);
+    expect(validLayout([...Array(15).fill(item), { ...item, x: 32 }])).toBe(false);
+    expect(validLayout(Array(17).fill(item))).toBe(false);
+    expect(validLayout(Array(16))).toBe(false);
+  });
+  it('uses the rotated footprint for rendering', () => {
+    expect(footprint({ asset: 'rug', x: 0, y: 0, rotation: 1 })).toEqual({ width: 4, height: 6 });
+  });
+  it('equality preserves paint order but ignores JSON key order', () => {
+    const first = { asset: 'desk' as const, x: 0, y: 0, rotation: 0 };
+    const second = { asset: 'rug' as const, x: 0, y: 0, rotation: 0 };
+    expect(sameLayout([first], [{ rotation: 0, y: 0, x: 0, asset: 'desk' }])).toBe(true);
+    expect(sameLayout([first, second], [second, first])).toBe(false);
+  });
+});

--- a/apps/office/src/blocks/block-contract.ts
+++ b/apps/office/src/blocks/block-contract.ts
@@ -1,0 +1,106 @@
+export const BLOCK_SIZE = 32;
+export const OBJECT_LIMIT = 16;
+export const FURNITURE = {
+  desk: { label: 'Desk', code: 'd', width: 4, height: 2 },
+  chair: { label: 'Chair', code: 'c', width: 2, height: 2 },
+  plant: { label: 'Plant', code: 'p', width: 2, height: 2 },
+  rug: { label: 'Rug', code: 'r', width: 6, height: 4 },
+} as const;
+export type Asset = keyof typeof FURNITURE;
+export interface Furniture {
+  asset: Asset;
+  x: number;
+  y: number;
+  rotation: number;
+}
+export interface Block {
+  revision: number;
+  objects: Furniture[];
+  updatedAtMs: number;
+}
+export function footprint(item: Furniture): { width: number; height: number } {
+  const { width, height } = FURNITURE[item.asset];
+  return item.rotation % 2 ? { width: height, height: width } : { width, height };
+}
+export function validFurniture(value: unknown): value is Furniture {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const item = value as Record<string, unknown>;
+  if (
+    Object.keys(item).length !== 4 ||
+    !Object.keys(item).every((key) => ['asset', 'x', 'y', 'rotation'].includes(key)) ||
+    typeof item.asset !== 'string' ||
+    !Object.hasOwn(FURNITURE, item.asset) ||
+    !Number.isInteger(item.x) ||
+    !Number.isInteger(item.y) ||
+    !Number.isInteger(item.rotation)
+  )
+    return false;
+  const furniture = item as unknown as Furniture;
+  const { width, height } = footprint(furniture);
+  return (
+    furniture.rotation >= 0 &&
+    furniture.rotation <= 3 &&
+    furniture.x >= 0 &&
+    furniture.y >= 0 &&
+    furniture.x + width <= BLOCK_SIZE &&
+    furniture.y + height <= BLOCK_SIZE
+  );
+}
+export function validLayout(value: unknown): value is Furniture[] {
+  return (
+    Array.isArray(value) && value.length <= OBJECT_LIMIT && Array.from(value).every(validFurniture)
+  );
+}
+export function sameLayout(left: Furniture[], right: Furniture[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((item, index) => {
+      const other = right[index];
+      return (
+        item.asset === other.asset &&
+        item.x === other.x &&
+        item.y === other.y &&
+        item.rotation === other.rotation
+      );
+    })
+  );
+}
+
+/** Storage-only encoding: asset, quarter turn, base-32 X, base-32 Y.
+ * Public views/commands retain named fields; one codec owns this representation.
+ */
+export function encodeLayout(objects: Furniture[]): string[] {
+  if (!validLayout(objects)) throw new Error('Invalid block layout.');
+  return objects.map(
+    (item) =>
+      `${FURNITURE[item.asset].code}${item.rotation}${item.x.toString(32)}${item.y.toString(32)}`
+  );
+}
+export function decodeLayout(value: unknown): Furniture[] {
+  if (!Array.isArray(value) || value.length > OBJECT_LIMIT)
+    throw new Error('Invalid stored layout.');
+  const objects = Array.from(value, (token) => {
+    if (typeof token !== 'string' || !/^[dcpr][0-3][0-9a-v]{2}$/.test(token))
+      throw new Error('Invalid stored furniture.');
+    const asset = (Object.keys(FURNITURE) as Asset[]).find(
+      (key) => FURNITURE[key].code === token[0]
+    )!;
+    return {
+      asset,
+      rotation: Number(token[1]),
+      x: parseInt(token[2], 32),
+      y: parseInt(token[3], 32),
+    };
+  });
+  if (!validLayout(objects)) throw new Error('Invalid stored footprint.');
+  return objects;
+}
+export class BlockConflict extends Error {
+  constructor() {
+    super('The block changed. Load the latest layout before editing again.');
+  }
+}
+export interface BlockPort {
+  watch(worldId: string, changed: (block: Block | null) => void, failed: () => void): () => void;
+  apply(worldId: string, revision: number, objects: Furniture[]): Promise<Block>;
+}

--- a/apps/office/src/blocks/block-scene.tsx
+++ b/apps/office/src/blocks/block-scene.tsx
@@ -1,0 +1,116 @@
+import { useId } from 'react';
+import type { Furniture } from './block-contract.js';
+import { BLOCK_SIZE, footprint, FURNITURE } from './block-contract.js';
+
+/** Only curated vector primitives render here; stored data cannot supply markup. */
+function Sprite({ item }: { item: Furniture }) {
+  const { width, height } = FURNITURE[item.asset];
+  const size = footprint(item);
+  return (
+    <g
+      transform={`translate(${item.x + size.width / 2} ${item.y + size.height / 2}) rotate(${item.rotation * 90}) translate(${-width / 2} ${-height / 2})`}
+    >
+      {item.asset === 'desk' && (
+        <>
+          <rect x="0.2" y="0.3" width="3.6" height="1.6" fill="var(--wood-dark)" />
+          <rect width="4" height="1.5" rx="0.15" fill="var(--wood)" />
+          <rect x="1.4" y="0.2" width="1.3" height="0.75" rx="0.08" fill="var(--ink)" />
+          <rect x="1.55" y="0.3" width="1" height="0.45" fill="var(--screen)" />
+          <rect x="1.5" y="1.05" width="1.1" height="0.25" fill="var(--paper)" />
+        </>
+      )}
+      {item.asset === 'chair' && (
+        <>
+          <rect x="0.3" y="0.3" width="1.4" height="1.5" rx="0.3" fill="var(--ink)" />
+          <rect x="0.3" y="0.2" width="1.4" height="0.5" rx="0.2" fill="var(--blue-dark)" />
+          <rect x="0.4" y="0.8" width="1.2" height="0.8" rx="0.2" fill="var(--blue)" />
+        </>
+      )}
+      {item.asset === 'plant' && (
+        <>
+          <rect x="0.5" y="1" width="1" height="0.8" rx="0.15" fill="var(--clay)" />
+          <path d="M1 1.4 C-0.5 0.5 0.2 -0.4 1 0.8 C1.9 -0.5 2.8 0.6 1 1.4" fill="var(--leaf)" />
+          <path d="M1 1.5 V0.5" stroke="var(--leaf-dark)" strokeWidth="0.1" />
+        </>
+      )}
+      {item.asset === 'rug' && (
+        <>
+          <rect width="6" height="4" rx="0.15" fill="var(--rug)" />
+          <rect
+            x="0.3"
+            y="0.3"
+            width="5.4"
+            height="3.4"
+            fill="none"
+            stroke="var(--paper)"
+            strokeWidth="0.12"
+          />
+          <path d="M1 2 H5 M3 1 V3" stroke="var(--rug-dark)" strokeWidth="0.15" />
+        </>
+      )}
+    </g>
+  );
+}
+
+export function BlockScene({
+  objects,
+  selected,
+  select,
+  move,
+}: {
+  objects: Furniture[];
+  selected: number | null;
+  select: (index: number) => void;
+  move: (x: number, y: number) => void;
+}) {
+  const pattern = useId();
+  return (
+    <svg
+      className="block-scene"
+      viewBox={`-1 -1 ${BLOCK_SIZE + 2} ${BLOCK_SIZE + 2}`}
+      role="img"
+      aria-label="Office layout, 32 by 32 tiles. Use the furniture controls to edit."
+      onClick={(event) => {
+        const matrix = event.currentTarget.getScreenCTM();
+        if (!matrix) return;
+        const point = new DOMPoint(event.clientX, event.clientY).matrixTransform(matrix.inverse());
+        move(Math.floor(point.x), Math.floor(point.y));
+      }}
+    >
+      <defs>
+        <pattern id={pattern} width="1" height="1" patternUnits="userSpaceOnUse">
+          <rect width="1" height="1" fill="var(--floor)" />
+          <path d="M1 0 H0 V1" fill="none" stroke="var(--grid)" strokeWidth="0.035" />
+        </pattern>
+      </defs>
+      <rect x="-0.6" y="-0.6" width="33.2" height="33.2" rx="0.5" fill="var(--wall)" />
+      <rect width="32" height="32" fill={`url(#${pattern})`} />
+      {objects.map((item, index) => {
+        const { width, height } = footprint(item);
+        return (
+          <g
+            key={index}
+            onClick={(event) => {
+              event.stopPropagation();
+              select(index);
+            }}
+          >
+            <Sprite item={item} />
+            {selected === index && (
+              <rect
+                x={item.x - 0.1}
+                y={item.y - 0.1}
+                width={width + 0.2}
+                height={height + 0.2}
+                fill="none"
+                stroke="var(--selection)"
+                strokeWidth="0.12"
+                strokeDasharray="0.25 0.15"
+              />
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/apps/office/src/blocks/block-state.test.ts
+++ b/apps/office/src/blocks/block-state.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBlockState } from './block-state.js';
+import { BlockConflict } from './block-contract.js';
+import type { Block, BlockPort, Furniture } from './block-contract.js';
+const objects: Furniture[] = [{ asset: 'desk', x: 0, y: 0, rotation: 0 }];
+function fixture() {
+  let changed: (block: Block | null) => void = () => {};
+  let failed = () => {};
+  const stop = vi.fn();
+  const port: BlockPort = {
+    watch: (_id, next, error) => {
+      changed = next;
+      failed = error;
+      return stop;
+    },
+    apply: vi.fn(async (_id, revision, next) => ({
+      revision: revision + 1,
+      objects: next,
+      updatedAtMs: 1,
+    })),
+  };
+  const state = createBlockState(port, 'a'.repeat(20));
+  return {
+    state,
+    port,
+    stop,
+    changed: (block: Block | null) => changed(block),
+    failed: () => failed(),
+  };
+}
+describe('one block editor lifetime', () => {
+  it('keeps edits local until explicit save commits the captured revision', async () => {
+    const f = fixture();
+    f.changed(null);
+    f.state.edit(objects);
+    expect(f.port.apply).not.toHaveBeenCalled();
+    await f.state.save();
+    expect(f.port.apply).toHaveBeenCalledExactlyOnceWith('a'.repeat(20), 0, objects);
+    expect(f.state.getSnapshot()).toMatchObject({
+      draft: null,
+      remote: { revision: 1, objects },
+      busy: false,
+    });
+    f.state.dispose();
+  });
+  it('retains the original draft across remote edits and conflicts', async () => {
+    const f = fixture();
+    f.changed(null);
+    f.state.edit(objects);
+    f.changed({ revision: 1, objects: [], updatedAtMs: 1 });
+    vi.mocked(f.port.apply).mockRejectedValueOnce(new BlockConflict());
+    await f.state.save();
+    expect(f.state.getSnapshot().draft).toEqual({ revision: 0, objects });
+    expect(f.state.getSnapshot().error).toContain('changed');
+    f.state.reset();
+    expect(f.state.getSnapshot()).toMatchObject({
+      draft: null,
+      remote: { revision: 1, objects: [] },
+    });
+    f.state.dispose();
+  });
+  it('transport failure preserves a retry and blocks concurrent saves', async () => {
+    const f = fixture();
+    f.changed(null);
+    f.state.edit(objects);
+    vi.mocked(f.port.apply).mockRejectedValueOnce(new Error('network'));
+    const first = f.state.save();
+    await f.state.save();
+    await first;
+    expect(f.port.apply).toHaveBeenCalledTimes(1);
+    expect(f.state.getSnapshot().error).toContain('could not be confirmed');
+    await f.state.save();
+    expect(f.port.apply).toHaveBeenNthCalledWith(2, 'a'.repeat(20), 0, objects);
+    f.state.dispose();
+  });
+  it('disposal clears content and fences late callbacks and saves', async () => {
+    const f = fixture();
+    f.changed(null);
+    f.state.edit(objects);
+    let resolve: (block: Block) => void = () => {};
+    vi.mocked(f.port.apply).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        })
+    );
+    const pending = f.state.save();
+    f.state.dispose();
+    f.state.dispose();
+    const block = { revision: 1, objects, updatedAtMs: 1 };
+    f.changed(block);
+    resolve(block);
+    await pending;
+    expect(f.stop).toHaveBeenCalledOnce();
+    expect(f.state.getSnapshot()).toMatchObject({ ready: false, remote: null, draft: null });
+  });
+  it('permission failure clears content and blocks edits', async () => {
+    const f = fixture();
+    f.changed({ revision: 1, objects, updatedAtMs: 1 });
+    f.state.edit([]);
+    f.failed();
+    f.state.edit(objects);
+    await f.state.save();
+    expect(f.state.getSnapshot()).toMatchObject({ ready: false, remote: null, draft: null });
+    expect(f.port.apply).not.toHaveBeenCalled();
+    f.state.dispose();
+  });
+});

--- a/apps/office/src/blocks/block-state.ts
+++ b/apps/office/src/blocks/block-state.ts
@@ -1,0 +1,87 @@
+import { BlockConflict, validLayout } from './block-contract.js';
+import type { Block, BlockPort, Furniture } from './block-contract.js';
+
+interface Snapshot {
+  ready: boolean;
+  remote: Block | null;
+  draft: { revision: number; objects: Furniture[] } | null;
+  busy: boolean;
+  error: string | null;
+}
+/** Created by the mounted block effect, never during React rendering. */
+export function createBlockState(port: BlockPort, worldId: string) {
+  let snapshot: Snapshot = { ready: false, remote: null, draft: null, busy: false, error: null };
+  let disposed = false;
+  const listeners = new Set<() => void>();
+  function publish(next: Partial<Snapshot>) {
+    if (disposed) return;
+    snapshot = { ...snapshot, ...next };
+    for (const listener of listeners) listener();
+  }
+  const stop = port.watch(
+    worldId,
+    (remote) => publish({ ready: true, remote }),
+    () => {
+      publish({
+        ready: false,
+        remote: null,
+        draft: null,
+        error: 'Block unavailable. Reopen the world to retry.',
+      });
+    }
+  );
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener: () => void) {
+      if (disposed) return () => {};
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    edit(objects: Furniture[]) {
+      if (disposed || !snapshot.ready || snapshot.busy) return;
+      if (!validLayout(objects)) {
+        publish({ error: 'Keep furniture inside the room and use at most 16 items.' });
+        return;
+      }
+      publish({
+        draft: { revision: snapshot.draft?.revision ?? snapshot.remote?.revision ?? 0, objects },
+        error: null,
+      });
+    },
+    reset() {
+      if (!snapshot.busy) publish({ draft: null, error: null });
+    },
+    async save() {
+      if (disposed || !snapshot.ready || !snapshot.draft || snapshot.busy) return;
+      const draft = snapshot.draft;
+      publish({ busy: true, error: null });
+      try {
+        const remote = await port.apply(worldId, draft.revision, draft.objects);
+        if (!snapshot.ready) return;
+        publish({
+          remote: (snapshot.remote?.revision ?? 0) > remote.revision ? snapshot.remote : remote,
+          draft: null,
+        });
+      } catch (error) {
+        publish({
+          error:
+            error instanceof BlockConflict
+              ? error.message
+              : 'Save could not be confirmed. Keep this draft and retry when connected.',
+        });
+      } finally {
+        publish({ busy: false });
+      }
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      stop();
+      listeners.clear();
+      snapshot = { ready: false, remote: null, draft: null, busy: false, error: null };
+    },
+  };
+}
+export type BlockState = ReturnType<typeof createBlockState>;

--- a/apps/office/src/blocks/block-view.tsx
+++ b/apps/office/src/blocks/block-view.tsx
@@ -1,0 +1,155 @@
+import { createContext, useContext, useEffect, useState, useSyncExternalStore } from 'react';
+import { FURNITURE, OBJECT_LIMIT } from './block-contract.js';
+import type { Asset, BlockPort, Furniture } from './block-contract.js';
+import { createBlockState } from './block-state.js';
+import type { BlockState } from './block-state.js';
+import { BlockScene } from './block-scene.js';
+import './block.css';
+
+export const BlockContext = createContext<BlockPort | undefined>(undefined);
+export function BlockPanel({ worldId }: { worldId: string }) {
+  const port = useContext(BlockContext);
+  const [state, setState] = useState<BlockState>();
+  useEffect(() => {
+    if (!port) return;
+    const next = createBlockState(port, worldId);
+    setState(next);
+    return () => next.dispose();
+  }, [port, worldId]);
+  return state ? <BlockEditor state={state} /> : null;
+}
+export function BlockEditor({ state }: { state: BlockState }) {
+  const { remote, draft, ready, busy, error } = useSyncExternalStore(
+    state.subscribe,
+    state.getSnapshot
+  );
+  const [selected, setSelected] = useState<number | null>(null);
+  const objects = draft?.objects ?? remote?.objects ?? [];
+  const item = selected === null ? undefined : objects[selected];
+  function update(changes: Partial<Furniture>) {
+    if (!item) return;
+    state.edit(
+      objects.map((value, index) => (index === selected ? { ...value, ...changes } : value))
+    );
+  }
+  function add(asset: Asset) {
+    state.edit([...objects, { asset, x: 14, y: 14, rotation: 0 }]);
+    setSelected(objects.length);
+  }
+  return (
+    <section className="block-editor" aria-label="Office block editor">
+      <div className="block-heading">
+        <div>
+          <p className="eyebrow">YOUR SPACE / HOME BLOCK</p>
+          <h2>Make room for your team.</h2>
+        </div>
+        <span role="status">
+          {!ready
+            ? 'Connecting…'
+            : busy
+              ? 'Saving…'
+              : draft
+                ? 'Unsaved changes'
+                : `Saved · revision ${remote?.revision ?? 0}`}
+        </span>
+      </div>
+      {error && <p role="alert">{error}</p>}
+      {ready && (
+        <div className="block-workbench">
+          <BlockScene
+            objects={objects}
+            selected={selected}
+            select={setSelected}
+            move={(x, y) => update({ x, y })}
+          />
+          <aside className="block-tools" aria-label="Furniture controls">
+            <h3>Small things, your space.</h3>
+            <p>
+              Add a piece, then select a tile to move it. Nothing is saved until you choose Save.
+            </p>
+            <div className="furniture-catalog">
+              {(Object.keys(FURNITURE) as Asset[]).map((asset) => (
+                <button
+                  key={asset}
+                  disabled={busy || objects.length >= OBJECT_LIMIT}
+                  onClick={() => add(asset)}
+                >
+                  Add {FURNITURE[asset].label.toLowerCase()}
+                </button>
+              ))}
+            </div>
+            <p>
+              {objects.length} / {OBJECT_LIMIT} pieces · 32 × 32 tiles
+            </p>
+            <ol className="furniture-list">
+              {objects.map((object, index) => (
+                <li key={index}>
+                  <button aria-pressed={selected === index} onClick={() => setSelected(index)}>
+                    {FURNITURE[object.asset].label} {index + 1}
+                  </button>
+                </li>
+              ))}
+            </ol>
+            {item && (
+              <fieldset disabled={busy}>
+                <legend>Selected {item.asset}</legend>
+                <label>
+                  Tile X
+                  <input
+                    type="number"
+                    min="0"
+                    max="31"
+                    value={item.x}
+                    onChange={(event) => update({ x: Number(event.target.value) })}
+                  />
+                </label>
+                <label>
+                  Tile Y
+                  <input
+                    type="number"
+                    min="0"
+                    max="31"
+                    value={item.y}
+                    onChange={(event) => update({ y: Number(event.target.value) })}
+                  />
+                </label>
+                <button onClick={() => update({ rotation: (item.rotation + 1) % 4 })}>
+                  Rotate clockwise
+                </button>
+                <button
+                  onClick={() => {
+                    state.edit(objects.filter((_, index) => index !== selected));
+                    setSelected(null);
+                  }}
+                >
+                  Remove selected
+                </button>
+              </fieldset>
+            )}
+            <div className="block-actions">
+              <button
+                className="block-save"
+                disabled={busy || !draft}
+                onClick={() => void state.save()}
+              >
+                Save layout
+              </button>
+              <button
+                disabled={busy || !draft}
+                onClick={() => {
+                  state.reset();
+                  setSelected(null);
+                }}
+              >
+                Load latest layout
+              </button>
+            </div>
+            <p className="block-note">
+              Private to you. Agent assignment and invitations are not connected yet.
+            </p>
+          </aside>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/office/src/blocks/block.css
+++ b/apps/office/src/blocks/block.css
@@ -1,0 +1,129 @@
+.block-editor {
+  --ink: #243745;
+  --wood: #d7a16a;
+  --wood-dark: #936540;
+  --screen: #8fb9bb;
+  --paper: #f9f3df;
+  --blue: #7a98b5;
+  --blue-dark: #4d678a;
+  --clay: #b96f50;
+  --leaf: #7b9c62;
+  --leaf-dark: #426848;
+  --rug: #c19a85;
+  --rug-dark: #8c625b;
+  --floor: #ece7d7;
+  --grid: #d6ceba;
+  --wall: #9ba68d;
+  --selection: #365c97;
+  margin-top: 40px;
+  border-top: 1px solid #cbd5c8;
+  padding-top: 24px;
+}
+.block-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+.block-heading h2 {
+  font-size: clamp(24px, 3vw, 36px);
+  letter-spacing: -0.04em;
+}
+.block-heading [role='status'] {
+  color: #58685d;
+  font-size: 13px;
+}
+.block-workbench {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 260px;
+  gap: 28px;
+  align-items: start;
+}
+.block-scene {
+  width: 100%;
+  display: block;
+  background: #dfe4d8;
+  border-radius: 12px;
+  padding: 20px;
+  touch-action: manipulation;
+}
+.block-tools {
+  font-size: 13px;
+}
+.block-tools h3 {
+  font-size: 18px;
+  margin-top: 0;
+}
+.block-tools button {
+  border: 1px solid #c3ccbd;
+  background: #fffdf6;
+  color: #23372d;
+  padding: 9px 12px;
+  border-radius: 6px;
+}
+.block-tools button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.furniture-catalog {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.furniture-list {
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  max-height: 180px;
+  overflow: auto;
+}
+.furniture-list [aria-pressed='true'] {
+  background: #dfe8d8;
+  border-color: #426848;
+}
+.block-tools fieldset {
+  border: 1px solid #c3ccbd;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.block-tools label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.block-tools input {
+  width: 60px;
+  padding: 6px;
+  font: inherit;
+}
+.block-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 20px;
+}
+.block-tools .block-save {
+  background: #285b43;
+  color: white;
+}
+.block-note {
+  color: #58685d;
+}
+.block-editor [role='alert'] {
+  color: #9b2c2c;
+}
+@media (max-width: 760px) {
+  .block-workbench {
+    grid-template-columns: 1fr;
+  }
+  .block-scene {
+    padding: 10px;
+  }
+}

--- a/apps/office/src/blocks/firebase-blocks.ts
+++ b/apps/office/src/blocks/firebase-blocks.ts
@@ -1,0 +1,104 @@
+import {
+  doc,
+  getDocFromServer,
+  onSnapshot,
+  runTransaction,
+  serverTimestamp,
+  Timestamp,
+} from 'firebase/firestore';
+import type { Firestore } from 'firebase/firestore';
+import { FirebaseError } from 'firebase/app';
+import {
+  BlockConflict,
+  sameLayout,
+  validLayout,
+  encodeLayout,
+  decodeLayout,
+} from './block-contract.js';
+import type { Block, BlockPort } from './block-contract.js';
+
+function readBlock(value: Record<string, unknown>): Block {
+  if (
+    Object.keys(value).length !== 4 ||
+    value.version !== 1 ||
+    !Number.isSafeInteger(value.revision) ||
+    (value.revision as number) < 1 ||
+    !(value.updatedAt instanceof Timestamp)
+  ) {
+    throw new Error('Unsupported block document.');
+  }
+  return {
+    revision: value.revision as number,
+    objects: decodeLayout(value.objects),
+    updatedAtMs: value.updatedAt.toMillis(),
+  };
+}
+export function createBlockPort(db: Firestore): BlockPort {
+  function reference(worldId: string) {
+    if (!/^[a-zA-Z0-9]{20}$/.test(worldId)) throw new Error('Invalid world ID.');
+    return doc(db, 'worlds', worldId, 'blocks', 'home');
+  }
+  return {
+    watch(worldId, changed, failed) {
+      return onSnapshot(
+        reference(worldId),
+        { includeMetadataChanges: true },
+        (snapshot) => {
+          if (snapshot.metadata.fromCache || snapshot.metadata.hasPendingWrites) return;
+          try {
+            changed(snapshot.exists() ? readBlock(snapshot.data()) : null);
+          } catch {
+            failed();
+          }
+        },
+        failed
+      );
+    },
+    async apply(worldId, revision, objects) {
+      if (
+        !Number.isSafeInteger(revision) ||
+        revision < 0 ||
+        revision >= Number.MAX_SAFE_INTEGER ||
+        !validLayout(objects)
+      ) {
+        throw new Error('Invalid block edit.');
+      }
+      const target = reference(worldId);
+      try {
+        await runTransaction(db, async (transaction) => {
+          const snapshot = await transaction.get(target);
+          const current = snapshot.exists() ? readBlock(snapshot.data()) : null;
+          if (current?.revision === revision + 1 && sameLayout(current.objects, objects)) return;
+          if ((current?.revision ?? 0) !== revision) throw new BlockConflict();
+          transaction.set(target, {
+            version: 1,
+            revision: revision + 1,
+            objects: encodeLayout(objects),
+            updatedAt: serverTimestamp(),
+          });
+        });
+      } catch (error) {
+        // Rules may reject a stale revision before Firestore retries a racing
+        // transaction. Classify it only after a fresh, authorized server read;
+        // never turn a revoked/foreign user's denial into a conflict or success.
+        if (error instanceof FirebaseError && error.code === 'permission-denied') {
+          const observed = await getDocFromServer(target).catch(() => {
+            throw error;
+          });
+          if (observed.exists()) {
+            const current = readBlock(observed.data());
+            if (current.revision === revision + 1 && sameLayout(current.objects, objects))
+              return current;
+            if (current.revision !== revision) throw new BlockConflict();
+          }
+        }
+        throw error;
+      }
+      // A separate server read confirms canonical timestamps without relying on
+      // pending-write snapshots. It may observe a newer edit, which must be kept.
+      const saved = await getDocFromServer(target);
+      if (!saved.exists()) throw new Error('Block unavailable.');
+      return readBlock(saved.data());
+    },
+  };
+}

--- a/apps/office/src/main.tsx
+++ b/apps/office/src/main.tsx
@@ -41,6 +41,7 @@ async function mount(): Promise<void> {
         router={createOfficeRouter()}
         session={runtime?.session}
         worlds={runtime?.worlds}
+        blocks={runtime?.blocks}
         mode={runtime?.mode}
       />
     </StrictMode>

--- a/apps/office/src/office-app.tsx
+++ b/apps/office/src/office-app.tsx
@@ -7,16 +7,20 @@ import { OfficeSessionContext, OfficeModeContext } from './auth/session-view.js'
 import type { OfficeSession } from './auth/session.js';
 import { WorldContext } from './worlds/world-view.js';
 import type { WorldState } from './worlds/world-state.js';
+import { BlockContext } from './blocks/block-view.js';
+import type { BlockPort } from './blocks/block-contract.js';
 
 export function OfficeApp({
   router,
   session,
   worlds,
+  blocks,
   mode = 'emulator',
 }: {
   router: ReturnType<typeof createOfficeRouter>;
   session?: OfficeSession;
   worlds?: WorldState;
+  blocks?: BlockPort;
   mode?: string;
 }): ReactElement {
   // A mounted app owns its UI state; tests and future embedded views cannot leak it.
@@ -26,7 +30,9 @@ export function OfficeApp({
       <OfficeSessionContext value={session}>
         <OfficeModeContext value={mode}>
           <WorldContext value={worlds}>
-            <RouterProvider router={router} />
+            <BlockContext value={blocks}>
+              <RouterProvider router={router} />
+            </BlockContext>
           </WorldContext>
         </OfficeModeContext>
       </OfficeSessionContext>

--- a/apps/office/src/worlds/world-view.tsx
+++ b/apps/office/src/worlds/world-view.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, useSyncExternalStore } 
 import { Link, useNavigate } from '@tanstack/react-router';
 import type { ReactElement, ReactNode } from 'react';
 import type { WorldState } from './world-state.js';
+import { BlockPanel } from '../blocks/block-view.js';
 
 export const WorldContext = createContext<WorldState | undefined>(undefined);
 
@@ -109,7 +110,7 @@ export function SelectedWorld({ state, id }: { state: WorldState; id: string }):
       <p>
         World ID: <code>{world.id}</code>
       </p>
-      <p>Your space is ready. Agent blocks and invitations are coming next.</p>
+      <BlockPanel key={world.id} worldId={world.id} />
     </section>
   );
 }

--- a/apps/office/tsconfig.json
+++ b/apps/office/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/contracts/office/README.md
+++ b/contracts/office/README.md
@@ -7,6 +7,10 @@ The separately versioned [private world document v1](private-world.md) is the
 not the work-handoff HTTP/JSON envelopes below. Its actual client adapter and
 Rules are exercised together in `apps/office/e2e/world-rules.spec.ts`.
 
+The [home block document v1](block-v1.md) extends that owner-only world with
+bounded, revision-checked decoration. Its vectors are shared by client and
+real Rules tests, not derived from implementation output.
+
 ## Single source of truth
 
 - `v1.schema.json` is JSON Schema 2020-12 for the initial work handoff ingress:

--- a/contracts/office/block-v1.md
+++ b/contracts/office/block-v1.md
@@ -1,0 +1,77 @@
+# Home block document v1
+
+Tracking: #192, the browser/data slice of #191. Agent commands, pairing and
+assignment are not implemented by this contract.
+
+`worlds/{worldId}/blocks/home` contains exactly `version: 1`, `revision`,
+`objects` and `updatedAt`. Authority comes from the existing immutable world's
+owner and current tester admission. There is no second owner/agent identity
+field. Other block IDs, enumeration and deletion remain denied. Clear a room by
+saving an empty object list, not resetting its revision counter. Previous layout
+versions are not retained as an edit-history feature.
+
+Revision starts at 1 and advances by exactly one, up to JavaScript's maximum safe
+integer. `updatedAt` is a Firestore timestamp equal to the write's server request
+time. The adapter accepts an expected revision (0 for missing). An online
+transaction applies only at that revision. At expected+1, identical ordered
+objects constitute an exact retry, with no new write or timestamp renewal.
+Anything else conflicts. A subsequent server read supplies canonical data and
+may observe a newer revision; it does not prove the writer still owns the latest
+edit. Errors after a commit remain uncertain, never an automatic replay with a
+new revision. The UI retains its original draft for explicit retry or discard.
+
+## Bounded scene
+
+The room is 32 by 32 tiles with a fixed, curated 16-color palette. Application
+inputs and projections use an ordered list of at most 16 exact maps:
+
+| Field      | Constraint                                   |
+| ---------- | -------------------------------------------- |
+| `asset`    | `desk`, `chair`, `plant` or `rug`            |
+| `x`, `y`   | Integer tile origin, starting at zero        |
+| `rotation` | Integer 0 through 3, clockwise quarter turns |
+
+Unrotated footprints are desk 4x2, chair/plant 2x2 and rug 6x4. Odd rotations
+swap dimensions; the complete footprint must fit in the room. Overlap is
+intentional decoration layering, painted in list order. There is no seat
+reservation or pathfinding claim. List positions are edit-local indices, not
+stable agent/object identities.
+
+Only bounded enums/numbers are accepted, with no arbitrary strings, artwork,
+URLs, markup or extra fields. This small fixed schema is well below the broader
+64 KiB decoration ceiling without relying on a nonexistent JSON byte-length
+check in Rules. Curated SVG primitives are repository code, not stored markup.
+
+Firestore's `objects` field stores that same ordered list as four-character
+ASCII tokens, not maps: asset (`d`, `c`, `p`, `r`), rotation (`0`..`3`), X and Y
+as one lowercase base-32 digit each (`0`..`9`, `a`..`v`). For example `d1us`
+is a desk rotated once at (30, 28). `block-contract.ts` owns the only codec;
+the browser and future command inputs retain readable named fields. There is
+no second stored layout or cache. Unknown tokens/fields reject, never truncate.
+
+The initially tested map representation exceeded the real Rules expression
+budget at the full 16-object boundary. Encoding permits one bounded regex per
+slot to enforce asset-specific rotated footprints, while retaining capacity and
+direct client writes. Vectors contain literal expected tokens independent of the
+encoder, and test both directions plus actual Rules. This is a pre-release
+contract refinement, not a migration of deployed data.
+
+Rules explicitly check all 16 possible slots because they cannot iterate over
+an arbitrary list. The independent vectors in `block-v1.vectors.json` run both
+against pure client validation and real Rules. Overflow, malformed last-slot and
+metadata/revision tests supplement the vectors; schema tests alone are not
+authorization evidence.
+
+## Lifecycle and cost
+
+Opening an admitted world subscribes to its single home block. Only confirmed
+server snapshots become saved state; a separate local draft is never presented
+as saved. Pointer placement and form/keyboard edits cause no remote writes.
+Save performs a transaction read, at most one document write, then one server
+read; transaction retries and Rules-dependent reads may add reads. Reset takes
+the latest server-confirmed layout and discards the local draft explicitly.
+
+Leaving the world or losing admission disposes the editor, its listener and
+private draft; late callbacks cannot repopulate it. Reload still signs out under
+the existing memory-only auth policy. Physical room decoration says nothing
+about an agent's connectivity, availability or execution.

--- a/contracts/office/block-v1.vectors.json
+++ b/contracts/office/block-v1.vectors.json
@@ -1,0 +1,87 @@
+[
+  {
+    "name": "desk at boundary",
+    "stored": "d0su",
+    "valid": true,
+    "item": { "asset": "desk", "x": 28, "y": 30, "rotation": 0 }
+  },
+  {
+    "name": "rotated desk at boundary",
+    "stored": "d1us",
+    "valid": true,
+    "item": { "asset": "desk", "x": 30, "y": 28, "rotation": 1 }
+  },
+  {
+    "name": "chair at boundary",
+    "stored": "c2uu",
+    "valid": true,
+    "item": { "asset": "chair", "x": 30, "y": 30, "rotation": 2 }
+  },
+  {
+    "name": "plant at boundary",
+    "stored": "p3uu",
+    "valid": true,
+    "item": { "asset": "plant", "x": 30, "y": 30, "rotation": 3 }
+  },
+  {
+    "name": "rug at boundary",
+    "stored": "r2qs",
+    "valid": true,
+    "item": { "asset": "rug", "x": 26, "y": 28, "rotation": 2 }
+  },
+  {
+    "name": "rotated rug at boundary",
+    "stored": "r3sq",
+    "valid": true,
+    "item": { "asset": "rug", "x": 28, "y": 26, "rotation": 3 }
+  },
+  {
+    "name": "desk overflows",
+    "stored": "d0tu",
+    "valid": false,
+    "item": { "asset": "desk", "x": 29, "y": 30, "rotation": 0 }
+  },
+  {
+    "name": "rotated desk overflows",
+    "stored": "d1ut",
+    "valid": false,
+    "item": { "asset": "desk", "x": 30, "y": 29, "rotation": 1 }
+  },
+  {
+    "name": "negative coordinate",
+    "stored": "p0-10",
+    "valid": false,
+    "item": { "asset": "plant", "x": -1, "y": 0, "rotation": 0 }
+  },
+  {
+    "name": "fractional coordinate",
+    "stored": "c00.50",
+    "valid": false,
+    "item": { "asset": "chair", "x": 0.5, "y": 0, "rotation": 0 }
+  },
+  {
+    "name": "invalid rotation",
+    "stored": "r400",
+    "valid": false,
+    "item": { "asset": "rug", "x": 0, "y": 0, "rotation": 4 }
+  },
+  {
+    "name": "asset URL",
+    "stored": "https://example.test/art.svg",
+    "valid": false,
+    "item": { "asset": "https://example.test/art.svg", "x": 0, "y": 0, "rotation": 0 }
+  },
+  {
+    "name": "extra content",
+    "stored": "d000<script>throw 1</script>",
+    "valid": false,
+    "item": { "asset": "desk", "x": 0, "y": 0, "rotation": 0, "html": "<script>throw 1</script>" }
+  },
+  {
+    "name": "missing coordinate",
+    "stored": "c00",
+    "valid": false,
+    "item": { "asset": "chair", "x": 0, "rotation": 0 }
+  },
+  { "name": "null item", "stored": null, "valid": false, "item": null }
+]

--- a/contracts/office/private-world.md
+++ b/contracts/office/private-world.md
@@ -28,6 +28,7 @@ Verified Google users may get their own admission document, but cannot list or
 write tester documents. Admission does not grant access to other owners' worlds.
 The Firebase Console operator uses IAM, not a client-side administrator role.
 
-Future `worlds/{worldId}/blocks/{blockId}` and `messages/{messageId}` will store
-bounded independent objects. They are denied until their feature contracts are
+The [home block v1](block-v1.md) contract opens only
+`worlds/{worldId}/blocks/home` to its approved world owner. Other blocks and
+`messages/{messageId}` remain denied until their feature contracts are
 implemented. World data does not authorize native agent execution.

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -24,6 +24,23 @@ Console-managed tester gate and direct client create/read of owner-only worlds;
 Firestore Rules enforce both gates, immutable fields and default-deny paths.
 This is not an invitation, presence or connected-agent implementation.
 
+#192 adds a single owner-only `home` block below an admitted world's route.
+`src/blocks/block-contract.ts` owns client values, catalog and footprint policy;
+`firebase-blocks.ts` implements its port using the existing initialized SDK.
+`block-state.ts` owns the server-confirmed projection and separate unsaved draft.
+It starts in the mounted `BlockPanel` effect, is keyed by world, and disposes on
+route/admission loss. Late observations and saves cannot restore disposed data.
+`block-scene.tsx` renders controlled vector primitives; `block-view.tsx` owns
+selection and controls. No canvas engine, generic scene framework, new global
+store or remote-state copy is introduced. Pointer selection/tile placement and
+equivalent numeric/keyboard controls edit locally; explicit Save uses the
+revision-checked Firestore transaction. Agent assignment/commands remain future
+#191 work. The contract and shared validation vectors live in `contracts/office`.
+The pure contract's sole codec converts readable furniture maps to four-character
+storage tokens. Actual Rules testing rejected the full-capacity map representation
+due to its expression budget; token validation retains all 16 objects and exact
+rotated bounds without a privileged CRUD service or weaker validation.
+
 `src/auth/firebase-session.ts` is the only Firebase initialization/composition owner.
 `firebase-config.ts` validates explicit activation before SDK initialization.
 `src/worlds/firebase-worlds.ts` owns direct SDK operations; `world-state.ts`

--- a/docs/office/design.md
+++ b/docs/office/design.md
@@ -60,7 +60,8 @@ grants deny world access. Authentication itself is not blocked by this gate.
 See [private world document v1](../../contracts/office/private-world.md) for
 the exact create/read and retry contract. Future blocks and messages live in
 world subcollections, not unbounded arrays on the root. Those paths currently
-deny all client access. Invitations and device/work operations below remain
+deny all client access except the owner-only `blocks/home` decoration slice
+specified in [home block v1](../../contracts/office/block-v1.md). Invitations and device/work operations below remain
 future design; they do not justify a generic backend for ordinary world storage.
 The initial owner-only world does not implement visitor memberships or presence.
 

--- a/services/office/Dockerfile
+++ b/services/office/Dockerfile
@@ -31,6 +31,7 @@ RUN pnpm --filter @tmt/office exec playwright install --with-deps chromium
 USER node
 COPY --from=emulators --chown=node:node /home/node/office/ /home/node/office/
 COPY --chown=node:node apps/office apps/office
+COPY --chown=node:node contracts/office contracts/office
 RUN --network=none pnpm office:check && pnpm office:test \
   && pnpm --filter @tmt/office exec vite build --outDir dist-preview \
   && pnpm --filter @tmt/office exec vite build --mode emulator \

--- a/services/office/README.md
+++ b/services/office/README.md
@@ -80,10 +80,19 @@ The UI observes changes and also provides **Check access again** for retry.
 No client can write this collection or list testers. Approval grants only
 access to the pilot; it does not grant access to another user's private world.
 
+Inside a world, the owner can arrange its single home block with curated
+furniture. Select an item, click a destination tile or use the coordinate inputs,
+rotate/remove it, then choose **Save layout**. Unsaved previews stay local.
+Concurrent edits conflict rather than silently overwrite; **Load latest layout**
+explicitly discards the draft in favor of the last server-confirmed view. These
+controls do not publish agents or grant any local execution authority.
+
 Rules-dependent document lookups can incur reads, including denied requests.
-The app has one tester listener after login and at most one selected-world
-listener. A create transaction reads one world and writes it once; retries may
-repeat reads. No global directory, per-frame writes or polling is used. Logout
+The app has one tester listener after login, at most one selected-world
+listener, and one home-block listener while the admitted world editor is mounted.
+A world create transaction reads one world and writes it once; a block save
+reads its revision, writes once and reads the canonical result. Retries and
+authorization checks may add reads. No global directory, per-frame writes or polling is used. Logout
 and access loss detach private listeners and clear the view. Memory-only caches
 do not recall information already disclosed. No custom claims or Admin server
 are needed to manage the pilot allowlist.

--- a/services/office/firestore.rules
+++ b/services/office/firestore.rules
@@ -14,6 +14,36 @@ service cloud.firestore {
         && get(/databases/$(database)/documents/testers/$(request.auth.uid)).data.enabled == true;
     }
 
+    function furniture(item) {
+      // Four ASCII characters: asset, turn, base-32 X/Y. The ranges enforce
+      // rotated footprints, not just token shape. See block-v1.md and vectors.
+      return item is string && item.matches(
+        '(d[02][0-9a-s][0-9a-u]|d[13][0-9a-u][0-9a-s]|[cp][0-3][0-9a-u]{2}|r[02][0-9a-q][0-9a-s]|r[13][0-9a-s][0-9a-q])'
+      );
+    }
+
+    function blockDocument() {
+      let value = request.resource.data;
+      let items = value.objects;
+      let count = items.size();
+      // Rules has no general iteration. Check every slot of the bounded list;
+      // the emulator suite includes malformed final-slot and overflow controls.
+      return value.keys().hasAll(['version', 'revision', 'objects', 'updatedAt'])
+        && value.keys().hasOnly(['version', 'revision', 'objects', 'updatedAt'])
+        && value.version == 1
+        && value.revision is int && value.revision >= 1 && value.revision <= 9007199254740991
+        && value.updatedAt == request.time
+        && items is list && count <= 16
+        && (count < 1 || furniture(items[0])) && (count < 2 || furniture(items[1]))
+        && (count < 3 || furniture(items[2])) && (count < 4 || furniture(items[3]))
+        && (count < 5 || furniture(items[4])) && (count < 6 || furniture(items[5]))
+        && (count < 7 || furniture(items[6])) && (count < 8 || furniture(items[7]))
+        && (count < 9 || furniture(items[8])) && (count < 10 || furniture(items[9]))
+        && (count < 11 || furniture(items[10])) && (count < 12 || furniture(items[11]))
+        && (count < 13 || furniture(items[12])) && (count < 14 || furniture(items[13]))
+        && (count < 15 || furniture(items[14])) && (count < 16 || furniture(items[15]));
+    }
+
     match /testers/{uid} {
       // Waiting users can inspect their own admission, never enumerate or grant it.
       allow get: if human() && request.auth.uid == uid;
@@ -36,9 +66,22 @@ service cloud.firestore {
         && request.resource.data.ownerUid == request.auth.uid
         && request.resource.data.createdAt == request.time;
       allow list, update, delete: if false;
+
+      match /blocks/{blockId} {
+        function ownsWorld() {
+          return approved() && blockId == 'home'
+            && get(/databases/$(database)/documents/worlds/$(worldId)).data.ownerUid == request.auth.uid;
+        }
+        allow get: if ownsWorld();
+        // Reject incompatible revisions before the bounded layout walk.
+        allow create: if request.resource.data.revision == 1 && ownsWorld() && blockDocument();
+        allow update: if request.resource.data.revision == resource.data.revision + 1
+          && ownsWorld() && blockDocument();
+        allow list, delete: if false;
+      }
     }
 
-    // Blocks, messages, memberships and every unspecified path remain closed.
+    // Other blocks, messages, memberships and every unspecified path remain closed.
     match /{document=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## Scope

Closes #192, the owner-only browser/data slice of #191. Parent #191 remains open for optional extension dispatch, scoped agent pairing, block commands and canonical installed skill delivery. Dependency #189 / PR #190 is now merged after all current-head checks passed.

Users can arrange a real 32x32 home block with curated desk/chair/plant/rug furniture, select and move through pointer or numeric/keyboard controls, rotate/remove, explicitly save, and reopen the persisted room. No agent connectivity or execution is implied.

## Architecture and primary review

Primary: Codex. Reviewed commit: `d3b704e0d0dcaa74a80b07ba11b6fd6d28dbf357` (all 28 changed files, existing world admission/route/session callers, both Docker owners, fixtures and documentation). Rebased original reviewed `c452743` onto merged #190; `git diff c452743 HEAD` is empty, proving the accepted tree is unchanged.

- Reused existing Firebase initialization, world ownership, admission gates and browser/emulator fixtures. The route-scoped block state owns one server-confirmed projection plus a deliberately unsaved draft; it does not mirror data in another global store.
- Pure catalog, geometry, validation and codec are in one block contract owner. Firestore effects, editor lifecycle, controlled SVG rendering and controls are separate modules. No new package, scene engine, generic store or service was added. Curated vector primitives fit this bounded requirement and preserve accessible form controls without an extra rendering dependency.
- A real full-capacity Rules test rejected the initial named-map storage representation at the 1000-expression limit. Replaced only storage representation with four-character tokens through the single codec, retained all 16 objects and exact rotated footprint checks, and recorded the decision in #192 and the contract. Shared vectors contain independently specified readable values and literal storage tokens. No production data or migration exists for the discarded format.
- A transaction race can be denied by Rules before Firestore retries. Conflict classification now requires a fresh authorized server read of a changed revision; foreign/revoked users still get denial. Exact retries do not rewrite or renew the block timestamp. Network uncertainty retains the original draft/revision; no offline submission queue.
- Primary inspected full-slot and overflow negative controls, both full-capacity create and update positive controls, owner/device isolation, concurrent outcome/durable state, actual interrupted browser transport, and late-disposal callbacks. Existing blanket denial tests still cover undeveloped block IDs rather than being removed.
- Primary viewed actual desktop and 390px editor screenshots, including pointer-selected/moved furniture. Narrow layout has no horizontal overflow. The visible red banner belongs to the Auth Emulator and is intentionally retained; these are not production screenshots. Pointer and keyboard/form operations are exercised in Chromium.
- ARCHITECTURE.md, Office architecture/design, contract, developer and operator guides are updated. No installed skill advertises unimplemented commands; that remains an explicit #191 acceptance requirement, not forgotten work.

## Verification

- [x] Primary reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results recorded below.
- [ ] Current-head required CI verified before authorized merge.

- `pnpm check` — passed, including root/Office type, lint, formatting and docs.
- `pnpm office:test` — 66 tests in 8 files passed.
- `pnpm test:run` — 146 tooling tests in 14 files passed.
- `docker build --target browser-tests -f services/office/Dockerfile -t tmt-office-browser:192-local .` — passed, including offline app checks/tests and preview/emulator/unconfigured-cloud builds.
- `docker run --init --shm-size=256m tmt-office-browser:192-local` — two fresh isolated full runs, 19 scenarios each: 37.4s and 41.2s, zero retries. First container retained only long enough to copy screenshots, then removed; second used `--rm`. No host credentials/data mounts or production requests.
- Final changes after these two runs were documentation and a Rules comment only; final `pnpm check` and `git diff --cached --check` passed again.

Failures during local development were used to refine implementation, not accepted as success: explicit JSON import attributes were required by the real Node/Playwright runner; full-capacity map Rules exhausted the expression budget; revision races surfaced a permission-denied transport error. The final tests retain the same capacity, bounds and causal conflict expectations.

## Lifecycle

Dedicated branch `feat/192-visual-block` in the main working directory. No extra worktree, native Rust changes, installed skill changes, cloud deployment, tester grants, publication or billing change. The prior ignored Firebase owner configuration is preserved. Keep #191 open and coordinate merge with #190; use one reviewed CI candidate after local acceptance.
