### PR TITLE
fix(office): keep create navigation in the mounted view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ or present planned behavior as shipped.
 
 ## Code organization
 
+- Prefer fixes that simplify ownership and data flow over accumulating defensive patches. Before adding flags, counters, branches or abstractions, check whether moving responsibility to its natural owner or removing redundant state eliminates the defect. Judge simplicity across the affected flow, not by the smallest diff. Keep necessary trust-boundary validation and behavior tests; this is not permission for unrelated rewrites.
 - Keep production behavior, test infrastructure, fixtures, and scenario assertions in clearly separated modules.
 - Prefer small, purpose-specific interfaces and existing dependency-injection boundaries over new global state or parallel abstractions.
 - Put shared behavior in one named helper only after more than one caller needs it; keep scenario-specific behavior close to the scenario.

--- a/apps/office/src/worlds/create-world.test.tsx
+++ b/apps/office/src/worlds/create-world.test.tsx
@@ -1,0 +1,146 @@
+import { createMemoryHistory } from '@tanstack/react-router';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, it, vi } from 'vitest';
+import { createSession } from '../auth/session.js';
+import { OfficeApp } from '../office-app.js';
+import { createOfficeRouter } from '../router.js';
+import { createWorldState } from './world-state.js';
+
+const worldId = 'a'.repeat(20);
+
+function fixture() {
+  let changeUser: (user: null) => void = () => {};
+  const session = createSession({
+    observe: (changed) => {
+      changeUser = changed;
+      changed({ uid: 'alice', displayName: 'Alice' });
+      return () => {};
+    },
+    signIn: async () => {},
+    signOut: async () => changeUser(null),
+    dispose: async () => {},
+  });
+  let complete: (id: string) => void = () => {};
+  let fail: (error: Error) => void = () => {};
+  const create = vi.fn(
+    () =>
+      new Promise<string>((resolve, reject) => {
+        complete = resolve;
+        fail = reject;
+      })
+  );
+  let admit: (enabled: boolean) => void = () => {};
+  const draft = vi.fn((name: string) => ({ id: worldId, name }));
+  const worlds = createWorldState(session, {
+    draft,
+    create,
+    watchAdmission: (_uid, changed) => {
+      admit = changed;
+      changed(true);
+      return () => {};
+    },
+    watch: (_id, changed) => {
+      changed(null);
+      return () => {};
+    },
+  });
+  const router = createOfficeRouter(createMemoryHistory({ initialEntries: ['/'] }));
+  const view = render(<OfficeApp router={router} session={session} worlds={worlds} />);
+  return {
+    router,
+    worlds,
+    create,
+    draft,
+    complete: () => complete(worldId),
+    fail: () => fail(new Error('Uncertain transport')),
+    revoke: () => admit(false),
+    signOut: () => changeUser(null),
+    async start() {
+      const user = userEvent.setup();
+      await user.type(await screen.findByLabelText('World name'), 'Studio');
+      await user.click(screen.getByRole('button', { name: 'Create world' }));
+      expect(create).toHaveBeenCalledOnce();
+    },
+    async dispose() {
+      view.unmount();
+      worlds.dispose();
+      await session.dispose();
+    },
+  };
+}
+
+it('the mounted form navigates after confirmed creation', async () => {
+  const f = fixture();
+  try {
+    await f.start();
+    await act(async () => f.complete());
+    await waitFor(() => expect(f.router.state.location.pathname).toBe(`/worlds/${worldId}`));
+  } finally {
+    await f.dispose();
+  }
+});
+
+it.each(['setup', 'world', 'return'] as const)(
+  'late creation does not take over a %s navigation',
+  async (destination) => {
+    const f = fixture();
+    try {
+      await f.start();
+      await act(async () => {
+        if (destination === 'world')
+          await f.router.navigate({ to: '/worlds/$worldId', params: { worldId: 'b'.repeat(20) } });
+        else await f.router.navigate({ to: '/setup' });
+      });
+      if (destination === 'return')
+        await act(async () => {
+          await f.router.navigate({ to: '/' });
+        });
+      const location = f.router.state.location.pathname;
+      await act(async () => f.complete());
+      expect(f.router.state.location.pathname).toBe(location);
+      expect(f.worlds.getSnapshot()).toMatchObject({ busy: false, draft: null });
+      expect(f.create).toHaveBeenCalledOnce();
+    } finally {
+      await f.dispose();
+    }
+  }
+);
+
+it.each(['revoke', 'signOut'] as const)(
+  '%s prevents late creation from navigating',
+  async (action) => {
+    const f = fixture();
+    try {
+      await f.start();
+      await act(async () => f[action]());
+      await act(async () => f.complete());
+      expect(f.router.state.location.pathname).toBe('/');
+      expect(screen.queryByLabelText('World name')).toBeNull();
+    } finally {
+      await f.dispose();
+    }
+  }
+);
+
+it('a remounted form retries the same uncertain creation explicitly', async () => {
+  const f = fixture();
+  try {
+    await f.start();
+    await act(async () => {
+      await f.router.navigate({ to: '/setup' });
+    });
+    await act(async () => f.fail());
+    await act(async () => {
+      await f.router.navigate({ to: '/' });
+    });
+    expect(f.create).toHaveBeenCalledOnce();
+    await userEvent.setup().click(await screen.findByRole('button', { name: 'Retry creation' }));
+    expect(f.draft).toHaveBeenCalledOnce();
+    expect(f.create.mock.calls[1]).toEqual(f.create.mock.calls[0]);
+    await act(async () => f.complete());
+    await waitFor(() => expect(f.router.state.location.pathname).toBe(`/worlds/${worldId}`));
+  } finally {
+    await f.dispose();
+  }
+});

--- a/apps/office/src/worlds/world-view.tsx
+++ b/apps/office/src/worlds/world-view.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, useSyncExternalStore } from 'react';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Link, Navigate, useNavigate } from '@tanstack/react-router';
 import type { ReactElement, ReactNode } from 'react';
 import type { WorldState } from './world-state.js';
 import { WORLD_ID_PATTERN } from './world-contract.js';
@@ -41,17 +41,17 @@ function Admission({
 export function CreateWorld({ state }: { state: WorldState }): ReactElement {
   const [name, setName] = useState('');
   const [worldId, setWorldId] = useState('');
+  const [createdId, setCreatedId] = useState<string | null>(null);
   const { busy, error, draft } = useSyncExternalStore(state.subscribe, state.getSnapshot);
   const navigate = useNavigate();
+  if (createdId) return <Navigate to="/worlds/$worldId" params={{ worldId: createdId }} />;
   return (
     <section aria-label="Create a world">
       <h2>Create your private world</h2>
       <form
         onSubmit={(event) => {
           event.preventDefault();
-          void state.create(name).then((id) => {
-            if (id) void navigate({ to: '/worlds/$worldId', params: { worldId: id } });
-          });
+          void state.create(name).then(setCreatedId);
         }}
       >
         <label htmlFor="world-name">World name</label>

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -48,7 +48,9 @@ Rules retain independent validation as the authority boundary, not a generated
 client-only guard. There is no second domain model or request layer. `world-state.ts`
 owns one admission listener and at most one selected-world listener. Session and
 admission generations fence late creates; route generations also fence world
-listener callbacks. A pending creation can still navigate after its form unmounts.
+listener callbacks. Creation success navigation is local to the mounted create
+form and rendered through the router; unmounted forms cannot redirect a later
+view. Leaving does not cancel the write or discard its session-owned retry draft.
 React subscribes
 directly, with no parallel Jotai/Query copy. Firestore cache-only snapshots never
 grant access or display world data; only server-confirmed observations do.


### PR DESCRIPTION
## Summary

- Make successful create navigation a mounted-view concern using the existing router's Navigate component.
- Keep in-flight creation and uncertain retry identity in the existing world-state owner, without new cancellation flags, counters, or managers.
- Record simplification-first corrections in AGENTS.md and update the Office architecture definition.

Closes #205. Parent audit: #198.

## Architecture and primary review

The primary reviewed the full change, CreateWorld/WorldGate, session-owned world-state, route selection, existing retry/revocation tests, and the installed Navigate implementation. The asynchronous callback now updates only local presentation state: an unmounted form cannot render navigation or redirect a later form. Leaving the page is not cancellation of a Firestore write and cannot authorize an automatic retry.

The production diff replaces four lines with four lines. The seven real-router scenarios cover mounted success; departure to setup or another world; departure and return before completion; revocation/sign-out; and explicit retry of the same uncertain draft. No mocked navigate function, sleeps, new dependency, store, or generation counter is added. The root architecture map remains accurate; detailed view/write ownership is defined in the linked Office architecture, not duplicated there.

## Verification

- Original implementation: three navigation regressions fail, four positive/authorization/retry controls pass.
- Corrected implementation: all seven focused scenarios pass.
- `pnpm office:check`, `pnpm office:test` (88 passed), and `pnpm office:build`: passed.
- `pnpm check` and `pnpm test:run` (155 passed): passed.
- Existing isolated Office browser/emulator gate: 19 passed; container build also passed Office quality, all 88 DOM/state tests, and preview/emulator/cloud builds. No host credentials or real Firebase project used.

No production Firebase, schema/Rules changes, native CLI changes, release, deployment, or CI/protection changes.
