### PR TITLE
fix(test): bound native sandbox process lifetimes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -274,6 +274,14 @@ only then removes fixture state. Signals are sent only to task-owned child
 processes. No host tmux server, provider installation or global environment
 mutation is test evidence.
 
+`test/support/cli-process.ts` owns each native sandbox's active child runs;
+descriptor clones share that lifetime. Direct-child exit starts same-group
+cleanup even when descendants retain output pipes. Success requires direct
+close and confirmed group absence; cleanup failure is bounded and retains
+fixture files for diagnosis. Sandbox disposal cancels outstanding runs before
+removing files. This is not containment of descendants that create new sessions,
+and does not replace the separate Docker harness or release verifier.
+
 The native process suite proves parser, configuration, identity, response,
 exchange, talk, installation and skill contracts through the real executable.
 Docker E2E supplies private tmux, caller, lifecycle, transport and cross-process

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -252,6 +252,14 @@ before fixture deletion, and receive signals only when they are task-owned.
 Tests never use host tmux, global provider state, or process-wide environment
 mutation as setup.
 
+Use `withSandbox` for callback-owned native fixtures. Its descriptor clones
+share active runs; disposal stops outstanding commands before deleting files
+and rejects later launches. Each run has its execution deadline plus at most
+one second to confirm direct close and process-group exit. Unconfirmed cleanup
+fails and reports the retained fixture path instead of deleting potentially
+live state. Focused lifecycle regressions live in `test/tooling/cli-process.test.ts`;
+they use explicit Node fixtures, not a product-runtime fallback.
+
 ## Docker E2E
 
 Run the full private tmux/caller lifecycle harness twice for lifecycle,

--- a/test/support/cli-process.ts
+++ b/test/support/cli-process.ts
@@ -5,7 +5,15 @@ import path from 'node:path';
 import { expect } from 'vitest';
 import { resolveCliExecutables, type CliExecutable } from './cli-executable.mjs';
 
+const lifecycleKey = Symbol('sandbox process lifetime');
+interface ActiveRun {
+  result: Promise<CliResult>;
+  cleanup: Promise<void>;
+  stop: () => void;
+}
+
 export interface Sandbox {
+  readonly [lifecycleKey]: { closing: boolean; runs: Set<ActiveRun> };
   readonly cli: CliExecutable;
   readonly root: string;
   readonly cwd: string;
@@ -32,7 +40,7 @@ export interface CliRunOptions {
   readonly closeStdin?: boolean;
   /** Combined stdout/stderr bound. Reply JSON can exceed the legacy 1 MiB bound. */
   readonly outputLimitBytes?: number;
-  /** Hard process-group deadline, including startup and cleanup. */
+  /** Execution deadline; termination has a separate bounded cleanup phase. */
   readonly deadlineMs?: number;
 }
 
@@ -60,6 +68,7 @@ export function createSandbox(executableEnv: NodeJS.ProcessEnv = process.env): S
     delete env.PI_CODING_AGENT_DIR;
     delete env.OPENCODE_CONFIG_DIR;
     return {
+      [lifecycleKey]: { closing: false, runs: new Set<ActiveRun>() },
       cli,
       root,
       cwd,
@@ -82,52 +91,155 @@ export function runCli(
   args: readonly string[],
   options: CliRunOptions = {}
 ): Promise<CliResult> {
+  const lifetime = sandbox[lifecycleKey];
+  if (lifetime.closing) return Promise.reject(new Error('CLI sandbox is closing.'));
+  const run = startRun(sandbox, args, options);
+  lifetime.runs.add(run);
+  // Keep failed cleanup registered so sandbox disposal cannot delete its files.
+  void run.cleanup.then(
+    () => lifetime.runs.delete(run),
+    () => {}
+  );
+  // A callback can fail before it awaits the run; disposal still owns cleanup.
+  void run.result.catch(() => {});
+  return run.result;
+}
+
+function startRun(sandbox: Sandbox, args: readonly string[], options: CliRunOptions): ActiveRun {
   for (const key of ['TMUX', 'TMUX_PANE', 'TMUX_TEAM_HOME']) delete sandbox.env[key];
   const outputLimitBytes = options.outputLimitBytes ?? 1024 * 1024;
   const deadlineMs = options.deadlineMs ?? 5_000;
   const hasStdin = options.stdin !== undefined;
-  return new Promise((resolve, reject) => {
-    const child = spawn(sandbox.cli.executable, [...sandbox.cli.args, ...args], {
-      cwd: sandbox.cwd,
-      env: sandbox.env,
-      detached: true,
-      stdio: [hasStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
-      windowsHide: true,
-    });
+  let cleaned: () => void = () => {};
+  let cleanupFailed: (error: Error) => void = () => {};
+  const cleanup = new Promise<void>((resolve, reject) => {
+    cleaned = resolve;
+    cleanupFailed = reject;
+  });
+  let stop = () => {};
+  const result = new Promise<CliResult>((resolve, reject) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(sandbox.cli.executable, [...sandbox.cli.args, ...args], {
+        cwd: sandbox.cwd,
+        env: sandbox.env,
+        detached: true,
+        stdio: [hasStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+    } catch (error) {
+      // Synchronous argument rejection creates no process to dispose.
+      cleaned();
+      reject(error);
+      return;
+    }
     // Decode at the stream boundary so a multibyte UTF-8 character split
     // across OS chunks cannot be corrupted by per-buffer toString() calls.
-    const stdoutStream = child.stdout;
-    const stderrStream = child.stderr;
-    if (!stdoutStream || !stderrStream) throw new Error('CLI subprocess output pipes unavailable.');
+    // Both descriptors are unconditionally configured as pipes above.
+    const stdoutStream = child.stdout!;
+    const stderrStream = child.stderr!;
     stdoutStream.setEncoding('utf8');
     stderrStream.setEncoding('utf8');
     let stdout = '';
     let stderr = '';
     let outputBytes = 0;
-    let timedOut = false;
-    let outputLimitExceeded = false;
-    const killProcessGroup = (): void => {
-      if (child.pid === undefined) return;
+    let failure: Error | undefined;
+    let cleanupError: Error | undefined;
+    let inspectionError: unknown;
+    let closed: { status: number | null; signal: NodeJS.Signals | null } | undefined;
+    let groupGone = child.pid === undefined;
+    let finishing = false;
+    let settled = false;
+    let cleanupDeadline = 0;
+    const groupExists = (): boolean => {
+      if (groupGone || child.pid === undefined) return false;
       try {
-        process.kill(-child.pid, 'SIGKILL');
-      } catch {
-        child.kill('SIGKILL');
+        process.kill(-child.pid, 0);
+        return true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
+          groupGone = true;
+          return false;
+        }
+        throw error;
       }
     };
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) {
+        cleanupFailed(error);
+        child.unref();
+        child.stdin?.destroy();
+        stdoutStream.destroy();
+        stderrStream.destroy();
+        reject(
+          failure
+            ? new AggregateError([failure, error], `${failure.message} ${error.message}`)
+            : error
+        );
+      } else {
+        cleaned();
+        if (failure) reject(failure);
+        else resolve({ ...closed!, stdout, stderr });
+      }
+    };
+    const pollCleanup = (): void => {
+      if (settled) return;
+      try {
+        groupExists();
+      } catch (error) {
+        // A transient probe failure is not proof of exit. Keep polling until
+        // absence is confirmed or the cleanup deadline expires.
+        inspectionError = error;
+      }
+      if (closed && groupGone) {
+        finish(cleanupError);
+        return;
+      }
+      if (performance.now() >= cleanupDeadline) {
+        finish(
+          new Error('CLI process cleanup did not confirm close and group exit within 1000ms.', {
+            cause: cleanupError ?? inspectionError,
+          })
+        );
+        return;
+      }
+      setTimeout(pollCleanup, 10);
+    };
+    const beginCleanup = (): void => {
+      if (finishing || settled) return;
+      finishing = true;
+      clearTimeout(timer);
+      cleanupDeadline = performance.now() + 1000;
+      try {
+        // Signal once while still owned; never signal a PID after observing absence.
+        if (groupExists()) process.kill(-child.pid!, 'SIGKILL');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ESRCH') groupGone = true;
+        else cleanupError = new Error('Could not stop CLI process group.', { cause: error });
+      }
+      pollCleanup();
+    };
     const timer = setTimeout(() => {
-      timedOut = true;
-      // A selected executable may launch children; kill the process group so a
-      // timeout cannot leave that descendant running after the test exits.
-      killProcessGroup();
+      failure ??= new Error(`CLI subprocess exceeded the ${deadlineMs} millisecond test bound.`);
+      beginCleanup();
     }, deadlineMs);
+    stop = () => {
+      failure ??= new Error('CLI run cancelled during sandbox disposal.');
+      beginCleanup();
+    };
     const readOutput =
       (stream: 'stdout' | 'stderr') =>
       (chunk: Buffer | string): void => {
         const text = chunk.toString();
         outputBytes += Buffer.byteLength(text);
         if (outputBytes > outputLimitBytes) {
-          outputLimitExceeded = true;
-          killProcessGroup();
+          failure ??= new Error(
+            `CLI subprocess exceeded the ${outputLimitBytes}-byte output bound.`
+          );
+          beginCleanup();
           return;
         }
         if (stream === 'stdout') stdout += text;
@@ -136,27 +248,27 @@ export function runCli(
     stdoutStream.on('data', readOutput('stdout'));
     stderrStream.on('data', readOutput('stderr'));
     if (child.stdin) child.stdin.on('error', () => undefined);
-    if (hasStdin && child.stdin) {
-      if (options.closeStdin === false) child.stdin.write(options.stdin);
-      else child.stdin.end(options.stdin);
-    }
     child.on('error', (error) => {
-      clearTimeout(timer);
-      if (outputLimitExceeded) {
-        reject(new Error(`CLI subprocess exceeded the ${outputLimitBytes}-byte output bound.`));
-      } else reject(error);
+      failure ??= error;
+      beginCleanup();
     });
-    child.on('close', (status, signal) => {
-      clearTimeout(timer);
-      if (outputLimitExceeded) {
-        reject(new Error(`CLI subprocess exceeded the ${outputLimitBytes}-byte output bound.`));
-      } else if (timedOut) {
-        reject(new Error(`CLI subprocess exceeded the ${deadlineMs} millisecond test bound.`));
-      } else {
-        resolve({ status, signal, stdout, stderr });
+    try {
+      if (hasStdin && child.stdin) {
+        if (options.closeStdin === false) child.stdin.write(options.stdin);
+        else child.stdin.end(options.stdin);
       }
+    } catch (error) {
+      failure = new Error('Could not write CLI stdin.', { cause: error });
+      beginCleanup();
+    }
+    // Descendants can keep inherited pipes open after the direct child exits.
+    child.once('exit', beginCleanup);
+    child.on('close', (status, signal) => {
+      closed = { status, signal };
+      beginCleanup();
     });
   });
+  return { result, cleanup, stop: () => stop() };
 }
 
 export function parseWholeStdout(result: CliResult): JsonDocument {
@@ -200,9 +312,26 @@ export function fileSnapshot(root: string): Record<string, string> {
 
 export async function withSandbox<T>(callback: (sandbox: Sandbox) => T | Promise<T>): Promise<T> {
   const sandbox = createSandbox();
+  let value: T | undefined;
+  let failure: { error: unknown } | undefined;
   try {
-    return await callback(sandbox);
-  } finally {
-    rmSync(sandbox.root, { recursive: true, force: true });
+    value = await callback(sandbox);
+  } catch (error) {
+    failure = { error };
   }
+  const lifetime = sandbox[lifecycleKey];
+  lifetime.closing = true;
+  const runs = [...lifetime.runs];
+  for (const run of runs) run.stop();
+  const results = await Promise.allSettled(runs.map((run) => run.cleanup));
+  const errors = results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []));
+  if (errors.length) {
+    throw new AggregateError(
+      failure ? [failure.error, ...errors] : errors,
+      `CLI sandbox cleanup failed; retained fixture at ${sandbox.root}.`
+    );
+  }
+  rmSync(sandbox.root, { recursive: true, force: true });
+  if (failure) throw failure.error;
+  return value as T;
 }

--- a/test/tooling/cli-process.test.ts
+++ b/test/tooling/cli-process.test.ts
@@ -1,0 +1,210 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, it, vi } from 'vitest';
+import { createSandbox, runCli, withSandbox } from '../support/cli-process.js';
+
+const roots: string[] = [];
+function fixture(mode = 'exit', output = 'ignore') {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tmt-process-lifetime-'));
+  roots.push(root);
+  const marker = path.join(root, 'ready.json');
+  const script = path.join(root, 'peer.mjs');
+  fs.writeFileSync(
+    script,
+    `
+    import { spawn } from 'node:child_process';
+    import fs from 'node:fs';
+    if (process.argv[2] === 'child') {
+      process.send('ready');
+      setInterval(() => {}, 1000);
+    } else {
+      const child = spawn(process.execPath, [import.meta.filename, 'child'], {
+        stdio: ['ignore', '${output}', '${output}', 'ipc'],
+      });
+      child.once('message', () => {
+        fs.writeFileSync(process.argv[2], JSON.stringify({ child: child.pid, group: process.pid }));
+        if (process.argv[3] === 'exit') process.exit(0);
+        if (process.argv[3] === 'overflow') process.stdout.write('over the limit');
+      });
+    }
+  `
+  );
+  const cli = { executable: process.execPath, args: [script, marker, mode] };
+  return { root, marker, cli };
+}
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    throw error;
+  }
+}
+async function until(condition: () => boolean) {
+  const deadline = performance.now() + 2000;
+  while (!condition()) {
+    if (performance.now() >= deadline) throw new Error('Fixture observation timed out.');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+async function cleanup(marker: string) {
+  if (!fs.existsSync(marker)) return;
+  const { group } = JSON.parse(fs.readFileSync(marker, 'utf8')) as { group: number };
+  if (alive(-group)) process.kill(-group, 'SIGKILL');
+  await until(() => !alive(-group));
+}
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+it.each(['ignore', 'inherit'])(
+  'normal parent exit cleans descendants with %s output',
+  async (output) => {
+    const f = fixture('exit', output);
+    const sandbox = createSandbox({ TMT_TEST_CLI: JSON.stringify(f.cli) });
+    roots.push(sandbox.root);
+    try {
+      expect(await runCli(sandbox, [])).toEqual({
+        status: 0,
+        signal: null,
+        stdout: '',
+        stderr: '',
+      });
+      const pids = JSON.parse(fs.readFileSync(f.marker, 'utf8')) as {
+        child: number;
+        group: number;
+      };
+      expect(alive(pids.child)).toBe(false);
+      expect(alive(-pids.group)).toBe(false);
+      expect(fs.existsSync(sandbox.root)).toBe(true);
+    } finally {
+      await cleanup(f.marker);
+    }
+  }
+);
+
+it('synchronous spawn rejection does not leave sandbox disposal waiting', async () => {
+  let root = '';
+  await withSandbox(async (sandbox) => {
+    root = sandbox.root;
+    await expect(runCli({ ...sandbox, cli: { executable: '\0', args: [] } }, [])).rejects.toThrow();
+  });
+  expect(fs.existsSync(root)).toBe(false);
+});
+
+it('disposed sandbox clones reject new runs without recreating files', async () => {
+  const sandbox = await withSandbox((sandbox) => ({ ...sandbox }));
+  await expect(runCli(sandbox, [])).rejects.toThrow('CLI sandbox is closing');
+  expect(fs.existsSync(sandbox.root)).toBe(false);
+});
+
+it('asynchronous spawn failure preserves the error and disposes the sandbox', async () => {
+  let root = '';
+  await withSandbox(async (sandbox) => {
+    root = sandbox.root;
+    const cli = { executable: path.join(root, 'missing-command'), args: [] };
+    await expect(runCli({ ...sandbox, cli }, [])).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+  expect(fs.existsSync(root)).toBe(false);
+});
+
+it('output overflow stops the complete group and preserves its bound error', async () => {
+  const f = fixture('overflow');
+  try {
+    await withSandbox(async (sandbox) => {
+      await expect(runCli({ ...sandbox, cli: f.cli }, [], { outputLimitBytes: 1 })).rejects.toThrow(
+        'CLI subprocess exceeded the 1-byte output bound.'
+      );
+      const { group } = JSON.parse(fs.readFileSync(f.marker, 'utf8')) as { group: number };
+      expect(alive(-group)).toBe(false);
+    });
+  } finally {
+    await cleanup(f.marker);
+  }
+});
+
+it('successful callback disposal stops concurrent runs shared through clones', async () => {
+  const fixtures = [fixture('hold'), fixture('hold')];
+  const runs: Promise<unknown>[] = [];
+  let root = '';
+  try {
+    const value = await withSandbox(async (sandbox) => {
+      root = sandbox.root;
+      for (const f of fixtures) runs.push(runCli({ ...sandbox, cli: f.cli }, []));
+      await until(() => fixtures.every((f) => fs.existsSync(f.marker)));
+      return 'complete';
+    });
+    expect(value).toBe('complete');
+    for (const f of fixtures) {
+      const { group } = JSON.parse(fs.readFileSync(f.marker, 'utf8')) as { group: number };
+      expect(alive(-group)).toBe(false);
+    }
+    expect(fs.existsSync(root)).toBe(false);
+    for (const run of runs) await expect(run).rejects.toThrow('cancelled during sandbox disposal');
+  } finally {
+    for (const f of fixtures) await cleanup(f.marker);
+    await Promise.allSettled(runs);
+  }
+});
+
+it('unconfirmed group exit is bounded and retains files and the original failure', async () => {
+  const f = fixture('hold');
+  const failure = new Error('Original scenario failure');
+  const kill = process.kill.bind(process);
+  let probe: { mockRestore(): void } | undefined;
+  let sandboxRoot = '';
+  let pending: Promise<unknown> | undefined;
+  try {
+    const disposal = withSandbox(async (sandbox) => {
+      sandboxRoot = sandbox.root;
+      roots.push(sandboxRoot);
+      pending = runCli({ ...sandbox, cli: f.cli }, []);
+      await until(() => fs.existsSync(f.marker));
+      const { group } = JSON.parse(fs.readFileSync(f.marker, 'utf8')) as { group: number };
+      // Still deliver the real cleanup signal. Only this fixture's observation
+      // is held alive to prove that absence, not a successful kill, is required.
+      probe = vi
+        .spyOn(process, 'kill')
+        .mockImplementation((pid, signal) =>
+          pid === -group && signal === 0 ? true : kill(pid, signal)
+        );
+      throw failure;
+    });
+    const error = await disposal.catch((error: unknown) => error);
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toContain(failure);
+    expect((error as Error).message).toContain('retained fixture');
+    expect(fs.existsSync(sandboxRoot)).toBe(true);
+    await expect(pending).rejects.toThrow('within 1000ms');
+  } finally {
+    probe?.mockRestore();
+    await cleanup(f.marker);
+    await pending?.catch(() => {});
+  }
+}, 5_000);
+
+it('callback failure stops an unawaited run before removing the sandbox', async () => {
+  const f = fixture('hold');
+  let sandboxRoot = '';
+  let pending: Promise<unknown> | undefined;
+  const failure = new Error('Scenario failed deliberately');
+  try {
+    await expect(
+      withSandbox(async (sandbox) => {
+        sandboxRoot = sandbox.root;
+        pending = runCli({ ...sandbox, cli: f.cli }, []);
+        void pending.catch(() => {});
+        await until(() => fs.existsSync(f.marker));
+        throw failure;
+      })
+    ).rejects.toBe(failure);
+    const { group } = JSON.parse(fs.readFileSync(f.marker, 'utf8')) as { group: number };
+    expect(alive(-group)).toBe(false);
+    expect(fs.existsSync(sandboxRoot)).toBe(false);
+  } finally {
+    await cleanup(f.marker);
+    await pending?.catch(() => {});
+  }
+});


### PR DESCRIPTION
## Summary

- Keep asynchronous native test runs owned by the existing sandbox, including descriptor clones and unawaited runs.
- Begin bounded same-group cleanup on direct-child exit, including descendants that retain output pipes. Report success only after direct close and confirmed group absence.
- Preserve fixture files and original scenario errors when cleanup cannot be confirmed; reject launches after disposal.

Closes #202. Parent audit: #198.

## Architecture and review

Reviewed head: `b73d6dbe4c6766efda0c5eaf809bd9b5b10e2531`.
The primary reviewed the complete helper/test/documentation diff and existing native/tooling callers. Luna independently reviewed the lifecycle and causal assertions. The synchronous spawn-rejection path now settles cleanup, and the fixed pipe configuration removes an unreachable post-spawn error branch. No new process manager, production behavior, E2E fixture owner, or release-verifier abstraction is introduced.

Cleanup failure is an explicit bounded exception: it rejects and retains files instead of claiming direct close or group absence. This does not contain descendants that create independent sessions. Architecture and developer guidance describe the resulting owner and contract only.

## Verification

- `pnpm check`: passed, including Office quality checks.
- `pnpm test:run`: 155 tests passed.
- Matching offline locked native build plus `pnpm test:native`: 152 tests passed on the integrated main base.
- New focused scenarios cover redirected/inherited descendant pipes, synchronous/asynchronous spawn failure, output overflow, concurrent descriptor clones, callback failure, post-disposal reuse, and unconfirmed cleanup with retained files and original error.
- Existing nonzero-exit, timeout, stdin, and multibyte native contracts remain passing.
- Red evidence: the original callback-failure helper returned while the independently observed process group was still alive. Initial normal-exit red execution also hit a macOS probe error during safety cleanup, so it is not counted as clean red evidence.
- `pnpm test:e2e` twice: 167 tests passed per run; the opt-in performance case was skipped. The second run includes the newly merged PID fix. Task-owned images were removed and absence verified.
- Linux Docker `pnpm exec vitest run test/tooling/cli-process.test.ts`: all 9 new focused cases passed with `--init --network none`.

No publishing, deployment, real agents, host tmux, production Firebase, or branch-protection changes.
