### PR TITLE
feat(office): add explicit optional companion lifecycle

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -109,8 +109,9 @@ jobs:
           TMT_NATIVE_REAL_CARGO=$(command -v cargo)
           export TMT_NATIVE_REAL_CARGO
           export CARGO="$GITHUB_WORKSPACE/scripts/native-cargo.sh"
-          dist plan --output-format=json --no-local-paths > "$RUNNER_TEMP/plan.json"
-          dist build --artifacts global --output-format=json --no-local-paths > "$RUNNER_TEMP/dist-manifest.json"
+          version=$(cargo metadata --manifest-path rust/Cargo.toml --locked --no-deps --format-version 1 | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).packages.find(p => p.name === "tmt-cli").version')
+          dist plan --tag "v$version" --output-format=json --no-local-paths > "$RUNNER_TEMP/plan.json"
+          dist build --tag "v$version" --artifacts global --output-format=json --no-local-paths > "$RUNNER_TEMP/dist-manifest.json"
           cp "$RUNNER_TEMP/dist-manifest.json" target/distrib/dist-manifest.json
           node scripts/generate-native-bootstrap.mjs --manifest target/distrib/dist-manifest.json --archive-dir target/distrib --plan "$RUNNER_TEMP/plan.json" > target/distrib/tmt-installer.sh
           sh -n target/distrib/tmt-installer.sh

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,7 +61,7 @@ jobs cannot satisfy either gate. No passing zero-test configuration is allowed.
 
 ## Runtime layers
 
-The three Rust crates have deliberately narrow responsibilities:
+The Rust crates have deliberately narrow responsibilities:
 
 | Layer             | Owner                           | Responsibility                                                                                                                                                                                                                              |
 | ----------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -74,6 +74,14 @@ dependency guard. It follows the actual Rust module tree, checks reviewed
 layer edges and shared declaration ownership, and fails closed for unsupported
 module remapping or incomplete discovery. It is a syntactic guard and never
 replaces review of behavior or effects.
+
+The optional `rust/crates/tmt-office` executable is independently versioned and
+currently implements only the internal compatibility probe. It depends on core,
+not the CLI, Firebase or SQLite. `tmt-core::office_protocol` owns the fixed typed
+handshake; `tmt-adapters::office_companion` verifies active installation ownership
+and composes the existing bounded subprocess runner under the installer lock.
+Its contract is [native companion handshake](contracts/office/native-companion.md).
+This is not public Office command support, pairing or a background connector.
 
 ## Public command boundary
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,7 +81,8 @@ not the CLI, Firebase or SQLite. `tmt-core::office_protocol` owns the fixed type
 handshake; `tmt-adapters::office_companion` verifies active installation ownership
 and composes the existing bounded subprocess runner under the installer lock.
 Its contract is [native companion handshake](contracts/office/native-companion.md).
-This is not public Office command support, pairing or a background connector.
+The public `office` subtree composes installation and this local probe; pairing
+and background connection remain unimplemented.
 
 ## Public command boundary
 
@@ -101,7 +102,9 @@ The maintained public surface is:
   `reply`, `result`, `talk`/`send`, `check`/`read`;
 - managed native updates through `upgrade`/`update`, with the hidden
   `__native-install` and `__native-refresh-skills` composition points used by
-  verified release tooling.
+  verified release tooling;
+- optional `office`, `office install|upgrade|status|uninstall`. Installation
+  requires consent; noninteractive root/status never download or prompt.
 
 The grammar owns option placement and rejection. Handlers do not search raw
 argv, create competing option parsers, or reinterpret payload text as flags.
@@ -252,7 +255,18 @@ both products use the same acquisition, receipt and atomic publication path.
 Office's command link, lock and current release are independent of the CLI's;
 existing CLI receipts retain their format. Manifest selection uses product and
 target together, rejecting ambiguous or multiply owned artifacts. This internal
-path is not a public Office installer, pairing implementation or release claim.
+path also serves public Office installation. `office_command` owns consent and
+typed composition, not a second downloader. Default Office prefix is the user's
+`.local`, independent of application configuration; `--prefix` selects another
+owned installation. Public distribution and pairing remain separate gates.
+GitHub selection filters CLI `v` and Office `tmt-office-v` tags independently.
+Downloaded bytes feed the same bounded artifact verifier directly; there is no
+extra download-to-disk/read-back stage. Before activating Office, publication
+executes the bounded versioned probe and rejects incompatible candidates.
+Removal validates ownership and deactivates links without deleting releases,
+skills or application data. It is recoverable, not a multi-file atomic deletion:
+a missing command link with a retained activation is reported as invalid and
+explicit uninstall can finish that state.
 
 - `artifact` consumes cargo-dist metadata and a matching archive, checking
   target, manifest membership, SHA-256, bounded compressed/expanded input,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -237,6 +237,15 @@ replaces an unmanaged path.
 Native executable installation is a different owner under
 `tmt-adapters::native_install`:
 
+Core's fixed `native_install::Product` policy owns CLI/Office package identity,
+inventory and installation namespace; it has no filesystem or network effects.
+The hidden offline installer accepts an explicit product (CLI by default), while
+both products use the same acquisition, receipt and atomic publication path.
+Office's command link, lock and current release are independent of the CLI's;
+existing CLI receipts retain their format. Manifest selection uses product and
+target together, rejecting ambiguous or multiply owned artifacts. This internal
+path is not a public Office installer, pairing implementation or release claim.
+
 - `artifact` consumes cargo-dist metadata and a matching archive, checking
   target, manifest membership, SHA-256, bounded compressed/expanded input,
   notices and executable contents;

--- a/NATIVE-INSTALL.md
+++ b/NATIVE-INSTALL.md
@@ -1,5 +1,14 @@
 # TMT native alpha installation
 
+For an optional `tmt-office` archive, use an installed native CLI:
+`tmt office install --yes --archive <archive.tar.gz> --manifest <dist-manifest.json>`.
+Then run `tmt office status`. Add the same `--prefix <folder>` to both commands
+for a custom installation. Office is independently versioned and currently only
+provides a local compatibility probe; installation does not pair, open a world
+or start a service. No public Office release is available yet.
+
+The remaining instructions apply to the core `tmt` archive.
+
 This archive contains the standalone Rust native alpha runtime. It needs no
 Node.js, npm, pnpm, Rust toolchain or source checkout to run. tmux and socket
 access are required for binding, sending and capturing live panes, not for

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ failure handling, or `tmt help` for command options.
 
 ## Development
 
+Office is an optional work in progress. Its CLI installation/status commands are
+implemented, but pairing and a public Office release are not available yet. See
+[Office commands](docs/office/commands.md); ordinary TMT use does not require it.
+
 Contributor-only requirements and checks are in [development](DEVELOPMENT.md).
 See [architecture](ARCHITECTURE.md) for runtime and test ownership.
 

--- a/contracts/office/README.md
+++ b/contracts/office/README.md
@@ -14,6 +14,9 @@ real Rules tests, not derived from implementation output.
 
 ## Single source of truth
 
+The [native companion handshake](native-companion.md) is an implemented internal
+local boundary, independently versioned from the remote work-handoff proposal.
+
 - `v1.schema.json` is JSON Schema 2020-12 for the initial work handoff ingress:
   negotiation offer, human work submission, connector evidence and final export.
 - `examples.json` contains valid wire examples. Authentication is supplied by

--- a/contracts/office/native-companion.md
+++ b/contracts/office/native-companion.md
@@ -1,0 +1,37 @@
+# Native companion handshake v1
+
+This internal local protocol is separate from the proposed remote work-handoff
+schema. It grants no Office access and does not replace pairing.
+
+The core-owned `OfficeInvocation` currently has one operation: `Probe`. Its exact
+argument vector is `__tmt-office`, `1`, `probe`. Unknown versions, operations,
+extra arguments and non-UTF-8 arguments fail with exit 1, empty stdout and a brief
+stderr diagnostic. There is no arbitrary argv forwarding or shell evaluation.
+
+Successful output is exactly two LF-terminated UTF-8 lines:
+
+```text
+TMT-OFFICE/1
+0.1.0-alpha.1
+```
+
+The second line is the companion's canonical package version, independent of
+the CLI version. The adapter allows at most 1024 bytes per output stream and a
+five-second execution deadline. Success requires exit 0, empty stderr, an exact
+supported handshake and a version matching the verified installation receipt.
+The fixed header identifies this explicit child response, never terminal scrollback.
+
+Only a verified active Office installation may be probed. The installer lock
+holds the selected release current during bounded execution; no PATH lookup or
+fallback to another executable is permitted. The existing subprocess owner
+handles deadline, output limits and cleanup. Handshake success says nothing about
+pairing, remote availability, granted capabilities or service startup.
+
+`tmt-core::office_protocol` owns request encoding and response validation, with
+literal positive/negative test vectors. The separate `tmt-office` executable has
+no Firebase, SQLite or networking dependency. It is currently excluded from
+public distribution. Synthetic archive process tests exercise the real compiled
+companion but are not cargo-dist artifact or public installer acceptance.
+
+Future operations require a reviewed typed contract before implementation.
+Do not reuse this probe response as a generic payload or remote authentication.

--- a/contracts/office/native-companion.md
+++ b/contracts/office/native-companion.md
@@ -18,20 +18,22 @@ TMT-OFFICE/1
 The second line is the companion's canonical package version, independent of
 the CLI version. The adapter allows at most 1024 bytes per output stream and a
 five-second execution deadline. Success requires exit 0, empty stderr, an exact
-supported handshake and a version matching the verified installation receipt.
+supported handshake and a version matching the verified receipt or candidate
+artifact during pre-activation validation.
 The fixed header identifies this explicit child response, never terminal scrollback.
 
-Only a verified active Office installation may be probed. The installer lock
-holds the selected release current during bounded execution; no PATH lookup or
+Only a verified owned release or staged candidate may be probed. The installer
+lock protects that selection during bounded execution; no PATH lookup or
 fallback to another executable is permitted. The existing subprocess owner
 handles deadline, output limits and cleanup. Handshake success says nothing about
 pairing, remote availability, granted capabilities or service startup.
 
 `tmt-core::office_protocol` owns request encoding and response validation, with
 literal positive/negative test vectors. The separate `tmt-office` executable has
-no Firebase, SQLite or networking dependency. It is currently excluded from
-public distribution. Synthetic archive process tests exercise the real compiled
-companion but are not cargo-dist artifact or public installer acceptance.
+no Firebase, SQLite or networking dependency. Local cargo-dist packaging is
+available; no public release has been published. Synthetic archive process tests
+exercise the real compiled companion. The independent native artifact verifier
+separately checks actual Office archives; neither constitutes public publication.
 
 Future operations require a reviewed typed contract before implementation.
 Do not reuse this probe response as a generic payload or remote authentication.

--- a/docs/native-release-verification.md
+++ b/docs/native-release-verification.md
@@ -166,6 +166,14 @@ with the same payload. Receipts record local-archive provenance, not authenticat
 public release provenance. Keep application state isolated separately when running
 identity/profile commands; installing the executable must not open a database.
 
+The internal `--product office` selector uses the same offline verifier/publisher
+for a `tmt-office` package and executable. Omission selects the CLI unchanged.
+Office installs under `lib/tmt-office` with only `bin/tmt-office`; it must not
+modify CLI links, receipts, application state or managed skills. Verify coexistence,
+cross-product rejection and interruption in isolated prefixes. Copied CLI binaries
+in synthetic Office test archives prove installation behavior only, not an actual
+Office companion, protocol compatibility or public distribution.
+
 Native adapter tests cover bounded archive acquisition and publication failures;
 native process contracts use the existing executable selector and sandbox. Test
 current/receipt tampering, manager collisions, pin changes, interrupted staging,

--- a/docs/native-release-verification.md
+++ b/docs/native-release-verification.md
@@ -172,7 +172,11 @@ Office installs under `lib/tmt-office` with only `bin/tmt-office`; it must not
 modify CLI links, receipts, application state or managed skills. Verify coexistence,
 cross-product rejection and interruption in isolated prefixes. Copied CLI binaries
 in synthetic Office test archives prove installation behavior only, not an actual
-Office companion, protocol compatibility or public distribution.
+Office companion, protocol compatibility or public distribution. The native
+process suite now separately copies the compiled `tmt-office` into synthetic
+archives and exercises its exact versioned probe. Build the workspace first;
+a missing companion is an error, never a fallback to the CLI. This additional
+evidence does not replace real cargo-dist archive and distribution acceptance.
 
 Native adapter tests cover bounded archive acquisition and publication failures;
 native process contracts use the existing executable selector and sandbox. Test

--- a/docs/native-release-verification.md
+++ b/docs/native-release-verification.md
@@ -51,6 +51,9 @@ The PR smoke matrix verifies raw native runtimes, not release archives.
 #135 introduced archive generation; later slices delivered installation.
 The target inventory and artifact metadata live in `dist-workspace.toml` and
 the generated cargo-dist manifest, not another TMT release catalog.
+Select the CLI release explicitly with `--tag v<CLI-version>` for direct
+`dist plan`/`dist build` calls: Office is independently versioned. The maintained
+build script resolves the selected package version from Cargo automatically.
 
 Install the pinned developer tools into a chosen tool directory (not needed by
 end users): cargo-dist 0.32.0 with `cargo install --locked`, and cargo-about
@@ -177,6 +180,31 @@ process suite now separately copies the compiled `tmt-office` into synthetic
 archives and exercises its exact versioned probe. Build the workspace first;
 a missing companion is an error, never a fallback to the CLI. This additional
 evidence does not replace real cargo-dist archive and distribution acceptance.
+
+### Office archives
+
+Generate an actual matching-host Office archive with the same toolchain and
+target policy, selecting Office's runtime dependency notices:
+
+```sh
+scripts/build-native-artifact.sh aarch64-apple-darwin office > /absolute/office-manifest.json
+node scripts/verify-native-artifact.mjs --product office \
+  --manifest /absolute/office-manifest.json \
+  --archive target/distrib/tmt-office-aarch64-apple-darwin.tar.gz \
+  --target aarch64-apple-darwin \
+  --notices rust/target/native-notices/THIRD-PARTY-NOTICES.txt --license LICENSE
+```
+
+Build products sequentially and retain their manifests, archives and generated
+notices separately before another build overwrites distribution output. The
+same bounded independent verifier checks inventory, hashes, notices and linkage;
+Office runtime proof requires its exact probe without creating application state,
+not CLI-only skill/SQLite commands. Follow with `office install --yes --archive
+<archive> --manifest <manifest> --prefix <task-owned-prefix>`, status, repeat
+installation and explicit uninstall. Inspect surviving bytes after rejected
+candidates and deactivation. Public availability is a separate authorized gate;
+local cargo-dist's package selection tag does not publish a Git tag. Public Office
+discovery uses `tmt-office-v<version>`; the existing CLI workflow remains CLI-only.
 
 Native adapter tests cover bounded archive acquisition and publication failures;
 native process contracts use the existing executable selector and sandbox. Test

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -83,8 +83,10 @@ Firebase setup is implied.
 There is no work connector, deployable service or shared browser runtime package yet.
 The independently versioned native `tmt-office` companion currently implements
 only the [internal local handshake](../../contracts/office/native-companion.md).
-It has no cloud access or public distribution; ordinary CLI operations do not
-execute or probe it. Shared native protocol values remain in the existing core.
+It has no cloud access or public distribution. The CLI's explicit `office`
+subtree installs, inspects, updates and deactivates it through existing native
+owners; other CLI operations do not execute or probe it. Shared native protocol
+values remain in the existing core.
 Create each only with its first concrete consumer and reviewed contract.
 Do not relocate established Rust, test, script or canonical skill paths simply
 to make the tree symmetric.

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -80,7 +80,11 @@ Firebase setup is implied.
 | `rust/`            | Existing local CLI, domain and concrete adapters                 | Office assets, Node or a Firebase account required by ordinary commands |
 | `docs/office`      | Definitions, scenarios and operational guidance                  | Describing planned behavior as shipped                                  |
 
-There is no connector crate, deployable service or shared runtime package yet.
+There is no work connector, deployable service or shared browser runtime package yet.
+The independently versioned native `tmt-office` companion currently implements
+only the [internal local handshake](../../contracts/office/native-companion.md).
+It has no cloud access or public distribution; ordinary CLI operations do not
+execute or probe it. Shared native protocol values remain in the existing core.
 Create each only with its first concrete consumer and reviewed contract.
 Do not relocate established Rust, test, script or canonical skill paths simply
 to make the tree symmetric.

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -1,7 +1,39 @@
-# Planned Office command experience
+# Office command experience
 
-Status: proposed commands, not part of the current CLI grammar or instructions
-for an available extension.
+## Implemented local installation
+
+The CLI exposes `office install`, `upgrade`, `status` and `uninstall`. Office is
+optional and independently versioned; no public Office release is available yet.
+Source builds and explicit local archives can exercise this boundary. Do not
+confuse successful local installation with pairing or a running connector.
+
+```sh
+tmt office install --yes
+tmt office status --json
+tmt office upgrade
+tmt office uninstall --yes
+```
+
+All accept `--prefix <folder>` inside the Office subtree; omission selects
+`~/.local`. Use the same prefix for subsequent operations. First installation
+defaults to alpha; install/upgrade retain the recorded channel unless explicitly
+given `--channel stable|alpha`. Office uses immutable `tmt-office-v<version>` releases
+and the shared native archive verifier. Explicit offline installation uses
+`office install --yes --archive <file> --manifest <file>` with both inputs.
+Without a published candidate, online installation fails rather than claiming
+success. `tmt upgrade` continues to update only the CLI and its managed skills.
+
+`status --json` returns `installed`, `version`, `protocolVersion` and `executable`
+after local ownership/integrity and handshake verification. It never checks cloud
+availability. Plain `tmt office` currently reports `OFFICE_NOT_PAIRED` after a
+successful probe; world opening and pairing are not implemented. Uninstall
+requires explicit consent and removes verified activation links only. Release
+files and unrelated data remain. A partial removal reports an invalid
+installation; repeat explicit uninstall to finish before reinstalling.
+
+## Planned connected commands
+
+The following connected behaviors are proposals, not installed instructions.
 
 | Command                                                    | Planned behavior                                                                                        |
 | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
@@ -55,8 +87,9 @@ error mappings must be fixed in the implementation ticket before adding grammar.
 
 The core Clap grammar owns syntax, help and completions for the maintained Office
 entrypoints. It produces typed invocations and dispatches to the verified extension;
-handlers never slice argv again. A versioned internal invocation contract
-must be defined before the executable boundary exists. Do not create a generic
+handlers never slice argv again. The versioned
+[internal handshake](../../contracts/office/native-companion.md) defines the
+current executable boundary. Do not create a generic
 plugin platform or move all TMT commands into extensions.
 
 ## Missing extension

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1269,6 +1269,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tmt-office"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "tmt-core",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/tmt-core", "crates/tmt-adapters", "crates/tmt-cli"]
+members = ["crates/tmt-core", "crates/tmt-adapters", "crates/tmt-cli", "crates/tmt-office"]
 resolver = "3"
 
 [workspace.package]

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -12,6 +12,8 @@ mod json_document;
 #[cfg(unix)]
 pub mod native_install;
 #[cfg(unix)]
+pub mod office_companion;
+#[cfg(unix)]
 pub mod process;
 #[cfg(unix)]
 mod release_http;

--- a/rust/crates/tmt-adapters/src/native_install/artifact.rs
+++ b/rust/crates/tmt-adapters/src/native_install/artifact.rs
@@ -50,18 +50,55 @@ pub(super) fn acquire_product(
     target: &str,
 ) -> io::Result<Artifact> {
     let bytes = bounded_file::read_no_follow(manifest, MANIFEST_LIMIT).map_err(io::Error::other)?;
-    let manifest: Value = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
     let name = archive
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| invalid("Native archive requires an ASCII filename."))?;
-    let (version, sha256) = metadata(product, &manifest, name, target)?;
+    let (version, sha256) = metadata_bytes(product, &bytes, name, target)?;
     let compressed =
         bounded_file::read_no_follow(archive, COMPRESSED_LIMIT).map_err(io::Error::other)?;
-    if digest(&compressed) != sha256 {
+    verified_archive(product, name, target, version, sha256, &compressed)
+}
+
+pub(super) fn acquire_bytes(
+    product: Product,
+    manifest: &[u8],
+    name: &str,
+    compressed: &[u8],
+    target: &str,
+) -> io::Result<Artifact> {
+    let (version, sha256) = metadata_bytes(product, manifest, name, target)?;
+    verified_archive(product, name, target, version, sha256, compressed)
+}
+
+fn metadata_bytes(
+    product: Product,
+    bytes: &[u8],
+    name: &str,
+    target: &str,
+) -> io::Result<(Version, String)> {
+    if bytes.len() > MANIFEST_LIMIT {
+        return Err(invalid("Native manifest exceeds its bound."));
+    }
+    let manifest: Value = serde_json::from_slice(bytes).map_err(io::Error::other)?;
+    metadata(product, &manifest, name, target)
+}
+
+fn verified_archive(
+    product: Product,
+    name: &str,
+    target: &str,
+    version: Version,
+    sha256: String,
+    compressed: &[u8],
+) -> io::Result<Artifact> {
+    if compressed.len() > COMPRESSED_LIMIT {
+        return Err(invalid("Native archive exceeds its bound."));
+    }
+    if digest(compressed) != sha256 {
         return Err(invalid("Native archive checksum mismatch."));
     }
-    let files = decode(product, &compressed, archive_root(name)?)?;
+    let files = decode(product, compressed, archive_root(name)?)?;
     Ok(Artifact {
         name: name.into(),
         version,

--- a/rust/crates/tmt-adapters/src/native_install/artifact.rs
+++ b/rust/crates/tmt-adapters/src/native_install/artifact.rs
@@ -2,7 +2,7 @@
 //!
 //! Never use generic archive unpacking: archive paths are not filesystem targets.
 
-use super::invalid;
+use super::{Product, invalid};
 use crate::bounded_file;
 pub(super) use crate::content_digest::sha256 as digest;
 use flate2::read::MultiGzDecoder;
@@ -17,12 +17,8 @@ use std::{
 pub(super) const COMPRESSED_LIMIT: usize = 64 * 1024 * 1024;
 pub(super) const MANIFEST_LIMIT: usize = 4 * 1024 * 1024;
 const EXPANDED_LIMIT: usize = 128 * 1024 * 1024;
-pub(super) const FILES: [&str; 4] = [
-    "tmt",
-    "LICENSE",
-    "NATIVE-INSTALL.md",
-    "THIRD-PARTY-NOTICES.txt",
-];
+#[cfg(test)]
+pub(super) const FILES: [&str; 4] = Product::Cli.files();
 
 #[derive(Debug)]
 pub(super) struct Artifact {
@@ -42,20 +38,30 @@ impl Artifact {
     }
 }
 
+#[cfg(test)]
 pub(super) fn acquire(manifest: &Path, archive: &Path, target: &str) -> io::Result<Artifact> {
+    acquire_product(Product::Cli, manifest, archive, target)
+}
+
+pub(super) fn acquire_product(
+    product: Product,
+    manifest: &Path,
+    archive: &Path,
+    target: &str,
+) -> io::Result<Artifact> {
     let bytes = bounded_file::read_no_follow(manifest, MANIFEST_LIMIT).map_err(io::Error::other)?;
     let manifest: Value = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
     let name = archive
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| invalid("Native archive requires an ASCII filename."))?;
-    let (version, sha256) = metadata(&manifest, name, target)?;
+    let (version, sha256) = metadata(product, &manifest, name, target)?;
     let compressed =
         bounded_file::read_no_follow(archive, COMPRESSED_LIMIT).map_err(io::Error::other)?;
     if digest(&compressed) != sha256 {
         return Err(invalid("Native archive checksum mismatch."));
     }
-    let files = decode(&compressed, archive_root(name)?)?;
+    let files = decode(product, &compressed, archive_root(name)?)?;
     Ok(Artifact {
         name: name.into(),
         version,
@@ -65,18 +71,33 @@ pub(super) fn acquire(manifest: &Path, archive: &Path, target: &str) -> io::Resu
     })
 }
 
-pub(super) fn select(manifest: &[u8], target: &str) -> io::Result<(String, Version)> {
+pub(super) fn select(
+    product: Product,
+    manifest: &[u8],
+    target: &str,
+) -> io::Result<(String, Version)> {
     if manifest.len() > MANIFEST_LIMIT {
         return Err(invalid("Native manifest exceeds its bound."));
     }
     let manifest: Value = serde_json::from_slice(manifest).map_err(io::Error::other)?;
+    let releases = manifest["releases"]
+        .as_array()
+        .ok_or_else(|| invalid("Native manifest releases are missing."))?;
     let matches = manifest["artifacts"]
         .as_object()
         .ok_or_else(|| invalid("Native manifest artifacts are missing."))?
         .iter()
-        .filter(|(_, value)| {
+        .filter(|(name, value)| {
             value["kind"] == "executable-zip"
                 && value["target_triples"] == serde_json::json!([target])
+                && releases.iter().any(|release| {
+                    release["app_name"] == product.package()
+                        && release["artifacts"].as_array().is_some_and(|assets| {
+                            assets
+                                .iter()
+                                .any(|asset| asset.as_str() == Some(name.as_str()))
+                        })
+                })
         })
         .map(|(name, _)| name)
         .collect::<Vec<_>>();
@@ -86,7 +107,7 @@ pub(super) fn select(manifest: &[u8], target: &str) -> io::Result<(String, Versi
         ));
     }
     let name = matches[0];
-    let (version, _) = metadata(&manifest, name, target)?;
+    let (version, _) = metadata(product, &manifest, name, target)?;
     Ok((name.clone(), version))
 }
 
@@ -103,7 +124,12 @@ fn archive_root(name: &str) -> io::Result<&str> {
         .ok_or_else(|| invalid("Invalid native archive filename."))
 }
 
-fn metadata(manifest: &Value, name: &str, target: &str) -> io::Result<(Version, String)> {
+fn metadata(
+    product: Product,
+    manifest: &Value,
+    name: &str,
+    target: &str,
+) -> io::Result<(Version, String)> {
     archive_root(name)?;
     let metadata = &manifest["artifacts"][name];
     if metadata["kind"] != "executable-zip"
@@ -127,7 +153,7 @@ fn metadata(manifest: &Value, name: &str, target: &str) -> io::Result<(Version, 
         })
         .collect::<io::Result<Vec<_>>>()?;
     inventory.sort_unstable();
-    let mut required = FILES;
+    let mut required = product.files();
     required.sort_unstable();
     if inventory != required {
         return Err(invalid("Unexpected native archive asset inventory."));
@@ -142,7 +168,7 @@ fn metadata(manifest: &Value, name: &str, target: &str) -> io::Result<(Version, 
                 .is_some_and(|assets| assets.iter().any(|asset| asset == name))
         })
         .collect::<Vec<_>>();
-    if releases.len() != 1 || releases[0]["app_name"] != "tmt-cli" {
+    if releases.len() != 1 || releases[0]["app_name"] != product.package() {
         return Err(invalid(
             "Native archive must belong to exactly one TMT release.",
         ));
@@ -155,7 +181,11 @@ fn metadata(manifest: &Value, name: &str, target: &str) -> io::Result<(Version, 
     Ok((version, sha256.into()))
 }
 
-fn decode(compressed: &[u8], root: &str) -> io::Result<BTreeMap<String, Vec<u8>>> {
+fn decode(
+    product: Product,
+    compressed: &[u8],
+    root: &str,
+) -> io::Result<BTreeMap<String, Vec<u8>>> {
     let mut expanded = Vec::new();
     MultiGzDecoder::new(compressed)
         .take((EXPANDED_LIMIT + 1) as u64)
@@ -184,13 +214,13 @@ fn decode(compressed: &[u8], root: &str) -> io::Result<BTreeMap<String, Vec<u8>>
         let name = path
             .strip_prefix(root)
             .and_then(|p| p.strip_prefix('/'))
-            .filter(|name| FILES.contains(name))
+            .filter(|name| product.files().contains(name))
             .ok_or_else(|| invalid("Unexpected native archive path."))?;
         let mode = entry.header().mode()?;
         if !entry.header().entry_type().is_file()
             || mode & 0o7000 != 0
             || entry.size() == 0
-            || (name == "tmt" && mode & 0o111 == 0)
+            || (name == product.executable() && mode & 0o111 == 0)
         {
             return Err(invalid(
                 "Native archive requires nonempty regular files with safe permissions.",
@@ -203,7 +233,7 @@ fn decode(compressed: &[u8], root: &str) -> io::Result<BTreeMap<String, Vec<u8>>
         entry.read_to_end(&mut contents)?;
         files.insert(name.into(), contents);
     }
-    if files.len() != FILES.len() {
+    if files.len() != product.files().len() {
         return Err(invalid("Native archive is missing required files."));
     }
     Ok(files)

--- a/rust/crates/tmt-adapters/src/native_install/artifact_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/artifact_tests.rs
@@ -11,6 +11,7 @@ use std::{
 use tar::{Builder, EntryType, Header};
 
 const TARGET: &str = "aarch64-apple-darwin";
+const OFFICE_PAYLOAD: &[u8] = b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'\n";
 
 #[path = "office_companion_tests.rs"]
 mod office_companion_tests;
@@ -155,7 +156,7 @@ fn product_fixture(entries: Vec<Entry>, package: &str, files: &[&str]) -> Fixtur
 }
 
 fn office_fixture() -> Fixture {
-    office_fixture_with_payload(b"office executable\n")
+    office_fixture_with_payload(OFFICE_PAYLOAD)
 }
 
 fn office_fixture_with_payload(payload: &[u8]) -> Fixture {
@@ -218,10 +219,7 @@ fn office_installation_and_exact_retry_preserve_cli_ownership_and_bytes() {
         office_report.executable,
         fs::canonicalize(&prefix).unwrap().join("bin/tmt-office")
     );
-    assert_eq!(
-        fs::read(&office_report.executable).unwrap(),
-        b"office executable\n"
-    );
+    assert_eq!(fs::read(&office_report.executable).unwrap(), OFFICE_PAYLOAD);
     assert_eq!(
         fs::read_link(&office_report.executable).unwrap(),
         PathBuf::from("../lib/tmt-office/current/tmt-office")
@@ -323,10 +321,7 @@ fn interrupted_office_pin_preserves_both_active_releases() {
             .active_executable,
         cli_report.active_executable
     );
-    assert_eq!(
-        fs::read(&office_report.executable).unwrap(),
-        b"office executable\n"
-    );
+    assert_eq!(fs::read(&office_report.executable).unwrap(), OFFICE_PAYLOAD);
 }
 
 #[test]

--- a/rust/crates/tmt-adapters/src/native_install/artifact_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/artifact_tests.rs
@@ -12,6 +12,9 @@ use tar::{Builder, EntryType, Header};
 
 const TARGET: &str = "aarch64-apple-darwin";
 
+#[path = "office_companion_tests.rs"]
+mod office_companion_tests;
+
 enum Entry {
     File {
         path: String,
@@ -152,11 +155,15 @@ fn product_fixture(entries: Vec<Entry>, package: &str, files: &[&str]) -> Fixtur
 }
 
 fn office_fixture() -> Fixture {
+    office_fixture_with_payload(b"office executable\n")
+}
+
+fn office_fixture_with_payload(payload: &[u8]) -> Fixture {
     let root = "tmux-team-1.2.3-aarch64-apple-darwin";
     let mut entries = valid_entries(root);
     entries[0] = Entry::File {
         path: format!("{root}/tmt-office"),
-        bytes: b"office executable\n".to_vec(),
+        bytes: payload.to_vec(),
         mode: 0o755,
     };
     product_fixture(

--- a/rust/crates/tmt-adapters/src/native_install/artifact_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/artifact_tests.rs
@@ -111,6 +111,10 @@ fn gzip_tar(entries: Vec<Entry>) -> Vec<u8> {
 }
 
 fn fixture(entries: Vec<Entry>) -> Fixture {
+    product_fixture(entries, "tmt-cli", &FILES)
+}
+
+fn product_fixture(entries: Vec<Entry>, package: &str, files: &[&str]) -> Fixture {
     let directory = TestDirectory::new();
     let name = "tmux-team-1.2.3-aarch64-apple-darwin.tar.gz".to_owned();
     let archive = directory.path.join(&name);
@@ -127,11 +131,11 @@ fn fixture(entries: Vec<Entry>) -> Fixture {
                     "name": name.clone(),
                     "target_triples": [TARGET],
                     "checksums": {"sha256": checksum},
-                    "assets": FILES.iter().map(|path| json!({"path": path})).collect::<Vec<_>>(),
+                    "assets": files.iter().map(|path| json!({"path": path})).collect::<Vec<_>>(),
                 }
             },
             "releases": [{
-                "app_name": "tmt-cli",
+                "app_name": package,
                 "app_version": "1.2.3",
                 "artifacts": [name.clone()]
             }]
@@ -145,6 +149,198 @@ fn fixture(entries: Vec<Entry>) -> Fixture {
         archive,
         name,
     }
+}
+
+fn office_fixture() -> Fixture {
+    let root = "tmux-team-1.2.3-aarch64-apple-darwin";
+    let mut entries = valid_entries(root);
+    entries[0] = Entry::File {
+        path: format!("{root}/tmt-office"),
+        bytes: b"office executable\n".to_vec(),
+        mode: 0o755,
+    };
+    product_fixture(
+        entries,
+        "tmt-office",
+        &[
+            "tmt-office",
+            "LICENSE",
+            "NATIVE-INSTALL.md",
+            "THIRD-PARTY-NOTICES.txt",
+        ],
+    )
+}
+
+fn install_fixture(
+    fixture: &Fixture,
+    prefix: &std::path::Path,
+    product: super::Product,
+) -> io::Result<super::InstallReport> {
+    super::install_product(
+        product,
+        super::InstallRequest {
+            archive: &fixture.archive,
+            manifest: &fixture.manifest,
+            prefix,
+            target: TARGET,
+            channel: tmt_core::native_install::Channel::Stable,
+            pin: tmt_core::native_install::PinAction::Preserve,
+        },
+        || Ok(()),
+    )
+}
+
+#[test]
+fn office_installation_and_exact_retry_preserve_cli_ownership_and_bytes() {
+    let cli = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let office = office_fixture();
+    let prefix = cli.directory.path.join("prefix");
+    let cli_report = install_fixture(&cli, &prefix, super::Product::Cli).unwrap();
+    let cli_receipt = fs::read(
+        cli_report
+            .active_executable
+            .parent()
+            .unwrap()
+            .join("receipt.json"),
+    )
+    .unwrap();
+    let cli_pointer = fs::read_link(prefix.join("lib/tmux-team/current")).unwrap();
+    let office_report = install_fixture(&office, &prefix, super::Product::Office).unwrap();
+    assert!(office_report.changed);
+    assert_eq!(
+        office_report.executable,
+        fs::canonicalize(&prefix).unwrap().join("bin/tmt-office")
+    );
+    assert_eq!(
+        fs::read(&office_report.executable).unwrap(),
+        b"office executable\n"
+    );
+    assert_eq!(
+        fs::read_link(&office_report.executable).unwrap(),
+        PathBuf::from("../lib/tmt-office/current/tmt-office")
+    );
+    let retry = install_fixture(&office, &prefix, super::Product::Office).unwrap();
+    assert!(!retry.changed);
+    assert_eq!(retry.active_executable, office_report.active_executable);
+    assert_eq!(
+        fs::read_link(prefix.join("lib/tmux-team/current")).unwrap(),
+        cli_pointer
+    );
+    assert_eq!(
+        fs::read(&cli_report.executable).unwrap(),
+        b"native executable\n"
+    );
+    assert_eq!(
+        fs::read(
+            cli_report
+                .active_executable
+                .parent()
+                .unwrap()
+                .join("receipt.json")
+        )
+        .unwrap(),
+        cli_receipt
+    );
+    super::inspect(&cli_report.executable).unwrap();
+    super::inspect_product(super::Product::Office, &office_report.executable).unwrap();
+    assert!(super::inspect(&office_report.executable).is_err());
+    assert!(super::inspect_product(super::Product::Office, &cli_report.executable).is_err());
+}
+
+#[test]
+fn cross_product_archives_are_rejected_before_creating_installation_prefix() {
+    for (fixture, product) in [
+        (office_fixture(), super::Product::Cli),
+        (
+            fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin")),
+            super::Product::Office,
+        ),
+    ] {
+        let prefix = fixture.directory.path.join("prefix");
+        assert!(install_fixture(&fixture, &prefix, product).is_err());
+        assert!(!prefix.exists());
+        assert_only_inputs_remain(&fixture);
+    }
+}
+
+#[test]
+fn interrupted_office_pin_preserves_both_active_releases() {
+    let cli = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let office = office_fixture();
+    let prefix = cli.directory.path.join("prefix");
+    let cli_report = install_fixture(&cli, &prefix, super::Product::Cli).unwrap();
+    let office_report = install_fixture(&office, &prefix, super::Product::Office).unwrap();
+    let office_root = prefix.join("lib/tmt-office");
+    let current = fs::read_link(office_root.join("current")).unwrap();
+    let mut calls = 0;
+    let error = super::install_product(
+        super::Product::Office,
+        super::InstallRequest {
+            archive: &office.archive,
+            manifest: &office.manifest,
+            prefix: &prefix,
+            target: TARGET,
+            channel: tmt_core::native_install::Channel::Stable,
+            pin: tmt_core::native_install::PinAction::PinCandidate,
+        },
+        || {
+            calls += 1;
+            if calls == 4 {
+                Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "test cancellation",
+                ))
+            } else {
+                Ok(())
+            }
+        },
+    )
+    .unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::Interrupted);
+    assert_eq!(calls, 4);
+    assert_eq!(fs::read_link(office_root.join("current")).unwrap(), current);
+    assert_eq!(
+        fs::read_dir(office_root.join("releases")).unwrap().count(),
+        1
+    );
+    assert!(
+        super::inspect_product(super::Product::Office, &office_report.executable)
+            .unwrap()
+            .state
+            .pinned_version
+            .is_none()
+    );
+    assert_eq!(
+        super::inspect(&cli_report.executable)
+            .unwrap()
+            .active_executable,
+        cli_report.active_executable
+    );
+    assert_eq!(
+        fs::read(&office_report.executable).unwrap(),
+        b"office executable\n"
+    );
+}
+
+#[test]
+fn office_command_collision_does_not_overwrite_user_file_or_cli() {
+    let cli = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let office = office_fixture();
+    let prefix = cli.directory.path.join("prefix");
+    let cli_report = install_fixture(&cli, &prefix, super::Product::Cli).unwrap();
+    fs::write(prefix.join("bin/tmt-office"), b"user managed command").unwrap();
+    assert!(install_fixture(&office, &prefix, super::Product::Office).is_err());
+    assert_eq!(
+        fs::read(prefix.join("bin/tmt-office")).unwrap(),
+        b"user managed command"
+    );
+    assert!(!prefix.join("lib/tmt-office/current").exists());
+    assert_eq!(
+        super::inspect(&cli_report.executable)
+            .unwrap()
+            .active_executable,
+        cli_report.active_executable
+    );
 }
 
 fn replace_archive(fixture: &Fixture, compressed: &[u8]) {
@@ -161,6 +357,80 @@ fn file_map(entries: &[(&str, &[u8])]) -> BTreeMap<String, Vec<u8>> {
         .iter()
         .map(|(name, bytes)| ((*name).to_owned(), bytes.to_vec()))
         .collect()
+}
+
+fn multi_product_manifest() -> serde_json::Value {
+    let cli = fixture(valid_entries("tmux-team-1.2.3-aarch64-apple-darwin"));
+    let office = office_fixture();
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&cli.manifest).unwrap()).unwrap();
+    let office_manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&office.manifest).unwrap()).unwrap();
+    let office_name = "tmt-office-aarch64-apple-darwin.tar.gz";
+    let mut office_asset = office_manifest["artifacts"][&office.name].clone();
+    office_asset["name"] = json!(office_name);
+    manifest["artifacts"][office_name] = office_asset;
+    manifest["releases"].as_array_mut().unwrap().push(json!({
+        "app_name": "tmt-office", "app_version": "0.1.0", "artifacts": [office_name]
+    }));
+    manifest
+}
+
+#[test]
+fn manifest_selection_keeps_products_and_versions_independent_on_the_same_target() {
+    let manifest = serde_json::to_vec(&multi_product_manifest()).unwrap();
+    assert_eq!(
+        artifact::select(super::Product::Cli, &manifest, TARGET).unwrap(),
+        (
+            "tmux-team-1.2.3-aarch64-apple-darwin.tar.gz".into(),
+            semver::Version::new(1, 2, 3)
+        )
+    );
+    assert_eq!(
+        artifact::select(super::Product::Office, &manifest, TARGET).unwrap(),
+        (
+            "tmt-office-aarch64-apple-darwin.tar.gz".into(),
+            semver::Version::new(0, 1, 0)
+        )
+    );
+}
+
+#[test]
+fn manifest_selection_rejects_cross_product_claims_and_duplicate_candidates() {
+    let mut shared = multi_product_manifest();
+    shared["releases"][0]["artifacts"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!("tmt-office-aarch64-apple-darwin.tar.gz"));
+    let error = artifact::select(
+        super::Product::Office,
+        &serde_json::to_vec(&shared).unwrap(),
+        TARGET,
+    )
+    .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native archive must belong to exactly one TMT release."
+    );
+
+    let mut duplicate = multi_product_manifest();
+    let mut asset = duplicate["artifacts"]["tmt-office-aarch64-apple-darwin.tar.gz"].clone();
+    asset["name"] = json!("second-office.tar.gz");
+    duplicate["artifacts"]["second-office.tar.gz"] = asset;
+    duplicate["releases"][1]["artifacts"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!("second-office.tar.gz"));
+    let error = artifact::select(
+        super::Product::Office,
+        &serde_json::to_vec(&duplicate).unwrap(),
+        TARGET,
+    )
+    .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Native manifest must select exactly one target archive."
+    );
 }
 
 fn root_entries(directory: &TestDirectory) -> Vec<String> {

--- a/rust/crates/tmt-adapters/src/native_install/managed.rs
+++ b/rust/crates/tmt-adapters/src/native_install/managed.rs
@@ -1,6 +1,6 @@
 //! Read-only ownership of the executing binary, independent of PATH/app state.
 
-use super::{invalid, publication::Layout};
+use super::{Product, invalid, publication::Layout};
 use std::{
     fs, io,
     path::{Path, PathBuf},
@@ -19,15 +19,19 @@ pub struct ManagedInstallation {
 }
 
 pub fn inspect(executable: &Path) -> io::Result<ManagedInstallation> {
+    inspect_product(Product::Cli, executable)
+}
+
+pub fn inspect_product(product: Product, executable: &Path) -> io::Result<ManagedInstallation> {
     let executable = fs::canonicalize(executable)?;
     let prefix = executable.ancestors().nth(5).ok_or_else(unmanaged)?;
-    let layout = Layout::existing(prefix).map_err(|_| unmanaged())?;
+    let layout = Layout::existing_product(prefix, product).map_err(|_| unmanaged())?;
     let current = layout.current()?.ok_or_else(unmanaged)?;
     let active = layout
         .root
         .join("releases")
         .join(current.id.to_string())
-        .join("tmt");
+        .join(product.executable());
     if executable != active {
         return Err(invalid(
             "This executable is not the active managed release. Run the current native installation, or update using its original package manager.",
@@ -35,7 +39,7 @@ pub fn inspect(executable: &Path) -> io::Result<ManagedInstallation> {
     }
     layout.check_links(true)?;
     Ok(ManagedInstallation {
-        executable: layout.prefix.join("bin/tmt"),
+        executable: layout.prefix.join("bin").join(product.executable()),
         active_executable: active,
         state: current.state,
         target: current.target,

--- a/rust/crates/tmt-adapters/src/native_install/managed.rs
+++ b/rust/crates/tmt-adapters/src/native_install/managed.rs
@@ -51,16 +51,25 @@ pub fn inspect_product(product: Product, executable: &Path) -> io::Result<Manage
 /// Keep the selected release current while its bounded skill-refresh child
 /// runs. Lock order is installation then skills; acquisition never holds either.
 pub fn with_active_release<T>(executable: &Path, operation: impl FnOnce() -> T) -> io::Result<T> {
-    let observed = inspect(executable)?;
-    let layout = Layout::existing(&observed.prefix)?;
+    with_active_product(Product::Cli, executable, |_| operation())
+}
+
+/// Run a bounded operation while the verified product remains the active release.
+pub fn with_active_product<T>(
+    product: Product,
+    executable: &Path,
+    operation: impl FnOnce(&ManagedInstallation) -> T,
+) -> io::Result<T> {
+    let observed = inspect_product(product, executable)?;
+    let layout = Layout::existing_product(&observed.prefix, product)?;
     let _lock = crate::file_lock::exclusive(&layout.root.join("install.lock"))?;
     if layout.current()?.map(|receipt| receipt.id) != Some(observed.id) {
         return Err(invalid(
-            "The active release changed before skill refresh. Retry from the current native executable.",
+            "The active release changed before the managed operation. Retry from the current native executable.",
         ));
     }
     layout.check_links(true)?;
-    Ok(operation())
+    Ok(operation(&observed))
 }
 
 fn unmanaged() -> io::Error {

--- a/rust/crates/tmt-adapters/src/native_install/mod.rs
+++ b/rust/crates/tmt-adapters/src/native_install/mod.rs
@@ -3,7 +3,9 @@
 mod artifact;
 pub use tmt_core::native_install::Product;
 mod managed;
-pub use managed::{ManagedInstallation, inspect, inspect_product, with_active_release};
+pub use managed::{
+    ManagedInstallation, inspect, inspect_product, with_active_product, with_active_release,
+};
 #[cfg(test)]
 mod artifact_tests;
 #[cfg(test)]

--- a/rust/crates/tmt-adapters/src/native_install/mod.rs
+++ b/rust/crates/tmt-adapters/src/native_install/mod.rs
@@ -1,6 +1,10 @@
 //! Verified native release acquisition and managed publication, without app state.
 
 mod artifact;
+mod online;
+mod remove;
+pub use online::{default_install_prefix, install_release};
+pub use remove::uninstall_office;
 pub use tmt_core::native_install::Product;
 mod managed;
 pub use managed::{
@@ -16,7 +20,7 @@ mod publication_tests;
 mod receipt;
 mod release;
 mod upgrade;
-pub use upgrade::{UpgradeFailure, UpgradeReport, UpgradeRequest, upgrade};
+pub use upgrade::{UpgradeFailure, UpgradeReport, UpgradeRequest, upgrade, upgrade_product};
 #[cfg(test)]
 mod test_support;
 
@@ -99,13 +103,41 @@ fn install_product_observed(
     checkpoint()?;
     let artifact =
         artifact::acquire_product(product, request.manifest, request.archive, request.target)?;
+    activate(
+        ActivationRequest {
+            product,
+            prefix: request.prefix,
+            channel: request.channel,
+            pin: request.pin,
+            expected,
+            provenance,
+        },
+        &artifact,
+        checkpoint,
+    )
+}
+
+struct ActivationRequest<'a> {
+    product: Product,
+    prefix: &'a Path,
+    channel: tmt_core::native_install::Channel,
+    pin: tmt_core::native_install::PinAction,
+    expected: Option<uuid::Uuid>,
+    provenance: Option<receipt::GitHubProvenance>,
+}
+
+fn activate(
+    request: ActivationRequest<'_>,
+    artifact: &artifact::Artifact,
+    mut checkpoint: impl FnMut() -> io::Result<()>,
+) -> io::Result<InstallReport> {
     plan_version(None, &artifact.version, request.channel, request.pin)
         .map_err(io::Error::other)?;
     checkpoint()?;
-    let layout = publication::Layout::open_product(request.prefix, product)?;
+    let layout = publication::Layout::open_product(request.prefix, request.product)?;
     let _lock = crate::file_lock::exclusive(&layout.root.join("install.lock"))?;
     let current = layout.current()?;
-    if let Some(expected) = expected
+    if let Some(expected) = request.expected
         && current.as_ref().map(|receipt| receipt.id) != Some(expected)
     {
         return Err(invalid(
@@ -132,10 +164,10 @@ fn install_product_observed(
         ));
     }
     let active_id = if plan.changed {
-        let mut receipt = receipt::Receipt::new(&artifact, plan.state);
-        receipt.provenance = provenance;
+        let mut receipt = receipt::Receipt::new(artifact, plan.state);
+        receipt.provenance = request.provenance;
         if let Err(error) = layout.publish(
-            &artifact,
+            artifact,
             &receipt,
             current.as_ref().map(|receipt| receipt.id),
             &mut checkpoint,

--- a/rust/crates/tmt-adapters/src/native_install/mod.rs
+++ b/rust/crates/tmt-adapters/src/native_install/mod.rs
@@ -1,8 +1,9 @@
 //! Verified native release acquisition and managed publication, without app state.
 
 mod artifact;
+pub use tmt_core::native_install::Product;
 mod managed;
-pub use managed::{ManagedInstallation, inspect, with_active_release};
+pub use managed::{ManagedInstallation, inspect, inspect_product, with_active_release};
 #[cfg(test)]
 mod artifact_tests;
 #[cfg(test)]
@@ -68,18 +69,38 @@ pub fn install(
     install_observed(request, None, None, checkpoint)
 }
 
+/// Install the explicitly selected fixed product; never discover one from archive data.
+pub fn install_product(
+    product: Product,
+    request: InstallRequest<'_>,
+    checkpoint: impl FnMut() -> io::Result<()>,
+) -> io::Result<InstallReport> {
+    install_product_observed(product, request, None, None, checkpoint)
+}
+
 fn install_observed(
+    request: InstallRequest<'_>,
+    expected: Option<uuid::Uuid>,
+    provenance: Option<receipt::GitHubProvenance>,
+    checkpoint: impl FnMut() -> io::Result<()>,
+) -> io::Result<InstallReport> {
+    install_product_observed(Product::Cli, request, expected, provenance, checkpoint)
+}
+
+fn install_product_observed(
+    product: Product,
     request: InstallRequest<'_>,
     expected: Option<uuid::Uuid>,
     provenance: Option<receipt::GitHubProvenance>,
     mut checkpoint: impl FnMut() -> io::Result<()>,
 ) -> io::Result<InstallReport> {
     checkpoint()?;
-    let artifact = artifact::acquire(request.manifest, request.archive, request.target)?;
+    let artifact =
+        artifact::acquire_product(product, request.manifest, request.archive, request.target)?;
     plan_version(None, &artifact.version, request.channel, request.pin)
         .map_err(io::Error::other)?;
     checkpoint()?;
-    let layout = publication::Layout::open(request.prefix)?;
+    let layout = publication::Layout::open_product(request.prefix, product)?;
     let _lock = crate::file_lock::exclusive(&layout.root.join("install.lock"))?;
     let current = layout.current()?;
     if let Some(expected) = expected
@@ -163,12 +184,12 @@ fn installed_report(
     changed: bool,
 ) -> InstallReport {
     InstallReport {
-        executable: layout.prefix.join("bin/tmt"),
+        executable: layout.prefix.join("bin").join(layout.product.executable()),
         active_executable: layout
             .root
             .join("releases")
             .join(active_id.to_string())
-            .join("tmt"),
+            .join(layout.product.executable()),
         version: version.into(),
         changed,
     }

--- a/rust/crates/tmt-adapters/src/native_install/office_companion_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/office_companion_tests.rs
@@ -1,0 +1,57 @@
+//! Hostile protocol fixtures exercise the managed execution boundary, not release artifacts.
+
+use super::{install_fixture, office_fixture_with_payload};
+use crate::{native_install::Product, office_companion::probe_office_companion};
+use std::fs;
+
+#[test]
+fn verified_probe_uses_the_installed_executable_and_preserves_its_receipt() {
+    let fixture = office_fixture_with_payload(b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'\n");
+    let prefix = fixture.directory.path.join("prefix");
+    let report = install_fixture(&fixture, &prefix, Product::Office).unwrap();
+    let receipt = report
+        .active_executable
+        .parent()
+        .unwrap()
+        .join("receipt.json");
+    let before = fs::read(&receipt).unwrap();
+    assert_eq!(probe_office_companion(&report.executable).unwrap(), "1.2.3");
+    assert_eq!(fs::read(receipt).unwrap(), before);
+}
+
+#[test]
+fn incompatible_noisy_and_nonzero_companions_are_not_successful_handshakes() {
+    for payload in [
+        b"#!/bin/sh\nprintf 'TMT-OFFICE/2\\n1.2.3\\n'\n".as_slice(),
+        b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n9.0.0\\n'\n",
+        b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'; printf 'warning' >&2\n",
+        b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'; exit 1\n",
+    ] {
+        let fixture = office_fixture_with_payload(payload);
+        let report = install_fixture(
+            &fixture,
+            &fixture.directory.path.join("prefix"),
+            Product::Office,
+        )
+        .unwrap();
+        assert!(probe_office_companion(&report.executable).is_err());
+    }
+}
+
+#[test]
+fn changed_payload_is_rejected_before_executing_it() {
+    let fixture = office_fixture_with_payload(b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'\n");
+    let report = install_fixture(
+        &fixture,
+        &fixture.directory.path.join("prefix"),
+        Product::Office,
+    )
+    .unwrap();
+    // If executed, this replacement would produce a distinct protocol failure.
+    fs::write(&report.active_executable, b"#!/bin/sh\nprintf 'tampered'\n").unwrap();
+    let error = probe_office_companion(&report.executable).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Installed release file has changed; refusing replacement."
+    );
+}

--- a/rust/crates/tmt-adapters/src/native_install/office_companion_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/office_companion_tests.rs
@@ -21,20 +21,35 @@ fn verified_probe_uses_the_installed_executable_and_preserves_its_receipt() {
 
 #[test]
 fn incompatible_noisy_and_nonzero_companions_are_not_successful_handshakes() {
-    for payload in [
-        b"#!/bin/sh\nprintf 'TMT-OFFICE/2\\n1.2.3\\n'\n".as_slice(),
-        b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n9.0.0\\n'\n",
-        b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'; printf 'warning' >&2\n",
-        b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'; exit 1\n",
+    for (payload, expected) in [
+        (
+            b"#!/bin/sh\nprintf 'TMT-OFFICE/2\\n1.2.3\\n'\n".as_slice(),
+            "Incompatible Office handshake.",
+        ),
+        (
+            b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n9.0.0\\n'\n",
+            "Office executable and installation versions disagree.",
+        ),
+        (
+            b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'; printf 'warning' >&2\n",
+            "Office handshake produced unexpected diagnostics.",
+        ),
+        (
+            b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'; exit 1\n",
+            "External command failed: Exit",
+        ),
     ] {
         let fixture = office_fixture_with_payload(payload);
-        let report = install_fixture(
-            &fixture,
-            &fixture.directory.path.join("prefix"),
-            Product::Office,
-        )
-        .unwrap();
-        assert!(probe_office_companion(&report.executable).is_err());
+        let prefix = fixture.directory.path.join("prefix");
+        let error = install_fixture(&fixture, &prefix, Product::Office).unwrap_err();
+        assert!(error.to_string().starts_with(expected), "{error}");
+        assert!(!prefix.join("lib/tmt-office/current").exists());
+        assert_eq!(
+            fs::read_dir(prefix.join("lib/tmt-office/releases"))
+                .unwrap()
+                .count(),
+            0
+        );
     }
 }
 
@@ -53,5 +68,70 @@ fn changed_payload_is_rejected_before_executing_it() {
     assert_eq!(
         error.to_string(),
         "Installed release file has changed; refusing replacement."
+    );
+}
+
+#[test]
+fn incompatible_upgrade_preserves_the_previous_working_release() {
+    let good = super::office_fixture();
+    let prefix = good.directory.path.join("prefix");
+    let previous = install_fixture(&good, &prefix, Product::Office).unwrap();
+    let before = fs::read(&previous.active_executable).unwrap();
+    let pointer = fs::read_link(prefix.join("lib/tmt-office/current")).unwrap();
+    let bad = office_fixture_with_payload(b"#!/bin/sh\nprintf 'TMT-OFFICE/2\\n1.2.4\\n'\n");
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&bad.manifest).unwrap()).unwrap();
+    manifest["releases"][0]["app_version"] = serde_json::json!("1.2.4");
+    fs::write(&bad.manifest, serde_json::to_vec(&manifest).unwrap()).unwrap();
+    let error = install_fixture(&bad, &prefix, Product::Office).unwrap_err();
+    assert_eq!(error.to_string(), "Incompatible Office handshake.");
+    assert_eq!(
+        fs::read_link(prefix.join("lib/tmt-office/current")).unwrap(),
+        pointer
+    );
+    assert_eq!(fs::read(&previous.active_executable).unwrap(), before);
+    assert_eq!(
+        probe_office_companion(&previous.executable).unwrap(),
+        "1.2.3"
+    );
+    assert_eq!(
+        fs::read_dir(prefix.join("lib/tmt-office/releases"))
+            .unwrap()
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn uninstall_preserves_unmanaged_links_and_tampered_releases() {
+    use std::os::unix::fs::symlink;
+    let fixture = super::office_fixture();
+    let prefix = fixture.directory.path.join("prefix");
+    let report = install_fixture(&fixture, &prefix, Product::Office).unwrap();
+    let original_link = fs::read_link(&report.executable).unwrap();
+    let pointer = fs::read_link(prefix.join("lib/tmt-office/current")).unwrap();
+    let user_file = fixture.directory.path.join("user-command");
+    fs::write(&user_file, b"user content").unwrap();
+    fs::remove_file(&report.executable).unwrap();
+    symlink(&user_file, &report.executable).unwrap();
+    assert!(crate::native_install::uninstall_office(&prefix).is_err());
+    assert_eq!(fs::read_link(&report.executable).unwrap(), user_file);
+    assert_eq!(fs::read(&user_file).unwrap(), b"user content");
+    assert_eq!(
+        fs::read_link(prefix.join("lib/tmt-office/current")).unwrap(),
+        pointer
+    );
+    fs::remove_file(&report.executable).unwrap();
+    symlink(&original_link, &report.executable).unwrap();
+    fs::write(&report.active_executable, b"user edited executable").unwrap();
+    let error = crate::native_install::uninstall_office(&prefix).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Installed release file has changed; refusing replacement."
+    );
+    assert_eq!(fs::read_link(&report.executable).unwrap(), original_link);
+    assert_eq!(
+        fs::read(&report.active_executable).unwrap(),
+        b"user edited executable"
     );
 }

--- a/rust/crates/tmt-adapters/src/native_install/online.rs
+++ b/rust/crates/tmt-adapters/src/native_install/online.rs
@@ -1,0 +1,121 @@
+//! First installation through the same release verifier and activation owner as updates.
+
+use super::{ActivationRequest, InstallReport, Product, activate, artifact, release};
+use std::{
+    io,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+use tmt_core::native_install::{Channel, PinAction};
+
+pub fn default_install_prefix() -> io::Result<PathBuf> {
+    std::env::home_dir()
+        .map(|home| home.join(".local"))
+        .ok_or_else(|| io::Error::other("Cannot determine the native installation home directory."))
+}
+
+pub fn install_release(
+    product: Product,
+    prefix: &Path,
+    target: &str,
+    channel: Channel,
+    checkpoint: impl FnMut() -> io::Result<()>,
+) -> io::Result<InstallReport> {
+    let client = crate::release_http::Https::new();
+    install_release_with(
+        product,
+        prefix,
+        target,
+        channel,
+        checkpoint,
+        |url, accept, limit, deadline| client.get(url, accept, limit, deadline),
+    )
+}
+
+fn install_release_with(
+    product: Product,
+    prefix: &Path,
+    target: &str,
+    channel: Channel,
+    mut checkpoint: impl FnMut() -> io::Result<()>,
+    get: impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>>,
+) -> io::Result<InstallReport> {
+    checkpoint()?;
+    let downloaded = release::download_product(
+        product,
+        channel,
+        None,
+        target,
+        Instant::now() + Duration::from_secs(60),
+        get,
+    )?;
+    checkpoint()?;
+    let artifact = artifact::acquire_bytes(
+        product,
+        &downloaded.manifest,
+        &downloaded.archive_name,
+        &downloaded.archive,
+        target,
+    )?;
+    activate(
+        ActivationRequest {
+            product,
+            prefix,
+            channel,
+            pin: PinAction::Preserve,
+            expected: None,
+            provenance: Some(downloaded.provenance),
+        },
+        &artifact,
+        checkpoint,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestDirectory;
+
+    #[test]
+    fn no_release_does_not_create_an_installation() {
+        let directory = TestDirectory::new();
+        let prefix = directory.path.join("prefix");
+        let mut calls = 0;
+        let error = install_release_with(
+            Product::Office,
+            &prefix,
+            "aarch64-apple-darwin",
+            Channel::Alpha,
+            || Ok(()),
+            |url, _, _, _| {
+                calls += 1;
+                assert_eq!(
+                    url,
+                    "https://api.github.com/repos/wkh237/tmux-team/releases?per_page=100&page=1"
+                );
+                Ok(b"[]".to_vec())
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        assert_eq!(calls, 1);
+        assert!(!prefix.exists());
+    }
+
+    #[test]
+    fn interruption_before_acquisition_has_no_network_or_filesystem_effect() {
+        let directory = TestDirectory::new();
+        let prefix = directory.path.join("prefix");
+        let error = install_release_with(
+            Product::Office,
+            &prefix,
+            "aarch64-apple-darwin",
+            Channel::Alpha,
+            || Err(io::Error::new(io::ErrorKind::Interrupted, "cancelled")),
+            |_, _, _, _| panic!("cancelled installation must not download"),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Interrupted);
+        assert!(!prefix.exists());
+    }
+}

--- a/rust/crates/tmt-adapters/src/native_install/publication.rs
+++ b/rust/crates/tmt-adapters/src/native_install/publication.rs
@@ -52,6 +52,7 @@ fn directory(path: &Path, create: bool) -> io::Result<()> {
 }
 
 impl Layout {
+    #[cfg(test)]
     pub fn existing(prefix: &Path) -> io::Result<Self> {
         Self::existing_product(prefix, Product::Cli)
     }

--- a/rust/crates/tmt-adapters/src/native_install/publication.rs
+++ b/rust/crates/tmt-adapters/src/native_install/publication.rs
@@ -1,10 +1,6 @@
 //! One durable release directory and one atomic activation pointer.
 
-use super::{
-    artifact::{Artifact, FILES},
-    invalid,
-    receipt::Receipt,
-};
+use super::{Product, artifact::Artifact, invalid, receipt::Receipt};
 use std::{
     fs::{self, File, OpenOptions},
     io::{self, Write},
@@ -33,6 +29,7 @@ impl std::error::Error for ActivatedError {
 }
 
 pub(super) struct Layout {
+    pub product: Product,
     pub prefix: PathBuf,
     pub root: PathBuf,
 }
@@ -56,9 +53,13 @@ fn directory(path: &Path, create: bool) -> io::Result<()> {
 
 impl Layout {
     pub fn existing(prefix: &Path) -> io::Result<Self> {
+        Self::existing_product(prefix, Product::Cli)
+    }
+
+    pub fn existing_product(prefix: &Path, product: Product) -> io::Result<Self> {
         directory(prefix, false)?;
         let prefix = fs::canonicalize(prefix)?;
-        let root = prefix.join("lib/tmux-team");
+        let root = prefix.join(product.namespace());
         for path in [
             prefix.join("lib"),
             prefix.join("bin"),
@@ -67,10 +68,19 @@ impl Layout {
         ] {
             directory(&path, false)?;
         }
-        Ok(Self { prefix, root })
+        Ok(Self {
+            prefix,
+            root,
+            product,
+        })
     }
 
+    #[cfg(test)]
     pub fn open(prefix: &Path) -> io::Result<Self> {
+        Self::open_product(prefix, Product::Cli)
+    }
+
+    pub fn open_product(prefix: &Path, product: Product) -> io::Result<Self> {
         if prefix.as_os_str().is_empty() {
             return Err(invalid("Installation prefix must not be empty."));
         }
@@ -85,10 +95,14 @@ impl Layout {
         let prefix = fs::canonicalize(&requested)?;
         directory(&prefix.join("lib"), true)?;
         directory(&prefix.join("bin"), true)?;
-        let root = prefix.join("lib/tmux-team");
+        let root = prefix.join(product.namespace());
         directory(&root, true)?;
         directory(&root.join("releases"), true)?;
-        Ok(Self { prefix, root })
+        Ok(Self {
+            prefix,
+            root,
+            product,
+        })
     }
 
     pub fn current(&self) -> io::Result<Option<Receipt>> {
@@ -108,11 +122,11 @@ impl Layout {
         if !fs::symlink_metadata(&release)?.file_type().is_dir() {
             return Err(invalid("Native current release is not a real directory."));
         }
-        Receipt::read(&release, &self.prefix, id).map(Some)
+        Receipt::read_product(self.product, &release, &self.prefix, id).map(Some)
     }
 
     pub fn check_links(&self, has_current: bool) -> io::Result<()> {
-        for name in ["tmt", "tmux-team"] {
+        for name in self.product.links() {
             let path = self.prefix.join("bin").join(name);
             match fs::symlink_metadata(&path) {
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {}
@@ -120,7 +134,7 @@ impl Layout {
                 Ok(metadata)
                     if has_current
                         && metadata.file_type().is_symlink()
-                        && fs::read_link(&path)? == Path::new("../lib/tmux-team/current/tmt") => {}
+                        && fs::read_link(&path)? == Path::new(&self.product.link_target()) => {}
                 Ok(_) => {
                     return Err(io::Error::new(
                         io::ErrorKind::AlreadyExists,
@@ -137,9 +151,9 @@ impl Layout {
 
     pub fn ensure_links(&self) -> io::Result<()> {
         self.check_links(true)?;
-        for name in ["tmt", "tmux-team"] {
+        for name in self.product.links() {
             let path = self.prefix.join("bin").join(name);
-            match symlink("../lib/tmux-team/current/tmt", &path) {
+            match symlink(self.product.link_target(), &path) {
                 Ok(()) => {}
                 Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
                     self.check_links(true)?
@@ -177,12 +191,16 @@ impl Layout {
         let mut pointer_created = false;
         let mut activated = false;
         let result = (|| {
-            for name in FILES {
+            for name in self.product.files() {
                 checkpoint()?;
                 write(
                     &release.join(name),
                     &artifact.files[name],
-                    if name == "tmt" { 0o755 } else { 0o644 },
+                    if name == self.product.executable() {
+                        0o755
+                    } else {
+                        0o644
+                    },
                 )?;
             }
             write(

--- a/rust/crates/tmt-adapters/src/native_install/publication.rs
+++ b/rust/crates/tmt-adapters/src/native_install/publication.rs
@@ -204,6 +204,12 @@ impl Layout {
                     },
                 )?;
             }
+            if self.product == Product::Office {
+                crate::office_companion::probe_candidate(
+                    &release.join(self.product.executable()),
+                    &artifact.version,
+                )?;
+            }
             write(
                 &release.join("receipt.json"),
                 &receipt.encode(&self.prefix)?,

--- a/rust/crates/tmt-adapters/src/native_install/receipt.rs
+++ b/rust/crates/tmt-adapters/src/native_install/receipt.rs
@@ -1,7 +1,8 @@
 //! Installation evidence is rooted in a release directory, not application config.
 
 use super::{
-    artifact::{Artifact, FILES, digest},
+    Product,
+    artifact::{Artifact, digest},
     invalid,
 };
 use crate::bounded_file;
@@ -58,13 +59,24 @@ impl Receipt {
         .map_err(io::Error::other)
     }
 
+    #[cfg(test)]
     pub fn read(directory: &Path, prefix: &Path, id: Uuid) -> io::Result<Self> {
+        Self::read_product(Product::Cli, directory, prefix, id)
+    }
+
+    pub fn read_product(
+        product: Product,
+        directory: &Path,
+        prefix: &Path,
+        id: Uuid,
+    ) -> io::Result<Self> {
         let mut inventory = fs::read_dir(directory)?
-            .take(FILES.len() + 2)
+            .take(product.files().len() + 2)
             .map(|entry| entry.map(|entry| entry.file_name()))
             .collect::<io::Result<Vec<_>>>()?;
         inventory.sort();
-        let mut expected = FILES
+        let mut expected = product
+            .files()
             .into_iter()
             .chain(["receipt.json"])
             .map(std::ffi::OsString::from)
@@ -138,16 +150,16 @@ impl Receipt {
         let hashes = value["file_sha256"]
             .as_object()
             .ok_or_else(|| invalid("Missing installed file digests."))?;
-        if hashes.len() != FILES.len() {
+        if hashes.len() != product.files().len() {
             return Err(invalid("Unexpected installed file digest inventory."));
         }
         let mut file_hashes = BTreeMap::new();
-        for name in FILES {
+        for name in product.files() {
             let metadata = fs::symlink_metadata(directory.join(name))?;
             let mode = metadata.permissions().mode();
             if !metadata.file_type().is_file()
                 || mode & 0o7000 != 0
-                || (name == "tmt" && mode & 0o111 == 0)
+                || (name == product.executable() && mode & 0o111 == 0)
             {
                 return Err(invalid(
                     "Installed release file type or permissions have changed.",

--- a/rust/crates/tmt-adapters/src/native_install/release.rs
+++ b/rust/crates/tmt-adapters/src/native_install/release.rs
@@ -112,7 +112,8 @@ pub(super) fn download(
         deadline,
         &mut get,
     )?;
-    let (archive_name, manifest_version) = artifact::select(&manifest, target)?;
+    let (archive_name, manifest_version) =
+        artifact::select(super::Product::Cli, &manifest, target)?;
     if manifest_version != version {
         return Err(invalid(
             "Release and cargo-dist manifest versions disagree.",

--- a/rust/crates/tmt-adapters/src/native_install/release.rs
+++ b/rust/crates/tmt-adapters/src/native_install/release.rs
@@ -18,7 +18,19 @@ pub(super) struct DownloadedRelease {
     pub provenance: GitHubProvenance,
 }
 
+#[cfg(test)]
 pub(super) fn download(
+    channel: Channel,
+    exact: Option<&Version>,
+    target: &str,
+    deadline: Instant,
+    get: impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>>,
+) -> io::Result<DownloadedRelease> {
+    download_product(super::Product::Cli, channel, exact, target, deadline, get)
+}
+
+pub(super) fn download_product(
+    product: super::Product,
     channel: Channel,
     exact: Option<&Version>,
     target: &str,
@@ -28,7 +40,7 @@ pub(super) fn download(
     let endpoint = format!("https://api.github.com/repos/{OFFICIAL_REPOSITORY}/releases");
     let document = if let Some(version) = exact {
         json(&get(
-            &format!("{endpoint}/tags/v{version}"),
+            &format!("{endpoint}/tags/{}{version}", product.tag_prefix()),
             "application/vnd.github+json",
             METADATA_LIMIT,
             deadline,
@@ -65,7 +77,11 @@ pub(super) fn download(
         }
         let candidates = releases
             .iter()
-            .filter_map(|release| version(release).ok().map(|version| (release, version)))
+            .filter_map(|release| {
+                version(product, release)
+                    .ok()
+                    .map(|version| (release, version))
+            })
             .collect::<Vec<_>>();
         let versions = candidates
             .iter()
@@ -86,7 +102,7 @@ pub(super) fn download(
             .0
             .clone()
     };
-    let version = version(&document)?;
+    let version = version(product, &document)?;
     if !channel.accepts(&version) || exact.is_some_and(|expected| expected != &version) {
         return Err(invalid(
             "Release version does not match the selected channel or exact version.",
@@ -112,8 +128,7 @@ pub(super) fn download(
         deadline,
         &mut get,
     )?;
-    let (archive_name, manifest_version) =
-        artifact::select(super::Product::Cli, &manifest, target)?;
+    let (archive_name, manifest_version) = artifact::select(product, &manifest, target)?;
     if manifest_version != version {
         return Err(invalid(
             "Release and cargo-dist manifest versions disagree.",
@@ -143,10 +158,10 @@ fn json(bytes: &[u8]) -> io::Result<Value> {
     serde_json::from_slice(bytes).map_err(|_| invalid("Invalid release metadata JSON."))
 }
 
-fn version(release: &Value) -> io::Result<Version> {
+fn version(product: super::Product, release: &Value) -> io::Result<Version> {
     release["tag_name"]
         .as_str()
-        .and_then(|tag| tag.strip_prefix('v'))
+        .and_then(|tag| tag.strip_prefix(product.tag_prefix()))
         .and_then(|version| version.parse().ok())
         .ok_or_else(|| invalid("Release tag is not a canonical native version."))
 }

--- a/rust/crates/tmt-adapters/src/native_install/release_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/release_tests.rs
@@ -8,7 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tar::{Builder, EntryType, Header};
-use tmt_core::native_install::Channel;
+use tmt_core::native_install::{Channel, Product};
 
 const TARGET: &str = "aarch64-apple-darwin";
 const MANIFEST_NAME: &str = "dist-manifest.json";
@@ -115,14 +115,14 @@ fn append_file(builder: &mut Builder<GzEncoder<Vec<u8>>>, path: &str, bytes: &[u
     builder.append(&header, bytes).unwrap();
 }
 
-fn archive(version: &str, target: &str) -> (String, Vec<u8>) {
-    let name = format!("tmux-team-{version}-{target}.tar.gz");
+fn archive(product: Product, version: &str, target: &str) -> (String, Vec<u8>) {
+    let name = format!("{}-{version}-{target}.tar.gz", product.package());
     let root = name.strip_suffix(".tar.gz").unwrap();
     let encoder = GzEncoder::new(Vec::new(), Compression::default());
     let mut builder = Builder::new(encoder);
     append_file(
         &mut builder,
-        &format!("{root}/tmt"),
+        &format!("{root}/{}", product.executable()),
         b"native executable\n",
         0o755,
     );
@@ -149,7 +149,16 @@ pub(in crate::native_install) fn valid_fixture(
     target: &str,
     release_id: u64,
 ) -> (Value, Vec<u8>, Vec<u8>, String) {
-    let (archive_name, archive) = archive(version, target);
+    product_fixture(Product::Cli, version, target, release_id)
+}
+
+fn product_fixture(
+    product: Product,
+    version: &str,
+    target: &str,
+    release_id: u64,
+) -> (Value, Vec<u8>, Vec<u8>, String) {
+    let (archive_name, archive) = archive(product, version, target);
     let manifest = serde_json::to_vec(&json!({
         "artifacts": {
             archive_name.clone(): {
@@ -157,14 +166,14 @@ pub(in crate::native_install) fn valid_fixture(
                 "name": archive_name.clone(),
                 "target_triples": [target],
                 "checksums": {"sha256": sha256(&archive)},
-                "assets": artifact::FILES
+                "assets": product.files()
                     .iter()
                     .map(|path| json!({"path": path}))
                     .collect::<Vec<_>>(),
             }
         },
         "releases": [{
-            "app_name": "tmt-cli",
+            "app_name": product.package(),
             "app_version": version,
             "artifacts": [archive_name.clone()]
         }]
@@ -172,7 +181,7 @@ pub(in crate::native_install) fn valid_fixture(
     .unwrap();
     let release = json!({
         "id": release_id,
-        "tag_name": format!("v{version}"),
+        "tag_name": format!("{}{version}", product.tag_prefix()),
         "draft": false,
         "immutable": true,
         "prerelease": version.contains('-'),
@@ -209,6 +218,80 @@ fn update_manifest_asset(release: &mut Value, manifest: &[u8]) {
         .unwrap();
     asset["size"] = json!(manifest.len());
     asset["digest"] = json!(format!("sha256:{}", sha256(manifest)));
+}
+
+#[test]
+fn office_discovery_ignores_cli_versions_and_uses_its_own_exact_tags() {
+    let (cli, _, _, _) = valid_fixture("99.0.0", TARGET, 400);
+    let (office, manifest, archive, _) =
+        product_fixture(Product::Office, "0.1.0-alpha.1", TARGET, 401);
+    let mut fixture = HttpFixture::default();
+    fixture.page(1, &[cli, office.clone()]);
+    register(&mut fixture, &office, &manifest, &archive);
+    let result = super::download_product(
+        Product::Office,
+        Channel::Alpha,
+        None,
+        TARGET,
+        deadline(),
+        |u, a, l, d| fixture.get(u, a, l, d),
+    )
+    .unwrap();
+    assert_eq!(result.version.to_string(), "0.1.0-alpha.1");
+    assert_eq!(
+        fixture
+            .calls
+            .iter()
+            .map(|c| c.url.clone())
+            .collect::<Vec<_>>(),
+        vec![page_url(1), asset_url(4011), asset_url(4012)]
+    );
+    let artifact = artifact::acquire_bytes(
+        Product::Office,
+        &result.manifest,
+        &result.archive_name,
+        &result.archive,
+        TARGET,
+    )
+    .unwrap();
+    assert!(artifact.files.contains_key("tmt-office"));
+    assert!(!artifact.files.contains_key("tmt"));
+    fixture.calls.clear();
+    let url = format!("{}/tags/tmt-office-v0.1.0-alpha.1", endpoint());
+    fixture.response(url.clone(), serde_json::to_vec(&office).unwrap());
+    super::download_product(
+        Product::Office,
+        Channel::Alpha,
+        Some(&"0.1.0-alpha.1".parse().unwrap()),
+        TARGET,
+        deadline(),
+        |u, a, l, d| fixture.get(u, a, l, d),
+    )
+    .unwrap();
+    assert_eq!(fixture.calls[0].url, url);
+}
+
+#[test]
+fn cli_only_releases_are_not_an_office_installation_candidate() {
+    let (cli, _, _, _) = valid_fixture("99.0.0-alpha.1", TARGET, 410);
+    let mut fixture = HttpFixture::default();
+    fixture.page(1, &[cli]);
+    let error = super::download_product(
+        Product::Office,
+        Channel::Alpha,
+        None,
+        TARGET,
+        deadline(),
+        |u, a, l, d| fixture.get(u, a, l, d),
+    )
+    .err()
+    .unwrap();
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    assert_eq!(
+        error.to_string(),
+        "No release is available in the selected native channel."
+    );
+    assert_eq!(fixture.calls.len(), 1);
 }
 
 #[test]

--- a/rust/crates/tmt-adapters/src/native_install/remove.rs
+++ b/rust/crates/tmt-adapters/src/native_install/remove.rs
@@ -1,0 +1,36 @@
+//! Deactivate only verified Office links; retained releases and app data are untouched.
+
+use super::{Product, invalid, publication::Layout};
+use std::{fs, io, path::Path};
+
+pub fn uninstall_office(prefix: &Path) -> io::Result<bool> {
+    let root = prefix.join(Product::Office.namespace());
+    match fs::symlink_metadata(&root) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return match fs::symlink_metadata(prefix.join("bin/tmt-office")) {
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+                Err(error) => Err(error),
+                Ok(_) => Err(invalid("Unmanaged Office command; refusing removal.")),
+            };
+        }
+        Err(error) => return Err(error),
+        Ok(_) => {}
+    }
+    let layout = Layout::existing_product(prefix, Product::Office)?;
+    let _lock = crate::file_lock::exclusive(&layout.root.join("install.lock"))?;
+    let current = layout.current()?;
+    layout.check_links(current.is_some())?;
+    if current.is_none() {
+        return Ok(false);
+    }
+    for name in Product::Office.links() {
+        match fs::remove_file(layout.prefix.join("bin").join(name)) {
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            result => result?,
+        }
+    }
+    fs::File::open(layout.prefix.join("bin"))?.sync_all()?;
+    fs::remove_file(layout.root.join("current"))?;
+    fs::File::open(&layout.root)?.sync_all()?;
+    Ok(true)
+}

--- a/rust/crates/tmt-adapters/src/native_install/upgrade.rs
+++ b/rust/crates/tmt-adapters/src/native_install/upgrade.rs
@@ -1,12 +1,8 @@
 //! Public update orchestration. Network acquisition never holds the install lock.
 
-use super::{
-    ActivatedInstallation, InstallReport, InstallRequest, inspect, install_observed, release,
-};
+use super::{ActivatedInstallation, ActivationRequest, InstallReport, activate, artifact, release};
 use std::{
-    fs,
-    io::{self, Write},
-    os::unix::fs::{DirBuilderExt, OpenOptionsExt},
+    io,
     path::Path,
     time::{Duration, Instant},
 };
@@ -63,19 +59,40 @@ pub fn upgrade(
     request: UpgradeRequest<'_>,
     checkpoint: impl FnMut() -> io::Result<()>,
 ) -> Result<UpgradeReport, UpgradeFailure> {
-    let client = crate::release_http::Https::new();
-    upgrade_with(request, checkpoint, |url, accept, limit, deadline| {
-        client.get(url, accept, limit, deadline)
-    })
+    upgrade_product(super::Product::Cli, request, checkpoint)
 }
 
+pub fn upgrade_product(
+    product: super::Product,
+    request: UpgradeRequest<'_>,
+    checkpoint: impl FnMut() -> io::Result<()>,
+) -> Result<UpgradeReport, UpgradeFailure> {
+    let client = crate::release_http::Https::new();
+    upgrade_product_with(
+        product,
+        request,
+        checkpoint,
+        |url, accept, limit, deadline| client.get(url, accept, limit, deadline),
+    )
+}
+
+#[cfg(test)]
 fn upgrade_with(
+    request: UpgradeRequest<'_>,
+    checkpoint: impl FnMut() -> io::Result<()>,
+    get: impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>>,
+) -> Result<UpgradeReport, UpgradeFailure> {
+    upgrade_product_with(super::Product::Cli, request, checkpoint, get)
+}
+
+fn upgrade_product_with(
+    product: super::Product,
     request: UpgradeRequest<'_>,
     mut checkpoint: impl FnMut() -> io::Result<()>,
     get: impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>>,
 ) -> Result<UpgradeReport, UpgradeFailure> {
     checkpoint()?;
-    let current = inspect(request.executable)?;
+    let current = super::inspect_product(product, request.executable)?;
     let selection = select_upgrade(
         &current.state,
         request.channel,
@@ -100,7 +117,8 @@ fn upgrade_with(
             skipped_pinned: true,
         });
     };
-    let downloaded = release::download(
+    let downloaded = release::download_product(
+        product,
         channel,
         exact.as_ref(),
         &current.target,
@@ -110,42 +128,26 @@ fn upgrade_with(
     let plan = plan_version(Some(&current.state), &downloaded.version, channel, pin)
         .map_err(io::Error::other)?;
     checkpoint()?;
-    // Only this successful create grants cleanup ownership. Never remove a
-    // colliding or abandoned staging directory from another invocation.
-    let stage = current
-        .prefix
-        .join("lib/tmux-team")
-        .join(format!(".download-{}", uuid::Uuid::new_v4()));
-    fs::DirBuilder::new().mode(0o700).create(&stage)?;
-    let archive = stage.join(&downloaded.archive_name);
-    let manifest = stage.join("dist-manifest.json");
-    let result = (|| {
-        for (path, bytes) in [
-            (&archive, &downloaded.archive),
-            (&manifest, &downloaded.manifest),
-        ] {
-            let mut file = fs::OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .mode(0o600)
-                .open(path)?;
-            file.write_all(bytes)?;
-        }
-        install_observed(
-            InstallRequest {
-                archive: &archive,
-                manifest: &manifest,
-                prefix: &current.prefix,
-                target: &current.target,
-                channel,
-                pin,
-            },
-            Some(current.id),
-            Some(downloaded.provenance),
-            &mut checkpoint,
-        )
-    })();
-    let result = result
+    let artifact = artifact::acquire_bytes(
+        product,
+        &downloaded.manifest,
+        &downloaded.archive_name,
+        &downloaded.archive,
+        &current.target,
+    )?;
+    let result = activate(
+        ActivationRequest {
+            product,
+            prefix: &current.prefix,
+            channel,
+            pin,
+            expected: Some(current.id),
+            provenance: Some(downloaded.provenance),
+        },
+        &artifact,
+        &mut checkpoint,
+    );
+    result
         .map(|installation| UpgradeReport {
             installation,
             state: plan.state.clone(),
@@ -163,27 +165,7 @@ fn upgrade_with(
                     })
                 });
             UpgradeFailure { activated, cause }
-        });
-    match (result, fs::remove_dir_all(&stage)) {
-        (result, Ok(())) => result,
-        (Ok(report), Err(cleanup)) => Err(UpgradeFailure {
-            activated: report.installation.changed.then(|| Box::new(report)),
-            cause: io::Error::new(
-                cleanup.kind(),
-                format!("Native update staging cleanup failed: {cleanup}"),
-            ),
-        }),
-        (Err(mut failure), Err(cleanup)) => {
-            failure.cause = io::Error::new(
-                failure.cause.kind(),
-                format!(
-                    "{}; native update staging cleanup failed: {cleanup}",
-                    failure.cause
-                ),
-            );
-            Err(failure)
-        }
-    }
+        })
 }
 
 #[cfg(test)]

--- a/rust/crates/tmt-adapters/src/native_install/upgrade_artifact_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/upgrade_artifact_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::native_install::{InstallRequest, install_observed};
 use crate::{
     content_digest::sha256,
     native_install::{artifact, publication::Layout},

--- a/rust/crates/tmt-adapters/src/native_install/upgrade_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/upgrade_tests.rs
@@ -1,8 +1,10 @@
 use super::*;
+use crate::native_install::inspect;
 use crate::native_install::{
     receipt::Receipt,
     test_support::{artifact, publish, published_layout, state},
 };
+use std::fs;
 
 fn release_download() -> impl FnMut(&str, &str, usize, Instant) -> io::Result<Vec<u8>> {
     let (release, manifest, archive, _) =
@@ -68,8 +70,8 @@ fn finalization_failure_reports_the_active_release_and_retry_repairs_links() {
         .join(old.id.to_string())
         .join("tmt");
     let mut checkpoints = 0;
-    // Four orchestration checkpoints precede the existing publisher's sequence.
-    let last_checkpoint = crate::native_install::test_support::checkpoint_count() + 4;
+    // Three orchestration checkpoints precede the publisher; downloads stay in memory.
+    let last_checkpoint = crate::native_install::test_support::checkpoint_count() + 3;
     let error = upgrade_with(
         UpgradeRequest {
             executable: &executable,

--- a/rust/crates/tmt-adapters/src/office_companion.rs
+++ b/rust/crates/tmt-adapters/src/office_companion.rs
@@ -17,30 +17,37 @@ use tmt_core::office_protocol::{
 /// Local compatibility inspection only: does not pair, authenticate or start a service.
 pub fn probe_office_companion(executable: &Path) -> io::Result<String> {
     native_install::with_active_product(Product::Office, executable, |installed| {
-        let args = OfficeInvocation::Probe.arguments().map(OsString::from);
-        let output = UnixCommandRunner
-            .execute(CommandRequest {
-                program: installed.active_executable.as_os_str(),
-                args: &args,
-                input: &[],
-                deadline: Instant::now() + Duration::from_secs(5),
-                max_output_bytes: OFFICE_PROTOCOL_OUTPUT_LIMIT,
-            })
-            .map_err(io::Error::other)?;
-        if !output.stderr.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Office handshake produced unexpected diagnostics.",
-            ));
-        }
-        let version = decode_office_probe(&output.stdout)
-            .map_err(|message| io::Error::new(io::ErrorKind::InvalidData, message))?;
-        if version != installed.state.version {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Office executable and installation versions disagree.",
-            ));
-        }
-        Ok(version.to_string())
+        probe_candidate(&installed.active_executable, &installed.state.version)
     })?
+}
+
+pub(crate) fn probe_candidate(
+    executable: &Path,
+    expected_version: &semver::Version,
+) -> io::Result<String> {
+    let args = OfficeInvocation::Probe.arguments().map(OsString::from);
+    let output = UnixCommandRunner
+        .execute(CommandRequest {
+            program: executable.as_os_str(),
+            args: &args,
+            input: &[],
+            deadline: Instant::now() + Duration::from_secs(5),
+            max_output_bytes: OFFICE_PROTOCOL_OUTPUT_LIMIT,
+        })
+        .map_err(io::Error::other)?;
+    if !output.stderr.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Office handshake produced unexpected diagnostics.",
+        ));
+    }
+    let version = decode_office_probe(&output.stdout)
+        .map_err(|message| io::Error::new(io::ErrorKind::InvalidData, message))?;
+    if &version != expected_version {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Office executable and installation versions disagree.",
+        ));
+    }
+    Ok(version.to_string())
 }

--- a/rust/crates/tmt-adapters/src/office_companion.rs
+++ b/rust/crates/tmt-adapters/src/office_companion.rs
@@ -1,0 +1,46 @@
+//! Verified, bounded execution of the optional companion; never resolves PATH.
+
+use crate::{
+    native_install::{self, Product},
+    process::{CommandRequest, CommandRunner, UnixCommandRunner},
+};
+use std::{
+    ffi::OsString,
+    io,
+    path::Path,
+    time::{Duration, Instant},
+};
+use tmt_core::office_protocol::{
+    OFFICE_PROTOCOL_OUTPUT_LIMIT, OfficeInvocation, decode_office_probe,
+};
+
+/// Local compatibility inspection only: does not pair, authenticate or start a service.
+pub fn probe_office_companion(executable: &Path) -> io::Result<String> {
+    native_install::with_active_product(Product::Office, executable, |installed| {
+        let args = OfficeInvocation::Probe.arguments().map(OsString::from);
+        let output = UnixCommandRunner
+            .execute(CommandRequest {
+                program: installed.active_executable.as_os_str(),
+                args: &args,
+                input: &[],
+                deadline: Instant::now() + Duration::from_secs(5),
+                max_output_bytes: OFFICE_PROTOCOL_OUTPUT_LIMIT,
+            })
+            .map_err(io::Error::other)?;
+        if !output.stderr.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Office handshake produced unexpected diagnostics.",
+            ));
+        }
+        let version = decode_office_probe(&output.stdout)
+            .map_err(|message| io::Error::new(io::ErrorKind::InvalidData, message))?;
+        if version != installed.state.version {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Office executable and installation versions disagree.",
+            ));
+        }
+        Ok(version.to_string())
+    })?
+}

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -196,6 +196,7 @@ pub fn grammar() -> Command {
         .subcommand(
             general("__native-install", "Internal offline native installation")
                 .hide(true)
+                .arg(Arg::new("product").long("product").default_value("cli").value_parser(tmt_core::native_install::Product::ALL.map(|product| product.as_str())))
                 .arg(Arg::new("archive").long("archive").required(true))
                 .arg(Arg::new("manifest").long("manifest").required(true))
                 .arg(Arg::new("prefix").long("prefix").required(true))

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -25,189 +25,226 @@ pub fn grammar() -> Command {
     ] {
         root = root.arg(option(id).global(true));
     }
+    root = root.subcommand(office_commands());
     root.subcommand(general("help", "Show help"))
-        .subcommand(
-            general("team", "Retired command")
-                .hide(true)
-                .arg(operand("scope", false)),
+    .subcommand(
+        general("team", "Retired command")
+            .hide(true)
+            .arg(operand("scope", false)),
+    )
+    .subcommand(general("init", "Create workspace settings"))
+    .subcommand(
+        general("list", "List global identities, lifetime and live presence")
+            .visible_alias("ls")
+            .arg(operand("target", false)),
+    )
+    .subcommand(
+        with_options(
+            general("add", "Bind an explicit pane; temporary unless saved"),
+            &["save"],
         )
-        .subcommand(general("init", "Create workspace settings"))
-        .subcommand(
-            general("list", "List global identities, lifetime and live presence")
-                .visible_alias("ls")
-                .arg(operand("target", false)),
+        .arg(operand("pane-target", true))
+        .arg(operand("name", true)),
+    )
+    .subcommand(
+        with_options(
+            general("name", "Bind this pane; temporary unless saved"),
+            &["save"],
         )
-        .subcommand(
-            with_options(
-                general("add", "Bind an explicit pane; temporary unless saved"),
-                &["save"],
+        .visible_alias("this")
+        .arg(operand("name", true)),
+    )
+    .subcommand(
+        with_options(
+            general(
+                "rm",
+                "Retire identity and remove role/preamble; keep pane/exchanges (--force for saved)",
+            ),
+            &["force"],
+        )
+        .visible_alias("remove")
+        .arg(operand("name", true)),
+    )
+    .subcommand(
+        with_options(
+            general("talk", "Send a request and wait for its durable reply"),
+            &[
+                "force",
+                "delay",
+                "detach",
+                "timeout",
+                "no-preamble",
+                "identity",
+            ],
+        )
+        .visible_alias("send")
+        .arg(operand("target", true))
+        .arg(operand("message", true)),
+    )
+    .subcommand(
+        with_options(
+            general("check", "Capture diagnostic pane output"),
+            &["lines"],
+        )
+        .visible_alias("read")
+        .arg(operand("target", true))
+        .arg(operand("capture-lines", false)),
+    )
+    .subcommand(general("whoami", "Show this pane's verified identity"))
+    .subcommand(general(
+        "unbind",
+        "Detach this pane; retire temporary identity",
+    ))
+    .subcommand(
+        general("config", "View or modify settings")
+            .subcommand(general("show", "Show settings"))
+            .subcommand(
+                with_options(general("set", "Set a setting"), &["global"])
+                    .arg(operand("key", true))
+                    .arg(operand("value", true).allow_negative_numbers(true)),
             )
-            .arg(operand("pane-target", true))
-            .arg(operand("name", true)),
-        )
-        .subcommand(
-            with_options(
-                general("name", "Bind this pane; temporary unless saved"),
-                &["save"],
+            .subcommand(general("clear", "Clear a local setting").arg(operand("key", false))),
+    )
+    .subcommand(
+        general("preamble", "Manage identity-owned preambles")
+            .subcommand(general("show", "Show preambles").arg(operand("agent", false)))
+            .subcommand(
+                general("set", "Set a preamble")
+                    .arg(operand("agent", true))
+                    .arg(operand("content", true).num_args(1..)),
             )
-            .visible_alias("this")
-            .arg(operand("name", true)),
+            .subcommand(general("clear", "Clear a preamble").arg(operand("agent", true))),
+    )
+    .subcommand(
+        with_options(
+            storage("x", "Inspect and acknowledge exchanges"),
+            &["identity", "limit", "after"],
         )
-        .subcommand(
-            with_options(
-                general("rm", "Retire identity and remove role/preamble; keep pane/exchanges (--force for saved)"),
-                &["force"],
-            )
-            .visible_alias("remove")
-            .arg(operand("name", true)),
-        )
-        .subcommand(
-            with_options(
-                general("talk", "Send a request and wait for its durable reply"),
-                &[
-                    "force",
-                    "delay",
-                    "detach",
-                    "timeout",
-                    "no-preamble",
-                    "identity",
-                ],
-            )
-            .visible_alias("send")
-            .arg(operand("target", true))
-            .arg(operand("message", true)),
-        )
-        .subcommand(
-            with_options(
-                general("check", "Capture diagnostic pane output"),
-                &["lines"],
-            )
-            .visible_alias("read")
-            .arg(operand("target", true))
-            .arg(operand("capture-lines", false)),
-        )
-        .subcommand(general("whoami", "Show this pane's verified identity"))
-        .subcommand(general(
-            "unbind",
-            "Detach this pane; retire temporary identity",
+        .subcommand(with_options(
+            storage("list", "List unacknowledged exchanges"),
+            &["identity", "limit", "after"],
         ))
         .subcommand(
-            general("config", "View or modify settings")
-                .subcommand(general("show", "Show settings"))
-                .subcommand(
-                    with_options(general("set", "Set a setting"), &["global"])
-                        .arg(operand("key", true))
-                        .arg(operand("value", true).allow_negative_numbers(true)),
-                )
-                .subcommand(general("clear", "Clear a local setting").arg(operand("key", false))),
-        )
-        .subcommand(
-            general("preamble", "Manage identity-owned preambles")
-                .subcommand(general("show", "Show preambles").arg(operand("agent", false)))
-                .subcommand(
-                    general("set", "Set a preamble")
-                        .arg(operand("agent", true))
-                        .arg(operand("content", true).num_args(1..)),
-                )
-                .subcommand(general("clear", "Clear a preamble").arg(operand("agent", true))),
-        )
-        .subcommand(
             with_options(
-                storage("x", "Inspect and acknowledge exchanges"),
-                &["identity", "limit", "after"],
-            )
-            .subcommand(with_options(
-                storage("list", "List unacknowledged exchanges"),
-                &["identity", "limit", "after"],
-            ))
-            .subcommand(
-                with_options(
-                    storage("show", "Show retained exchange content"),
-                    &["identity"],
-                )
-                .arg(operand("request-id", true)),
-            )
-            .subcommand(
-                with_options(
-                    storage("ack", "Acknowledge an observed revision"),
-                    &["identity"],
-                )
-                .arg(option("revision").required(true))
-                .arg(operand("request-id", true)),
-            )
-            .subcommand(with_options(
-                storage("ackall", "Acknowledge the current identity snapshot"),
+                storage("show", "Show retained exchange content"),
                 &["identity"],
-            )),
-        )
-        .subcommand(
-            storage("identity", "Manage identity records without probing tmux")
-                .subcommand_required(true)
-                .subcommand(
-                    storage("create", "Create or save an identity").arg(operand("name", true)),
-                )
-                .subcommand(storage("show", "Show an identity").arg(operand("name", true)))
-                .subcommand(storage("list", "List non-retired identities")),
-        )
-        .subcommand(
-            with_options(general("role", "Manage role profiles"), &["identity"])
-                .subcommand_required(true)
-                .subcommand(with_options(general("show", "Show a role"), &["identity"]))
-                .subcommand(
-                    with_options(
-                        general("set", "Set a role from inline text or file"),
-                        &["identity", "file"],
-                    )
-                    .arg(operand("content", false)),
-                )
-                .subcommand(with_options(
-                    general("clear", "Clear a role"),
-                    &["identity"],
-                )),
-        )
-        .subcommand(
-            with_options(
-                storage("reply", "Submit an exact final response"),
-                &["file", "message", "stdin"],
             )
-            .arg(option("receipt").required(true))
             .arg(operand("request-id", true)),
         )
         .subcommand(
-            storage("result", "Retrieve a retained final response")
-                .arg(operand("request-id", true)),
-        )
-        .subcommand(
             with_options(
-                general("install", "Install or refresh agent skills"),
-                &["force", "dir"],
+                storage("ack", "Acknowledge an observed revision"),
+                &["identity"],
             )
-            .arg(operand("agent", false).value_parser(
-                tmt_core::skill_provider::Provider::ALL.into_iter().map(|provider| provider.as_str()).chain(["all"]).collect::<Vec<_>>()
-            ).ignore_case(true)),
-        )
-        .subcommand(general("completion", "Generate shell completion").arg(operand("shell", false)))
-        .subcommand(general("upgrade", "Upgrade the native CLI and refresh managed skills")
-            .visible_alias("update")
-            .arg(Arg::new("channel").long("channel").value_parser(tmt_core::native_install::Channel::ALL.map(|channel| channel.as_str())))
-            .arg(Arg::new("to").long("to").conflicts_with("unpin"))
-            .arg(Arg::new("unpin").long("unpin").action(ArgAction::SetTrue)))
-        .subcommand(general("__native-refresh-skills", "Internal managed skill refresh").hide(true))
-        .subcommand(
-            general("__native-install", "Internal offline native installation")
-                .hide(true)
-                .arg(Arg::new("product").long("product").default_value("cli").value_parser(tmt_core::native_install::Product::ALL.map(|product| product.as_str())))
-                .arg(Arg::new("archive").long("archive").required(true))
-                .arg(Arg::new("manifest").long("manifest").required(true))
-                .arg(Arg::new("prefix").long("prefix").required(true))
-                .arg(Arg::new("channel").long("channel").required(true).value_parser(tmt_core::native_install::Channel::ALL.map(|channel| channel.as_str())))
-                .arg(Arg::new("pin").long("pin").action(ArgAction::SetTrue).conflicts_with("unpin"))
-                .arg(Arg::new("unpin").long("unpin").action(ArgAction::SetTrue)),
+            .arg(option("revision").required(true))
+            .arg(operand("request-id", true)),
         )
         .subcommand(with_options(
-            general("learn", "Read agent guidance"),
-            &["skill"],
-        ))
+            storage("ackall", "Acknowledge the current identity snapshot"),
+            &["identity"],
+        )),
+    )
+    .subcommand(
+        storage("identity", "Manage identity records without probing tmux")
+            .subcommand_required(true)
+            .subcommand(storage("create", "Create or save an identity").arg(operand("name", true)))
+            .subcommand(storage("show", "Show an identity").arg(operand("name", true)))
+            .subcommand(storage("list", "List non-retired identities")),
+    )
+    .subcommand(
+        with_options(general("role", "Manage role profiles"), &["identity"])
+            .subcommand_required(true)
+            .subcommand(with_options(general("show", "Show a role"), &["identity"]))
+            .subcommand(
+                with_options(
+                    general("set", "Set a role from inline text or file"),
+                    &["identity", "file"],
+                )
+                .arg(operand("content", false)),
+            )
+            .subcommand(with_options(
+                general("clear", "Clear a role"),
+                &["identity"],
+            )),
+    )
+    .subcommand(
+        with_options(
+            storage("reply", "Submit an exact final response"),
+            &["file", "message", "stdin"],
+        )
+        .arg(option("receipt").required(true))
+        .arg(operand("request-id", true)),
+    )
+    .subcommand(
+        storage("result", "Retrieve a retained final response").arg(operand("request-id", true)),
+    )
+    .subcommand(
+        with_options(
+            general("install", "Install or refresh agent skills"),
+            &["force", "dir"],
+        )
+        .arg(
+            operand("agent", false)
+                .value_parser(
+                    tmt_core::skill_provider::Provider::ALL
+                        .into_iter()
+                        .map(|provider| provider.as_str())
+                        .chain(["all"])
+                        .collect::<Vec<_>>(),
+                )
+                .ignore_case(true),
+        ),
+    )
+    .subcommand(general("completion", "Generate shell completion").arg(operand("shell", false)))
+    .subcommand(
+        general(
+            "upgrade",
+            "Upgrade the native CLI and refresh managed skills",
+        )
+        .visible_alias("update")
+        .arg(
+            Arg::new("channel").long("channel").value_parser(
+                tmt_core::native_install::Channel::ALL.map(|channel| channel.as_str()),
+            ),
+        )
+        .arg(Arg::new("to").long("to").conflicts_with("unpin"))
+        .arg(Arg::new("unpin").long("unpin").action(ArgAction::SetTrue)),
+    )
+    .subcommand(general("__native-refresh-skills", "Internal managed skill refresh").hide(true))
+    .subcommand(
+        general("__native-install", "Internal offline native installation")
+            .hide(true)
+            .arg(
+                Arg::new("product")
+                    .long("product")
+                    .default_value("cli")
+                    .value_parser(
+                        tmt_core::native_install::Product::ALL.map(|product| product.as_str()),
+                    ),
+            )
+            .arg(Arg::new("archive").long("archive").required(true))
+            .arg(Arg::new("manifest").long("manifest").required(true))
+            .arg(Arg::new("prefix").long("prefix").required(true))
+            .arg(
+                Arg::new("channel")
+                    .long("channel")
+                    .required(true)
+                    .value_parser(
+                        tmt_core::native_install::Channel::ALL.map(|channel| channel.as_str()),
+                    ),
+            )
+            .arg(
+                Arg::new("pin")
+                    .long("pin")
+                    .action(ArgAction::SetTrue)
+                    .conflicts_with("unpin"),
+            )
+            .arg(Arg::new("unpin").long("unpin").action(ArgAction::SetTrue)),
+    )
+    .subcommand(with_options(
+        general("learn", "Read agent guidance"),
+        &["skill"],
+    ))
 }
 
 fn base(name: &'static str, about: &'static str) -> Command {
@@ -225,6 +262,38 @@ fn storage(name: &'static str, about: &'static str) -> Command {
 
 fn general(name: &'static str, about: &'static str) -> Command {
     with_options(storage(name, about), &["wait", "team"])
+}
+
+fn office(name: &'static str, about: &'static str) -> Command {
+    general(name, about).arg(Arg::new("prefix").long("prefix").global(true))
+}
+
+fn office_commands() -> Command {
+    office("office", "Manage the optional Office companion")
+        .subcommand(office("status", "Inspect the local Office installation"))
+        .subcommand(
+            office("install", "Explicitly install the Office companion")
+                .arg(Arg::new("yes").long("yes").action(ArgAction::SetTrue))
+                .arg(Arg::new("archive").long("archive").requires("manifest"))
+                .arg(Arg::new("manifest").long("manifest").requires("archive"))
+                .arg(Arg::new("channel").long("channel").value_parser(
+                    tmt_core::native_install::Channel::ALL.map(|channel| channel.as_str()),
+                )),
+        )
+        .subcommand(
+            office("upgrade", "Explicitly update the Office companion").arg(
+                Arg::new("channel").long("channel").value_parser(
+                    tmt_core::native_install::Channel::ALL.map(|channel| channel.as_str()),
+                ),
+            ),
+        )
+        .subcommand(
+            office(
+                "uninstall",
+                "Deactivate Office without deleting retained data",
+            )
+            .arg(Arg::new("yes").long("yes").action(ArgAction::SetTrue)),
+        )
 }
 
 fn with_options(mut command: Command, ids: &[&'static str]) -> Command {

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -61,6 +61,10 @@ pub enum Invocation {
         unpin: bool,
     },
     NativeRefreshSkills,
+    Office {
+        prefix: Option<String>,
+        operation: OfficeOperation,
+    },
     NativeInstall {
         product: tmt_core::native_install::Product,
         archive: String,
@@ -68,6 +72,24 @@ pub enum Invocation {
         prefix: String,
         channel: tmt_core::native_install::Channel,
         pin: tmt_core::native_install::PinAction,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OfficeOperation {
+    Open,
+    Status,
+    Install {
+        yes: bool,
+        archive: Option<String>,
+        manifest: Option<String>,
+        channel: Option<tmt_core::native_install::Channel>,
+    },
+    Upgrade {
+        channel: Option<tmt_core::native_install::Channel>,
+    },
+    Uninstall {
+        yes: bool,
     },
 }
 

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -62,6 +62,7 @@ pub enum Invocation {
     },
     NativeRefreshSkills,
     NativeInstall {
+        product: tmt_core::native_install::Product,
         archive: String,
         manifest: String,
         prefix: String,

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -13,6 +13,7 @@ mod install_command;
 mod invocation;
 mod native_install_command;
 mod native_upgrade_command;
+mod office_command;
 mod output;
 mod parser;
 mod profile_command;
@@ -142,6 +143,10 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         Invocation::NativeRefreshSkills => {
             drop(stdout);
             return skill_refresh_command::execute(parsed.mode);
+        }
+        Invocation::Office { prefix, operation } => {
+            drop(stdout);
+            return office_command::execute(prefix, operation, parsed.mode);
         }
         Invocation::NativeInstall {
             product,

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -144,6 +144,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
             return skill_refresh_command::execute(parsed.mode);
         }
         Invocation::NativeInstall {
+            product,
             archive,
             manifest,
             prefix,
@@ -152,6 +153,7 @@ fn execute(parsed: invocation::Parsed) -> io::Result<u8> {
         } => {
             drop(stdout);
             return native_install_command::execute(
+                product,
                 &archive,
                 &manifest,
                 &prefix,

--- a/rust/crates/tmt-cli/src/native_install_command.rs
+++ b/rust/crates/tmt-cli/src/native_install_command.rs
@@ -8,6 +8,7 @@ use std::{
 use tmt_core::native_install::{Channel, PinAction};
 
 pub fn execute(
+    product: tmt_core::native_install::Product,
     archive: &str,
     manifest: &str,
     prefix: &str,
@@ -45,7 +46,7 @@ pub fn execute(
         channel,
         pin,
     };
-    let report = match tmt_adapters::native_install::install(request, || {
+    let report = match tmt_adapters::native_install::install_product(product, request, || {
         if interrupt.is_interrupted() {
             Err(io::Error::new(
                 io::ErrorKind::Interrupted,
@@ -77,12 +78,13 @@ pub fn execute(
     } else {
         writeln!(
             stdout,
-            "{} tmt {} at {}",
+            "{} {} {} at {}",
             if report.changed {
                 "Installed"
             } else {
                 "Current"
             },
+            product.executable(),
             report.version,
             report.executable.display()
         )?;

--- a/rust/crates/tmt-cli/src/native_install_command.rs
+++ b/rust/crates/tmt-cli/src/native_install_command.rs
@@ -16,20 +16,19 @@ pub fn execute(
     pin: PinAction,
     mode: OutputMode,
 ) -> io::Result<u8> {
-    let target = match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("macos", "aarch64") => "aarch64-apple-darwin",
-        ("macos", "x86_64") => "x86_64-apple-darwin",
-        ("linux", "aarch64") => "aarch64-unknown-linux-musl",
-        ("linux", "x86_64") => "x86_64-unknown-linux-musl",
-        _ => {
-            return Failure::new(
-                "NATIVE_INSTALL_UNSUPPORTED",
-                "No native artifact is supported for this platform.",
-                1,
-            )
-            .publish(mode);
-        }
-    };
+    let target =
+        match tmt_core::native_install::native_target(std::env::consts::OS, std::env::consts::ARCH)
+        {
+            Some(target) => target,
+            None => {
+                return Failure::new(
+                    "NATIVE_INSTALL_UNSUPPORTED",
+                    "No native artifact is supported for this platform.",
+                    1,
+                )
+                .publish(mode);
+            }
+        };
     let interrupt = match tmt_adapters::interrupt::Interrupt::install() {
         Ok(interrupt) => interrupt,
         Err(error) => {

--- a/rust/crates/tmt-cli/src/office_command.rs
+++ b/rust/crates/tmt-cli/src/office_command.rs
@@ -1,0 +1,331 @@
+//! Optional Office composition; no application database, implicit service or PATH dispatch.
+
+use crate::{
+    invocation::{OfficeOperation, OutputMode},
+    output::Failure,
+};
+use serde_json::json;
+use std::{
+    fs,
+    io::{self, BufRead, IsTerminal, Read, Write},
+    path::{Path, PathBuf},
+};
+use tmt_adapters::{
+    native_install::{self, InstallRequest, Product, UpgradeRequest},
+    office_companion::probe_office_companion,
+};
+use tmt_core::native_install::{Channel, PinAction};
+
+const INSTALL_HINT: &str = "Install Office with: tmt office install --yes";
+
+fn consent(yes: bool, mode: OutputMode, action: &str) -> Result<bool, Failure> {
+    if yes {
+        return Ok(true);
+    }
+    if mode.json || !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        return Err(Failure::new(
+            "OFFICE_CONSENT_REQUIRED",
+            format!("{action} requires explicit --yes; no changes were made."),
+            1,
+        ));
+    }
+    let mut stderr = io::stderr().lock();
+    write!(stderr, "{action}? [y/N] ")
+        .and_then(|()| stderr.flush())
+        .map_err(|e| failure("OFFICE_IO_ERROR", e))?;
+    let mut answer = Vec::new();
+    io::stdin()
+        .lock()
+        .take(256)
+        .read_until(b'\n', &mut answer)
+        .map_err(|e| failure("OFFICE_IO_ERROR", e))?;
+    Ok(matches!(
+        std::str::from_utf8(&answer)
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn failure(code: &'static str, error: impl std::error::Error + 'static) -> Failure {
+    Failure::new(code, error.to_string(), 1).caused_by(error)
+}
+
+fn report(value: serde_json::Value, human: &str, mode: OutputMode) -> io::Result<u8> {
+    writeln!(
+        io::stdout().lock(),
+        "{}",
+        if mode.json {
+            value.to_string()
+        } else {
+            human.into()
+        }
+    )?;
+    Ok(0)
+}
+
+fn installed(executable: &Path) -> Result<bool, Failure> {
+    match fs::symlink_metadata(executable) {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            // A missing command link is recoverable partial removal, not proof
+            // that the owned activation disappeared.
+            let prefix = executable
+                .parent()
+                .and_then(Path::parent)
+                .expect("Office command prefix");
+            match fs::symlink_metadata(prefix.join(Product::Office.namespace()).join("current")) {
+                Ok(_) => Err(Failure::new(
+                    "OFFICE_INSTALLATION_INVALID",
+                    "Office has an activation but no command link. Finish removal with office uninstall --yes, then reinstall.",
+                    1,
+                )),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+                Err(e) => Err(failure("OFFICE_INSTALLATION_INVALID", e)),
+            }
+        }
+        Err(e) => Err(failure("OFFICE_INSTALLATION_INVALID", e)),
+    }
+}
+
+fn install(
+    prefix: &Path,
+    archive: Option<&str>,
+    manifest: Option<&str>,
+    channel: Channel,
+) -> Result<native_install::InstallReport, Failure> {
+    let interrupt = tmt_adapters::interrupt::Interrupt::install()
+        .map_err(|e| failure("OFFICE_INSTALL_FAILED", e))?;
+    let checkpoint = || {
+        if interrupt.is_interrupted() {
+            Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "Office installation interrupted. Inspect office status before retrying.",
+            ))
+        } else {
+            Ok(())
+        }
+    };
+    let target =
+        tmt_core::native_install::native_target(std::env::consts::OS, std::env::consts::ARCH)
+            .ok_or_else(|| {
+                Failure::new(
+                    "OFFICE_UNSUPPORTED",
+                    "No Office artifact supports this platform.",
+                    1,
+                )
+            })?;
+    let result = match (archive, manifest) {
+        (Some(archive), Some(manifest)) => native_install::install_product(
+            Product::Office,
+            InstallRequest {
+                archive: Path::new(archive),
+                manifest: Path::new(manifest),
+                prefix,
+                target,
+                channel,
+                pin: PinAction::Preserve,
+            },
+            checkpoint,
+        ),
+        (None, None) => {
+            let executable = prefix.join("bin/tmt-office");
+            if installed(&executable)? {
+                native_install::upgrade_product(
+                    Product::Office,
+                    UpgradeRequest {
+                        executable: &executable,
+                        channel: Some(channel),
+                        exact: None,
+                        unpin: false,
+                    },
+                    checkpoint,
+                )
+                .map(|report| report.installation)
+                .map_err(|error| io::Error::new(error.kind(), error))
+            } else {
+                native_install::install_release(
+                    Product::Office,
+                    prefix,
+                    target,
+                    channel,
+                    checkpoint,
+                )
+            }
+        }
+        _ => {
+            return Err(Failure::new(
+                "USAGE_ERROR",
+                "Archive and manifest must be supplied together.",
+                1,
+            ));
+        }
+    };
+    result.map_err(|e| {
+        Failure::new(
+            if archive.is_none() && e.kind() == io::ErrorKind::NotFound {
+                "OFFICE_RELEASE_UNAVAILABLE"
+            } else {
+                "OFFICE_INSTALL_FAILED"
+            },
+            format!("{e} Inspect office status before retrying."),
+            if e.kind() == io::ErrorKind::Interrupted {
+                130
+            } else {
+                1
+            },
+        )
+        .caused_by(e)
+    })
+}
+
+pub fn execute(
+    prefix: Option<String>,
+    operation: OfficeOperation,
+    mode: OutputMode,
+) -> io::Result<u8> {
+    match run(prefix, operation, mode) {
+        Ok(code) => Ok(code),
+        Err(error) => error.publish(mode),
+    }
+}
+
+fn run(
+    prefix: Option<String>,
+    operation: OfficeOperation,
+    mode: OutputMode,
+) -> Result<u8, Failure> {
+    let prefix = prefix
+        .map(PathBuf::from)
+        .map_or_else(native_install::default_install_prefix, Ok)
+        .map_err(|e| failure("OFFICE_LOCATION_INVALID", e))?;
+    if prefix.as_os_str().is_empty() {
+        return Err(Failure::new(
+            "OFFICE_LOCATION_INVALID",
+            "Installation prefix must not be empty.",
+            1,
+        ));
+    }
+    let executable = prefix.join("bin/tmt-office");
+    match operation {
+        OfficeOperation::Status | OfficeOperation::Open => {
+            if !installed(&executable)? {
+                if matches!(operation, OfficeOperation::Status)
+                    || mode.json
+                    || !io::stdin().is_terminal()
+                    || !io::stderr().is_terminal()
+                {
+                    return Err(Failure::new("OFFICE_NOT_INSTALLED", INSTALL_HINT, 1));
+                }
+                if !consent(
+                    false,
+                    mode,
+                    "Install the verified optional Office companion",
+                )? {
+                    return Ok(0);
+                }
+                install(&prefix, None, None, Channel::Alpha)?;
+            }
+            let interrupt = tmt_adapters::interrupt::Interrupt::install()
+                .map_err(|e| failure("OFFICE_IO_ERROR", e))?;
+            let result = probe_office_companion(&executable);
+            if interrupt.is_interrupted() {
+                return Err(Failure::new(
+                    "OFFICE_INTERRUPTED",
+                    "Office inspection interrupted; no connection was started.",
+                    130,
+                ));
+            }
+            let version = result.map_err(|e| failure("OFFICE_INCOMPATIBLE", e))?;
+            if matches!(operation, OfficeOperation::Open) {
+                return Err(Failure::new(
+                    "OFFICE_NOT_PAIRED",
+                    "Office is installed. World pairing and opening are not available in this build.",
+                    1,
+                ));
+            }
+            report(json!({"installed": true, "version": version, "protocolVersion": tmt_core::office_protocol::OFFICE_PROTOCOL_VERSION, "executable": executable}), &format!("Office {version} is installed and compatible. No connection was started."), mode).map_err(|e| failure("OFFICE_IO_ERROR", e))
+        }
+        OfficeOperation::Install {
+            yes,
+            archive,
+            manifest,
+            channel,
+        } => {
+            if !consent(yes, mode, "Install the verified optional Office companion")? {
+                return Ok(0);
+            }
+            let current = if installed(&executable)? {
+                Some(
+                    native_install::inspect_product(Product::Office, &executable)
+                        .map_err(|e| failure("OFFICE_INSTALLATION_INVALID", e))?,
+                )
+            } else {
+                None
+            };
+            let channel = channel
+                .or_else(|| current.as_ref().map(|current| current.state.channel))
+                .unwrap_or(Channel::Alpha);
+            let result = install(&prefix, archive.as_deref(), manifest.as_deref(), channel)?;
+            report(json!({"installed":true,"changed":result.changed,"version":result.version,"executable":result.executable}), &format!("Office {} installed. Pairing is separate.", result.version), mode).map_err(|e| failure("OFFICE_IO_ERROR", e))
+        }
+        OfficeOperation::Upgrade { channel } => {
+            if !installed(&executable)? {
+                return Err(Failure::new("OFFICE_NOT_INSTALLED", INSTALL_HINT, 1));
+            }
+            let interrupt = tmt_adapters::interrupt::Interrupt::install()
+                .map_err(|e| failure("OFFICE_UPGRADE_FAILED", e))?;
+            let result = native_install::upgrade_product(
+                Product::Office,
+                UpgradeRequest {
+                    executable: &executable,
+                    channel,
+                    exact: None,
+                    unpin: false,
+                },
+                || {
+                    if interrupt.is_interrupted() {
+                        Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "Office update interrupted.",
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                },
+            )
+            .map_err(|e| {
+                Failure::new(
+                    "OFFICE_UPGRADE_FAILED",
+                    format!("{e} Inspect office status before retrying."),
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        130
+                    } else {
+                        1
+                    },
+                )
+                .caused_by(e)
+            })?;
+            report(json!({"installed":true,"changed":result.installation.changed,"version":result.installation.version,"skippedPinned":result.skipped_pinned}), &format!("Office {} is current.", result.installation.version), mode).map_err(|e| failure("OFFICE_IO_ERROR", e))
+        }
+        OfficeOperation::Uninstall { yes } => {
+            if !consent(
+                yes,
+                mode,
+                "Deactivate Office (retained releases and user data will be kept)",
+            )? {
+                return Ok(0);
+            }
+            let changed = native_install::uninstall_office(&prefix)
+                .map_err(|e| failure("OFFICE_UNINSTALL_FAILED", e))?;
+            report(
+                json!({"installed":false,"changed":changed,"retainedReleases":true}),
+                "Office is deactivated. Release bytes and user data were retained.",
+                mode,
+            )
+            .map_err(|e| failure("OFFICE_IO_ERROR", e))
+        }
+    }
+}

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -149,6 +149,8 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
         },
         ["__native-refresh-skills"] => Invocation::NativeRefreshSkills,
         ["__native-install"] => Invocation::NativeInstall {
+            product: tmt_core::native_install::Product::parse(&required(m, "product"))
+                .expect("product was validated by grammar"),
             archive: required(m, "archive"),
             manifest: required(m, "manifest"),
             prefix: required(m, "prefix"),

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -147,6 +147,31 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
             exact: text(m, "to"),
             unpin: flag(m, "unpin"),
         },
+        ["office"]
+        | ["office", "status"]
+        | ["office", "install"]
+        | ["office", "upgrade"]
+        | ["office", "uninstall"] => Invocation::Office {
+            prefix: text(m, "prefix"),
+            operation: match path.last().copied() {
+                Some("status") => OfficeOperation::Status,
+                Some("install") => OfficeOperation::Install {
+                    yes: flag(m, "yes"),
+                    archive: text(m, "archive"),
+                    manifest: text(m, "manifest"),
+                    channel: text(m, "channel")
+                        .and_then(|value| tmt_core::native_install::Channel::parse(&value)),
+                },
+                Some("upgrade") => OfficeOperation::Upgrade {
+                    channel: text(m, "channel")
+                        .and_then(|value| tmt_core::native_install::Channel::parse(&value)),
+                },
+                Some("uninstall") => OfficeOperation::Uninstall {
+                    yes: flag(m, "yes"),
+                },
+                _ => OfficeOperation::Open,
+            },
+        },
         ["__native-refresh-skills"] => Invocation::NativeRefreshSkills,
         ["__native-install"] => Invocation::NativeInstall {
             product: tmt_core::native_install::Product::parse(&required(m, "product"))

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -68,6 +68,7 @@ fn internal_native_install_requires_explicit_inputs_and_typed_pin_policy() {
     assert_eq!(
         parsed.invocation,
         Invocation::NativeInstall {
+            product: tmt_core::native_install::Product::Cli,
             archive: "archive.tar.gz".into(),
             manifest: "manifest.json".into(),
             prefix: "/prefix with spaces".into(),
@@ -84,6 +85,18 @@ fn internal_native_install_requires_explicit_inputs_and_typed_pin_policy() {
             if actual == if pin == "--pin" { PinAction::PinCandidate } else { PinAction::Clear })
         );
     }
+    let mut office = input.to_vec();
+    office.extend(["--product", "office"]);
+    assert!(matches!(
+        super::parse(&self::args(&office)).unwrap().invocation,
+        Invocation::NativeInstall {
+            product: tmt_core::native_install::Product::Office,
+            ..
+        }
+    ));
+    let mut invalid_product = input.to_vec();
+    invalid_product.extend(["--product", "third-party"]);
+    assert_eq!(parse_error(&invalid_product).code, "USAGE_ERROR");
     let mut conflict = input.to_vec();
     conflict.extend(["--pin", "--unpin"]);
     assert_eq!(parse_error(&conflict).code, "USAGE_ERROR");

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -10,6 +10,57 @@ fn args(values: &[&str]) -> Vec<OsString> {
 }
 
 #[test]
+fn office_prefix_is_scoped_to_its_subtree_and_file_inputs_are_paired() {
+    use crate::invocation::OfficeOperation;
+    for input in [
+        vec![
+            "office",
+            "--prefix",
+            "/prefix with spaces",
+            "status",
+            "--json",
+        ],
+        vec![
+            "office",
+            "status",
+            "--prefix",
+            "/prefix with spaces",
+            "--json",
+        ],
+    ] {
+        assert_eq!(
+            parsed(&input).invocation,
+            Invocation::Office {
+                prefix: Some("/prefix with spaces".into()),
+                operation: OfficeOperation::Status,
+            }
+        );
+    }
+    assert_eq!(
+        parsed(&["office", "install", "--yes"]).invocation,
+        Invocation::Office {
+            prefix: None,
+            operation: OfficeOperation::Install {
+                yes: true,
+                archive: None,
+                manifest: None,
+                channel: None,
+            }
+        }
+    );
+    for input in [
+        vec!["office", "install", "--archive", "file"],
+        vec!["office", "install", "--manifest", "file"],
+        vec!["office", "status", "--yes"],
+        vec!["office", "upgrade", "--channel", "beta"],
+        vec!["office", "pair"],
+        vec!["ls", "--prefix", "/prefix"],
+    ] {
+        assert_eq!(parse_error(&input).code, "USAGE_ERROR");
+    }
+}
+
+#[test]
 fn native_upgrade_alias_and_selection_share_one_typed_contract() {
     for command in ["upgrade", "update"] {
         let invocation = parsed(&[

--- a/rust/crates/tmt-cli/src/skill_reminder.rs
+++ b/rust/crates/tmt-cli/src/skill_reminder.rs
@@ -85,6 +85,7 @@ mod tests {
             },
             Invocation::NativeRefreshSkills,
             Invocation::NativeInstall {
+                product: tmt_core::native_install::Product::Cli,
                 archive: "archive.tar.gz".into(),
                 manifest: "manifest.json".into(),
                 prefix: "/explicit-prefix".into(),

--- a/rust/crates/tmt-cli/src/skill_reminder.rs
+++ b/rust/crates/tmt-cli/src/skill_reminder.rs
@@ -21,6 +21,7 @@ fn eligible(parsed: &Parsed, interactive: bool) -> bool {
                 | Invocation::Upgrade { .. }
                 | Invocation::NativeInstall { .. }
                 | Invocation::NativeRefreshSkills
+                | Invocation::Office { .. }
         )
 }
 

--- a/rust/crates/tmt-cli/tests/architecture.rs
+++ b/rust/crates/tmt-cli/tests/architecture.rs
@@ -51,7 +51,7 @@ fn workspace_obeys_native_architecture() {
         .collect();
     assert_eq!(
         packages,
-        BTreeSet::from(["tmt-core", "tmt-adapters", "tmt-cli"]),
+        BTreeSet::from(["tmt-core", "tmt-adapters", "tmt-cli", "tmt-office"]),
         "Review native package boundaries when changing workspace members"
     );
     for package in metadata["packages"].as_array().expect("Cargo packages") {

--- a/rust/crates/tmt-cli/tests/architecture/cases.rs
+++ b/rust/crates/tmt-cli/tests/architecture/cases.rs
@@ -423,6 +423,28 @@ fn dependency_policy_rejects_unknown_workspace_packages() {
 }
 
 #[test]
+fn companion_reuses_core_without_cli_or_storage_dependencies() {
+    assert!(
+        policy::dependency_violations(&package(
+            "tmt-office",
+            vec![dependency("tmt-core", "normal", None, None)]
+        ))
+        .is_empty()
+    );
+    for name in ["tmt-cli", "tmt-adapters", "rusqlite", "ureq"] {
+        assert_eq!(
+            policy::dependency_violations(&package(
+                "tmt-office",
+                vec![dependency(name, "normal", None, None)]
+            )),
+            vec![format!(
+                "tmt-office: unreviewed production dependency {name} (kind=\"normal\", target=null, rename=null)"
+            )]
+        );
+    }
+}
+
+#[test]
 fn receipt_dependencies_stay_at_their_reviewed_layer() {
     assert!(
         policy::dependency_violations(&package(

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -36,6 +36,7 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
             "signal-hook",
             "sha2",
         ],
+        "tmt-office" => &["tmt-core"],
         "tmt-cli" => &[
             "unicode-width",
             "tmt-core",

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod identity;
 pub mod limits;
 pub mod names;
 pub mod native_install;
+pub mod office_protocol;
 pub mod profile;
 pub mod request;
 pub mod retention;

--- a/rust/crates/tmt-core/src/native_install.rs
+++ b/rust/crates/tmt-core/src/native_install.rs
@@ -3,6 +3,16 @@
 mod product;
 pub use product::Product;
 
+pub fn native_target(os: &str, architecture: &str) -> Option<&'static str> {
+    match (os, architecture) {
+        ("macos", "aarch64") => Some("aarch64-apple-darwin"),
+        ("macos", "x86_64") => Some("x86_64-apple-darwin"),
+        ("linux", "aarch64") => Some("aarch64-unknown-linux-musl"),
+        ("linux", "x86_64") => Some("x86_64-unknown-linux-musl"),
+        _ => None,
+    }
+}
+
 use semver::Version;
 use std::{cmp::Ordering, error::Error, fmt};
 

--- a/rust/crates/tmt-core/src/native_install.rs
+++ b/rust/crates/tmt-core/src/native_install.rs
@@ -1,5 +1,8 @@
 //! Pure release-channel and version policy; no filesystem or transport effects.
 
+mod product;
+pub use product::Product;
+
 use semver::Version;
 use std::{cmp::Ordering, error::Error, fmt};
 

--- a/rust/crates/tmt-core/src/native_install/product.rs
+++ b/rust/crates/tmt-core/src/native_install/product.rs
@@ -7,6 +7,12 @@ pub enum Product {
 }
 
 impl Product {
+    pub const fn tag_prefix(self) -> &'static str {
+        match self {
+            Self::Cli => "v",
+            Self::Office => "tmt-office-v",
+        }
+    }
     pub const ALL: [Self; 2] = [Self::Cli, Self::Office];
 
     pub const fn as_str(self) -> &'static str {

--- a/rust/crates/tmt-core/src/native_install/product.rs
+++ b/rust/crates/tmt-core/src/native_install/product.rs
@@ -1,0 +1,65 @@
+//! Fixed artifact identities for the CLI and its optional Office companion.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Product {
+    Cli,
+    Office,
+}
+
+impl Product {
+    pub const ALL: [Self; 2] = [Self::Cli, Self::Office];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Office => "office",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|product| product.as_str() == value)
+    }
+
+    pub const fn executable(self) -> &'static str {
+        match self {
+            Self::Cli => "tmt",
+            Self::Office => "tmt-office",
+        }
+    }
+
+    pub const fn package(self) -> &'static str {
+        match self {
+            Self::Cli => "tmt-cli",
+            Self::Office => "tmt-office",
+        }
+    }
+
+    pub const fn namespace(self) -> &'static str {
+        match self {
+            Self::Cli => "lib/tmux-team",
+            Self::Office => "lib/tmt-office",
+        }
+    }
+
+    pub const fn links(self) -> &'static [&'static str] {
+        match self {
+            Self::Cli => &["tmt", "tmux-team"],
+            Self::Office => &["tmt-office"],
+        }
+    }
+
+    pub fn link_target(self) -> String {
+        format!("../{}/current/{}", self.namespace(), self.executable())
+    }
+
+    pub const fn files(self) -> [&'static str; 4] {
+        [
+            self.executable(),
+            "LICENSE",
+            "NATIVE-INSTALL.md",
+            "THIRD-PARTY-NOTICES.txt",
+        ]
+    }
+}

--- a/rust/crates/tmt-core/src/office_protocol.rs
+++ b/rust/crates/tmt-core/src/office_protocol.rs
@@ -1,0 +1,95 @@
+//! Versioned internal companion handshake, not terminal output recognition.
+
+use semver::Version;
+
+pub const OFFICE_PROTOCOL_VERSION: &str = "1";
+pub const OFFICE_PROTOCOL_OUTPUT_LIMIT: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OfficeInvocation {
+    Probe,
+}
+
+impl OfficeInvocation {
+    pub fn arguments(self) -> [&'static str; 3] {
+        match self {
+            Self::Probe => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "probe"],
+        }
+    }
+
+    pub fn parse(arguments: &[&str]) -> Result<Self, &'static str> {
+        if arguments == Self::Probe.arguments() {
+            Ok(Self::Probe)
+        } else {
+            Err("Unsupported Office invocation or protocol version.")
+        }
+    }
+}
+
+pub fn encode_office_probe(version: &Version) -> String {
+    format!("TMT-OFFICE/{OFFICE_PROTOCOL_VERSION}\n{version}\n")
+}
+
+pub fn decode_office_probe(bytes: &[u8]) -> Result<Version, &'static str> {
+    if bytes.len() > OFFICE_PROTOCOL_OUTPUT_LIMIT {
+        return Err("Office handshake exceeds its bound.");
+    }
+    let text = std::str::from_utf8(bytes).map_err(|_| "Invalid Office handshake encoding.")?;
+    let prefix = format!("TMT-OFFICE/{OFFICE_PROTOCOL_VERSION}\n");
+    let version = text
+        .strip_prefix(&prefix)
+        .and_then(|text| text.strip_suffix('\n'))
+        .ok_or("Incompatible Office handshake.")?;
+    let parsed: Version = version
+        .parse()
+        .map_err(|_| "Invalid Office companion version.")?;
+    if encode_office_probe(&parsed).as_bytes() != bytes {
+        return Err("Noncanonical Office handshake.");
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_invocation_and_independent_package_version_round_trip() {
+        assert_eq!(
+            OfficeInvocation::parse(&["__tmt-office", "1", "probe"]),
+            Ok(OfficeInvocation::Probe)
+        );
+        let version = Version::parse("0.1.0-alpha.1").unwrap();
+        assert_eq!(
+            encode_office_probe(&version),
+            "TMT-OFFICE/1\n0.1.0-alpha.1\n"
+        );
+        assert_eq!(
+            decode_office_probe(b"TMT-OFFICE/1\n0.1.0-alpha.1\n"),
+            Ok(version)
+        );
+    }
+
+    #[test]
+    fn unknown_versions_extra_arguments_and_noisy_responses_are_rejected() {
+        for args in [
+            vec![],
+            vec!["__tmt-office", "2", "probe"],
+            vec!["__tmt-office", "1", "probe", "extra"],
+            vec!["__tmt-office", "1", "pair"],
+        ] {
+            assert!(OfficeInvocation::parse(&args).is_err());
+        }
+        for bytes in [
+            b"TMT-OFFICE/2\n0.1.0\n".as_slice(),
+            b"TMT-OFFICE/1\n0.1.0\nextra\n",
+            b"noise\nTMT-OFFICE/1\n0.1.0\n",
+            b"TMT-OFFICE/1\n0.1.0",
+            b"TMT-OFFICE/1\nv0.1.0\n",
+            b"\xff",
+        ] {
+            assert!(decode_office_probe(bytes).is_err());
+        }
+        assert!(decode_office_probe(&vec![b'x'; OFFICE_PROTOCOL_OUTPUT_LIMIT + 1]).is_err());
+    }
+}

--- a/rust/crates/tmt-office/Cargo.toml
+++ b/rust/crates/tmt-office/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tmt-office"
+version = "0.1.0-alpha.1"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+
+[package.metadata.dist]
+dist = false
+
+[dependencies]
+tmt-core.workspace = true
+
+[lints]
+workspace = true

--- a/rust/crates/tmt-office/Cargo.toml
+++ b/rust/crates/tmt-office/Cargo.toml
@@ -8,7 +8,7 @@ publish.workspace = true
 repository.workspace = true
 
 [package.metadata.dist]
-dist = false
+dist = true
 
 [dependencies]
 tmt-core.workspace = true

--- a/rust/crates/tmt-office/src/main.rs
+++ b/rust/crates/tmt-office/src/main.rs
@@ -1,0 +1,37 @@
+//! Internal optional companion entrypoint. No implicit authentication or service.
+
+use std::{
+    io::{self, Write},
+    process::ExitCode,
+};
+use tmt_core::office_protocol::{OfficeInvocation, encode_office_probe};
+
+fn main() -> ExitCode {
+    let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
+    let text = arguments
+        .iter()
+        .map(|arg| arg.to_str())
+        .collect::<Option<Vec<_>>>();
+    let invocation = text
+        .as_deref()
+        .ok_or("Office arguments must be UTF-8.")
+        .and_then(OfficeInvocation::parse);
+    let result = match invocation {
+        Ok(OfficeInvocation::Probe) => {
+            let version = env!("CARGO_PKG_VERSION")
+                .parse()
+                .expect("Cargo validates the package version");
+            io::stdout()
+                .lock()
+                .write_all(encode_office_probe(&version).as_bytes())
+        }
+        Err(message) => {
+            let _ = writeln!(io::stderr().lock(), "{message}");
+            return ExitCode::FAILURE;
+        }
+    };
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(_) => ExitCode::FAILURE,
+    }
+}

--- a/scripts/build-native-artifact.sh
+++ b/scripts/build-native-artifact.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 set -eu
 
-if [ "$#" -ne 1 ]; then
-  printf '%s\n' 'Usage: scripts/build-native-artifact.sh <cargo-dist target>' >&2
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  printf '%s\n' 'Usage: scripts/build-native-artifact.sh <cargo-dist target> [cli|office]' >&2
   exit 2
 fi
 target=$1
+product=${2:-cli}
+case "$product" in cli|office) ;; *) printf '%s\n' 'Unknown native product.' >&2; exit 2 ;; esac
 repo=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
 cd "$repo/rust"
 # Resolve the repository toolchain before cargo-dist discovers the generic root
@@ -23,16 +25,22 @@ TMT_NATIVE_REAL_CARGO=${TMT_NATIVE_REAL_CARGO:-$(command -v cargo)}
 export TMT_NATIVE_REAL_CARGO
 CARGO="$repo/scripts/native-cargo.sh"
 export CARGO
+package_id=$(cargo pkgid --locked -p "tmt-$product")
+# Cargo emits either #version or #name@version for a resolved package ID.
+version=${package_id##*#}
+version=${version##*@}
+tag="v$version"
+if [ "$product" = office ]; then tag="tmt-office-v$version"; fi
 # cargo-dist checks its own version against dist-workspace.toml.
 cd "$repo"
-dist generate --check --target "$target"
+dist generate --check --target "$target" --tag "$tag"
 cd "$repo/rust"
 mkdir -p target/native-notices
-cargo-about generate --manifest-path crates/tmt-cli/Cargo.toml \
+cargo-about generate --manifest-path "crates/tmt-$product/Cargo.toml" \
   --config about.toml --target "$target" --locked --offline --fail about.hbs \
   --output-file target/native-notices/THIRD-PARTY-NOTICES.txt
 
 # Keep diagnostics on stderr and cargo-dist's authoritative manifest on stdout.
 # Callers save stdout alongside the archives, then run the independent verifier.
 cd "$repo"
-dist build --artifacts local --target "$target" --output-format=json --no-local-paths
+dist build --artifacts local --target "$target" --tag "$tag" --output-format=json --no-local-paths

--- a/scripts/native-artifact-policy.mjs
+++ b/scripts/native-artifact-policy.mjs
@@ -6,7 +6,15 @@ import path from 'node:path';
 import { gunzipSync } from 'node:zlib';
 import * as tar from 'tar';
 
-const requiredFiles = ['tmt', 'LICENSE', 'NATIVE-INSTALL.md', 'THIRD-PARTY-NOTICES.txt'];
+function runtimeFiles(product = 'cli') {
+  assert(['cli', 'office'].includes(product), 'Unknown native product');
+  return [
+    product === 'cli' ? 'tmt' : 'tmt-office',
+    'LICENSE',
+    'NATIVE-INSTALL.md',
+    'THIRD-PARTY-NOTICES.txt',
+  ];
+}
 const compressedLimit = 64 * 1024 * 1024;
 const expandedLimit = 128 * 1024 * 1024;
 
@@ -38,7 +46,8 @@ export function readBoundedFile(file, limit) {
 }
 
 /** Consume cargo-dist metadata; do not maintain a second checksum/version catalog. */
-export function selectNativeArtifact(manifestFile, archiveFile, target) {
+export function selectNativeArtifact(manifestFile, archiveFile, target, product = 'cli') {
+  const requiredFiles = runtimeFiles(product);
   const manifest = JSON.parse(readBoundedFile(manifestFile, 4 * 1024 * 1024));
   const name = path.basename(archiveFile);
   archiveRootName(name);
@@ -49,7 +58,7 @@ export function selectNativeArtifact(manifestFile, archiveFile, target) {
   assert(/^[a-f0-9]{64}$/.test(artifact.checksums?.sha256), 'Manifest requires SHA-256');
   const releases = manifest.releases?.filter((release) => release.artifacts.includes(name));
   assert.equal(releases?.length, 1, 'Archive must belong to exactly one release');
-  assert.equal(releases[0].app_name, 'tmt-cli', 'Archive must belong to the TMT release');
+  assert.equal(releases[0].app_name, `tmt-${product}`, 'Archive must belong to the TMT release');
   const version = releases[0].app_version;
   assert(typeof version === 'string' && version.length > 0, 'Manifest requires a version');
   assert.deepEqual(
@@ -57,11 +66,18 @@ export function selectNativeArtifact(manifestFile, archiveFile, target) {
     [...requiredFiles].sort(),
     'Manifest must describe exactly the native runtime files'
   );
-  return { name, version, target, sha256: artifact.checksums.sha256 };
+  return {
+    name,
+    version,
+    target,
+    sha256: artifact.checksums.sha256,
+    ...(product === 'office' ? { product } : {}),
+  };
 }
 
 /** Extract only verified regular files into an owned directory and always remove it. */
 export async function withNativeArtifact(archiveFile, metadata, inspect) {
+  const requiredFiles = runtimeFiles(metadata.product);
   const rootName = archiveRootName(metadata.name);
   const compressed = readBoundedFile(archiveFile, compressedLimit);
   assert.equal(
@@ -89,7 +105,7 @@ export async function withNativeArtifact(archiveFile, metadata, inspect) {
         assert.equal(entry.type, 'File', `Native archive entry must be regular: ${entry.path}`);
         assert.equal(entry.mode & 0o7000, 0, 'Native archive must not set special permission bits');
         assert(entry.size > 0, `Empty native archive entry: ${entry.path}`);
-        if (entry.path.endsWith('/tmt')) {
+        if (entry.path === `${rootName}/${requiredFiles[0]}`) {
           assert(entry.mode & 0o111, 'Native executable lacks execute permission');
         }
       },

--- a/scripts/native-runtime-proof.mjs
+++ b/scripts/native-runtime-proof.mjs
@@ -82,6 +82,7 @@ export function verifyNativeRuntime({
   skill,
   profileContent,
   subject,
+  product = 'cli',
   matchingHostMessage = `${subject} requires a matching native host`,
 }) {
   assert(fs.statSync(executable).isFile(), `${subject} must be a regular file`);
@@ -101,6 +102,18 @@ export function verifyNativeRuntime({
     verifyLinkage(executable, cwd, env, subject);
 
     const run = (args) => runPackedCommand(executable, args, { cwd, env });
+    assert(['cli', 'office'].includes(product), 'Unknown native runtime product');
+    if (product === 'office') {
+      assert.equal(
+        run(['__tmt-office', '1', 'probe']),
+        `TMT-OFFICE/1\n${version}\n`,
+        `${subject} handshake mismatch`
+      );
+      assert(!fs.existsSync(xdg), 'Office probe must not initialize config state');
+      assert.deepEqual(fs.readdirSync(home), [], 'Office probe must not create home state');
+      assert.deepEqual(fs.readdirSync(cwd), [], 'Office probe must not create workspace state');
+      return;
+    }
     const json = (args) => JSON.parse(run([...args, '--json']));
     const globalRoot = path.join(xdg, 'tmux-team');
     assert.equal(run(['--version']).trim(), version, `${subject} version mismatch`);

--- a/scripts/verify-native-artifact.mjs
+++ b/scripts/verify-native-artifact.mjs
@@ -14,14 +14,27 @@ const { values } = parseArgs({
     skill: { type: 'string' },
     notices: { type: 'string' },
     license: { type: 'string' },
+    product: { type: 'string', default: 'cli' },
   },
 });
-for (const name of ['manifest', 'archive', 'target', 'skill', 'notices', 'license']) {
+for (const name of [
+  'manifest',
+  'archive',
+  'target',
+  'notices',
+  'license',
+  ...(values.product === 'cli' ? ['skill'] : []),
+]) {
   assert(values[name], `--${name} is required`);
 }
-const metadata = selectNativeArtifact(values.manifest, values.archive, values.target);
+const metadata = selectNativeArtifact(
+  values.manifest,
+  values.archive,
+  values.target,
+  values.product
+);
 assertNativeTarget(values.target, 'Artifact requires a matching native host');
-const skill = fs.readFileSync(values.skill, 'utf8');
+const skill = values.skill ? fs.readFileSync(values.skill, 'utf8') : undefined;
 const notices = fs.readFileSync(values.notices, 'utf8');
 assert(
   !/<year>|<copyright holders>/.test(notices),
@@ -40,7 +53,8 @@ await withNativeArtifact(values.archive, metadata, async (artifactRoot) => {
     'Native archive license differs from the selected source'
   );
   verifyNativeRuntime({
-    executable: path.join(artifactRoot, 'tmt'),
+    executable: path.join(artifactRoot, values.product === 'cli' ? 'tmt' : 'tmt-office'),
+    product: values.product,
     target: metadata.target,
     version: metadata.version,
     skill,
@@ -49,6 +63,6 @@ await withNativeArtifact(values.archive, metadata, async (artifactRoot) => {
     matchingHostMessage: 'Artifact requires a matching native host',
   });
   console.log(
-    `Verified native archive ${metadata.name}: linkage, version, skill, managed install, SQLite persistence`
+    `Verified native archive ${metadata.name}: ${values.product === 'cli' ? 'linkage, version, skill, managed install, SQLite persistence' : 'linkage, exact Office handshake, no application state'}`
   );
 });

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -425,6 +425,29 @@ before using remembered commands. Pi can load `/skill:tmux-team`; OpenCode uses
 its `skill` tool. Installation does not bypass provider permissions or guarantee
 that a running conversation has refreshed its instructions.
 
+## Optional Office installation
+
+Office is separate from pane messaging. `tmt office status --json` verifies only
+the local companion and protocol; it does not report online agents or start a
+connection. Missing Office returns `OFFICE_NOT_INSTALLED`. Do not install it
+unless the user requests Office. Installation requires explicit consent:
+`tmt office install --yes`; updates use `tmt office upgrade`. Both accept
+`--channel stable|alpha`; a first install defaults to alpha, while later calls
+retain the recorded channel. No public Office release is available yet; do not
+invent a download URL or report a missing release as success.
+
+The default prefix is `~/.local`; use `tmt office --prefix <folder> ...` for
+another installation, consistently across commands. Explicit local installation
+accepts paired `--archive <file> --manifest <file>` inputs on `office install`.
+`tmt office uninstall --yes` removes only verified Office activation links and
+retains release files, CLI installation, skills and application data.
+Noninteractive/JSON invocations never prompt or install implicitly. Interactive
+`tmt office` offers a default-No installation prompt. The installed root command
+currently returns `OFFICE_NOT_PAIRED`: pairing, world opening, decoration and
+notebooks are not available through this CLI yet. Do not guess their commands.
+After any failed mutation, inspect `office status` before retrying; failure can
+occur after activation. Ordinary TMT commands do not probe Office.
+
 ## Configuration safety
 
 Use `tmt config show --json` to inspect resolved settings and file paths.

--- a/test/e2e/office-consent.e2e.test.ts
+++ b/test/e2e/office-consent.e2e.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { withE2EFixture } from './harness.js';
+import { spawnRealTmuxCli } from './real-tmux-caller.js';
+
+describe('optional Office consent on a real terminal', () => {
+  it.each(['', 'n', 'no'])(
+    'declines installation with %j without creating an installation',
+    async (answer) => {
+      await withE2EFixture(async (fixture) => {
+        const prefix = path.join(fixture.root, 'optional office');
+        const process = await spawnRealTmuxCli(fixture, ['office', '--prefix', prefix], {
+          name: 'office-consent',
+          json: false,
+          terminal: true,
+        });
+        fs.writeFileSync(process.releasePath, 'run');
+        await fixture.waitForCapture((text) => text.includes('[y/N]'), process.pane);
+        expect(fs.existsSync(process.exitPath)).toBe(false);
+        expect(fs.existsSync(prefix)).toBe(false);
+        if (answer) fixture.tmux(['send-keys', '-t', process.pane, '-l', answer]);
+        fixture.tmux(['send-keys', '-t', process.pane, 'Enter']);
+        await fixture.waitFor(
+          () =>
+            fs.existsSync(process.exitPath) && fs.readFileSync(process.exitPath, 'utf8') === '0',
+          5_000,
+          'declined Office exit'
+        );
+        expect(fs.existsSync(prefix)).toBe(false);
+        const status = await fixture.runJsonCli(['office', '--prefix', prefix, 'status']);
+        expect(status.code).toBe(1);
+        expect(status.json).toMatchObject({ error: { code: 'OFFICE_NOT_INSTALLED' } });
+      });
+    }
+  );
+});

--- a/test/native/native-installation.test.ts
+++ b/test/native/native-installation.test.ts
@@ -68,8 +68,10 @@ async function createArtifact(
   const manifest = path.join(fixtureRoot, 'manifest.json');
   mkdirSync(root, { recursive: true });
   const executableName = product === 'cli' ? 'tmt' : 'tmt-office';
-  // The copied CLI proves installer byte preservation, not an Office release or protocol.
-  copyFileSync(sandbox.cli.executable, path.join(root, executableName));
+  // Office is built independently. Never substitute the CLI for a missing companion.
+  const source =
+    product === 'cli' ? sandbox.cli.executable : path.resolve('rust/target/debug/tmt-office');
+  copyFileSync(source, path.join(root, executableName));
   const executable = path.join(root, executableName);
   chmodSync(executable, 0o755);
   if (executableSuffix.byteLength > 0)
@@ -194,8 +196,24 @@ describe('native installation process contract', () => {
         });
         expect(readlinkSync(installed.executable)).toBe('../lib/tmt-office/current/tmt-office');
         expect(
-          readFileSync(installed.executable).equals(readFileSync(sandbox.cli.executable))
+          readFileSync(installed.executable).equals(
+            readFileSync(path.resolve('rust/target/debug/tmt-office'))
+          )
         ).toBe(true);
+        const probe = await runCli(
+          { ...sandbox, cli: { executable: installed.executable, args: [] } },
+          ['__tmt-office', '1', 'probe']
+        );
+        expect(probe.status).toBe(0);
+        expect(probe.stderr).toBe('');
+        expect(probe.stdout).toBe('TMT-OFFICE/1\n0.1.0-alpha.1\n');
+        const rejected = await runCli(
+          { ...sandbox, cli: { executable: installed.executable, args: [] } },
+          ['__tmt-office', '2', 'probe']
+        );
+        expect(rejected.status).toBe(1);
+        expect(rejected.stdout).toBe('');
+        expect(rejected.stderr).toBe('Unsupported Office invocation or protocol version.\n');
         expect(await install(sandbox, office, prefix, ['--product', 'office'])).toEqual({
           ...installed,
           changed: false,

--- a/test/native/native-installation.test.ts
+++ b/test/native/native-installation.test.ts
@@ -8,6 +8,7 @@ import {
   readlinkSync,
   readdirSync,
   realpathSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import path from 'node:path';
@@ -176,6 +177,74 @@ function artifactChecksum(fixture: ArtifactFixture): string {
 }
 
 describe('native installation process contract', () => {
+  it(
+    'exposes explicit Office installation, local status and recoverable deactivation',
+    { timeout: 60_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const prefix = installPrefix(sandbox);
+        const office = (args: string[]) =>
+          runCli(sandbox, ['office', '--prefix', prefix, ...args, '--json'], {
+            deadlineMs: INSTALL_PROCESS_BUDGET_MS,
+          });
+        expectError(await office(['status']), 'OFFICE_NOT_INSTALLED');
+        expectError(await office([]), 'OFFICE_NOT_INSTALLED');
+        expectError(await office(['install']), 'OFFICE_CONSENT_REQUIRED');
+        expectError(await office(['uninstall']), 'OFFICE_CONSENT_REQUIRED');
+        expectError(
+          await office(['install', '--yes', '--archive', 'missing', '--manifest', 'missing']),
+          'OFFICE_INSTALL_FAILED'
+        );
+        expect(existsSync(prefix)).toBe(false);
+        const fixture = await createArtifact(sandbox, '0.1.0-alpha.1', new Uint8Array(), 'office');
+        const args = [
+          'install',
+          '--yes',
+          '--archive',
+          fixture.archive,
+          '--manifest',
+          fixture.manifest,
+        ];
+        const installed = await office(args);
+        expect(installed.status, installed.stdout + installed.stderr).toBe(0);
+        expect(parseWholeStdout(installed)).toMatchObject({
+          installed: true,
+          changed: true,
+          version: '0.1.0-alpha.1',
+        });
+        const status = await office(['status']);
+        expect(status.status, status.stdout + status.stderr).toBe(0);
+        expect(status.stderr).toBe('');
+        expect(parseWholeStdout(status)).toMatchObject({
+          installed: true,
+          protocolVersion: '1',
+          version: '0.1.0-alpha.1',
+        });
+        expectError(await office([]), 'OFFICE_NOT_PAIRED');
+        expect(parseWholeStdout(await office(args))).toMatchObject({ changed: false });
+        const payload = readFileSync(path.join(prefix, 'bin/tmt-office'));
+        const releases = path.join(prefix, 'lib/tmt-office/releases');
+        const release = readdirSync(releases)[0];
+        // Interrupted removal may lose the command link before the activation.
+        // Report that state honestly and allow explicit removal to finish.
+        unlinkSync(path.join(prefix, 'bin/tmt-office'));
+        expectError(await office(['status']), 'OFFICE_INSTALLATION_INVALID');
+        expect(parseWholeStdout(await office(['uninstall', '--yes']))).toEqual({
+          installed: false,
+          changed: true,
+          retainedReleases: true,
+        });
+        expect(readFileSync(path.join(releases, release, 'tmt-office')).equals(payload)).toBe(true);
+        expectError(await office(['status']), 'OFFICE_NOT_INSTALLED');
+        expect(parseWholeStdout(await office(['uninstall', '--yes']))).toMatchObject({
+          changed: false,
+        });
+        expect(parseWholeStdout(await office(args))).toMatchObject({ changed: true });
+        expect(existsSync(sandbox.database)).toBe(false);
+      });
+    }
+  );
+
   it(
     'installs Office explicitly without changing CLI bytes, receipts or application state',
     { timeout: 60_000 },
@@ -536,7 +605,9 @@ describe('native installation process contract', () => {
         const completion = await runCli(sandbox, ['completion', shell]);
         expect(completion.status).toBe(0);
         expect(completion.stdout).not.toContain('__native-install');
-        expect(completion.stdout).not.toContain('--archive');
+        expect(completion.stdout).not.toContain('--product');
+        // Offline Office installation is public; only the internal publisher is hidden.
+        expect(completion.stdout).toContain('--archive');
       }
       expect(existsSync(sandbox.database)).toBe(false);
     });

--- a/test/native/native-installation.test.ts
+++ b/test/native/native-installation.test.ts
@@ -56,18 +56,21 @@ function nativeTarget(): string {
 async function createArtifact(
   sandbox: Sandbox,
   version: string,
-  executableSuffix: Uint8Array = new Uint8Array()
+  executableSuffix: Uint8Array = new Uint8Array(),
+  product: 'cli' | 'office' = 'cli'
 ): Promise<ArtifactFixture> {
   const target = nativeTarget();
-  const name = `tmux-team-${version}-${target}.tar.gz`;
-  const fixtureRoot = path.join(sandbox.root, 'native archive inputs with spaces');
+  const name = `${product}-${version}-${target}.tar.gz`;
+  const fixtureRoot = path.join(sandbox.root, 'native archive inputs with spaces', product);
   const tree = path.join(fixtureRoot, 'tree');
   const root = path.join(tree, name.slice(0, -'.tar.gz'.length));
   const archive = path.join(fixtureRoot, name);
   const manifest = path.join(fixtureRoot, 'manifest.json');
   mkdirSync(root, { recursive: true });
-  copyFileSync(sandbox.cli.executable, path.join(root, 'tmt'));
-  const executable = path.join(root, 'tmt');
+  const executableName = product === 'cli' ? 'tmt' : 'tmt-office';
+  // The copied CLI proves installer byte preservation, not an Office release or protocol.
+  copyFileSync(sandbox.cli.executable, path.join(root, executableName));
+  const executable = path.join(root, executableName);
   chmodSync(executable, 0o755);
   if (executableSuffix.byteLength > 0)
     writeFileSync(executable, Buffer.concat([readFileSync(executable), executableSuffix]));
@@ -85,10 +88,16 @@ async function createArtifact(
           name,
           target_triples: [target],
           checksums: { sha256: checksum },
-          assets: REQUIRED_FILES.map((file) => ({ path: file })),
+          assets: REQUIRED_FILES.map((file) => ({ path: file === 'tmt' ? executableName : file })),
         },
       },
-      releases: [{ app_name: 'tmt-cli', app_version: version, artifacts: [name] }],
+      releases: [
+        {
+          app_name: product === 'cli' ? 'tmt-cli' : 'tmt-office',
+          app_version: version,
+          artifacts: [name],
+        },
+      ],
     })}\n`
   );
   return { archive, manifest, version, target };
@@ -132,7 +141,7 @@ async function install(
     ],
     { deadlineMs: INSTALL_PROCESS_BUDGET_MS }
   );
-  expect(result.status).toBe(0);
+  expect(result.status, result.stdout + result.stderr).toBe(0);
   expect(result.stderr).toBe('');
   return parseWholeStdout(result) as unknown as InstallResult;
 }
@@ -165,6 +174,42 @@ function artifactChecksum(fixture: ArtifactFixture): string {
 }
 
 describe('native installation process contract', () => {
+  it(
+    'installs Office explicitly without changing CLI bytes, receipts or application state',
+    { timeout: 60_000 },
+    async () => {
+      await withSandbox(async (sandbox) => {
+        const version = (await runCli(sandbox, ['--version'])).stdout.trim();
+        const cli = await createArtifact(sandbox, version);
+        const prefix = installPrefix(sandbox);
+        const installedCli = await install(sandbox, cli, prefix);
+        const cliReceipt = readFileSync(receiptPath(prefix));
+        const pointer = readlinkSync(currentPointer(prefix));
+        const office = await createArtifact(sandbox, '0.1.0-alpha.1', new Uint8Array(), 'office');
+        const installed = await install(sandbox, office, prefix, ['--product', 'office']);
+        expect(installed).toEqual({
+          executable: path.join(realpathSync(prefix), 'bin/tmt-office'),
+          version: '0.1.0-alpha.1',
+          changed: true,
+        });
+        expect(readlinkSync(installed.executable)).toBe('../lib/tmt-office/current/tmt-office');
+        expect(
+          readFileSync(installed.executable).equals(readFileSync(sandbox.cli.executable))
+        ).toBe(true);
+        expect(await install(sandbox, office, prefix, ['--product', 'office'])).toEqual({
+          ...installed,
+          changed: false,
+        });
+        expect(readlinkSync(currentPointer(prefix))).toBe(pointer);
+        expect(readFileSync(receiptPath(prefix)).equals(cliReceipt)).toBe(true);
+        expect(
+          readFileSync(installedCli.executable).equals(readFileSync(sandbox.cli.executable))
+        ).toBe(true);
+        expect(existsSync(sandbox.database)).toBe(false);
+      });
+    }
+  );
+
   it(
     'installs a real copied native executable from spaced paths and runs it with an empty PATH',
     { timeout: 60_000 },

--- a/test/tooling/native-artifact-policy.test.ts
+++ b/test/tooling/native-artifact-policy.test.ts
@@ -16,7 +16,8 @@ const { selectNativeArtifact, withNativeArtifact } = (await import(
   selectNativeArtifact: (
     manifestFile: string,
     archiveFile: string,
-    target: string
+    target: string,
+    product?: 'cli' | 'office'
   ) => NativeArtifact;
   withNativeArtifact: <T>(
     archiveFile: string,
@@ -37,6 +38,7 @@ interface NativeArtifact {
 }
 
 interface ArchiveOptions {
+  readonly product?: 'cli' | 'office';
   readonly duplicate?: string;
   readonly executable?: boolean;
   readonly extra?: string;
@@ -70,12 +72,14 @@ async function createArchiveFixture(
   const manifestFile = path.join(fixtureRoot, 'manifest.json');
   fs.mkdirSync(root, { recursive: true });
 
-  for (const file of REQUIRED_FILES) {
+  const executable = options.product === 'office' ? 'tmt-office' : 'tmt';
+  const files = [executable, ...REQUIRED_FILES.slice(1)];
+  for (const file of files) {
     if (file === options.omit) continue;
     const target = path.join(root, file);
-    fs.writeFileSync(target, `${file} fixture\n`, { mode: file === 'tmt' ? 0o755 : 0o644 });
+    fs.writeFileSync(target, `${file} fixture\n`, { mode: file === executable ? 0o755 : 0o644 });
   }
-  if (options.executable === false) fs.chmodSync(path.join(root, 'tmt'), 0o644);
+  if (options.executable === false) fs.chmodSync(path.join(root, executable), 0o644);
   if (options.specialPermissions) fs.chmodSync(path.join(root, 'tmt'), 0o4755);
   if (options.extra !== undefined) {
     fs.writeFileSync(path.join(root, options.extra), 'unexpected test fixture\n');
@@ -117,17 +121,19 @@ async function createArchiveFixture(
         name,
         target_triples: [TARGET],
         checksums: { sha256 },
-        assets: REQUIRED_FILES.map((file) => ({ path: file })),
+        assets: files.map((file) => ({ path: file })),
       },
     },
-    releases: [{ app_name: 'tmt-cli', app_version: VERSION, artifacts: [name] }],
+    releases: [
+      { app_name: `tmt-${options.product ?? 'cli'}`, app_version: VERSION, artifacts: [name] },
+    ],
   };
   fs.writeFileSync(manifestFile, `${JSON.stringify(manifest)}\n`);
   return {
     archiveFile,
     manifestFile,
     manifest,
-    metadata: selectNativeArtifact(manifestFile, archiveFile, TARGET),
+    metadata: selectNativeArtifact(manifestFile, archiveFile, TARGET, options.product),
   };
 }
 
@@ -141,6 +147,31 @@ function withArtifactMetadata(sha256: string): NativeArtifact {
 }
 
 describe('native artifact policy', () => {
+  it('verifies Office through the shared allowlist without accepting CLI ownership or a non-executable payload', async () => {
+    await withSandbox(async (sandbox) => {
+      const office = await createArchiveFixture(sandbox, { product: 'office' });
+      await withNativeArtifact(office.archiveFile, office.metadata, (root) => {
+        expect(fs.readdirSync(root).sort()).toEqual([
+          'LICENSE',
+          'NATIVE-INSTALL.md',
+          'THIRD-PARTY-NOTICES.txt',
+          'tmt-office',
+        ]);
+        expect(fs.readFileSync(path.join(root, 'tmt-office'), 'utf8')).toBe('tmt-office fixture\n');
+      });
+      expect(() => selectNativeArtifact(office.manifestFile, office.archiveFile, TARGET)).toThrow(
+        'Archive must belong to the TMT release'
+      );
+      const cli = await createArchiveFixture(sandbox);
+      expect(() =>
+        selectNativeArtifact(cli.manifestFile, cli.archiveFile, TARGET, 'office')
+      ).toThrow('Archive must belong to the TMT release');
+      const invalid = await createArchiveFixture(sandbox, { product: 'office', executable: false });
+      await expect(
+        withNativeArtifact(invalid.archiveFile, invalid.metadata, () => undefined)
+      ).rejects.toThrow('Native executable lacks execute permission');
+    });
+  });
   it.each([
     ['notices', 'stale notices', 'Native archive notices differ from the generated inventory'],
     ['license', 'stale license', 'Native archive license differs from the selected source'],


### PR DESCRIPTION
## Summary

Closes #177. Part of Office #173; enables the installation boundary required by #209 and #191, not pairing or a connector.

- Add the independently versioned, core-only `tmt-office` companion and exact bounded protocol probe.
- Expose `tmt office install|upgrade|status|uninstall`, scoped `--prefix`, explicit consent and paired offline archive inputs. Noninteractive/JSON root commands never download or prompt. Installed root reports `OFFICE_NOT_PAIRED` until pairing is implemented.
- Reuse the native artifact verifier, receipts, lock, version policy, HTTP acquisition and atomic activation. Office candidates must pass the probe before activation. CLI and Office namespaces and release selection remain independent.
- Remove redundant downloaded-byte disk staging. Deactivation preserves release bytes and user data; partial removal is reported honestly and can be completed explicitly.
- Extend the existing cargo-dist build and independent archive/runtime verifier for Office, retaining CLI-only bootstrap/release workflow selection. Update architecture, command definitions, archive instructions and canonical installed skill.

## Contract refinement

Office release tags use `tmt-office-v<version>`, matching cargo-dist's independently versioned package convention. This supersedes the preliminary `office-v` prefix recorded in #177. CLI tags remain `v<version>`. No tags, releases, deployments, Firebase changes or host product installations are performed by this PR.

## Verification

- Local Rust workspace: 432 passed; the normally ignored real-archive upgrade gate was separately selected and passed once. Strict all-target Clippy, rustfmt and Rust 1.88 build passed.
- Complete native process suite: 154 passed; final focused installation suite: 8 passed. Retained tooling: 156 passed. `pnpm check` and canonical skill validation passed.
- Two Docker-isolated lifecycle passes are recorded in the issue, including real tmux terminal default-No/No consent. No real agents or host tmux servers were used.
- Actual matching-host cargo-dist Office archive: strict inventory/hash/notices/linkage/protocol proof plus public install/status/retry/uninstall in isolated state without runtime tools on PATH.
- Actual CLI cargo-dist archives: old and new runtime verification, 5.0.0-alpha.1 to 5.0.0-alpha.2 managed update/pin/conflict/state preservation, selected adapter archive gate, and controlled-curl bootstrap regression.
- Raw CI platform smoke remains distinct from multi-platform Office publication acceptance. No public Office release exists; missing online releases are failures, not successful installs.

## Primary architecture review

Reviewed head: a5a8bfb3f54a15f20146d0d8c2dd15dbe6b79866. Inspected changed production files, callers, protocol, ownership/activation lifecycle, adversarial fixtures, parser/output, packaging, workflow product selection, and documentation. Earlier product-policy and companion checkpoints were reviewed on this same issue branch.

The primary retained architecture and integration ownership. Independent Luna scans additionally checked preservation and packaging boundaries. Findings fixed: subtree prefix validation, stale hidden-completion expectation, local-file error classification, partial-removal status, and stale public/handshake documentation. Cargo-dist selection was independently verified to isolate both products. No parallel downloader, process owner, configuration system or request/storage engine was added.

## Deferred intentionally

Pairing/assignment (#209), decoration (#191), notebooks (#210), message board (#211), agent appearance (#212), and optional specialized skills (#213). Installation is not permission to authenticate, publish agents, start services or access a world. Public publication remains a separately authorized gate.
