### PR TITLE
fix(office): stabilize admission and block projections

### DIFF
--- a/apps/office/src/blocks/block-state.test.ts
+++ b/apps/office/src/blocks/block-state.test.ts
@@ -29,6 +29,79 @@ function fixture() {
   };
 }
 describe('one block editor lifetime', () => {
+  it('late observations cannot roll back a confirmed save or a newer remote revision', async () => {
+    const f = fixture();
+    f.changed(null);
+    f.state.edit(objects);
+    await f.state.save();
+    f.changed(null);
+    expect(f.state.getSnapshot().remote?.revision).toBe(1);
+    f.changed({ revision: 3, objects: [], updatedAtMs: 3 });
+    f.state.edit(objects);
+    f.changed({ revision: 2, objects, updatedAtMs: 2 });
+    expect(f.state.getSnapshot()).toMatchObject({
+      remote: { revision: 3, objects: [] },
+      draft: { revision: 3, objects },
+    });
+    f.state.dispose();
+  });
+  it('a newer watch revision survives an older pending save confirmation', async () => {
+    const f = fixture();
+    f.changed(null);
+    f.state.edit(objects);
+    let resolve: (block: Block) => void = () => {};
+    vi.mocked(f.port.apply).mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        })
+    );
+    const pending = f.state.save();
+    f.changed({ revision: 2, objects: [], updatedAtMs: 2 });
+    resolve({ revision: 1, objects, updatedAtMs: 1 });
+    await pending;
+    expect(f.state.getSnapshot()).toMatchObject({
+      remote: { revision: 2, objects: [] },
+      draft: null,
+      busy: false,
+    });
+    f.state.dispose();
+  });
+  it.each(['success', 'failure'])(
+    'a terminal watch failure fences late snapshots and save %s',
+    async (outcome) => {
+      const f = fixture();
+      f.changed(null);
+      f.state.edit(objects);
+      let resolve: (block: Block) => void = () => {};
+      let reject: (error: Error) => void = () => {};
+      vi.mocked(f.port.apply).mockImplementation(
+        () =>
+          new Promise((done, fail) => {
+            resolve = done;
+            reject = fail;
+          })
+      );
+      const pending = f.state.save();
+      f.failed();
+      const block = { revision: 1, objects, updatedAtMs: 1 };
+      f.changed(block);
+      if (outcome === 'success') resolve(block);
+      else reject(new Error('Late network failure'));
+      await pending;
+      expect(f.state.getSnapshot()).toMatchObject({
+        ready: false,
+        remote: null,
+        draft: null,
+        busy: false,
+        error: 'Block unavailable. Reopen the world to retry.',
+      });
+      f.state.edit(objects);
+      await f.state.save();
+      expect(f.port.apply).toHaveBeenCalledOnce();
+      f.state.dispose();
+    }
+  );
   it('keeps edits local until explicit save commits the captured revision', async () => {
     const f = fixture();
     f.changed(null);

--- a/apps/office/src/blocks/block-state.ts
+++ b/apps/office/src/blocks/block-state.ts
@@ -12,20 +12,30 @@ interface Snapshot {
 export function createBlockState(port: BlockPort, worldId: string) {
   let snapshot: Snapshot = { ready: false, remote: null, draft: null, busy: false, error: null };
   let disposed = false;
+  let watchFailed = false;
   const listeners = new Set<() => void>();
   function publish(next: Partial<Snapshot>) {
     if (disposed) return;
     snapshot = { ...snapshot, ...next };
     for (const listener of listeners) listener();
   }
+  // Transaction confirmation and watch delivery can arrive in either order.
+  // The contract has increasing revisions and no delete operation.
+  function latest(remote: Block | null): Block | null {
+    return (snapshot.remote?.revision ?? 0) > (remote?.revision ?? 0) ? snapshot.remote : remote;
+  }
   const stop = port.watch(
     worldId,
-    (remote) => publish({ ready: true, remote }),
+    (remote) => {
+      if (!watchFailed) publish({ ready: true, remote: latest(remote) });
+    },
     () => {
+      watchFailed = true;
       publish({
         ready: false,
         remote: null,
         draft: null,
+        busy: false,
         error: 'Block unavailable. Reopen the world to retry.',
       });
     }
@@ -59,12 +69,13 @@ export function createBlockState(port: BlockPort, worldId: string) {
       publish({ busy: true, error: null });
       try {
         const remote = await port.apply(worldId, draft.revision, draft.objects);
-        if (!snapshot.ready) return;
+        if (disposed || watchFailed) return;
         publish({
-          remote: (snapshot.remote?.revision ?? 0) > remote.revision ? snapshot.remote : remote,
+          remote: latest(remote),
           draft: null,
         });
       } catch (error) {
+        if (disposed || watchFailed) return;
         publish({
           error:
             error instanceof BlockConflict

--- a/apps/office/src/worlds/world-state.test.ts
+++ b/apps/office/src/worlds/world-state.test.ts
@@ -40,6 +40,24 @@ function fixture() {
 const world: World = { id: 'a'.repeat(20), name: 'Private', ownerUid: 'alice', createdAtMs: 1 };
 
 describe('private world lifetime', () => {
+  it('duplicate approval preserves the selected world and its active subscription', () => {
+    const f = fixture();
+    f.state.select(world.id);
+    f.admissions[0](true);
+    f.worlds[0](world);
+    const observed: Array<World | null> = [];
+    const unsubscribe = f.state.subscribe(() => observed.push(f.state.getSnapshot().world));
+    f.admissions[0](true);
+    expect(f.state.getSnapshot().world).toEqual(world);
+    expect(observed).not.toContain(null);
+    expect(f.port.watch).toHaveBeenCalledOnce();
+    expect(f.stopWorld).not.toHaveBeenCalled();
+    f.admissions[0](false);
+    expect(f.state.getSnapshot().world).toBeNull();
+    expect(f.stopWorld).toHaveBeenCalledOnce();
+    unsubscribe();
+    f.state.dispose();
+  });
   it('invalid local input reports validation feedback without a draft or transport', async () => {
     const f = fixture();
     f.admissions[0](true);

--- a/apps/office/src/worlds/world-state.ts
+++ b/apps/office/src/worlds/world-state.ts
@@ -72,6 +72,7 @@ export function createWorldState(session: OfficeSession, port: WorldPort) {
       uid,
       (enabled) => {
         if (disposed || current !== admissionGeneration) return;
+        if (snapshot.admission === (enabled ? 'approved' : 'waiting')) return;
         publish({ admission: enabled ? 'approved' : 'waiting', error: null });
         if (!enabled) {
           generation++;

--- a/apps/office/src/worlds/world-view.test.tsx
+++ b/apps/office/src/worlds/world-view.test.tsx
@@ -1,0 +1,95 @@
+import { createMemoryHistory } from '@tanstack/react-router';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, it, vi } from 'vitest';
+import { createSession } from '../auth/session.js';
+import { OfficeApp } from '../office-app.js';
+import { createOfficeRouter } from '../router.js';
+import { createWorldState } from './world-state.js';
+import type { World } from './world-contract.js';
+import type { Furniture } from '../blocks/block-contract.js';
+
+it('reconfirmed admission retains the mounted editor draft until an explicit save', async () => {
+  const world: World = {
+    id: 'a'.repeat(20),
+    name: 'Private studio',
+    ownerUid: 'alice',
+    createdAtMs: 1,
+  };
+  const session = createSession({
+    observe: (changed) => {
+      changed({ uid: 'alice', displayName: 'Alice' });
+      return () => {};
+    },
+    signIn: async () => {},
+    signOut: async () => {},
+    dispose: async () => {},
+  });
+  let admit: (enabled: boolean) => void = () => {};
+  let observeWorld: (value: World | null) => void = () => {};
+  const watch = vi.fn((_id: string, changed: (value: World | null) => void) => {
+    observeWorld = changed;
+    return () => {};
+  });
+  const worlds = createWorldState(session, {
+    draft: () => {
+      throw new Error('This scenario opens an existing world.');
+    },
+    create: async () => {
+      throw new Error('This scenario must not create a world.');
+    },
+    watchAdmission: (_uid, changed) => {
+      admit = changed;
+      return () => {};
+    },
+    watch,
+  });
+  const apply = vi.fn(async (_id: string, revision: number, objects: Furniture[]) => ({
+    revision: revision + 1,
+    objects,
+    updatedAtMs: 1,
+  }));
+  const stopBlock = vi.fn();
+  admit(true);
+  const router = createOfficeRouter(
+    createMemoryHistory({
+      initialEntries: [`/worlds/${world.id}`],
+    })
+  );
+  const view = render(
+    <OfficeApp
+      router={router}
+      session={session}
+      worlds={worlds}
+      blocks={{
+        watch: (_id, changed) => {
+          changed(null);
+          return stopBlock;
+        },
+        apply,
+      }}
+    />
+  );
+  try {
+    const user = userEvent.setup();
+    await waitFor(() => expect(watch).toHaveBeenCalledOnce());
+    await act(async () => observeWorld(world));
+    await user.click(await screen.findByRole('button', { name: 'Add desk' }));
+    await act(async () => admit(true));
+    expect(screen.getByText('Unsaved changes', { exact: true })).toBeDefined();
+    expect(stopBlock).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Save layout' }));
+    await screen.findByText('Saved · revision 1', { exact: true });
+    expect(apply).toHaveBeenCalledExactlyOnceWith(world.id, 0, [
+      { asset: 'desk', x: 14, y: 14, rotation: 0 },
+    ]);
+    await act(async () => admit(false));
+    expect(screen.queryByRole('region', { name: 'Office block editor' })).toBeNull();
+    expect(stopBlock).toHaveBeenCalledOnce();
+  } finally {
+    view.unmount();
+    worlds.dispose();
+    await session.dispose();
+  }
+});

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -28,6 +28,10 @@ This is not an invitation, presence or connected-agent implementation.
 `src/blocks/block-contract.ts` owns client values, catalog and footprint policy;
 `firebase-blocks.ts` implements its port using the existing initialized SDK.
 `block-state.ts` owns the server-confirmed projection and separate unsaved draft.
+Watch observations and save confirmations share one nondecreasing revision
+projection. A failed watch is terminal until the block is reopened; late
+callbacks cannot restore its content. Repeated unchanged admission leaves the
+active world subscription and editor draft intact.
 It starts in the mounted `BlockPanel` effect, is keyed by world, and disposes on
 route/admission loss. Late observations and saves cannot restore disposed data.
 `block-scene.tsx` renders controlled vector primitives; `block-view.tsx` owns
@@ -49,8 +53,10 @@ concrete adapter. The contract owns shared client validation and the adapter
 implements it; the block adapter and world form reuse its world-ID contract.
 Rules retain independent validation as the authority boundary, not a generated
 client-only guard. There is no second domain model or request layer. `world-state.ts`
-owns one admission listener and at most one selected-world listener. Session,
-admission and route generations fence late callbacks/creates. React subscribes
+owns one admission listener and at most one selected-world listener. Session and
+admission generations fence late creates; route generations also fence world
+listener callbacks. A pending creation can still navigate after its form unmounts.
+React subscribes
 directly, with no parallel Jotai/Query copy. Firestore cache-only snapshots never
 grant access or display world data; only server-confirmed observations do.
 The document contract is in `contracts/office/private-world.md`; Rules are the


### PR DESCRIPTION
## Scope

Closes #199. Focused child of architecture audit #198, under Office #173.

- Preserve the selected world and mounted editor on unchanged admission notifications.
- Use one monotonic block revision projection for both watch and save confirmations.
- Fence callbacks and save completions after terminal watch failure.
- Preserve drafts until explicit save; no schema, permission, command or production changes.

## Architecture and review

- Owners remain `world-state.ts` and `block-state.ts`; no generic store, second cache or new dependency. The former watch/save policy drift is consolidated in the existing block owner.
- Detailed resulting invariants are updated in `docs/office/architecture.md`, the root architecture's designated lifecycle owner. Root layer/dependency ownership is unchanged. The document also corrects an overstatement: route listeners are fenced, but pending creation can still navigate after form unmount; that separate finding remains tracked in #198.
- Primary reviewer: Codex; three bounded Luna audits informed #198, with independent Office review of this fix.
- Reviewed head: `502ebaaf84a896ed8bee2c87dcf9534641aab594`.
- Primary reviewed changed files, actual world/block views, Firestore adapters, contracts and existing state/browser/Rules tests. Watch and transaction reads are independent observation paths; no-delete/increasing-revision policy justifies ignoring older observations, not suppressing errors.

## Verification

- [x] Primary reviewer reviewed every changed file and relevant callers/tests.
- [x] Exact commands and results are recorded below.
- [ ] CI was checked on the current commit before authorized merge.

- Three deterministic regression cases failed original state logic, then passed the fix.
- The real-router editor regression separately failed with the original admission logic, then passed; it proves a draft remains mounted, no implicit write occurs, explicit Save uses the original revision/layout, and real revocation disposes the editor.
- Additional tests cover newer watch evidence during pending save, late success/failure after terminal watch error, and retained original failure presentation.
- `pnpm office:check`: passed.
- `pnpm office:test`: 81 tests passed in 10 files.
- `pnpm office:build`: passed.
- `pnpm check`: passed; `pnpm test:run`: 146 tests passed in 14 files.
- `git diff --check` and final Office architecture formatting: passed.
- Full isolated Office Docker browser/Rules suite passed on the runtime fix and again on the final strengthened test tree: 19 scenarios per run. Docker build also runs Office quality, all 81 DOM/unit tests on the final tree, and preview/emulator/cloud builds. No host credentials, production project or mounted host services.
- No native runtime change; no local rerun of unrelated native matrices. Existing CI selection and protection remain unchanged.

## Project lifecycle

- #199 is In Progress; audit results and deferred work are recorded in #198.
- One issue branch `fix/199-office-projection-lifetime` based on main, no additional worktree.
- PR #197 remains separate and unmerged. Its Office save assertion failed in CI, while the original runtime passed all 19 local browser scenarios. The confirmed ordering defects are relevant but do not establish the exact CI cause; no blind rerun or timeout weakening was used.
- No publishing, Firebase deployment or new Office integration. Merge only after required CI is green on the reviewed head.
