### PR TITLE
Office: specify the data-only sandbox and clean up ownership boundaries

### DIFF
--- a/.agents/skills/tmt-release/SKILL.md
+++ b/.agents/skills/tmt-release/SKILL.md
@@ -20,30 +20,34 @@ Use this skill for release-line maintenance, v4 compatibility fixes, v5 promotio
 
 ## Promotion and prerelease checks
 
-- For Rust archives, follow DEVELOPMENT's native Rust release archive procedure.
+Read the complete [native release verification guide](../../../docs/native-release-verification.md)
+before archive, installer, upgrade, bootstrap or publication work. It owns the
+procedures referenced below; DEVELOPMENT owns ordinary native checks.
+
+- For Rust archives, follow the guide's native Rust release archive procedure.
   Keep cargo-dist's manifest as the artifact metadata owner; independently verify
   bounded extraction, notices, linkage, skill installation and persisted state.
   Raw PR runtime checks do not establish release archive correctness. Do not enable a
   generated installer or publication workflow merely to obtain local archives.
-- Follow DEVELOPMENT's native runtime and archive verification for artifact changes.
+- Follow DEVELOPMENT's native runtime checks and the guide's archive verification for artifact changes.
   Reuse the shared runtime proof for linkage, exact embedded skills and SQLite
   reopen behavior. Keep the independent archive inventory/checksum/notices and
   installer failure/cleanup evidence; raw binaries are not release artifacts.
-- For native binary publication changes, also follow DEVELOPMENT's offline
+- For native binary publication changes, also follow the guide's offline
   installer lifecycle procedure using actual separately versioned archives.
   Keep ownership anchored in the installation prefix, not application-state
   selectors; verify old executable preservation, pin policy, partial command-link
   finalization and unchanged data. The internal preview entrypoint is not a
   public bootstrap or permission to replace a user/package-manager installation.
 - Promotion requires passing Code quality, Unit tests, and Docker E2E checks.
-- For a public native alpha, follow DEVELOPMENT's explicit multi-platform
+- For a public native alpha, follow the guide's explicit multi-platform
   release preparation procedure. The manual artifact workflow never publishes;
   all four final native verifiers must pass on the recorded reviewed commit.
   Keep cargo-dist as the merged manifest owner. Authorized publication uses an
   immutable draft-to-published GitHub release and verifies its attestation and
   public installer before promoting README instructions. Do not equate a
   downloadable CI bundle with a published or accepted release.
-- For curl bootstrap, follow DEVELOPMENT's native curl bootstrap verification.
+- For curl bootstrap, follow the guide's native curl bootstrap verification.
   Generate from final verified cargo-dist artifacts and invoke the existing
   native publisher; do not enable a competing stock installer. Test an actual
   matching-host archive without Node/Rust on runtime PATH, and distinguish

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,36 +35,20 @@ delivery. Future connector dispatch reuses native request/storage ownership,
 not CLI-output scraping or a competing exchange engine. Ordinary CLI operations
 remain independent of Office.
 
-`services/office` now contains the isolated Firebase emulator bootstrap (#184),
-not a deployed service. Its shared demo-project configuration and Firestore rules
-enforce owner-only private worlds and the Console-managed tester gate (#189).
-No HTTP/Admin product service is needed for direct client world creation/reads.
-Owner-local project aliases/secrets are
-excluded from Git and Docker; the image has no host credential/data mounts.
-`scripts/verify-office-emulators.mjs` proves emulator transport and fixture
-cleanup separately from native tmux E2E and future Office authorization tests.
+Office has three app-owned boundaries: `auth` initializes Firebase/session,
+`worlds` owns admission and world access, and `blocks` owns the layout contract,
+codec, adapter and editor lifecycle. Rules enforce authority; views never grant
+it. Remote snapshots have one owner, separate from unsaved drafts and ephemeral
+presentation state. No stored markup executes and no parallel layout is stored.
+The detailed lifecycle and verification map lives only in
+[Office architecture](docs/office/architecture.md); exact persisted data belongs
+in [Office contracts](contracts/office/README.md).
 
-Office's explicit emulator/cloud modes share one app-owned Firebase/session boundary
-under `apps/office/src/auth`, with memory-only persistence. `src/worlds` owns
-the direct Firestore adapter and session-scoped admission/selected-world state.
-Its Firebase-free `world-contract.ts` is the single client port/value/validation
-owner; pure state does not depend on the concrete SDK adapter.
-Rules, not the UI, enforce tester admission and immutable owner authority.
-`src/blocks` adds one owner-only home block: pure catalog/geometry/validation,
-an SDK adapter and a mounted editor state owner. Remote snapshots and an explicit
-unsaved draft are separate, not duplicated caches. The view renders curated SVG
-primitives; it cannot execute stored markup. Block writes use expected revisions
-and online transactions, and reuse world ownership rather than adding another
-identity record. See `contracts/office/block-v1.md` for the bounded data contract.
-The same pure block owner encodes readable furniture into short storage tokens;
-Rules validate complete footprints within their expression budget. No parallel
-named-field copy is stored.
-React subscribes to the observer-backed session rather than copying identity into
-Jotai. The opt-in `browser-tests` stage of the same emulator Dockerfile proves
-real browser session behavior with local auth and an explicit public Google
-script allowlist, not fully offline OAuth; its default stage remains
-the lightweight emulator environment. See Office architecture for lifecycle and
-failure ownership. No cloud membership service or connector is implemented.
+`services/office` owns isolated emulator infrastructure and Rules, not a deployed
+backend. Owner-local configuration stays outside Git and Docker. Native tmux,
+Office browser/Rules and bootstrap smoke proofs retain separate fixture owners.
+Community props and exploration remain a [data-only sandbox plan](docs/office/sandbox.md),
+not a shipped runtime SDK, identity registry or alternate exchange engine.
 
 `scripts/ci-scope.mjs` owns conservative affected-area selection and final gate
 validation. Office-only source/docs avoid native matrices; native source/skill

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -63,8 +63,9 @@ Use the [development skill](.agents/skills/tmt-dev/SKILL.md) to apply them.
 
 Office is a React SPA, not a second CLI runtime. Keep routes, view components
 and UI state under `apps/office/src`, with behavioral tests beside the owner.
-Use TanStack Router for navigation and Jotai for ephemeral presentation state;
-do not parse URLs or invent an application-wide store in view components.
+Use TanStack Router for navigation and Jotai for shared cross-view presentation
+state; component-local forms and selection may use React state.
+Do not parse URLs or invent an application-wide store in view components.
 Remote state gets one owner, not mirrored Query/Jotai/Firestore copies. See
 [Office architecture](docs/office/architecture.md) before adding a service,
 contract, drawing dependency or cross-package abstraction.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -150,6 +150,11 @@ disposable Auth/Firestore emulators and three strict-port preview servers, then
 Playwright. The cloud build must fail closed without operator configuration;
 it never contacts a real project during automated tests.
 It uses one worker, no retries, bounded waits and independent browser contexts.
+Only failed-transaction assertions use the Firestore fixture's 20-second budget:
+the pinned SDK's five attempts can spend 12.1875 seconds in jittered backoff
+alone. Keep the ordinary 10-second UI expectation and 30-second scenario limits.
+Those scenarios assert intercepted transaction reads and independent durable
+state before and after explicit retry; a timeout alone is not transport evidence.
 Auth responses are real and local. The suite also exercises the real Firestore
 SDK against Rules: immutable creation/retry, cross-user denial, self-grant denial,
 shape validation, and browser grant/create/revocation. Operator fixtures
@@ -341,245 +346,14 @@ The same distinction applies to release artifacts: raw PR executables prove
 source-runtime behavior only. They do not prove archive inventory, notices,
 checksums or bootstrap behavior. Linkage is checked in both raw and archive proof.
 
-## Native Rust release archives
+## Native release verification
 
-### Explicit multi-platform release preparation
-
-`Native release artifacts` (`.github/workflows/native-release.yml`) is manually
-dispatched, not part of every PR. Dispatch on the authorized release's reviewed,
-required-checks-green main commit and record the run ID and exact SHA in its
-issue. It builds on native macOS arm64/x64 and Linux arm64/x64 hosts using the
-existing pinned tools and `build-native-artifact.sh`. A shared matrix keeps
-build and final verification hosts aligned; dispatches outside main are skipped.
-Cached packaging tools are keyed
-by OS, architecture and exact tool versions; they are developer tools only.
-
-cargo-dist itself merges the downloaded `*-dist-manifest.json` inputs through
-`dist build --artifacts global --output-format=json --no-local-paths`. Do not
-hand-merge artifact JSON or enable another installer. Generate a complete
-`dist plan` on the same source and pass it as bootstrap `--plan`: the generator
-requires exact planned archive names/targets, preventing a missing matrix target
-from silently shrinking the release. Bootstrap generation verifies TMT ownership
-and archive inventory/digests before generating code; the final matrix
-then executes both existing verifiers against this final manifest and compares
-the regenerated script bytes. All jobs must pass before publication, even if
-the assembled artifact can already be downloaded. CI artifacts expire in seven
-days. Notices alongside the bundle are verification inputs; each archive also
-contains its own target-filtered notices.
-
-Publication remains a separately authorized operation, not a workflow side
-effect. Verify the run's exact commit and all required PR checks; enable GitHub
-release immutability before creating a draft prerelease. Attach the four tar.gz
-archives, final `dist-manifest.json` and `tmt-installer.sh`, verify their uploaded
-SHA-256 digests and only then publish the draft. Verify `immutable: true`, tag
-commit and GitHub release attestation (`gh release verify` and
-`gh release verify-asset`). Never replace an immutable release's assets or move
-its tag. A repair needs a new reviewed version.
-
-Before promoting README installation instructions, run the actual public script
-with an isolated HOME, application root and prefix, verify version, exact skill,
-PATH selection and `tmt upgrade --json` against live immutable metadata. Do not
-mutate a host installation. Record this separately from controlled-curl fixture
-evidence. npm publication is not part of native GitHub release publication.
-
-The PR smoke matrix verifies raw native runtimes, not release archives.
-#135 introduced archive generation; later slices delivered installation.
-The target inventory and artifact metadata live in `dist-workspace.toml` and
-the generated cargo-dist manifest, not another TMT release catalog.
-
-Install the pinned developer tools into a chosen tool directory (not needed by
-end users): cargo-dist 0.32.0 with `cargo install --locked`, and cargo-about
-0.9.2 with `cargo install --locked --features cli`. Put their binaries on PATH.
-Fetch the locked workspace dependencies before the offline notice step.
-Build targets sequentially in one checkout, or use separate worktrees: the
-generator's distribution directory and generated notice input are per-checkout.
-
-```sh
-# Choose a target from dist-workspace.toml that matches the verification host.
-native_manifest=$(mktemp)
-MACOSX_DEPLOYMENT_TARGET=11.0 scripts/build-native-artifact.sh aarch64-apple-darwin > "$native_manifest"
-node scripts/verify-native-artifact.mjs \
-  --manifest "$native_manifest" \
-  --archive target/distrib/tmt-cli-aarch64-apple-darwin.tar.gz \
-  --target aarch64-apple-darwin --skill skills/tmux-team/SKILL.md \
-  --notices rust/target/native-notices/THIRD-PARTY-NOTICES.txt --license LICENSE
-```
-
-Review the generated `rust/target/native-notices/THIRD-PARTY-NOTICES.txt` against
-the locked, archive-target-filtered runtime graph, including Unicode copyrights;
-the verifier compares the archived notices and license with these selected
-inputs and rejects placeholder attribution. A successful generator
-is not legal certification. Keep the complete notice text with redistributed
-binaries. The verifier bounds inputs (64 MiB compressed, 128 MiB expanded),
-requires exactly the four runtime files, and removes its private staging after
-success or failure. It runs the extracted executable with no Node/Rust/tmux on
-PATH and verifies native SQLite persistence through public commands. macOS
-requires system `otool`; Linux requires `readelf` for static-musl linkage checks.
-
-`test/native/artifact.Dockerfile` provides a local matching-architecture Linux
-musl build and verifier. Set `TARGET_TRIPLE` from the selected generator target,
-give the image a task-owned name, then run it with `--rm --init --network none`
-and `--archive artifacts/<manifest archive name> --target <target>`. Remove that
-owned image after verification. Emulated execution and cross-compilation alone
-do not satisfy native target acceptance. This optional image is not the tmux
-E2E harness or a publication workflow.
-
-Negative archive tests use real tar fixtures and causal guard assertions.
-Exercise checksum corruption, truncation, missing executable/notices, links,
-unexpected paths, duplicates, bounds and cleanup; never accept any arbitrary
-process error as proof of the intended check. Inspect exact manifest and archive
-bytes from the final source before running the reviewed CI candidate.
-
-## Offline native installer verification
-
-### Native update verification
-
-`tmt upgrade [--channel stable|alpha] [--to <version> | --unpin] [--json]`
-and `tmt update` share one grammar and implementation. Use task-owned managed
-prefixes, never a user's installed command or app data. The invoking executable
-must be the active release; an unmanaged checkout binary fails before networking.
-Production has no test endpoint or TLS bypass. API fixtures inject only the
-adapter's acquisition boundary; actual local TLS fixtures use test-only trust.
-Test old/new real release archives separately from synthetic tar fixtures, with
-different embedded skills, to prove the newly active executable supplies refresh.
-
-Check pinned no-network behavior, explicit pin/unpin, unchanged release identity,
-preserved old bytes, missing/mutable release rejection, dual digest checks,
-same-version integrity and concurrent pin fencing. Cancellation and finalization
-tests must inspect active receipts and surviving executables, not only exit codes.
-After activation, skill failures retain a partial report and nonzero status;
-malformed/nonzero/oversized/timed-out child output is never a success. The existing
-process runner retains bounded output only for completed nonzero exits and never
-prints it implicitly. Verify both byte preservation and task-owned cleanup.
-
-The synchronous HTTPS dependency is pinned ureq 3.4.0 (MIT/Apache-2.0, upstream
-MSRV 1.85), selected without an async runtime or curl fallback. The lockfile and
-workspace MSRV 1.88 remain authoritative for the complete graph. rustls and
-platform-verifier use native trust and library proxy environment behavior.
-Runtime attribution includes ISC crypto and CDLA-Permissive-2.0 certificate data;
-generate target-filtered notices through cargo-about and retain complete texts.
-rcgen/rustls local-server fixtures are dev-only, not production endpoint options.
-
-The explicit actual-archive acceptance test requires separately versioned,
-matching-host cargo-dist artifacts with different embedded skills. It is ignored
-by ordinary tests, not counted as release proof until selected and passed:
-
-```sh
-TMT_UPGRADE_OLD_ARCHIVE=/absolute/old/archive.tar.gz \
-TMT_UPGRADE_OLD_MANIFEST=/absolute/old/manifest.json \
-TMT_UPGRADE_NEW_ARCHIVE=/absolute/new/archive.tar.gz \
-TMT_UPGRADE_NEW_MANIFEST=/absolute/new/manifest.json \
-TMT_UPGRADE_TARGET=aarch64-apple-darwin \
-cargo test --locked --manifest-path rust/Cargo.toml -p tmt-adapters \
-  cargo_dist_upgrade_refreshes_real_artifacts_and_preserves_conflicts -- --ignored
-```
-
-Require one selected passing test, not an empty filtered run. This test injects
-canonical acquisition responses but executes real old/new binaries, managed
-skill installation, partial hidden refresh and repair in scrubbed task-owned
-state. It does not claim to contact a public release or exercise the public CLI
-over a fake production endpoint. Run the independent artifact verifier too.
-
-### Offline composition
-
-The internal entrypoint consumes a local cargo-dist archive and manifest. It is
-not advertised by help/completion and does not change `tmt install` skill syntax.
-Use a task-owned prefix and matching host archive, never an existing user install:
-
-```sh
-native_prefix=$(mktemp -d)
-rust/target/debug/tmt __native-install \
-  --archive target/distrib/tmt-cli-aarch64-apple-darwin.tar.gz \
-  --manifest "$native_manifest" --prefix "$native_prefix" --channel alpha --json
-"$native_prefix/bin/tmt" --version
-```
-
-`--pin` pins the selected candidate, `--unpin` clears an existing pin, and omission
-preserves its state. Neither authorizes a downgrade. Repeated exact artifacts are
-no-ops after ownership validation; metadata-only changes activate a new receipt
-with the same payload. Receipts record local-archive provenance, not authenticated
-public release provenance. Keep application state isolated separately when running
-identity/profile commands; installing the executable must not open a database.
-
-Native adapter tests cover bounded archive acquisition and publication failures;
-native process contracts use the existing executable selector and sandbox. Test
-current/receipt tampering, manager collisions, pin changes, interrupted staging,
-lock contention, missing command-link repair and retained previous releases.
-Assert surviving bytes and cleanup, not merely a failed exit. Tests comparing
-large executable buffers must use exact `Buffer.equals`
-checks rather than structural object matchers: enumerating every byte can exhaust
-the test runner's heap on debug binaries. Verify the comparator detects a changed
-byte; do not replace byte equality with a size-only assertion or raise CI memory
-limits to hide assertion overhead. Installation cases also use an explicit
-15-second subprocess budget for debug
-archive hashing/decompression and durable publication, distinct from the ordinary
-CLI's five-second test budget and each scenario's 60-second cap. Keep ordinary
-command and production timeout policies unchanged; validate installation budgets
-under constrained local resources rather than treating CI as a timing probe.
-Synthetic filesystem
-fixtures are not proof of runnable release artifacts: retain separate actual
-cargo-dist archive execution and target/linkage/notice evidence. Run the shared
-skill-installation regressions when changing shared file locks or content digests.
-
-For actual old-to-new acceptance, build two separately versioned cargo-dist
-archives in task-owned source copies. Do not alter the repository release version
-or publish fixtures merely to test updates. The newer archive must contain the
-offline installer; the older artifact must run its real reported version. Verify
-each archive's notices/linkage with the artifact verifier above, then run:
-
-```sh
-node scripts/verify-native-installation.mjs \
-  --previous-archive "$previous_archive" --previous-manifest "$previous_manifest" \
-  --archive "$next_archive" --manifest "$next_manifest" \
-  --target aarch64-apple-darwin --skill skills/tmux-team/SKILL.md
-```
-
-This reuses the bounded packed-command runner and independent archive verifier.
-It checks exact old/new versions with no runtime PATH, pinned rejection, explicit
-unpin advancement, a retained executable, no-op and downgrade rejection, exact
-embedded skill and unchanged SQLite bytes during installation. Its temporary
-prefix/application state is always invocation-owned and removed afterward.
-
-## Native curl bootstrap verification
-
-Generate the release-specific script only after final cargo-dist archives and
-their independent runtime verification. All selected archives must be present;
-the manifest, not a hand-maintained version table, owns the generated facts:
-
-```sh
-node scripts/generate-native-bootstrap.mjs \
-  --manifest /absolute/dist-manifest.json --archive-dir /absolute/artifacts \
-  > /absolute/artifacts/tmt-installer.sh
-sh -n /absolute/artifacts/tmt-installer.sh
-node scripts/verify-native-bootstrap.mjs \
-  --manifest /absolute/dist-manifest.json \
-  --archive /absolute/artifacts/tmt-cli-aarch64-apple-darwin.tar.gz \
-  --target aarch64-apple-darwin --skill skills/tmux-team/SKILL.md
-```
-
-The last command requires actual matching-host release artifacts, uses isolated
-HOME/state/PATH, real shell utilities and the new native executable. Only curl
-acquisition is replaced with task-owned fixture copies; production has no test
-endpoint. It checks repeat/no-op, explicit pin followed by no-network upgrade,
-exact installed skill bytes, old npm command preservation, PATH warning and
-temporary cleanup. It is not live GitHub download or cross-target evidence.
-
-The existing `test/native/artifact.Dockerfile` also carries this verifier. After
-building its task-owned matching-architecture image, run the normal artifact
-entrypoint, then repeat with `--entrypoint node` and
-`scripts/verify-native-bootstrap.mjs --manifest native-manifest.json --archive
-artifacts/<archive-name> --target <target> --skill expected-skill.md`. Keep
-`--rm --init --network none` and remove only the task-owned image afterwards.
-
-`test/tooling/native-bootstrap.test.ts` covers the generated shell's negative paths with
-the existing bounded CLI sandbox and a synthetic executable for orchestration.
-Do not count that stub as native publication evidence; pair it with the actual
-artifact verifier. Run `pnpm check`, unit tests and two Docker lifecycle passes
-before the reviewed CI candidate. Keep generated outputs out of source control.
-No new runtime dependency, data migration or public publication is authorized
-by generation. An authorized release must upload the exact verified manifest,
-archives and generated script, establish immutable release/provenance evidence,
-and verify the public download before the README advertises it as available.
+For archive, installer, upgrade, bootstrap or publication changes, read the
+complete [native release verification guide](docs/native-release-verification.md)
+before acting. It owns the exact commands, actual-archive evidence and authorized
+publication gates. Ordinary changes do not need to load release-only procedures.
+The runtime smoke matrix above remains part of native PR verification; raw
+executables are not proof of release archives or public installation.
 
 ## Installed guidance source ownership
 

--- a/apps/office/e2e/blocks.spec.ts
+++ b/apps/office/e2e/blocks.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { test, signIn } from './browser-session.js';
-import { setTester, readBlockDocument } from './firestore-fixture.js';
+import {
+  setTester,
+  readBlockDocument,
+  TRANSACTION_FAILURE_TIMEOUT_MS,
+} from './firestore-fixture.js';
 
 async function prepareStudio(page: Page) {
   await signIn(page, 'Decorator');
@@ -93,9 +97,16 @@ test('a disconnected save keeps a local draft and reconnect cannot silently publ
   const { worldId } = await prepareStudio(page);
   await page.getByRole('button', { name: 'Add desk', exact: true }).click();
   const transport = 'http://127.0.0.1:8080/**';
-  await context.route(transport, (route) => route.abort('internetdisconnected'));
+  let abortedReads = 0;
+  await context.route(transport, (route) => {
+    if (route.request().url().includes(':batchGet')) abortedReads++;
+    return route.abort('internetdisconnected');
+  });
   await page.getByRole('button', { name: 'Save layout', exact: true }).click();
-  await expect(page.getByRole('alert')).toContainText('Save could not be confirmed');
+  await expect(page.getByRole('alert')).toContainText('Save could not be confirmed', {
+    timeout: TRANSACTION_FAILURE_TIMEOUT_MS,
+  });
+  expect(abortedReads).toBeGreaterThan(0);
   await expect(page.getByText('Unsaved changes', { exact: true })).toBeVisible();
   expect(await readBlockDocument(worldId)).toBeNull();
   await context.unroute(transport);

--- a/apps/office/e2e/firestore-fixture.ts
+++ b/apps/office/e2e/firestore-fixture.ts
@@ -122,3 +122,7 @@ export async function createFirestoreFixture() {
     },
   };
 }
+// Pinned Firebase uses five transaction attempts with 1s initial retry delay,
+// factor 1.5 and +/-50% jitter: four waits can total 12.1875s. Allow transport
+// overhead only for failed-transaction assertions, not every UI expectation.
+export const TRANSACTION_FAILURE_TIMEOUT_MS = 20_000;

--- a/apps/office/e2e/worlds.spec.ts
+++ b/apps/office/e2e/worlds.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { test, signIn } from './browser-session.js';
-import { setTester, ownedWorlds } from './firestore-fixture.js';
+import { setTester, ownedWorlds, TRANSACTION_FAILURE_TIMEOUT_MS } from './firestore-fixture.js';
 
 test('transport failure cannot queue a create across reconnect; explicit retry creates exactly once', async ({
   openSession,
@@ -12,10 +12,17 @@ test('transport failure cannot queue a create across reconnect; explicit retry c
   await expect(page.getByRole('button', { name: 'Create world', exact: true })).toBeVisible();
   expect(await ownedWorlds(uid)).toEqual([]);
   const transport = 'http://127.0.0.1:8080/**';
-  await context.route(transport, (route) => route.abort('internetdisconnected'));
+  let abortedReads = 0;
+  await context.route(transport, (route) => {
+    if (route.request().url().includes(':batchGet')) abortedReads++;
+    return route.abort('internetdisconnected');
+  });
   await page.getByLabel('World name').fill('Reconnect room');
   await page.getByRole('button', { name: 'Create world', exact: true }).click();
-  await expect(page.getByRole('alert')).toContainText('could not be confirmed');
+  await expect(page.getByRole('alert')).toContainText('could not be confirmed', {
+    timeout: TRANSACTION_FAILURE_TIMEOUT_MS,
+  });
+  expect(abortedReads).toBeGreaterThan(0);
   expect(await ownedWorlds(uid)).toEqual([]);
   await context.unroute(transport);
   expect(await ownedWorlds(uid)).toEqual([]);

--- a/apps/office/src/blocks/block-view.test.tsx
+++ b/apps/office/src/blocks/block-view.test.tsx
@@ -1,0 +1,38 @@
+import { act, render, screen } from '@testing-library/react';
+import { expect, it } from 'vitest';
+import type { Block } from './block-contract.js';
+import { createBlockState } from './block-state.js';
+import { BlockEditor } from './block-view.js';
+
+it('distinguishes connecting, absent, saved and unavailable block observations', () => {
+  let changed: (block: Block | null) => void = () => {};
+  let failed = () => {};
+  const state = createBlockState(
+    {
+      watch: (_id, next, error) => {
+        changed = next;
+        failed = error;
+        return () => {};
+      },
+      apply: async () => {
+        throw new Error('This read-only scenario must not write.');
+      },
+    },
+    'a'.repeat(20)
+  );
+  const view = render(<BlockEditor state={state} />);
+  try {
+    expect(screen.getByRole('status').textContent).toBe('Connecting…');
+    act(() => changed(null));
+    expect(screen.getByRole('status').textContent).toBe('No saved layout yet');
+    act(() => changed({ revision: 1, objects: [], updatedAtMs: 1 }));
+    expect(screen.getByRole('status').textContent).toBe('Saved · revision 1');
+    act(failed);
+    expect(screen.getByRole('status').textContent).toBe('Block unavailable');
+    expect(screen.getByRole('alert').textContent).toContain('Reopen the world');
+    expect(screen.queryByRole('button', { name: 'Save layout' })).toBeNull();
+  } finally {
+    view.unmount();
+    state.dispose();
+  }
+});

--- a/apps/office/src/blocks/block-view.tsx
+++ b/apps/office/src/blocks/block-view.tsx
@@ -45,12 +45,16 @@ export function BlockEditor({ state }: { state: BlockState }) {
         </div>
         <span role="status">
           {!ready
-            ? 'Connecting…'
+            ? error
+              ? 'Block unavailable'
+              : 'Connecting…'
             : busy
               ? 'Saving…'
               : draft
                 ? 'Unsaved changes'
-                : `Saved · revision ${remote?.revision ?? 0}`}
+                : remote
+                  ? `Saved · revision ${remote.revision}`
+                  : 'No saved layout yet'}
         </span>
       </div>
       {error && <p role="alert">{error}</p>}

--- a/apps/office/src/blocks/firebase-blocks.ts
+++ b/apps/office/src/blocks/firebase-blocks.ts
@@ -8,6 +8,7 @@ import {
 } from 'firebase/firestore';
 import type { Firestore } from 'firebase/firestore';
 import { FirebaseError } from 'firebase/app';
+import { validWorldId } from '../worlds/world-contract.js';
 import {
   BlockConflict,
   sameLayout,
@@ -35,7 +36,7 @@ function readBlock(value: Record<string, unknown>): Block {
 }
 export function createBlockPort(db: Firestore): BlockPort {
   function reference(worldId: string) {
-    if (!/^[a-zA-Z0-9]{20}$/.test(worldId)) throw new Error('Invalid world ID.');
+    if (!validWorldId(worldId)) throw new Error('Invalid world ID.');
     return doc(db, 'worlds', worldId, 'blocks', 'home');
   }
   return {

--- a/apps/office/src/worlds/firebase-worlds.ts
+++ b/apps/office/src/worlds/firebase-worlds.ts
@@ -8,7 +8,7 @@ import {
 } from 'firebase/firestore';
 import type { Firestore } from 'firebase/firestore';
 
-import { validWorldName } from './world-contract.js';
+import { validWorldId, validWorldName } from './world-contract.js';
 import type { World, WorldDraft, WorldPort } from './world-contract.js';
 
 function readWorld(id: string, value: Record<string, unknown>): World {
@@ -37,7 +37,7 @@ export function createWorldPort(db: Firestore): WorldPort {
       return { id: doc(collection(db, 'worlds')).id, name };
     },
     async create(draft: WorldDraft, uid: string): Promise<string> {
-      if (!/^[a-zA-Z0-9]{20}$/.test(draft.id) || !validWorldName(draft.name)) {
+      if (!validWorldId(draft.id) || !validWorldName(draft.name)) {
         throw new Error('Invalid world draft.');
       }
       const reference = doc(db, 'worlds', draft.id);
@@ -59,7 +59,7 @@ export function createWorldPort(db: Firestore): WorldPort {
       return draft.id;
     },
     watch(id: string, changed: (world: World | null) => void, failed: () => void): () => void {
-      if (!/^[a-zA-Z0-9]{20}$/.test(id)) {
+      if (!validWorldId(id)) {
         failed();
         return () => {};
       }

--- a/apps/office/src/worlds/world-contract.test.ts
+++ b/apps/office/src/worlds/world-contract.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import { validWorldName } from './world-contract.js';
+import { validWorldId, validWorldName, WORLD_ID_PATTERN } from './world-contract.js';
+
+describe('world ID contract', () => {
+  it.each([
+    ['aA09'.repeat(5), true],
+    ['a'.repeat(19), false],
+    ['a'.repeat(21), false],
+    ['a'.repeat(19) + '/', false],
+    ['a'.repeat(19) + '_', false],
+    ['a'.repeat(19) + 'é', false],
+    ['', false],
+  ])('validates %j with the same pattern used by the form', (id, valid) => {
+    expect(validWorldId(id)).toBe(valid);
+    const input = document.createElement('input');
+    input.required = true;
+    input.pattern = WORLD_ID_PATTERN;
+    input.value = id;
+    expect(input.checkValidity()).toBe(valid);
+  });
+
+  it('rejects trailing line terminators', () => {
+    expect(validWorldId('a'.repeat(20) + '\n')).toBe(false);
+    expect(validWorldId('a'.repeat(20) + '\r')).toBe(false);
+  });
+});
 
 describe('world name feedback', () => {
   it.each(['', ' ', '\u00a0', '\u3000', '\ud800', 'line\nbreak', 'x'.repeat(81), '😀'.repeat(81)])(

--- a/apps/office/src/worlds/world-contract.ts
+++ b/apps/office/src/worlds/world-contract.ts
@@ -1,3 +1,10 @@
+export const WORLD_ID_PATTERN = '[a-zA-Z0-9]{20}';
+const worldIdPattern = new RegExp(`^${WORLD_ID_PATTERN}$`);
+
+export function validWorldId(id: string): boolean {
+  return worldIdPattern.test(id);
+}
+
 export interface World {
   id: string;
   name: string;

--- a/apps/office/src/worlds/world-view.tsx
+++ b/apps/office/src/worlds/world-view.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, useSyncExternalStore } 
 import { Link, useNavigate } from '@tanstack/react-router';
 import type { ReactElement, ReactNode } from 'react';
 import type { WorldState } from './world-state.js';
+import { WORLD_ID_PATTERN } from './world-contract.js';
 import { BlockPanel } from '../blocks/block-view.js';
 
 export const WorldContext = createContext<WorldState | undefined>(undefined);
@@ -78,7 +79,7 @@ export function CreateWorld({ state }: { state: WorldState }): ReactElement {
           id="open-world-id"
           value={worldId}
           required
-          pattern="[a-zA-Z0-9]{20}"
+          pattern={WORLD_ID_PATTERN}
           onChange={(event) => setWorldId(event.target.value)}
         />
         <button>Open world</button>

--- a/docs/native-release-verification.md
+++ b/docs/native-release-verification.md
@@ -1,0 +1,247 @@
+# Native release verification
+
+Task-specific contributor reference extracted from DEVELOPMENT.md. Run commands
+from the repository root unless stated otherwise. Read this entire guide for
+archive, installer, upgrade, bootstrap or publication work; ordinary Office and
+CLI changes use the focused checks in [Development](../DEVELOPMENT.md).
+This is verification guidance, not publication authorization.
+
+## Native Rust release archives
+
+### Explicit multi-platform release preparation
+
+`Native release artifacts` (`.github/workflows/native-release.yml`) is manually
+dispatched, not part of every PR. Dispatch on the authorized release's reviewed,
+required-checks-green main commit and record the run ID and exact SHA in its
+issue. It builds on native macOS arm64/x64 and Linux arm64/x64 hosts using the
+existing pinned tools and `build-native-artifact.sh`. A shared matrix keeps
+build and final verification hosts aligned; dispatches outside main are skipped.
+Cached packaging tools are keyed
+by OS, architecture and exact tool versions; they are developer tools only.
+
+cargo-dist itself merges the downloaded `*-dist-manifest.json` inputs through
+`dist build --artifacts global --output-format=json --no-local-paths`. Do not
+hand-merge artifact JSON or enable another installer. Generate a complete
+`dist plan` on the same source and pass it as bootstrap `--plan`: the generator
+requires exact planned archive names/targets, preventing a missing matrix target
+from silently shrinking the release. Bootstrap generation verifies TMT ownership
+and archive inventory/digests before generating code; the final matrix
+then executes both existing verifiers against this final manifest and compares
+the regenerated script bytes. All jobs must pass before publication, even if
+the assembled artifact can already be downloaded. CI artifacts expire in seven
+days. Notices alongside the bundle are verification inputs; each archive also
+contains its own target-filtered notices.
+
+Publication remains a separately authorized operation, not a workflow side
+effect. Verify the run's exact commit and all required PR checks; enable GitHub
+release immutability before creating a draft prerelease. Attach the four tar.gz
+archives, final `dist-manifest.json` and `tmt-installer.sh`, verify their uploaded
+SHA-256 digests and only then publish the draft. Verify `immutable: true`, tag
+commit and GitHub release attestation (`gh release verify` and
+`gh release verify-asset`). Never replace an immutable release's assets or move
+its tag. A repair needs a new reviewed version.
+
+Before promoting README installation instructions, run the actual public script
+with an isolated HOME, application root and prefix, verify version, exact skill,
+PATH selection and `tmt upgrade --json` against live immutable metadata. Do not
+mutate a host installation. Record this separately from controlled-curl fixture
+evidence. npm publication is not part of native GitHub release publication.
+
+The PR smoke matrix verifies raw native runtimes, not release archives.
+#135 introduced archive generation; later slices delivered installation.
+The target inventory and artifact metadata live in `dist-workspace.toml` and
+the generated cargo-dist manifest, not another TMT release catalog.
+
+Install the pinned developer tools into a chosen tool directory (not needed by
+end users): cargo-dist 0.32.0 with `cargo install --locked`, and cargo-about
+0.9.2 with `cargo install --locked --features cli`. Put their binaries on PATH.
+Fetch the locked workspace dependencies before the offline notice step.
+Build targets sequentially in one checkout, or use separate worktrees: the
+generator's distribution directory and generated notice input are per-checkout.
+
+```sh
+# Choose a target from dist-workspace.toml that matches the verification host.
+native_manifest=$(mktemp)
+MACOSX_DEPLOYMENT_TARGET=11.0 scripts/build-native-artifact.sh aarch64-apple-darwin > "$native_manifest"
+node scripts/verify-native-artifact.mjs \
+  --manifest "$native_manifest" \
+  --archive target/distrib/tmt-cli-aarch64-apple-darwin.tar.gz \
+  --target aarch64-apple-darwin --skill skills/tmux-team/SKILL.md \
+  --notices rust/target/native-notices/THIRD-PARTY-NOTICES.txt --license LICENSE
+```
+
+Review the generated `rust/target/native-notices/THIRD-PARTY-NOTICES.txt` against
+the locked, archive-target-filtered runtime graph, including Unicode copyrights;
+the verifier compares the archived notices and license with these selected
+inputs and rejects placeholder attribution. A successful generator
+is not legal certification. Keep the complete notice text with redistributed
+binaries. The verifier bounds inputs (64 MiB compressed, 128 MiB expanded),
+requires exactly the four runtime files, and removes its private staging after
+success or failure. It runs the extracted executable with no Node/Rust/tmux on
+PATH and verifies native SQLite persistence through public commands. macOS
+requires system `otool`; Linux requires `readelf` for static-musl linkage checks.
+
+`test/native/artifact.Dockerfile` provides a local matching-architecture Linux
+musl build and verifier. Set `TARGET_TRIPLE` from the selected generator target,
+give the image a task-owned name, then run it with `--rm --init --network none`
+and `--archive artifacts/<manifest archive name> --target <target>`. Remove that
+owned image after verification. Emulated execution and cross-compilation alone
+do not satisfy native target acceptance. This optional image is not the tmux
+E2E harness or a publication workflow.
+
+Negative archive tests use real tar fixtures and causal guard assertions.
+Exercise checksum corruption, truncation, missing executable/notices, links,
+unexpected paths, duplicates, bounds and cleanup; never accept any arbitrary
+process error as proof of the intended check. Inspect exact manifest and archive
+bytes from the final source before running the reviewed CI candidate.
+
+## Offline native installer verification
+
+### Native update verification
+
+`tmt upgrade [--channel stable|alpha] [--to <version> | --unpin] [--json]`
+and `tmt update` share one grammar and implementation. Use task-owned managed
+prefixes, never a user's installed command or app data. The invoking executable
+must be the active release; an unmanaged checkout binary fails before networking.
+Production has no test endpoint or TLS bypass. API fixtures inject only the
+adapter's acquisition boundary; actual local TLS fixtures use test-only trust.
+Test old/new real release archives separately from synthetic tar fixtures, with
+different embedded skills, to prove the newly active executable supplies refresh.
+
+Check pinned no-network behavior, explicit pin/unpin, unchanged release identity,
+preserved old bytes, missing/mutable release rejection, dual digest checks,
+same-version integrity and concurrent pin fencing. Cancellation and finalization
+tests must inspect active receipts and surviving executables, not only exit codes.
+After activation, skill failures retain a partial report and nonzero status;
+malformed/nonzero/oversized/timed-out child output is never a success. The existing
+process runner retains bounded output only for completed nonzero exits and never
+prints it implicitly. Verify both byte preservation and task-owned cleanup.
+
+The synchronous HTTPS dependency is pinned ureq 3.4.0 (MIT/Apache-2.0, upstream
+MSRV 1.85), selected without an async runtime or curl fallback. The lockfile and
+workspace MSRV 1.88 remain authoritative for the complete graph. rustls and
+platform-verifier use native trust and library proxy environment behavior.
+Runtime attribution includes ISC crypto and CDLA-Permissive-2.0 certificate data;
+generate target-filtered notices through cargo-about and retain complete texts.
+rcgen/rustls local-server fixtures are dev-only, not production endpoint options.
+
+The explicit actual-archive acceptance test requires separately versioned,
+matching-host cargo-dist artifacts with different embedded skills. It is ignored
+by ordinary tests, not counted as release proof until selected and passed:
+
+```sh
+TMT_UPGRADE_OLD_ARCHIVE=/absolute/old/archive.tar.gz \
+TMT_UPGRADE_OLD_MANIFEST=/absolute/old/manifest.json \
+TMT_UPGRADE_NEW_ARCHIVE=/absolute/new/archive.tar.gz \
+TMT_UPGRADE_NEW_MANIFEST=/absolute/new/manifest.json \
+TMT_UPGRADE_TARGET=aarch64-apple-darwin \
+cargo test --locked --manifest-path rust/Cargo.toml -p tmt-adapters \
+  cargo_dist_upgrade_refreshes_real_artifacts_and_preserves_conflicts -- --ignored
+```
+
+Require one selected passing test, not an empty filtered run. This test injects
+canonical acquisition responses but executes real old/new binaries, managed
+skill installation, partial hidden refresh and repair in scrubbed task-owned
+state. It does not claim to contact a public release or exercise the public CLI
+over a fake production endpoint. Run the independent artifact verifier too.
+
+### Offline composition
+
+The internal entrypoint consumes a local cargo-dist archive and manifest. It is
+not advertised by help/completion and does not change `tmt install` skill syntax.
+Use a task-owned prefix and matching host archive, never an existing user install:
+
+```sh
+native_prefix=$(mktemp -d)
+rust/target/debug/tmt __native-install \
+  --archive target/distrib/tmt-cli-aarch64-apple-darwin.tar.gz \
+  --manifest "$native_manifest" --prefix "$native_prefix" --channel alpha --json
+"$native_prefix/bin/tmt" --version
+```
+
+`--pin` pins the selected candidate, `--unpin` clears an existing pin, and omission
+preserves its state. Neither authorizes a downgrade. Repeated exact artifacts are
+no-ops after ownership validation; metadata-only changes activate a new receipt
+with the same payload. Receipts record local-archive provenance, not authenticated
+public release provenance. Keep application state isolated separately when running
+identity/profile commands; installing the executable must not open a database.
+
+Native adapter tests cover bounded archive acquisition and publication failures;
+native process contracts use the existing executable selector and sandbox. Test
+current/receipt tampering, manager collisions, pin changes, interrupted staging,
+lock contention, missing command-link repair and retained previous releases.
+Assert surviving bytes and cleanup, not merely a failed exit. Tests comparing
+large executable buffers must use exact `Buffer.equals`
+checks rather than structural object matchers: enumerating every byte can exhaust
+the test runner's heap on debug binaries. Verify the comparator detects a changed
+byte; do not replace byte equality with a size-only assertion or raise CI memory
+limits to hide assertion overhead. Installation cases also use an explicit
+15-second subprocess budget for debug
+archive hashing/decompression and durable publication, distinct from the ordinary
+CLI's five-second test budget and each scenario's 60-second cap. Keep ordinary
+command and production timeout policies unchanged; validate installation budgets
+under constrained local resources rather than treating CI as a timing probe.
+Synthetic filesystem
+fixtures are not proof of runnable release artifacts: retain separate actual
+cargo-dist archive execution and target/linkage/notice evidence. Run the shared
+skill-installation regressions when changing shared file locks or content digests.
+
+For actual old-to-new acceptance, build two separately versioned cargo-dist
+archives in task-owned source copies. Do not alter the repository release version
+or publish fixtures merely to test updates. The newer archive must contain the
+offline installer; the older artifact must run its real reported version. Verify
+each archive's notices/linkage with the artifact verifier above, then run:
+
+```sh
+node scripts/verify-native-installation.mjs \
+  --previous-archive "$previous_archive" --previous-manifest "$previous_manifest" \
+  --archive "$next_archive" --manifest "$next_manifest" \
+  --target aarch64-apple-darwin --skill skills/tmux-team/SKILL.md
+```
+
+This reuses the bounded packed-command runner and independent archive verifier.
+It checks exact old/new versions with no runtime PATH, pinned rejection, explicit
+unpin advancement, a retained executable, no-op and downgrade rejection, exact
+embedded skill and unchanged SQLite bytes during installation. Its temporary
+prefix/application state is always invocation-owned and removed afterward.
+
+## Native curl bootstrap verification
+
+Generate the release-specific script only after final cargo-dist archives and
+their independent runtime verification. All selected archives must be present;
+the manifest, not a hand-maintained version table, owns the generated facts:
+
+```sh
+node scripts/generate-native-bootstrap.mjs \
+  --manifest /absolute/dist-manifest.json --archive-dir /absolute/artifacts \
+  > /absolute/artifacts/tmt-installer.sh
+sh -n /absolute/artifacts/tmt-installer.sh
+node scripts/verify-native-bootstrap.mjs \
+  --manifest /absolute/dist-manifest.json \
+  --archive /absolute/artifacts/tmt-cli-aarch64-apple-darwin.tar.gz \
+  --target aarch64-apple-darwin --skill skills/tmux-team/SKILL.md
+```
+
+The last command requires actual matching-host release artifacts, uses isolated
+HOME/state/PATH, real shell utilities and the new native executable. Only curl
+acquisition is replaced with task-owned fixture copies; production has no test
+endpoint. It checks repeat/no-op, explicit pin followed by no-network upgrade,
+exact installed skill bytes, old npm command preservation, PATH warning and
+temporary cleanup. It is not live GitHub download or cross-target evidence.
+
+The existing `test/native/artifact.Dockerfile` also carries this verifier. After
+building its task-owned matching-architecture image, run the normal artifact
+entrypoint, then repeat with `--entrypoint node` and
+`scripts/verify-native-bootstrap.mjs --manifest native-manifest.json --archive
+artifacts/<archive-name> --target <target> --skill expected-skill.md`. Keep
+`--rm --init --network none` and remove only the task-owned image afterwards.
+
+`test/tooling/native-bootstrap.test.ts` covers the generated shell's negative paths with
+the existing bounded CLI sandbox and a synthetic executable for orchestration.
+Do not count that stub as native publication evidence; pair it with the actual
+artifact verifier. Run `pnpm check`, unit tests and two Docker lifecycle passes
+before the reviewed CI candidate. Keep generated outputs out of source control.
+No new runtime dependency, data migration or public publication is authorized
+by generation. An authorized release must upload the exact verified manifest,
+archives and generated script, establish immutable release/provenance evidence,
+and verify the public download before the README advertises it as available.

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -46,7 +46,9 @@ rotated bounds without a privileged CRUD service or weaker validation.
 `src/worlds/firebase-worlds.ts` owns direct SDK operations; `world-state.ts`
 depends on the Firebase-free `world-contract.ts` port and value types, not the
 concrete adapter. The contract owns shared client validation and the adapter
-implements it; there is no second domain model or request layer. `world-state.ts`
+implements it; the block adapter and world form reuse its world-ID contract.
+Rules retain independent validation as the authority boundary, not a generated
+client-only guard. There is no second domain model or request layer. `world-state.ts`
 owns one admission listener and at most one selected-world listener. Session,
 admission and route generations fence late callbacks/creates. React subscribes
 directly, with no parallel Jotai/Query copy. Firestore cache-only snapshots never
@@ -82,7 +84,8 @@ to make the tree symmetric.
 ## Frontend decisions
 
 - React + Vite SPA with TanStack Router; no Next.js, SSR or TanStack Start.
-- Jotai owns ephemeral UI state. Each mounted app owns its store. No identity,
+- Jotai owns shared cross-view presentation state; component-local forms and
+  selection use React state. Each mounted app owns its store. No identity,
   authentication or durable task state is inferred from a UI atom.
 - TanStack Query is the chosen future owner for non-streaming remote requests
   when needed. It is not installed without a consumer. Firestore streams need a
@@ -101,9 +104,16 @@ to make the tree symmetric.
 
 ## Trust boundaries for later design
 
+[Sandbox design](sandbox.md) owns the planned data-only prop and exploration
+boundary. It does not introduce a runtime/plugin SDK into the current app or
+extend the fixed-asset block codec. Keep future native inputs and rendering
+conformant to a versioned contract, not a second layout model.
+
 The browser is an untrusted client of server-enforced membership rules. A local
-connector must be explicitly installed, paired and running before it can expose
-selected local agents. Visiting, chatting, board editing, requesting work and
+connector must be explicitly installed, paired and running before it can receive
+remote work for selected local agents. One-shot block operations are a separate
+scoped authorization path, not a requirement to run a background process.
+Visiting, chatting, board editing, requesting work and
 executing locally are separate permissions. An optional receptionist can route
 work but cannot replace authentication or authorization.
 

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -1,6 +1,7 @@
 # Planned Office command experience
 
-Design for #174, implemented later by #177/#178. None of these commands is in
+Design for #174/#191, refined by #194 and implemented later by #177/#178.
+None of these commands is in
 the current CLI grammar. These examples are contracts to implement, not install
 instructions for a currently published extension.
 
@@ -16,6 +17,44 @@ instructions for a currently published extension.
 | `tmt office unpublish <identity>`                          | Reject new work for that published identity, without deleting local identity or retained exchanges      |
 | `tmt office unpair`                                        | Revoke remotely, then remove local credentials; offline failure reports pending revocation, not success |
 | `tmt office social <identity> --minutes 10 --max-turns 20` | Request a bounded, opt-in social session; participants may decline and workspace tools stay disabled    |
+
+## Decoration and discovery refinement
+
+The following syntax is proposed, not part of the shipped grammar. `status`
+remains local; remote discovery reports only permitted resources. Installation,
+human approval of pairing and block assignment are separate from remote work
+publication. Visitors need only a browser. Installing the extension does not
+provision a Firebase project or deploy a website.
+
+| Proposed command                                                                         | Result                                                                              |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `tmt office --help`                                                                      | Core-owned help, available without an installed extension                           |
+| `tmt office inspect --json`                                                              | Selected world, effective allowed capabilities and observation freshness            |
+| `tmt office map --json`                                                                  | Bounded permitted spatial projection, not unrestricted world enumeration            |
+| `tmt office block ls --json`                                                             | Allowed blocks and assignments, without guessing IDs                                |
+| `tmt office block show <block-id> --json`                                                | Canonical layout and revision                                                       |
+| `tmt office block apply <block-id> --file <layout.json> --if-revision <revision> --json` | Conditional complete-layout edit, confirmed by the server; stale revisions conflict |
+| `tmt office props ls --json`                                                             | The world's admitted prop catalog                                                   |
+| `tmt office props show <prop-id> --json`                                                 | Pinned version, geometry and supported data, never executable instructions          |
+
+`props` is the proposed catalog owner, replacing the earlier conversational
+`block catalog` alternative; do not implement both aliases speculatively.
+Authoring syntax is intentionally undecided until its bounded schema exists.
+No current Rules enumeration or custom-asset support is implied by this table.
+The [sandbox design](sandbox.md) owns prop admission, identity/assignment lifetime,
+untrusted content and optional contextual notices.
+
+One-shot discovery/edits should use valid scoped credentials without requiring
+`run`; continuous event/work reception requires the foreground connector.
+Grant renewal and offline expiry must be resolved in #178 before this ships.
+Non-tmux agents use the same commands. Missing or ambiguous context fails before
+mutation, never inferred from folder, pane or display name. Agent usage is:
+discover permission/catalog, read layout/revision, apply once, then summarize.
+After uncertain writes reread before retrying; never silently advance the expected
+revision to overwrite another editor. Final envelopes, byte/query bounds and
+error mappings must be fixed in the implementation ticket before adding grammar.
+
+## Typed dispatch
 
 The core Clap grammar owns syntax, help and completions for the maintained Office
 entrypoints. It produces typed invocations and dispatches to the verified extension;

--- a/docs/office/design.md
+++ b/docs/office/design.md
@@ -13,9 +13,16 @@ objects, opt into a finite social session and request revision-bound review.
 Connecting blocks is not connecting databases or automatically trusting another
 computer. Independently deployed worlds do not federate in v1.
 
-Visitors need only a browser. Bringing local agents requires an installed,
-paired and foreground-running connector. Native TMT remains usable without
+Visitors need only a browser. One-shot agent decoration requires an installed
+extension and valid scoped pairing/assignment, not a resident connector.
+Continuous local event/work reception requires a foreground-running connector.
+Credential renewal remains an implementation gate in #178. Native TMT remains usable without
 Office, Node, Firebase or a background process. No agent is a human account.
+
+The [data-only sandbox refinement](sandbox.md) owns community props, structured
+exploration, temporary/saved identity assignments and trusted contextual notices.
+Community content provides neither runtime code nor prompts. This refines the
+decoration path; the remote-work protocol below remains separately authorized.
 
 ## Ownership and identifiers
 
@@ -301,9 +308,10 @@ These are conservative PoC defaults, not existing CLI settings:
   tombstone deletion a changed deadline cannot be compared with old fields.
   Clients must never reuse an ID or silently turn an expired retry into a new
   submission. An explicit new request uses a fresh random ID and new admission.
-- Blocks: 32 by 32 tiles, one 16-color indexed palette, at most 64 KiB validated
-  decoration data. No scripts, HTML, arbitrary SVG, external URLs or embedded
-  instructions. Rendering-library choice is deferred to #179.
+- Blocks: the implemented [home block v1](../../contracts/office/block-v1.md)
+  narrows the original 64 KiB ceiling to 16 curated objects on a 32x32 grid,
+  rendered with repository-controlled SVG/CSS. Custom props require the versioned
+  sandbox successor; no arbitrary artwork is accepted by the current codec.
 - One opted-in social session per agent: at most 10 minutes and 20 agent turns,
   with a caller-configured cost ceiling. Zero workspace tools/private context by
   default. No automatic social session merely because agents stand nearby.

--- a/docs/office/sandbox.md
+++ b/docs/office/sandbox.md
@@ -1,0 +1,115 @@
+# Data-only Office sandbox
+
+Status: approved direction recorded in #194, not shipped APIs. #191 still owns
+the first real agent-decoration integration. [Architecture](architecture.md)
+describes current behavior; [commands](commands.md) owns proposed CLI syntax.
+
+## Boundary
+
+Office is an optional TMT extension. Community content inside Office is data,
+not another executable plugin system. A prop authoring API accepts declarative
+pixel data, palette indices, dimensions and bounded metadata. It never accepts
+scripts, shaders, HTML, arbitrary SVG, external asset URLs, prompts, tool calls
+or behavior hooks. Only the trusted renderer interprets a supported schema.
+The existing curated SVG primitives are repository code, not permission to
+upload SVG. No runtime SDK, marketplace or general plugin loader is needed.
+
+Authoring, world admission and placement are separate operations:
+
+1. Validate and preview a candidate; identify an immutable version by verified
+   content. Updating a prop creates a new version, not changed bytes at an old ID.
+2. A world owner explicitly admits that version to the world's available catalog.
+   Visiting or discovering a prop never installs or authorizes it automatically.
+3. An assigned agent may place admitted props within its block's bounds and
+   object budget. Layout revisions retain the existing conditional-write policy.
+
+Removing a catalog entry prevents new placement. Existing references remain
+identifiable; unavailable or unsupported assets render a bounded placeholder,
+without fetching arbitrary URLs or breaking the room. Clearing placed objects
+is a separate explicit layout edit. Distribution, referenced-asset retention
+and garbage collection must be specified before storage implementation.
+
+The fixed four-asset [home block v1](../../contracts/office/block-v1.md) remains
+unchanged. Custom props need a versioned successor contract, not permissive
+fallback decoding or a parallel layout copy. Before implementation, fix numeric
+byte/dimension/palette/catalog quotas, identifier and digest format, schema,
+storage paths, access rules and operation costs. Shared independent conformance
+vectors must cover the renderer, native input and authoritative write boundary;
+do not assume Firestore Rules can validate arbitrary artwork cheaply.
+
+## Exploration without execution
+
+Exploration returns structured, permission-filtered world/block observations,
+available prop versions, geometry and allowed operations. It does not move an
+agent, start a session, install content or grant work authority. A map is a
+permitted projection, not an unrestricted world directory. Report observation
+age and unknown/offline states rather than inventing live presence. Query scope,
+pagination and listener counts must be bounded before these endpoints ship.
+
+Capability descriptions come from trusted TMT schemas. Community names, pixels
+and metadata are untrusted data even after shape validation; visual text can
+still contain prompt injection. Initially omit free-form instructions and
+behavior descriptions, constrain labels/control characters and separate their
+origin in output. Never interpolate community text into system notices or
+agent instructions. A data sandbox reduces execution risk; it does not make
+all content safe for an already-privileged model to obey.
+
+## Identity, assignment and decoration
+
+Reuse local TMT identity UUIDs; do not create a second agent registry. A world
+owns its blocks, and a scoped assignment permits a particular device/local
+identity to edit a selected block. Both temporary and saved identities qualify.
+Names, pane titles and folders are never authority. Assignment is separate from
+publishing a remote work capability.
+
+| Event                                         | Assignment and block result                                       |
+| --------------------------------------------- | ----------------------------------------------------------------- |
+| Temporary identity conclusively retires       | End assignment authority; retain decoration as unassigned space   |
+| Saved identity is offline                     | Retain assignment, but do not claim current availability          |
+| New identity reuses a display name            | No inherited assignment or credentials                            |
+| Owner reassigns the block                     | Fence the former grant; preserve layout unless explicitly cleared |
+| Local evidence or connectivity is unavailable | Report unknown; never treat uncertainty as proof of retirement    |
+
+Do not create an enduring block automatically for every temporary identity.
+Start with explicit owner assignment; self-service seats and capacity policy are
+later work. The server cannot instantly observe a disconnected local pane.
+Before device writes ship, specify principal-to-identity binding, finite lease
+duration/renewal, revocation checks and stale-writer fencing. Local commands must
+reject retired identities; server authorization must expire without trusting
+the client to report retirement. Lease expiry suspends authority, not decoration
+retention, and is not proof that an agent died. TTL physical deletion is not an
+authorization mechanism. One-shot edits should not require a resident connector;
+define bounded grant renewal before promising that experience.
+
+## Trusted contextual notices
+
+Optional notices announce local identity creation, newly assigned space or
+changed access; they are event-driven, not random prompts or cloud broadcasts.
+Deduplicate by immutable local identity and event revision, not display name.
+Use locally known state with no per-command Firestore lookup. User configuration
+can disable advisory notices; required command errors still report normally.
+
+Never modify reply bodies, files, receipts or exact command payloads. Human-mode
+advisories may use stderr; JSON stdout retains the existing native envelope.
+Any future structured notice field needs one reviewed output contract before
+implementation. Use fixed trusted wording and safe identifiers, not community
+prose. Advertising an assignment is not authorization to install, pair or spend
+model tokens. Update the canonical installed skill only with actual commands.
+
+## Acceptance gates for implementation slices
+
+- Reject executable/unknown fields, external references, malformed palette or
+  pixels, oversized inputs and unauthorized/cross-block writes; retain positive
+  controls at full supported capacity.
+- Prove immutable-version verification, unsupported/missing-asset placeholders
+  and independent durable layout results, not a renderer-only mock.
+- Exercise temporary retirement, saved/offline identity, same-name replacement,
+  reassignment, lease expiry and disconnected stale writers.
+- Prove exploration has no installation, execution or unauthorized disclosure
+  effects; measure bounded reads/writes rather than per-frame synchronization.
+- Test notice deduplication, disabled mode, control-character handling, zero
+  added network lookups and byte-identical JSON/payload output.
+
+Implement installation/pairing and fixed-catalog agent decoration first (#191),
+then a bounded authoring/catalog slice. Social chat, arbitrary runtimes, remote
+work, guest federation and production deployment are not authorized here.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:native": "vitest run --config test/native/vitest.config.ts",
     "test:run": "vitest run",
     "lint": "oxlint test/ scripts/*.mjs",
-    "docs:format:check": "prettier --check --ignore-path .gitignore AGENTS.md ARCHITECTURE.md CONVENTIONS.md DEVELOPMENT.md RUST-REWRITE.md PERFORMANCE-BASELINE.md \".agents/skills/**/SKILL.md\" .github/pull_request_template.md \"docs/office/**/*.md\" services/office/README.md \"contracts/office/*.md\"",
+    "docs:format:check": "prettier --check --ignore-path .gitignore AGENTS.md ARCHITECTURE.md CONVENTIONS.md DEVELOPMENT.md docs/native-release-verification.md RUST-REWRITE.md PERFORMANCE-BASELINE.md \".agents/skills/**/SKILL.md\" .github/pull_request_template.md \"docs/office/**/*.md\" services/office/README.md \"contracts/office/*.md\"",
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --write test/ scripts/*.mjs tsconfig.json tsconfig.e2e.json vitest.config.ts package.json .github/workflows/ci.yml services/office/firebase.json services/office/compose.yaml \"contracts/office/*.json\"",
     "format:check": "prettier --check test/ scripts/*.mjs tsconfig.json tsconfig.e2e.json vitest.config.ts package.json .github/workflows/ci.yml services/office/firebase.json services/office/compose.yaml \"contracts/office/*.json\"",


### PR DESCRIPTION
## Scope

Closes #194, under #173. Dependency #192 / PR #193 is merged. #191 remains open for actual extension/pairing/agent commands and installed guidance.

Record the data-only prop sandbox, permission-filtered exploration, temporary/saved identity assignments and trusted optional event notices. All new Office syntax is explicitly proposed, not shipped. No runtime SDK, custom prop storage, credentials, cloud deployment or release is added.

## Primary architecture review

Reviewed head: `5b1e9beb6d7deeae955eba3b49ab78bd07c9df1d` (all 20 changed files and affected callers/tests). Read-only Luna audit supplements primary inspection.

- Reuse: world ID validation was repeated in the world create/watch adapter, block adapter and form. The existing pure world contract now owns the pattern and validator; caller-specific failure behavior remains. Rules intentionally retain independent authoritative validation. Trailing-line-terminator tests preserve existing rejection; this is not a newly discovered regex vulnerability.
- Correctness: absent block documents no longer claim `Saved · revision 0`; terminal watch failures no longer claim connection progress. DOM tests drive the actual state owner through connecting, absent, persisted and failed observations. Restoring the old absent-state label makes the new test fail for the intended text, then restoring the fix passes.
- No speculative generic store: auth observer lifetime, session/world admission generations and mounted block draft lifecycle differ. Inspection found no reason to combine these owners or mirror them into Jotai/Query. Jotai documentation now accurately distinguishes cross-view presentation from React-local forms/selection. Native boundary inventory and the existing architecture guard found no failing layer edge; this is not an exhaustive security/performance audit of every native module.
- Documentation SSOT: root architecture links to the detailed Office lifecycle map instead of copying it. Command syntax lives in commands.md; sandbox.md owns future content/lifetime policy. Corrected old all-agent-use-requires-connector and undecided-renderer wording. Sandbox data cannot provide runtime or prompt instructions, and metadata remains untrusted even after validation.
- Progressive disclosure: DEVELOPMENT.md drops from 627 to 401 lines, including five new lines explaining the verified transaction-failure budget. Release-only procedures moved intact to docs/native-release-verification.md; exact extracted content equality verified. The release skill explicitly requires that guide for relevant work; formatting coverage includes the moved file. No publication gate or evidence requirement was deleted.
- Local E2E found a genuine test timing mismatch: the generic 10-second expectation was shorter than the pinned SDK's possible 12.1875-second retry backoff. After inspecting TransactionRunner/ExponentialBackoff, only two failed-transaction assertions now allow 20 seconds, owned by the existing Firestore fixture. Default UI/scenario caps and product behavior remain unchanged. Both cases additionally require an intercepted transaction read; durable no-write-before-retry and exactly-once outcomes remain. An unchanged diagnostic rerun passing was not accepted as a fix.

## Verification

- `pnpm check`: passed on final files.
- `pnpm office:test`: 75 tests in 9 files passed.
- `pnpm test:run`: 146 tests in 14 files passed.
- `cargo test --offline --locked --manifest-path rust/Cargo.toml --test architecture`: 20 passed, using the existing task-local Rust toolchain. No native product changes; not claiming full Rust/runtime/release coverage locally.
- Existing skill-creator validator: release skill valid (reused existing isolated Python environment; no dependency added).
- All 36 local Markdown link targets in touched guidance exist; release procedure content preserved exactly.
- `docker build --target browser-tests -f services/office/Dockerfile -t tmt-office-browser:194-local .`: passed from final files. Two fresh `docker run --rm --init --shm-size=256m tmt-office-browser:194-local` runs: 19/19 passed in 38.8s and 41.3s. Each uses one worker, zero retries and no host credentials/data mounts. Existing negative Rules permission logs are expected assertions, not ignored scenario failures.
- Build still reports the existing >500 kB bundle warning. No threshold increase or speculative chunk refactor in this change.

## Delivery gates

- [x] Primary reviewed changed implementation, contracts, callers and verification.
- [x] Architecture and development guidance synchronized.
- [ ] Current-head required CI passed before any authorized merge.

One issue branch in the main checkout, no additional worktree. Installed end-user skill is unchanged because proposed Office commands do not exist yet. Numeric custom-prop quotas, credential/lease renewal and authoring grammar remain explicit implementation gates rather than invented defaults.
