### PR TITLE
feat(office): enforce scoped agent resource grants

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,7 +45,10 @@ The detailed lifecycle and verification map lives only in
 in [Office contracts](contracts/office/README.md).
 
 `services/office` owns isolated emulator infrastructure and Rules, not a deployed
-backend. Owner-local configuration stays outside Git and Docker. Native tmux,
+backend. Rules enforce scoped custom-principal grants for UUID blocks, using the
+existing layout validator and live owner admission. Issuance and native pairing
+remain unimplemented; see the canonical agent-grant contract for lease and
+revocation semantics. Owner-local configuration stays outside Git and Docker. Native tmux,
 Office browser/Rules and bootstrap smoke proofs retain separate fixture owners.
 Community props and exploration remain a [data-only sandbox plan](docs/office/sandbox.md),
 not a shipped runtime SDK, identity registry or alternate exchange engine.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -157,7 +157,11 @@ Those scenarios assert intercepted transaction reads and independent durable
 state before and after explicit retry; a timeout alone is not transport evidence.
 Auth responses are real and local. The suite also exercises the real Firestore
 SDK against Rules: immutable creation/retry, cross-user denial, self-grant denial,
-shape validation, and browser grant/create/revocation. Operator fixtures
+shape validation, and browser grant/create/revocation. The separate agent-grant
+Rules suite adds custom-principal tokens, assigned UUID blocks, claim/capability
+isolation, malformed/expired grants and one-way owner revocation with unchanged
+cached tokens. This is not evidence of credential issuance, protected native
+storage or end-to-end pairing. Operator fixtures
 also independently inspect saved block layouts. Home-block scenarios cover
 revision races, exact retries, Rules/client conformance vectors, bounded list
 validation, owner/device isolation and browser placement/save/reopen/revocation.

--- a/apps/office/e2e/agent-grant-rules.spec.ts
+++ b/apps/office/e2e/agent-grant-rules.spec.ts
@@ -1,0 +1,291 @@
+import { test, expect } from '@playwright/test';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDocFromServer,
+  getDocsFromServer,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
+import { createWorldPort } from '../src/worlds/firebase-worlds.js';
+import { createFirestoreFixture, setTester, writeAgentGrantFields } from './firestore-fixture.js';
+
+async function withAssignment(
+  run: (setup: Awaited<ReturnType<typeof assignment>>) => Promise<void>
+): Promise<void> {
+  const fixture = await createFirestoreFixture();
+  try {
+    await run(await assignment(fixture));
+  } finally {
+    await fixture.dispose();
+  }
+}
+
+async function assignment(fixture: Awaited<ReturnType<typeof createFirestoreFixture>>) {
+  const owner = await fixture.client(true);
+  const installationId = crypto.randomUUID();
+  const identityId = crypto.randomUUID();
+  const claims = {
+    tmtOfficeAgent: true,
+    tmtInstallationId: installationId,
+    tmtIdentityId: identityId,
+  };
+  const agent = await fixture.client(false, 'device', claims);
+  const worlds = createWorldPort(owner.db);
+  const world = worlds.draft('Scoped studio');
+  await worlds.create(world, owner.uid);
+  const blockId = crypto.randomUUID();
+  const createdAt = Date.now() - 60_000;
+  // Literal wire values are an independent operator oracle, not a product codec.
+  const fields: Record<string, unknown> = {
+    version: { integerValue: '1' },
+    ownerUid: { stringValue: owner.uid },
+    installationId: { stringValue: installationId },
+    identityId: { stringValue: identityId },
+    blockId: { stringValue: blockId },
+    capabilities: {
+      arrayValue: { values: [{ stringValue: 'layout.read' }, { stringValue: 'layout.write' }] },
+    },
+    enabled: { booleanValue: true },
+    createdAt: { timestampValue: new Date(createdAt).toISOString() },
+    expiresAt: { timestampValue: new Date(createdAt + 86_400_000).toISOString() },
+  };
+  await writeAgentGrantFields(world.id, agent.uid, fields);
+  return {
+    fixture,
+    owner,
+    agent,
+    world,
+    blockId,
+    fields,
+    claims,
+    createdAt,
+    agentBlock: doc(agent.db, 'worlds', world.id, 'blocks', blockId),
+    ownerBlock: doc(owner.db, 'worlds', world.id, 'blocks', blockId),
+    ownerGrant: doc(owner.db, 'worlds', world.id, 'agentGrants', agent.uid),
+  };
+}
+
+const layout = (revision: number, objects: string[] = ['d000']) => ({
+  version: 1,
+  revision,
+  objects,
+  updatedAt: serverTimestamp(),
+});
+const denied = (operation: Promise<unknown>) =>
+  expect(operation).rejects.toMatchObject({ code: 'permission-denied' });
+
+test('an assigned principal edits only its block with the existing bounded revision contract', async () => {
+  await withAssignment(
+    async ({ fixture, owner, agent, world, blockId, agentBlock, ownerBlock, claims }) => {
+      expect((await getDocFromServer(agentBlock)).exists()).toBe(false);
+      // Exercise the full Rules expression budget on both create and update.
+      await setDoc(agentBlock, layout(1, Array(16).fill('d000')));
+      expect((await getDocFromServer(ownerBlock)).data()?.objects).toHaveLength(16);
+      await setDoc(agentBlock, layout(2, Array(16).fill('p000')));
+      const stored = (await getDocFromServer(ownerBlock)).data();
+      expect(stored?.revision).toBe(2);
+      for (const invalid of [
+        layout(2),
+        layout(4),
+        layout(3, Array(17).fill('d000')),
+        layout(3, [...Array(15).fill('d000'), 'd0v0']),
+        { ...layout(3), ownerUid: agent.uid },
+        { ...layout(3), updatedAt: 0 },
+      ])
+        await denied(setDoc(agentBlock, invalid));
+      await denied(deleteDoc(agentBlock));
+      for (const otherBlock of ['home', crypto.randomUUID()]) {
+        const target = doc(agent.db, 'worlds', world.id, 'blocks', otherBlock);
+        await denied(getDocFromServer(target));
+        await denied(setDoc(target, layout(1)));
+      }
+      // Copying even valid binding labels cannot substitute for the granted UID.
+      const other = await fixture.client(false, 'device', claims);
+      await denied(getDocFromServer(doc(other.db, 'worlds', world.id, 'blocks', blockId)));
+      const secondWorld = createWorldPort(owner.db).draft('Separate world');
+      await createWorldPort(owner.db).create(secondWorld, owner.uid);
+      await denied(setDoc(doc(agent.db, 'worlds', secondWorld.id, 'blocks', blockId), layout(1)));
+      expect((await getDocFromServer(ownerBlock)).data()).toEqual(stored);
+    }
+  );
+});
+
+test('layout grants confer no world, grant, notebook, profile, board or work authority', async () => {
+  await withAssignment(async ({ agent, world, agentBlock, ownerBlock }) => {
+    await setDoc(agentBlock, layout(1));
+    await denied(getDocFromServer(doc(agent.db, 'worlds', world.id)));
+    for (const path of ['agentGrants', 'notebooks', 'profiles', 'board', 'messages', 'exchanges']) {
+      const target = doc(agent.db, 'worlds', world.id, path, agent.uid);
+      await denied(getDocFromServer(target));
+      await denied(setDoc(target, { enabled: true }));
+    }
+    await denied(getDocsFromServer(collection(agent.db, 'worlds', world.id, 'blocks')));
+    expect((await getDocFromServer(ownerBlock)).data()?.revision).toBe(1);
+  });
+});
+
+test('a read-only grant cannot mutate even its own assigned layout', async () => {
+  await withAssignment(async ({ agent, world, fields, agentBlock, ownerBlock }) => {
+    await setDoc(ownerBlock, layout(1));
+    await writeAgentGrantFields(world.id, agent.uid, {
+      ...fields,
+      capabilities: { arrayValue: { values: [{ stringValue: 'layout.read' }] } },
+    });
+    const stored = (await getDocFromServer(agentBlock)).data();
+    expect(stored?.objects).toEqual(['d000']);
+    await denied(setDoc(agentBlock, layout(2, [])));
+    expect((await getDocFromServer(ownerBlock)).data()).toEqual(stored);
+  });
+});
+
+test('malformed or expired grants fail closed with the same authenticated token', async () => {
+  await withAssignment(async ({ agent, world, fields, agentBlock, ownerBlock, createdAt }) => {
+    await setDoc(agentBlock, layout(1));
+    const token = await agent.auth.currentUser!.getIdToken();
+    const stored = (await getDocFromServer(ownerBlock)).data();
+    const mutations: Record<string, unknown>[] = [
+      { version: { integerValue: '2' } },
+      { version: { doubleValue: 1 } },
+      { extra: { booleanValue: true } },
+      { ownerUid: { stringValue: 'another-owner' } },
+      { installationId: { stringValue: 'copied-label' } },
+      { installationId: { stringValue: crypto.randomUUID() } },
+      { identityId: { stringValue: 'alice' } },
+      { identityId: { stringValue: crypto.randomUUID() } },
+      { blockId: { stringValue: 'home' } },
+      { enabled: { booleanValue: false } },
+      { enabled: { stringValue: 'true' } },
+      { expiresAt: { timestampValue: new Date(Date.now() - 1000).toISOString() } },
+      { expiresAt: { timestampValue: new Date(createdAt + 86_400_001).toISOString() } },
+      { expiresAt: { integerValue: '9999999999999' } },
+      { createdAt: { timestampValue: new Date(Date.now() + 60_000).toISOString() } },
+      { capabilities: { arrayValue: { values: [{ stringValue: 'layout.write' }] } } },
+      {
+        capabilities: {
+          arrayValue: { values: [{ stringValue: 'layout.read' }, { stringValue: 'board.write' }] },
+        },
+      },
+    ];
+    for (const changes of mutations) {
+      await writeAgentGrantFields(world.id, agent.uid, { ...fields, ...changes });
+      await denied(getDocFromServer(agentBlock));
+      await denied(setDoc(agentBlock, layout(2, [])));
+    }
+    for (const key of Object.keys(fields)) {
+      const incomplete = { ...fields };
+      delete incomplete[key];
+      await writeAgentGrantFields(world.id, agent.uid, incomplete);
+      await denied(getDocFromServer(agentBlock));
+    }
+    await writeAgentGrantFields(world.id, agent.uid, fields);
+    expect((await getDocFromServer(agentBlock)).data()).toEqual(stored);
+    expect(await agent.auth.currentUser!.getIdToken()).toBe(token);
+  });
+});
+
+test('client identities cannot mint grants or impersonate the scoped custom principal', async () => {
+  await withAssignment(
+    async ({
+      fixture,
+      owner,
+      agent,
+      world,
+      fields,
+      blockId,
+      agentBlock,
+      ownerBlock,
+      ownerGrant,
+      claims,
+    }) => {
+      await setDoc(agentBlock, layout(1));
+      const grant = (await getDocFromServer(ownerGrant)).data()!;
+      const actors = [
+        owner,
+        agent,
+        await fixture.client(true),
+        await fixture.client(true, 'device'),
+        await fixture.client(false, 'device', { ...claims, tmtOfficeAgent: 'true' }),
+        await fixture.client(false, 'device', { ...claims, tmtOfficeAgent: false }),
+        await fixture.client(false, 'anonymous'),
+      ];
+      for (const actor of actors) {
+        await denied(
+          setDoc(doc(actor.db, 'worlds', world.id, 'agentGrants', crypto.randomUUID()), grant)
+        );
+        await denied(deleteDoc(doc(actor.db, 'worlds', world.id, 'agentGrants', agent.uid)));
+        await denied(getDocsFromServer(collection(actor.db, 'worlds', world.id, 'agentGrants')));
+      }
+      // Even an operator-created record is insufficient for a human, anonymous
+      // user or an unrelated custom-token role. Approved tester status is no bypass.
+      for (const actor of actors.slice(2)) {
+        await writeAgentGrantFields(world.id, actor.uid, fields);
+        const target = doc(actor.db, 'worlds', world.id, 'blocks', blockId);
+        await denied(getDocFromServer(target));
+        await denied(setDoc(target, layout(2)));
+        await denied(
+          updateDoc(doc(actor.db, 'worlds', world.id, 'agentGrants', agent.uid), { enabled: false })
+        );
+      }
+      await denied(
+        updateDoc(doc(agent.db, 'worlds', world.id, 'agentGrants', agent.uid), { enabled: false })
+      );
+      expect((await getDocFromServer(ownerBlock)).data()?.revision).toBe(1);
+      expect((await getDocFromServer(ownerGrant)).data()).toEqual(grant);
+    }
+  );
+});
+
+test('owner revocation is one-way, denies cached credentials and retains the exact block', async () => {
+  await withAssignment(
+    async ({ agent, owner, world, fields, agentBlock, ownerBlock, ownerGrant }) => {
+      await setDoc(agentBlock, layout(1));
+      const token = await agent.auth.currentUser!.getIdToken();
+      const stored = (await getDocFromServer(ownerBlock)).data();
+      const grant = (await getDocFromServer(ownerGrant)).data();
+      for (const changes of [
+        { blockId: crypto.randomUUID() },
+        { identityId: crypto.randomUUID() },
+        { installationId: crypto.randomUUID() },
+        { ownerUid: agent.uid },
+        { capabilities: ['layout.read'] },
+        { expiresAt: serverTimestamp() },
+        { enabled: false, blockId: crypto.randomUUID() },
+      ])
+        await denied(updateDoc(ownerGrant, changes));
+      expect((await getDocFromServer(ownerGrant)).data()).toEqual(grant);
+      await updateDoc(ownerGrant, { enabled: false });
+      await denied(getDocFromServer(agentBlock));
+      await denied(setDoc(agentBlock, layout(2)));
+      await denied(updateDoc(ownerGrant, { enabled: true }));
+      expect(await agent.auth.currentUser!.getIdToken()).toBe(token);
+      expect((await getDocFromServer(ownerBlock)).data()).toEqual(stored);
+      expect((await getDocFromServer(ownerGrant)).data()).toEqual({ ...grant, enabled: false });
+      // Test tester revocation independently, not masked by an already-disabled grant.
+      await writeAgentGrantFields(world.id, agent.uid, fields);
+      expect((await getDocFromServer(agentBlock)).data()).toEqual(stored);
+      await setTester(owner.uid, false);
+      await denied(getDocFromServer(agentBlock));
+      await denied(setDoc(agentBlock, layout(2)));
+      await denied(getDocFromServer(ownerBlock));
+      await setTester(owner.uid, true);
+      expect((await getDocFromServer(ownerBlock)).data()).toEqual(stored);
+      expect((await getDocFromServer(agentBlock)).data()).toEqual(stored);
+      // Fail-closed recovery may disable a malformed record without repairing it.
+      await writeAgentGrantFields(world.id, agent.uid, {
+        ...fields,
+        extra: { booleanValue: true },
+      });
+      await denied(getDocFromServer(agentBlock));
+      await updateDoc(ownerGrant, { enabled: false });
+      expect((await getDocFromServer(ownerGrant)).data()).toEqual({
+        ...grant,
+        extra: true,
+        enabled: false,
+      });
+      expect((await getDocFromServer(ownerBlock)).data()).toEqual(stored);
+    }
+  );
+});

--- a/apps/office/e2e/firestore-fixture.ts
+++ b/apps/office/e2e/firestore-fixture.ts
@@ -68,7 +68,23 @@ export async function writeTesterFields(
   uid: string,
   fields: Record<string, unknown>
 ): Promise<void> {
-  const response = await fetch(`${documents}/testers/${encodeURIComponent(uid)}`, {
+  await writeOperatorDocument(`testers/${encodeURIComponent(uid)}`, fields);
+}
+
+export async function writeAgentGrantFields(
+  worldId: string,
+  principalUid: string,
+  fields: Record<string, unknown>
+): Promise<void> {
+  expect(worldId).toMatch(/^[a-zA-Z0-9]{20}$/);
+  await writeOperatorDocument(
+    `worlds/${worldId}/agentGrants/${encodeURIComponent(principalUid)}`,
+    fields
+  );
+}
+
+async function writeOperatorDocument(path: string, fields: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${documents}/${path}`, {
     method: 'PATCH',
     headers: { authorization: 'Bearer owner', 'content-type': 'application/json' },
     body: JSON.stringify({ fields }),
@@ -82,7 +98,8 @@ export async function createFirestoreFixture() {
   return {
     async client(
       approved = false,
-      provider: 'google' | 'unverified' | 'anonymous' | 'device' = 'google'
+      provider: 'google' | 'unverified' | 'anonymous' | 'device' = 'google',
+      claims: Record<string, unknown> = {}
     ) {
       const app = initializeApp({ projectId, apiKey: 'demo-key' }, crypto.randomUUID());
       const auth = initializeAuth(app);
@@ -97,7 +114,7 @@ export async function createFirestoreFixture() {
       const customToken = () => {
         // Unsigned fixture credential is accepted only by the Auth Emulator.
         const part = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64url');
-        return `${part({ alg: 'none', typ: 'JWT' })}.${part({ uid: identity, aud: 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit', iss: 'fixture@example.test', sub: 'fixture@example.test', iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 3600 })}.`;
+        return `${part({ alg: 'none', typ: 'JWT' })}.${part({ uid: identity, claims, aud: 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit', iss: 'fixture@example.test', sub: 'fixture@example.test', iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 3600 })}.`;
       };
       const { user } =
         provider === 'anonymous'

--- a/contracts/office/README.md
+++ b/contracts/office/README.md
@@ -3,6 +3,10 @@
 Private-world and home-block document contracts are implemented in the browser
 and Rules. The remote work-handoff protocol remains a proposal, not a deployed API.
 
+The [agent resource grant v1](agent-grant-v1.md) adds server-enforced access to
+assigned UUID blocks. Credential issuance, native pairing and the agent-block UI
+remain separate work; the browser currently edits only the owner's home block.
+
 The separately versioned [private world document v1](private-world.md) is the
 direct-Firestore contract. It uses native Firestore timestamps and Rules,
 not the work-handoff HTTP/JSON envelopes below. Its actual client adapter and

--- a/contracts/office/agent-grant-v1.md
+++ b/contracts/office/agent-grant-v1.md
@@ -1,0 +1,103 @@
+# Agent resource grant v1
+
+Implemented Rules boundary for future pairing, not a shipped credential issuer,
+assignment UI or native command. Automated evidence uses isolated Auth/Firestore
+emulators. No production activation or human credential sharing is implied.
+
+## Principal and document
+
+Each selected installation/local identity/world binding has a distinct Firebase
+custom-auth principal. Its trusted token contains `tmtOfficeAgent: true`,
+`tmtInstallationId` and `tmtIdentityId`. The latter two must match the live grant.
+The issuer must never reuse a retired principal for a different binding. A
+device-wide credential must not implicitly authorize every agent on that device.
+Display names, folders and pane IDs are neither credentials nor lookup keys.
+
+`worlds/{worldId}/agentGrants/{principalUid}` contains exactly:
+
+| Field            | Value                                                                        |
+| ---------------- | ---------------------------------------------------------------------------- |
+| `version`        | Integer `1`                                                                  |
+| `ownerUid`       | String matching the immutable world's human owner                            |
+| `installationId` | Lowercase hyphenated UUID of the originating installation                    |
+| `identityId`     | Existing local identity UUID, lowercase and hyphenated                       |
+| `blockId`        | Independent lowercase hyphenated UUID, never `home`                          |
+| `capabilities`   | Exactly `['layout.read']` or `['layout.read', 'layout.write']` in that order |
+| `enabled`        | Boolean; only `true` grants access                                           |
+| `createdAt`      | Firestore timestamp, not later than the server request time                  |
+| `expiresAt`      | Firestore timestamp, after creation and at most 24 hours later               |
+
+Access requires `createdAt <= request.time < expiresAt`, valid schema, current
+owner tester admission and matching authenticated principal/installation/identity.
+An ID token or locally cached approval alone never grants access. Unknown fields,
+versions, capabilities, malformed identifiers and timestamps fail closed.
+
+Grants are issued only by the future trusted pairing service. All client creates,
+deletes and lists are denied. Only the admitted world owner can read a known
+grant or change `enabled: true` to `false`, without changing any other field.
+Owners cannot enlarge, renew or reactivate it through Firestore client writes.
+They may also disable a malformed record as fail-closed recovery. Agents cannot
+read grant metadata, revoke another identity or grant themselves authority.
+
+## Resource behavior
+
+The block uses the existing [block v1](block-v1.md) document and revision rules
+at `worlds/{worldId}/blocks/{blockId}`. There is no second layout codec or stored
+owner field. An active reader can fetch only that block (including its absence).
+A writer can create revision 1 or advance by exactly one. Enumeration, deletion,
+other blocks and the owner's `home` remain denied to agents. The admitted owner
+can read/edit `home` and UUID blocks, including retained unassigned blocks.
+Neither owner nor agent can delete a block; clearing uses an empty layout.
+
+Layout authority confers no world-root, notebook, profile, board, message, work
+dispatch or general Firestore access. Those capabilities need separately reviewed
+contracts. Presentation cannot grant permission. The browser still edits only
+`home`; this boundary does not claim an agent-block UI already exists.
+
+Revocation denies subsequent server operations even with the same cached token.
+It neither erases retained blocks nor recalls already disclosed content. Expiry
+is checked by Rules, not eventual TTL deletion. Previously authorized writes can
+have committed before revocation; clients must not assume cancellation.
+
+## Pairing and credential lifecycle requirements
+
+These requirements constrain subsequent #209 slices; they are not implemented
+by these Rules:
+
+- Follow the [explicit approval/proof flow](../../docs/office/design.md#invitations-and-pairing).
+  The owner approves the actual deployment, installation, selected identity,
+  resource and capabilities. Only a trusted service issues the principal/custom
+  token; no anonymous-provider enablement or browser-minted credentials.
+- Use a 24-hour default and maximum resource lease. Renewal must recheck current
+  owner admission, the exact approved binding and its non-revoked state. Token
+  refresh alone cannot extend a lease or reactivate a revoked grant. Whether
+  native renewal is automatic belongs to the credential-lifecycle slice, not
+  a mandatory daily human prompt implied by these Rules.
+  Re-pairing after revocation creates a new principal.
+  The issuer must enforce these transitions itself: Admin writes bypass Rules.
+- Store agent refresh credentials through a native protected-store adapter,
+  separate from config, source, argv, output and logs. Verify platform protection
+  and any fallback before use. Never transfer the human's refresh token or a
+  service-account key. ID tokens are short-lived transport credentials; Firebase
+  refresh does not replace live grant enforcement.
+- Conclusive temporary-identity retirement must disable local use and revoke
+  remotely, retaining resources for the owner. Offline retirement cannot revoke
+  a server record immediately: retain pending revocation, retry explicitly on
+  reconnect and rely on the finite lease as the upper bound. Do not claim prompt
+  or filesystem permissions isolate mutually hostile agents under one OS user.
+- Preserve identity/resource ownership across saved reconnect and block moves.
+  A replacement same-name UUID inherits neither credentials nor retained notes.
+  Pairing supplies authority, not memory orchestration or model-driven behavior.
+
+## Verification ownership
+
+`apps/office/e2e/agent-grant-rules.spec.ts` uses real custom-auth emulator tokens,
+direct SDK requests and independent operator fixtures. It proves scoped writes,
+full layout bounds, cross-principal/world/capability denial, claim mismatch,
+malformed/expired grants, one-way revocation and retained content. Existing block
+vectors remain in their original suite. These tests do not prove secure issuance,
+protected native storage, native retirement, renewal or usable end-to-end pairing.
+
+Sources: [custom tokens](https://firebase.google.com/docs/auth/admin/create-custom-tokens),
+[session lifetime](https://firebase.google.com/docs/auth/admin/manage-sessions),
+[Rules and privileged SDK boundaries](https://firebase.google.com/docs/firestore/security/rules-conditions).

--- a/contracts/office/block-v1.md
+++ b/contracts/office/block-v1.md
@@ -1,12 +1,14 @@
-# Home block document v1
+# Block document v1
 
-Implemented owner-only decoration contract. Agent commands, pairing and
-assignment are not defined by this contract.
+Implemented decoration contract. The browser edits the owner-only home block;
+[agent grants](agent-grant-v1.md) reuse this exact document at UUID block IDs.
+Agent commands and pairing are not defined by this contract.
 
 `worlds/{worldId}/blocks/home` contains exactly `version: 1`, `revision`,
 `objects` and `updatedAt`. Authority comes from the existing immutable world's
 owner and current tester admission. There is no second owner/agent identity
-field. Other block IDs, enumeration and deletion remain denied. Clear a room by
+field. UUID blocks use the separate scoped authorization contract; other block
+IDs, enumeration and deletion remain denied. Clear a room by
 saving an empty object list, not resetting its revision counter. Previous layout
 versions are not retained as an edit-history feature.
 

--- a/contracts/office/private-world.md
+++ b/contracts/office/private-world.md
@@ -29,6 +29,7 @@ write tester documents. Admission does not grant access to other owners' worlds.
 The Firebase Console operator uses IAM, not a client-side administrator role.
 
 The [home block v1](block-v1.md) contract opens only
-`worlds/{worldId}/blocks/home` to its approved world owner. Other blocks and
-`messages/{messageId}` remain denied until their feature contracts are
-implemented. World data does not authorize native agent execution.
+`worlds/{worldId}/blocks/home` to its approved world owner. The
+[agent grant v1](agent-grant-v1.md) boundary also permits scoped UUID blocks and
+owner revocation of trusted grants. Other blocks and `messages/{messageId}`
+remain denied. World data does not authorize native agent execution.

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -19,7 +19,14 @@ Console-managed tester gate controls direct client create/read of owner-only wor
 Firestore Rules enforce both gates, immutable fields and default-deny paths.
 This is not an invitation, presence or connected-agent implementation.
 
-Each admitted world has a single owner-only `home` block.
+Rules also implement the [agent grant boundary](../../contracts/office/agent-grant-v1.md):
+trusted per-agent principals can access only an assigned UUID block with matching
+installation/identity claims, live capability/lease and current owner admission.
+Only the owner can revoke a grant; clients cannot issue or enlarge one. This
+adds no issuer, native credentials or pairing UI. Retained UUID blocks use the
+existing layout validator; no parallel layout/ownership document is introduced.
+
+The current browser edits one owner-only `home` block per admitted world.
 `src/blocks/block-contract.ts` owns client values, catalog and footprint policy;
 `firebase-blocks.ts` implements its port using the existing initialized SDK.
 `block-state.ts` owns the server-confirmed projection and separate unsaved draft.
@@ -158,7 +165,11 @@ tests allow its script GETs on `apis.google.com`, keep all auth requests local,
 and reject other destinations. This is not a fully offline flow. Direct-SDK
 Rules scenarios additionally prove tester/owner isolation and immutable creation;
 the browser world scenario proves grant/create/read/revocation through the UI.
-They do not prove connector lifecycle, real Google login or remote collaboration.
+`agent-grant-rules.spec.ts` separately proves scoped custom-principal access,
+claim mismatches, malformed/expired grants, one-way revocation with cached tokens,
+retained blocks and capability isolation. Its privileged fixture documents and
+unsigned emulator-only custom tokens do not prove production credential issuance.
+These suites do not prove connector lifecycle, real Google login or remote collaboration.
 
 On tester revocation, subsequent server reads/writes are denied and the app's
 admission stream clears the view and detaches its world listener. Do not claim instantaneous

--- a/docs/office/design.md
+++ b/docs/office/design.md
@@ -68,7 +68,9 @@ See [private world document v1](../../contracts/office/private-world.md) for
 the exact create/read and retry contract. Future blocks and messages live in
 world subcollections, not unbounded arrays on the root. Those paths currently
 deny all client access except the owner-only `blocks/home` decoration slice
-specified in [home block v1](../../contracts/office/block-v1.md). Invitations and device/work operations below remain
+specified in [block v1](../../contracts/office/block-v1.md) and scoped UUID blocks
+under [agent grant v1](../../contracts/office/agent-grant-v1.md). Grant enforcement
+does not implement issuance or pairing. Invitations and device/work operations below remain
 future design; they do not justify a generic backend for ordinary world storage.
 The initial owner-only world does not implement visitor memberships or presence.
 
@@ -102,7 +104,9 @@ not a generic backend wrapping every Firestore read. Privileged SDK calls bypass
 Firestore rules, so these handlers must perform the same current membership,
 resource and device checks themselves and use restricted IAM. Browser direct
 reads/board writes remain constrained by rules and bounded queries. No client
-may directly write membership, device grants, dispatch permits or final status.
+may directly issue or enlarge membership, device grants, dispatch permits or
+final status. The implemented agent-grant contract permits only one-way owner
+revocation through client Rules, not client issuance or renewal.
 
 World operators are trusted with cloud-visible data; v1 is not end-to-end
 encrypted. Do not upload private repository content by default. Request previews
@@ -126,16 +130,18 @@ Pairing is a separate authorization from installation and login:
    to a rate-limited pairing endpoint. A pending pairing expires in five minutes.
 2. It shows a short comparison code and opens the configured deployment's pairing
    page. The code is an identifier, not sufficient to claim the device.
-3. The logged-in human chooses a world and sees the device label/fingerprint and
-   exact requested capabilities. They approve explicitly. No auto-approval from
+3. The logged-in human chooses a world and sees the device label/fingerprint,
+   selected local identity and exact requested resources/capabilities. They approve explicitly. No auto-approval from
    an agent message, a URL parameter or a claimed owner UID.
 4. The originating connector proves possession of its secret and claims the
-   approval once. The service creates a distinct device principal and returns a
+   approval once. The service creates a distinct principal for the selected
+   installation/identity/world binding and returns a
    short-lived Firebase custom token; only that device exchanges it for its own
    credentials. Neither the pairing URL nor ordinary output contains bearer or
    refresh tokens. Custom-token issuance stays server-side.
-5. The local owner separately selects identities/capabilities to publish. Default
-   publication is empty. Credentials use an adapter-owned protected store, never
+5. This scoped resource approval does not publish work capabilities. The local
+   owner separately opts into work publication; its default is empty.
+   Credentials use an adapter-owned protected store, never
    the app config, source tree, process arguments or logs. The credential adapter must verify the
    selected platform store and secure fallback before use.
 

--- a/services/office/README.md
+++ b/services/office/README.md
@@ -6,6 +6,12 @@ creation/read of owner-only worlds. Rules require operator-managed tester
 admission. Cloud deployment, invitations, guest memberships and presence are
 not implied by this implementation. Unspecified paths remain denied.
 
+Rules also enforce [scoped agent grants](../../contracts/office/agent-grant-v1.md)
+for UUID blocks with live expiry, capability and owner-admission checks. The
+trusted issuer and native pairing are not implemented. Do not manually enable
+anonymous authentication or create production agent grants to simulate pairing.
+The current browser continues to edit only the owner's home block.
+
 See [the architecture](../../docs/office/architecture.md). Add functions only
 when a trusted operation cannot be safely implemented with reviewed rules and
 client contracts. Never place local TMT database or process access here.

--- a/services/office/firestore.rules
+++ b/services/office/firestore.rules
@@ -7,11 +7,33 @@ service cloud.firestore {
         && request.auth.token.email_verified == true;
     }
 
+    function testerEnabled(uid) {
+      return exists(/databases/$(database)/documents/testers/$(uid))
+        && get(/databases/$(database)/documents/testers/$(uid)).data.keys().hasOnly(['enabled'])
+        && get(/databases/$(database)/documents/testers/$(uid)).data.enabled == true;
+    }
+
     function approved() {
-      return human()
-        && exists(/databases/$(database)/documents/testers/$(request.auth.uid))
-        && get(/databases/$(database)/documents/testers/$(request.auth.uid)).data.keys().hasOnly(['enabled'])
-        && get(/databases/$(database)/documents/testers/$(request.auth.uid)).data.enabled == true;
+      return human() && testerEnabled(request.auth.uid);
+    }
+
+    function uuid(value) {
+      return value is string
+        && value.matches('^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$');
+    }
+
+    function agentGrant(value) {
+      return value.keys().hasAll(['version', 'ownerUid', 'installationId', 'identityId', 'blockId', 'capabilities', 'enabled', 'createdAt', 'expiresAt'])
+        && value.keys().hasOnly(['version', 'ownerUid', 'installationId', 'identityId', 'blockId', 'capabilities', 'enabled', 'createdAt', 'expiresAt'])
+        && value.version is int && value.version == 1
+        && value.ownerUid is string
+        && uuid(value.installationId) && uuid(value.identityId) && uuid(value.blockId)
+        && (value.capabilities == ['layout.read'] || value.capabilities == ['layout.read', 'layout.write'])
+        && value.enabled == true
+        && value.createdAt is timestamp && value.expiresAt is timestamp
+        && value.createdAt <= request.time && request.time < value.expiresAt
+        && value.expiresAt > value.createdAt
+        && value.expiresAt <= value.createdAt + duration.value(24, 'h');
     }
 
     function furniture(item) {
@@ -51,6 +73,25 @@ service cloud.firestore {
     }
 
     match /worlds/{worldId} {
+      function ownsWorld() {
+        return approved()
+          && get(/databases/$(database)/documents/worlds/$(worldId)).data.ownerUid == request.auth.uid;
+      }
+
+      function agentAccess(blockId, capability) {
+        let grant = get(/databases/$(database)/documents/worlds/$(worldId)/agentGrants/$(request.auth.uid)).data;
+        // A custom principal alone is not authority. Check the live, immutable
+        // binding on every operation, including requests with a cached ID token.
+        return request.auth.token.firebase.sign_in_provider == 'custom'
+          && request.auth.token.tmtOfficeAgent == true
+          && agentGrant(grant)
+          && request.auth.token.tmtInstallationId == grant.installationId
+          && request.auth.token.tmtIdentityId == grant.identityId
+          && grant.blockId == blockId && capability in grant.capabilities
+          && get(/databases/$(database)/documents/worlds/$(worldId)).data.ownerUid == grant.ownerUid
+          && testerEnabled(grant.ownerUid);
+      }
+
       // Missing-document reads permit online create transactions. Existing world
       // metadata remains owner-only; the UI does not distinguish denied/missing.
       allow get: if approved() && (resource == null || resource.data.ownerUid == request.auth.uid);
@@ -67,16 +108,28 @@ service cloud.firestore {
         && request.resource.data.createdAt == request.time;
       allow list, update, delete: if false;
 
-      match /blocks/{blockId} {
-        function ownsWorld() {
-          return approved() && blockId == 'home'
-            && get(/databases/$(database)/documents/worlds/$(worldId)).data.ownerUid == request.auth.uid;
-        }
+      match /agentGrants/{principalUid} {
         allow get: if ownsWorld();
+        // Issuance/renewal is a trusted service operation, not a client write.
+        // An owner may only revoke; no edits can reactivate or enlarge a grant.
+        allow update: if ownsWorld() && resource.data.enabled == true
+          && request.resource.data.enabled == false
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['enabled']);
+        allow create, list, delete: if false;
+      }
+
+      match /blocks/{blockId} {
+        function ownerAccess() {
+          return (blockId == 'home' || uuid(blockId)) && ownsWorld();
+        }
+        allow get: if ownerAccess() || (request.auth != null && agentAccess(blockId, 'layout.read'));
         // Reject incompatible revisions before the bounded layout walk.
-        allow create: if request.resource.data.revision == 1 && ownsWorld() && blockDocument();
+        allow create: if request.resource.data.revision == 1
+          && (ownerAccess() || (request.auth != null && agentAccess(blockId, 'layout.write')))
+          && blockDocument();
         allow update: if request.resource.data.revision == resource.data.revision + 1
-          && ownsWorld() && blockDocument();
+          && (ownerAccess() || (request.auth != null && agentAccess(blockId, 'layout.write')))
+          && blockDocument();
         allow list, delete: if false;
       }
     }


### PR DESCRIPTION
## Scope

Closes #215; first authorization slice of #209 (which remains open), milestone #173.

Add live, per-principal agent grants for assigned UUID blocks. Custom-auth tokens must match the grant's installation and identity UUIDs; only explicit layout capabilities are enabled. The admitted world owner can revoke, but no client can create, enlarge, renew, reactivate, delete or enumerate grants. Reuse the existing block shape/revision validator for personal blocks; the browser still edits only `home`.

This is an enforcement foundation, not working pairing: no issuer, native credentials, new commands, assignment UI, memory engine, remote execution, deployment or release.

## Architecture and review

- The primary reviewed every changed file, existing owner/home Rules, direct-SDK fixtures, block callers and contract vectors at `89cbe280f51bd72ff7868bcf4638328571784f3c`.
- Rules remain the sole client authorization boundary. The existing tester gate and bounded layout validator are reused; a private operator-write helper serves two fixture callers. No duplicate scene codec, state store, parser, network owner or native runtime was added.
- The UUID-block extension is deliberate: agent space must not overwrite the human's home. Retained blocks remain owner-editable after revocation; lists/deletes stay denied.
- Independent Luna review found no blocking authorization issue. Its suggestions are addressed: trusted claim comparisons, explicit list denial, post-admission recovery, exact 24-hour acceptance / one-millisecond overflow rejection. Primary review also added malformed-record revocation recovery and unchanged durable-state assertions.
- A valid cached ID token is insufficient after live revocation/expiry. The canonical contract distinguishes Rules enforcement from trusted Admin issuance (which bypasses Rules), native secret protection and retirement reconciliation still to implement.
- `ARCHITECTURE.md`, Office architecture/design and document contracts are updated together. Existing core skill remains truthful because no public command shipped.

## Verification

- [x] Primary reviewed every changed file and relevant callers/tests.
- [x] Local evidence recorded below.
- [x] All 17 CI checks succeeded on reviewed head `89cbe280f51bd72ff7868bcf4638328571784f3c`; run `34550658601`. No retry, gate bypass or CI-fix push.

Commands and results:

- `pnpm check`: passed (root tooling/docs and Office type/lint/format).
- `pnpm test:run`: 156 tests passed.
- `docker build --target browser-tests -f services/office/Dockerfile -t tmt-office-215:local .`: passed; Office quality, 88 unit/DOM tests, preview/emulator/unconfigured-cloud builds. Existing bundle-size advisories are unchanged; no suppressed warning or gate change.
- Focused actual Auth/Firestore emulator grant suite: 6 scenarios passed.
- `docker run --rm --init --shm-size=256m tmt-office-215:local`: complete browser/Rules suite passed twice (26 scenarios each); final reviewed version 26 passed in 41.4s. The final run includes all refinements above. No host credentials, real project or host tmux were used.
- `git diff --check`: passed.

Native source/install/skill bytes are unchanged; no native behavior claim is based on these browser tests. Required conservative CI still selects its normal gates; nothing was weakened to save quota.

## Project lifecycle

- Branch: `feat/215-office-agent-grants`; one main checkout, no extra worktree.
- #209 records the staged delivery plan; #210 records the autonomous identity/memory design gate; #212 records the later owner-selected tmux Luna acceptance session.
- No Firebase activation, cloud writes, host product installation, publication or deployment occurred.
- Merge only after required CI succeeds on this reviewed head. Clean the branch and task-owned Docker image after successful handoff.
