### PR TITLE
fix(office): decouple save confirmation from watch recovery

### DIFF
--- a/apps/office/e2e/blocks.spec.ts
+++ b/apps/office/e2e/blocks.spec.ts
@@ -90,6 +90,34 @@ test('owner arranges, explicitly saves, reopens and loses block access on revoca
   await expect(page.getByRole('region', { name: 'Office block editor' })).toHaveCount(0);
 });
 
+test('save confirmation uses the available request channel while watches reconnect', async ({
+  openSession,
+}) => {
+  const { page, context } = await openSession();
+  const { worldId } = await prepareStudio(page);
+  await page.getByRole('button', { name: 'Add desk', exact: true }).click();
+  let blockedWatches = 0;
+  // GAPI probes connectivity after an offline event; block the optional probe.
+  await context.route('https://www.google.com/images/cleardot.gif*', (route) => route.abort());
+  await context.setOffline(true);
+  await context.route('http://127.0.0.1:8080/**', (route) => {
+    if (route.request().url().includes('/Listen/')) {
+      blockedWatches++;
+      return route.abort('internetdisconnected');
+    }
+    return route.continue();
+  });
+  await context.setOffline(false);
+  await page.getByRole('button', { name: 'Save layout', exact: true }).click();
+  await expect
+    .poll(() => readBlockDocument(worldId))
+    .toMatchObject({
+      fields: { revision: { integerValue: '1' } },
+    });
+  expect(blockedWatches).toBeGreaterThan(0);
+  await expect(page.getByText('Saved · revision 1', { exact: true })).toBeVisible();
+});
+
 test('a disconnected save keeps a local draft and reconnect cannot silently publish it', async ({
   openSession,
 }) => {

--- a/apps/office/src/blocks/firebase-blocks.ts
+++ b/apps/office/src/blocks/firebase-blocks.ts
@@ -1,11 +1,4 @@
-import {
-  doc,
-  getDocFromServer,
-  onSnapshot,
-  runTransaction,
-  serverTimestamp,
-  Timestamp,
-} from 'firebase/firestore';
+import { doc, onSnapshot, runTransaction, serverTimestamp, Timestamp } from 'firebase/firestore';
 import type { Firestore } from 'firebase/firestore';
 import { FirebaseError } from 'firebase/app';
 import { validWorldId } from '../worlds/world-contract.js';
@@ -65,6 +58,8 @@ export function createBlockPort(db: Firestore): BlockPort {
         throw new Error('Invalid block edit.');
       }
       const target = reference(worldId);
+      // One-shot confirmation must not depend on the watch channel reconnecting.
+      const readCurrent = () => runTransaction(db, (transaction) => transaction.get(target));
       try {
         await runTransaction(db, async (transaction) => {
           const snapshot = await transaction.get(target);
@@ -83,7 +78,7 @@ export function createBlockPort(db: Firestore): BlockPort {
         // transaction. Classify it only after a fresh, authorized server read;
         // never turn a revoked/foreign user's denial into a conflict or success.
         if (error instanceof FirebaseError && error.code === 'permission-denied') {
-          const observed = await getDocFromServer(target).catch(() => {
+          const observed = await readCurrent().catch(() => {
             throw error;
           });
           if (observed.exists()) {
@@ -97,7 +92,7 @@ export function createBlockPort(db: Firestore): BlockPort {
       }
       // A separate server read confirms canonical timestamps without relying on
       // pending-write snapshots. It may observe a newer edit, which must be kept.
-      const saved = await getDocFromServer(target);
+      const saved = await readCurrent();
       if (!saved.exists()) throw new Error('Block unavailable.');
       return readBlock(saved.data());
     },

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -34,6 +34,9 @@ selection and controls. No canvas engine, generic scene framework, new global
 store or remote-state copy is introduced. Pointer selection/tile placement and
 equivalent numeric/keyboard controls edit locally; explicit Save uses the
 revision-checked Firestore transaction. Agent assignment and commands are not implemented. The contract and shared validation vectors live in `contracts/office`.
+Save confirmation and conflict inspection use one-shot transaction reads in the
+same adapter, independent of watch-channel recovery. Watch snapshots remain
+the ongoing projection, not an acknowledgment channel for explicit saves.
 The pure contract's sole codec converts readable furniture maps to four-character
 storage tokens, allowing Rules to validate all 16 objects and exact rotated
 bounds within their expression budget.


### PR DESCRIPTION
## Summary

- Keep block-save confirmation and conflict inspection on one-shot transaction reads in the existing adapter.
- Leave snapshot listeners responsible only for ongoing remote projections.
- Add a real-browser regression that blocks Listen while allowing transaction RPCs and independently verifies the committed revision before expecting UI confirmation.

Closes #207. Parent audit: #198. Unblocks investigation of #206 / #205.

## Evidence and limits

CI on #206 failed the existing disconnected-save scenario after explicit reconnect retry. Five local repetitions of that original scenario passed; the historical CI cause is not claimed conclusively.

A deterministic related defect is proven on unchanged main: with watch transport blocked, the write commits revision 1 but getDocFromServer cannot confirm it. The independent emulator read passes, blocked Listen requests are observed, and the UI reports an unconfirmed save. The final regression fails only the saved-state assertion on the original runtime and passes with this correction. The installed SDK implements getDocFromServer using a snapshot listener.

## Architecture and primary review

Reviewed the full adapter/test/docs diff, block-state revision projection, existing Rules/conflict/retry scenarios, fixture network boundaries and the installed SDK read path. The local readCurrent closure shares the two one-shot read callers; no manager, dependency, cancellation counter, write replay or larger timeout is introduced. A read-only transaction preserves server authorization and canonical decoding without adding a listener. Permission-denied fallback retains the original error when inspection is denied.

The test blocks GAPI's optional connectivity probe after an offline event; it does not allow another external destination. Browser/Firestore data and credentials are demo-only. Detailed ownership is maintained in Office architecture; the root map still points to that definition.

## Verification

- Final focused original runtime: causal failure after independent committed-state and blocked-watch assertions.
- Corrected focused browser scenario: passed.
- `pnpm check`, `pnpm test:run` (155 passed), Office checks/tests (81 passed): passed.
- Docker build: Office check, DOM tests, preview/emulator/cloud builds passed.
- Full isolated browser/Rules suite twice: 20 passed each (40.5s and 41.7s), including the original disconnected-save scenario. Diagnostic containers and images removed after preserving local red evidence.

No production Firebase, CLI, schema, Rules, release, navigation or CI/protection changes.
