### PR TITLE
feat(office): add explicit owner pairing approval

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,10 +36,13 @@ delivery. Future connector dispatch reuses native request/storage ownership,
 not CLI-output scraping or a competing exchange engine. Ordinary CLI operations
 remain independent of Office.
 
-Office has three app-owned boundaries: `auth` initializes Firebase/session,
+Office has four app-owned boundaries: `auth` initializes Firebase/session,
 `worlds` owns admission and world access, and `blocks` owns the layout contract,
-codec, adapter and editor lifecycle. Rules enforce authority; views never grant
-it. Remote snapshots have one owner, separate from unsaved drafts and ephemeral
+codec, adapter and editor lifecycle. `pairing` owns public-link decoding, explicit
+owner approval/revocation and sanitized action state, reusing the selected-world
+lifecycle and authenticated runtime composition. Rules and the trusted issuer
+enforce authority; views never grant it. Remote snapshots have one owner, separate
+from unsaved drafts and ephemeral
 presentation state. No stored markup executes and no parallel layout is stored.
 The detailed lifecycle and verification map lives only in
 [Office architecture](docs/office/architecture.md); exact persisted data belongs

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -183,6 +183,17 @@ propagate through `emulators:exec`; do not count a skipped or empty suite as pro
 The selected Office CI job runs this same target. Native tmux E2E remains
 separate. Remove the task-owned verification image when no longer needed.
 
+`pairing-browser.spec.ts` proves real browser consent -> issuer approval ->
+original-proof claim -> scoped block write -> cached-token denial after owner
+revocation, plus same-request reopening, non-owner denial, lost-response retry
+and logout during a pending confirmation. Inspect the actual approval POST body
+as well as durable state; URL-only capture is not proof of a secret-free body.
+The originating proof is a fixture, not a native CLI. DOM/state tests separately
+cover admission/route fencing and explicit consent. Browser and service decoders
+consume the same literal pairing corpus; browser encoding tests use an independent
+Node encoder. Review desktop/narrow screenshots rather than accepting their
+existence as visual proof.
+
 For focused service checks use `pnpm office:service:check`,
 `pnpm office:service:test` and `pnpm office:service:build`. `pnpm check` also runs
 the combined `@tmt/office type:check:e2e`; standalone `office:check` deliberately

--- a/apps/office/.env.example
+++ b/apps/office/.env.example
@@ -4,3 +4,5 @@ VITE_FIREBASE_API_KEY=
 VITE_FIREBASE_PROJECT_ID=
 VITE_FIREBASE_AUTH_DOMAIN=
 VITE_FIREBASE_APP_ID=
+# Optional, separately deployed trusted pairing base URL (HTTPS, no query/fragment).
+VITE_OFFICE_PAIRING_URL=

--- a/apps/office/e2e/pairing-browser.spec.ts
+++ b/apps/office/e2e/pairing-browser.spec.ts
@@ -1,0 +1,229 @@
+import { randomBytes, createHash } from 'node:crypto';
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { signInWithCustomToken } from 'firebase/auth';
+import { doc, getDocFromServer, setDoc, serverTimestamp } from 'firebase/firestore';
+import { test, signIn } from './browser-session.js';
+import { createFirestoreFixture, setTester } from './firestore-fixture.js';
+import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
+
+const endpoint = 'http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing';
+
+function requestFor(worldId: string) {
+  const bytes = randomBytes(32);
+  const secret = bytes.toString('base64url');
+  const request = {
+    version: 1,
+    pairingId: createHash('sha256').update(bytes).digest('hex'),
+    worldId,
+    installationId: crypto.randomUUID(),
+    identityId: crypto.randomUUID(),
+    installationLabel: 'My workstation',
+    identityLabel: 'Alice <helper>',
+    capabilities: ['layout.read', 'layout.write'],
+  };
+  const fragment = `tmt-pair=${Buffer.from(JSON.stringify(request)).toString('base64url')}`;
+  return { request, secret, url: `http://127.0.0.1:4173/worlds/${worldId}/pair#${fragment}` };
+}
+
+async function admitOwner(
+  page: Page,
+  db: ReturnType<typeof createPairingEmulatorFixture>['db'],
+  worldId: string
+) {
+  await signIn(page, 'OfficeOwner');
+  const uid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+  await db
+    .collection('worlds')
+    .doc(worldId)
+    .set({ version: 1, name: 'My personal office', ownerUid: uid, createdAt: new Date() });
+  await expect(page.getByRole('heading', { name: 'Waiting for access' })).toBeVisible();
+  await setTester(uid, true);
+  await expect(page.getByRole('region', { name: 'Agent pairing request' })).toBeVisible();
+  return uid;
+}
+
+test('explicit browser consent issues usable scoped access and revocation preserves the workspace', async ({
+  openSession,
+}, info) => {
+  const admin = createPairingEmulatorFixture();
+  const clients = await createFirestoreFixture();
+  try {
+    const worldId = admin.db.collection('worlds').doc().id;
+    const { request, secret, url } = requestFor(worldId);
+    const { page, requests } = await openSession(url);
+    await expect(page.getByRole('button', { name: 'Approve pairing' })).toHaveCount(0);
+    await admitOwner(page, admin.db, worldId);
+    const record = admin.db.collection('officePairings').doc(request.pairingId);
+    expect((await record.get()).exists).toBe(false);
+    expect(requests.filter((target) => target.pathname.endsWith('/approve'))).toEqual([]);
+    await expect(page.getByText('Alice <helper>', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Approve pairing' })).toBeDisabled();
+    await page.getByRole('link', { name: 'Skip to content' }).focus();
+    await page.keyboard.press('Enter');
+    expect(page.url()).toBe(url);
+    await expect(page.locator('#main')).toBeFocused();
+    await page.locator('#main').evaluate((element) => element.blur());
+    await page.screenshot({ path: info.outputPath('pairing-desktop.png'), fullPage: true });
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.screenshot({ path: info.outputPath('pairing-narrow.png'), fullPage: true });
+    await page.getByRole('checkbox', { name: 'I recognize this agent and installation.' }).check();
+    const approvalRequest = page.waitForRequest(
+      (outgoing) => outgoing.url() === `${endpoint}/approve` && outgoing.method() === 'POST'
+    );
+    await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+    const outgoing = await approvalRequest;
+    expect(outgoing.postDataJSON()).toEqual(request);
+    expect(outgoing.url()).not.toContain(secret);
+    expect(outgoing.postData()).not.toContain(secret);
+    expect(await outgoing.headerValue('authorization')).toMatch(/^Bearer \S+$/);
+    await expect(page.getByRole('status').filter({ hasText: 'Approved. Return' })).toBeVisible();
+    const stored = (await record.get()).data()!;
+    expect(stored.request).toEqual(request);
+    const approvals = requests.filter((target) => target.pathname.endsWith('/approve')).length;
+    await page.getByRole('link', { name: 'Office', exact: true }).click();
+    await expect(page.getByRole('region', { name: 'Agent pairing request' })).toHaveCount(0);
+    await page.goBack();
+    await expect(page.getByRole('button', { name: 'Approve pairing', exact: true })).toBeDisabled();
+    expect(page.url()).toBe(url);
+    expect(requests.filter((target) => target.pathname.endsWith('/approve'))).toHaveLength(
+      approvals
+    );
+    await page.getByRole('checkbox').check();
+    await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+    await expect(page.getByRole('status').filter({ hasText: 'Approved. Return' })).toBeVisible();
+    expect((await record.get()).data()).toEqual(stored);
+    const claim = await fetch(`${endpoint}/claim`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ version: 1, secret }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    expect(claim.status).toBe(200);
+    const credential = (await claim.json()) as {
+      customToken: string;
+      principalUid: string;
+      blockId: string;
+    };
+    expect(credential.principalUid).toBe(stored.principalUid);
+    expect(credential.blockId).toBe(stored.blockId);
+    const agent = await clients.client(false, 'device');
+    await signInWithCustomToken(agent.auth, credential.customToken);
+    const target = doc(agent.db, 'worlds', worldId, 'blocks', credential.blockId);
+    await setDoc(target, {
+      version: 1,
+      revision: 1,
+      objects: ['d000'],
+      updatedAt: serverTimestamp(),
+    });
+    const block = admin.db
+      .collection('worlds')
+      .doc(worldId)
+      .collection('blocks')
+      .doc(credential.blockId);
+    const before = (await block.get()).data();
+    expect(before?.objects).toEqual(['d000']);
+    await page.getByRole('button', { name: 'Revoke request' }).click();
+    await expect(page.getByRole('status').filter({ hasText: 'Request revoked.' })).toBeVisible();
+    expect((await record.get()).data()?.enabled).toBe(false);
+    await expect(getDocFromServer(target)).rejects.toMatchObject({ code: 'permission-denied' });
+    expect((await block.get()).data()).toEqual(before);
+    expect(page.url()).not.toContain(secret);
+    expect(await page.locator('body').innerText()).not.toContain(credential.customToken);
+    expect(requests.some((target) => target.href.includes(secret))).toBe(false);
+  } finally {
+    try {
+      await clients.dispose();
+    } finally {
+      await admin.dispose();
+    }
+  }
+});
+
+test('an admitted non-owner cannot use the pairing route to approve another world', async ({
+  openSession,
+}) => {
+  const admin = createPairingEmulatorFixture();
+  try {
+    const worldId = admin.db.collection('worlds').doc().id;
+    const { request, url } = requestFor(worldId);
+    await admin.db.collection('worlds').doc(worldId).set({
+      version: 1,
+      name: 'Another owner private office',
+      ownerUid: crypto.randomUUID(),
+      createdAt: new Date(),
+    });
+    const { page, requests } = await openSession(url);
+    await signIn(page, 'Visitor');
+    const uid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+    await setTester(uid, true);
+    await expect(page.getByRole('heading', { name: 'World unavailable' })).toBeVisible();
+    await expect(page.getByRole('region', { name: 'Agent pairing request' })).toHaveCount(0);
+    expect(requests.filter((target) => target.pathname.endsWith('/approve'))).toEqual([]);
+    expect((await admin.db.collection('officePairings').doc(request.pairingId).get()).exists).toBe(
+      false
+    );
+  } finally {
+    await admin.dispose();
+  }
+});
+
+test('lost approval response retries the same binding and logout fences a late confirmation', async ({
+  openSession,
+}) => {
+  const admin = createPairingEmulatorFixture();
+  try {
+    const worldId = admin.db.collection('worlds').doc().id;
+    const { request, url } = requestFor(worldId);
+    const { page } = await openSession(url);
+    await admitOwner(page, admin.db, worldId);
+    await page.route(
+      '**/officePairing/approve',
+      async (route) => {
+        const submitted = await route.fetch();
+        expect(submitted.status()).toBe(200);
+        await route.abort();
+      },
+      { times: 1 }
+    );
+    await page.getByRole('checkbox').check();
+    await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+    await expect(page.getByRole('alert')).toContainText('may already have completed');
+    const record = admin.db.collection('officePairings').doc(request.pairingId);
+    const approved = (await record.get()).data();
+    expect(approved?.request).toEqual(request);
+    let finish: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    let submitted = false;
+    let delivered = false;
+    await page.route(
+      '**/officePairing/approve',
+      async (route) => {
+        const response = await route.fetch();
+        submitted = true;
+        await gate;
+        await route.fulfill({ response });
+        delivered = true;
+      },
+      { times: 1 }
+    );
+    try {
+      await page.getByRole('button', { name: 'Retry same approval' }).click();
+      await expect.poll(() => submitted).toBe(true);
+      await page.getByRole('button', { name: 'Sign out', exact: true }).click();
+      await expect(page.getByRole('region', { name: 'Agent pairing request' })).toHaveCount(0);
+      finish();
+      // The client discards the body after logout; transport delivery, not a
+      // fully consumed response body, is the relevant late-completion boundary.
+      await expect.poll(() => delivered).toBe(true);
+      await expect(page.getByRole('status').filter({ hasText: 'Approved. Return' })).toHaveCount(0);
+      expect((await record.get()).data()).toEqual(approved);
+    } finally {
+      finish();
+    }
+  } finally {
+    await admin.dispose();
+  }
+});

--- a/apps/office/src/auth/firebase-session.ts
+++ b/apps/office/src/auth/firebase-session.ts
@@ -20,6 +20,7 @@ import { officeFirebaseConfig } from './firebase-config.js';
 import { createWorldPort } from '../worlds/firebase-worlds.js';
 import { createWorldState } from '../worlds/world-state.js';
 import { createBlockPort } from '../blocks/firebase-blocks.js';
+import { createPairingPort, pairingEndpoint } from '../pairing/pairing-transport.js';
 
 /** One composition root for both explicit environments, outside React rendering. */
 export function startOfficeRuntime(
@@ -29,6 +30,7 @@ export function startOfficeRuntime(
 ) {
   const config = officeFirebaseConfig(mode, hostname, settings);
   if (!config) return undefined;
+  const pairingUrl = pairingEndpoint(mode, settings);
   const app = initializeApp(config, `office-${crypto.randomUUID()}`);
   const auth = initializeAuth(app, {
     persistence: inMemoryPersistence,
@@ -58,6 +60,7 @@ export function startOfficeRuntime(
     session,
     worlds,
     blocks: createBlockPort(db),
+    pairing: pairingUrl ? createPairingPort(auth, pairingUrl) : undefined,
     mode,
     dispose: async () => {
       worlds.dispose();

--- a/apps/office/src/main.tsx
+++ b/apps/office/src/main.tsx
@@ -42,6 +42,7 @@ async function mount(): Promise<void> {
         session={runtime?.session}
         worlds={runtime?.worlds}
         blocks={runtime?.blocks}
+        pairing={runtime?.pairing}
         mode={runtime?.mode}
       />
     </StrictMode>

--- a/apps/office/src/office-app.tsx
+++ b/apps/office/src/office-app.tsx
@@ -9,18 +9,22 @@ import { WorldContext } from './worlds/world-view.js';
 import type { WorldState } from './worlds/world-state.js';
 import { BlockContext } from './blocks/block-view.js';
 import type { BlockPort } from './blocks/block-contract.js';
+import { PairingContext } from './pairing/pairing-view.js';
+import type { PairingPort } from './pairing/pairing-contract.js';
 
 export function OfficeApp({
   router,
   session,
   worlds,
   blocks,
+  pairing,
   mode = 'emulator',
 }: {
   router: ReturnType<typeof createOfficeRouter>;
   session?: OfficeSession;
   worlds?: WorldState;
   blocks?: BlockPort;
+  pairing?: PairingPort;
   mode?: string;
 }): ReactElement {
   // A mounted app owns its UI state; tests and future embedded views cannot leak it.
@@ -31,7 +35,9 @@ export function OfficeApp({
         <OfficeModeContext value={mode}>
           <WorldContext value={worlds}>
             <BlockContext value={blocks}>
-              <RouterProvider router={router} />
+              <PairingContext value={pairing}>
+                <RouterProvider router={router} />
+              </PairingContext>
             </BlockContext>
           </WorldContext>
         </OfficeModeContext>

--- a/apps/office/src/pairing/pairing-contract.test.ts
+++ b/apps/office/src/pairing/pairing-contract.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { Buffer } from 'node:buffer';
+import vectors from '../../../../contracts/office/pairing-examples.json' with { type: 'json' };
+import {
+  parseApprovedPairing,
+  parsePairingFragment,
+  parseRevokedPairing,
+  type PairingRequest,
+} from './pairing-contract.js';
+
+type PairingVectors = { valid: PairingRequest[]; invalid: unknown[] };
+const pairingVectors = vectors as PairingVectors;
+const BASE64URL = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+function encodeBytes(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function encodeJson(value: unknown): string {
+  return encodeBytes(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function fragment(value: unknown, hash = true): string {
+  return `${hash ? '#' : ''}tmt-pair=${encodeJson(value)}`;
+}
+
+function noncanonical(encoded: string): string {
+  const last = encoded.length - 1;
+  const digit = BASE64URL.indexOf(encoded[last]);
+  const mask = encoded.length % 4 === 2 ? 0b110000 : 0b111100;
+  const replacement = (digit & mask) | 1;
+  return `${encoded.slice(0, last)}${BASE64URL[replacement]}`;
+}
+
+describe('pairing request vectors', () => {
+  it('keeps a nonempty positive and negative conformance corpus', () => {
+    expect(pairingVectors.valid.length).toBeGreaterThan(0);
+    expect(pairingVectors.invalid.length).toBeGreaterThan(0);
+  });
+  it.each(pairingVectors.valid)('accepts the literal valid request %#', (request) => {
+    expect(parsePairingFragment(fragment(request), request.worldId)).toEqual(request);
+    expect(parsePairingFragment(fragment(request, false), request.worldId)).toEqual(request);
+  });
+
+  it.each(pairingVectors.invalid)('rejects the literal invalid request %#', (request) => {
+    expect(() => parsePairingFragment(fragment(request), pairingVectors.valid[0].worldId)).toThrow(
+      'Invalid pairing input.'
+    );
+  });
+
+  it('rejects route mismatch, query-like fragments, oversized encodings and invalid UTF-8', () => {
+    const request = pairingVectors.valid[0];
+    const json = JSON.stringify(request);
+    const padded = json.length % 3 === 0 ? `${json} ` : json;
+    const encoded = Buffer.from(padded).toString('base64url');
+    expect(() => parsePairingFragment(fragment(request), 'B'.repeat(20))).toThrow();
+    expect(() => parsePairingFragment(`${fragment(request)}&extra`, request.worldId)).toThrow();
+    expect(() => parsePairingFragment(`#tmt-pair=${'A'.repeat(4097)}`, request.worldId)).toThrow();
+    const altered = noncanonical(encoded);
+    expect(Buffer.from(altered, 'base64url')).toEqual(Buffer.from(encoded, 'base64url'));
+    expect(() => parsePairingFragment(`#tmt-pair=${altered}`, request.worldId)).toThrow();
+    expect(() =>
+      parsePairingFragment(
+        `#tmt-pair=${encodeBytes(new Uint8Array([123, 34, 0xc3, 0x28, 125]))}`,
+        request.worldId
+      )
+    ).toThrow();
+    const atLimit = ' '.repeat(2048 - Buffer.byteLength(json)) + json;
+    expect(
+      parsePairingFragment(
+        `#tmt-pair=${Buffer.from(atLimit).toString('base64url')}`,
+        request.worldId
+      )
+    ).toEqual(request);
+    expect(() =>
+      parsePairingFragment(
+        `#tmt-pair=${Buffer.from(` ${atLimit}`).toString('base64url')}`,
+        request.worldId
+      )
+    ).toThrow();
+  });
+});
+
+describe('approved and revoked response decoding', () => {
+  const request = pairingVectors.valid[0];
+  const approved = {
+    ...request,
+    principalUid: 'office-agent:00000000-0000-4000-8000-000000000003',
+    blockId: '00000000-0000-4000-8000-000000000004',
+    expiresAt: 1_800_000_000_000,
+  };
+
+  it('accepts an exact approved response and revocation response', () => {
+    expect(parseApprovedPairing(approved, request)).toEqual(approved);
+    expect(
+      parseRevokedPairing(
+        { version: 1, pairingId: request.pairingId, revoked: true },
+        request.pairingId
+      )
+    ).toBeUndefined();
+  });
+
+  it.each([
+    { customToken: 'never accepted' },
+    { ownerUid: 'never accepted' },
+    { principalUid: 'agent' },
+    { blockId: 'block' },
+    { expiresAt: 0 },
+    { expiresAt: 1.5 },
+    { expiresAt: Number.MAX_SAFE_INTEGER + 1 },
+    { expiresAt: 8_640_000_000_000_001 },
+    { identityId: '00000000-0000-4000-8000-000000000099' },
+  ])('rejects altered approved response %#', (change) => {
+    expect(() => parseApprovedPairing({ ...approved, ...change }, request)).toThrow(
+      'Invalid pairing input.'
+    );
+  });
+
+  it.each([
+    { version: 2, pairingId: request.pairingId, revoked: true },
+    { version: 1, pairingId: '0'.repeat(64), revoked: true },
+    { version: 1, pairingId: request.pairingId, revoked: false },
+    { version: 1, pairingId: request.pairingId, revoked: true, extra: true },
+  ])('rejects altered revoke response %#', (value) => {
+    expect(() => parseRevokedPairing(value, request.pairingId)).toThrow('Invalid pairing input.');
+  });
+});

--- a/apps/office/src/pairing/pairing-contract.ts
+++ b/apps/office/src/pairing/pairing-contract.ts
@@ -1,0 +1,221 @@
+import { WORLD_ID_PATTERN } from '../worlds/world-contract.js';
+
+export type PairingCapabilities = ['layout.read'] | ['layout.read', 'layout.write'];
+
+export interface PairingRequest {
+  version: 1;
+  pairingId: string;
+  worldId: string;
+  installationId: string;
+  identityId: string;
+  installationLabel: string;
+  identityLabel: string;
+  capabilities: PairingCapabilities;
+}
+
+export interface ApprovedPairing extends PairingRequest {
+  principalUid: string;
+  blockId: string;
+  expiresAt: number;
+}
+
+export interface PairingPort {
+  approve(request: PairingRequest, ownerUid: string): Promise<ApprovedPairing>;
+  revoke(pairingId: string, ownerUid: string): Promise<void>;
+}
+
+export class PairingActionError extends Error {
+  constructor(readonly kind: 'denied' | 'unavailable' | 'conflict' | 'uncertain') {
+    super(
+      {
+        denied: 'Pairing was denied. Check your account and current access.',
+        unavailable: 'This request is unavailable or expired. Request a new pairing link.',
+        conflict: 'This challenge already has a different approved binding. Request a new link.',
+        uncertain:
+          'The service could not confirm the result. Keep this link and retry the same action; a submitted change may already have completed.',
+      }[kind]
+    );
+  }
+}
+
+const REQUEST_KEYS = [
+  'version',
+  'pairingId',
+  'worldId',
+  'installationId',
+  'identityId',
+  'installationLabel',
+  'identityLabel',
+  'capabilities',
+] as const;
+const APPROVED_KEYS = [...REQUEST_KEYS, 'principalUid', 'blockId', 'expiresAt'];
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const PAIRING_ID = /^[0-9a-f]{64}$/;
+const WORLD_ID = new RegExp(`^${WORLD_ID_PATTERN}$`);
+const FRAGMENT_PREFIX = 'tmt-pair=';
+const MAX_DECODED_FRAGMENT_BYTES = 2048;
+const MAX_FRAGMENT_PAYLOAD = Math.ceil((MAX_DECODED_FRAGMENT_BYTES * 4) / 3);
+const MAX_DATE_MS = 8_640_000_000_000_000;
+
+function invalid(): never {
+  throw new Error('Invalid pairing input.');
+}
+
+function exact(value: Record<string, unknown>, keys: readonly string[]): void {
+  if (Object.keys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(value, key)))
+    invalid();
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) invalid();
+  return value as Record<string, unknown>;
+}
+
+function label(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    [...value].length <= 80 &&
+    value.trim().length > 0 &&
+    !/[\p{Cc}\p{Cs}]/u.test(value)
+  );
+}
+
+function matches(value: unknown, pattern: RegExp): value is string {
+  return typeof value === 'string' && pattern.test(value);
+}
+
+function capabilities(value: unknown): PairingCapabilities | undefined {
+  if (!Array.isArray(value) || value[0] !== 'layout.read') return undefined;
+  if (value.length === 1) return ['layout.read'];
+  if (value.length === 2 && value[1] === 'layout.write') return ['layout.read', 'layout.write'];
+  return undefined;
+}
+
+function parseRequest(value: unknown, worldId: string): PairingRequest {
+  const input = record(value);
+  exact(input, REQUEST_KEYS);
+  const parsedCapabilities = capabilities(input.capabilities);
+  if (
+    input.version !== 1 ||
+    !matches(input.pairingId, PAIRING_ID) ||
+    !matches(input.worldId, WORLD_ID) ||
+    input.worldId !== worldId ||
+    !matches(input.installationId, UUID) ||
+    !matches(input.identityId, UUID) ||
+    !label(input.installationLabel) ||
+    !label(input.identityLabel) ||
+    !parsedCapabilities
+  )
+    invalid();
+  return {
+    version: 1,
+    pairingId: input.pairingId,
+    worldId: input.worldId,
+    installationId: input.installationId,
+    identityId: input.identityId,
+    installationLabel: input.installationLabel,
+    identityLabel: input.identityLabel,
+    capabilities: parsedCapabilities,
+  };
+}
+
+function requestFields(value: Record<string, unknown>): Record<string, unknown> {
+  const request: Record<string, unknown> = {};
+  for (const key of REQUEST_KEYS) request[key] = value[key];
+  return request;
+}
+
+function equalRequest(left: PairingRequest, right: PairingRequest): boolean {
+  return (
+    left.version === right.version &&
+    left.pairingId === right.pairingId &&
+    left.worldId === right.worldId &&
+    left.installationId === right.installationId &&
+    left.identityId === right.identityId &&
+    left.installationLabel === right.installationLabel &&
+    left.identityLabel === right.identityLabel &&
+    left.capabilities.length === right.capabilities.length &&
+    left.capabilities.every((capability, index) => capability === right.capabilities[index])
+  );
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  return Uint8Array.from(atob(value.replace(/-/g, '+').replace(/_/g, '/')), (character) =>
+    character.charCodeAt(0)
+  );
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export function parsePairingFragment(fragment: string, worldId: string): PairingRequest {
+  try {
+    if (
+      typeof fragment !== 'string' ||
+      fragment.length > 1 + FRAGMENT_PREFIX.length + MAX_FRAGMENT_PAYLOAD
+    )
+      invalid();
+    if (!matches(worldId, WORLD_ID)) invalid();
+    const value = fragment.startsWith('#') ? fragment.slice(1) : fragment;
+    if (!value.startsWith(FRAGMENT_PREFIX)) invalid();
+    const encoded = value.slice(FRAGMENT_PREFIX.length);
+    if (
+      encoded.length === 0 ||
+      encoded.length > MAX_FRAGMENT_PAYLOAD ||
+      !/^[A-Za-z0-9_-]+$/.test(encoded)
+    )
+      invalid();
+    const bytes = decodeBase64Url(encoded);
+    if (bytes.length > MAX_DECODED_FRAGMENT_BYTES) invalid();
+    const json = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    const canonical = new TextEncoder().encode(json);
+    if (encodeBase64Url(canonical) !== encoded) invalid();
+    return parseRequest(JSON.parse(json), worldId);
+  } catch {
+    invalid();
+  }
+}
+
+export function parseApprovedPairing(input: unknown, expected: PairingRequest): ApprovedPairing {
+  try {
+    const expectedRequest = parseRequest(expected, expected.worldId);
+    const value = record(input);
+    exact(value, APPROVED_KEYS);
+    const request = parseRequest(requestFields(value), expectedRequest.worldId);
+    if (!equalRequest(request, expectedRequest)) invalid();
+    if (
+      typeof value.principalUid !== 'string' ||
+      !value.principalUid.startsWith('office-agent:') ||
+      !UUID.test(value.principalUid.slice('office-agent:'.length)) ||
+      !matches(value.blockId, UUID) ||
+      typeof value.expiresAt !== 'number' ||
+      !Number.isSafeInteger(value.expiresAt) ||
+      value.expiresAt <= 0 ||
+      value.expiresAt > MAX_DATE_MS
+    )
+      invalid();
+    return {
+      ...request,
+      principalUid: value.principalUid,
+      blockId: value.blockId,
+      expiresAt: value.expiresAt,
+    };
+  } catch {
+    invalid();
+  }
+}
+
+export function parseRevokedPairing(input: unknown, pairingId: string): void {
+  try {
+    if (!matches(pairingId, PAIRING_ID)) invalid();
+    const value = record(input);
+    exact(value, ['version', 'pairingId', 'revoked']);
+    if (value.version !== 1 || value.pairingId !== pairingId || value.revoked !== true) invalid();
+  } catch {
+    invalid();
+  }
+}

--- a/apps/office/src/pairing/pairing-state.test.ts
+++ b/apps/office/src/pairing/pairing-state.test.ts
@@ -1,0 +1,87 @@
+import { expect, it, vi } from 'vitest';
+import { createPairingState } from './pairing-state.js';
+import { PairingActionError } from './pairing-contract.js';
+import type { ApprovedPairing, PairingRequest, PairingPort } from './pairing-contract.js';
+
+const request: PairingRequest = {
+  version: 1,
+  pairingId: 'a'.repeat(64),
+  worldId: 'a'.repeat(20),
+  installationId: '00000000-0000-4000-8000-000000000001',
+  identityId: '00000000-0000-4000-8000-000000000002',
+  installationLabel: 'Workstation',
+  identityLabel: 'Alice',
+  capabilities: ['layout.read'],
+};
+const binding: ApprovedPairing = {
+  ...request,
+  principalUid: 'office-agent:00000000-0000-4000-8000-000000000003',
+  blockId: '00000000-0000-4000-8000-000000000004',
+  expiresAt: 2_000_000_000_000,
+};
+function fixture() {
+  const port: PairingPort = { approve: vi.fn(async () => binding), revoke: vi.fn(async () => {}) };
+  return { port, state: createPairingState(port, request, 'owner') };
+}
+
+it('viewing is read-only; concurrent actions serialize and uncertain approval retries preserve the request', async () => {
+  const { port, state } = fixture();
+  expect(port.approve).not.toHaveBeenCalled();
+  let reject: (error: Error) => void = () => {};
+  vi.mocked(port.approve).mockImplementationOnce(
+    () =>
+      new Promise((_, fail) => {
+        reject = fail;
+      })
+  );
+  const pending = state.approve();
+  await state.approve();
+  await state.revoke();
+  expect(port.approve).toHaveBeenCalledExactlyOnceWith(request, 'owner');
+  expect(port.revoke).not.toHaveBeenCalled();
+  reject(new Error('Do not expose a bearer or raw service failure'));
+  await pending;
+  expect(state.getSnapshot()).toMatchObject({ attempted: true, busy: false, approved: null });
+  expect(state.getSnapshot().error).toContain('may already have completed');
+  expect(state.getSnapshot().error).not.toContain('bearer');
+  await state.approve();
+  expect(port.approve).toHaveBeenLastCalledWith(request, 'owner');
+  expect(state.getSnapshot().approved).toEqual(binding);
+  state.dispose();
+});
+
+it('failed revocation preserves confirmed approval; explicit retry revokes once without reapproval', async () => {
+  const { port, state } = fixture();
+  await state.approve();
+  vi.mocked(port.revoke).mockRejectedValueOnce(new PairingActionError('uncertain'));
+  await state.revoke();
+  expect(state.getSnapshot()).toMatchObject({ approved: binding, revoked: false });
+  await state.revoke();
+  expect(port.revoke).toHaveBeenLastCalledWith(request.pairingId, 'owner');
+  expect(state.getSnapshot()).toMatchObject({ approved: null, revoked: true, error: null });
+  await state.approve();
+  expect(port.approve).toHaveBeenCalledOnce();
+  state.dispose();
+});
+
+it('disposal clears private results, suppresses late completion and prevents subsequent actions', async () => {
+  const { port, state } = fixture();
+  let resolve: (binding: ApprovedPairing) => void = () => {};
+  vi.mocked(port.approve).mockImplementationOnce(
+    () =>
+      new Promise((done) => {
+        resolve = done;
+      })
+  );
+  const changed = vi.fn();
+  state.subscribe(changed);
+  const pending = state.approve();
+  expect(changed).toHaveBeenCalledOnce();
+  state.dispose();
+  resolve(binding);
+  await pending;
+  await state.approve();
+  expect(changed).toHaveBeenCalledOnce();
+  expect(state.getSnapshot()).toMatchObject({ approved: null, attempted: false, busy: false });
+  expect(port.approve).toHaveBeenCalledOnce();
+});

--- a/apps/office/src/pairing/pairing-state.ts
+++ b/apps/office/src/pairing/pairing-state.ts
@@ -1,0 +1,67 @@
+import { PairingActionError } from './pairing-contract.js';
+import type { ApprovedPairing, PairingRequest, PairingPort } from './pairing-contract.js';
+
+interface PairingSnapshot {
+  busy: boolean;
+  attempted: boolean;
+  approved: ApprovedPairing | null;
+  revoked: boolean;
+  error: string | null;
+}
+
+/** One mounted request owns actions; disposal fences results, not remote writes. */
+export function createPairingState(port: PairingPort, request: PairingRequest, ownerUid: string) {
+  let snapshot: PairingSnapshot = {
+    busy: false,
+    attempted: false,
+    approved: null,
+    revoked: false,
+    error: null,
+  };
+  let disposed = false;
+  const listeners = new Set<() => void>();
+  function publish(change: Partial<PairingSnapshot>) {
+    if (disposed) return;
+    snapshot = { ...snapshot, ...change };
+    for (const listener of listeners) listener();
+  }
+  async function act(action: () => Promise<Partial<PairingSnapshot>>) {
+    if (disposed || snapshot.busy || snapshot.revoked) return;
+    publish({ busy: true, attempted: true, error: null });
+    try {
+      publish(await action());
+    } catch (error) {
+      publish({
+        error:
+          error instanceof PairingActionError
+            ? error.message
+            : new PairingActionError('uncertain').message,
+      });
+    } finally {
+      publish({ busy: false });
+    }
+  }
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener: () => void) {
+      if (disposed) return () => {};
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    approve: () => act(async () => ({ approved: await port.approve(request, ownerUid) })),
+    revoke: () =>
+      act(async () => {
+        await port.revoke(request.pairingId, ownerUid);
+        return { approved: null, revoked: true };
+      }),
+    dispose() {
+      disposed = true;
+      listeners.clear();
+      snapshot = { busy: false, attempted: false, approved: null, revoked: false, error: null };
+    },
+  };
+}
+
+export type PairingState = ReturnType<typeof createPairingState>;

--- a/apps/office/src/pairing/pairing-transport.test.ts
+++ b/apps/office/src/pairing/pairing-transport.test.ts
@@ -1,0 +1,101 @@
+import { expect, it, vi } from 'vitest';
+import { createPairingPort, pairingEndpoint } from './pairing-transport.js';
+
+const pairingId = 'a'.repeat(64);
+const endpoint = 'https://pair.example/officePairing';
+const response = () =>
+  new Response(JSON.stringify({ version: 1, pairingId, revoked: true }), {
+    headers: { 'content-type': 'application/json' },
+  });
+
+it('only explicit deployment settings select an endpoint, never request or preview data', () => {
+  expect(pairingEndpoint('preview', { VITE_OFFICE_PAIRING_URL: endpoint })).toBeUndefined();
+  expect(pairingEndpoint('cloud', {})).toBeUndefined();
+  expect(pairingEndpoint('cloud', { VITE_OFFICE_PAIRING_URL: endpoint })).toBe(endpoint);
+  expect(pairingEndpoint('emulator', { VITE_OFFICE_PAIRING_URL: endpoint })).toBe(
+    'http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing'
+  );
+  for (const value of [
+    'http://pair.example/',
+    'https://user:secret@pair.example/',
+    'https://pair.example/?token=x',
+    'https://pair.example/#other',
+    'https://pair.example/a/../b',
+  ])
+    expect(() => pairingEndpoint('cloud', { VITE_OFFICE_PAIRING_URL: value })).toThrow();
+});
+
+it('uses the selected owner token only in a no-redirect/no-cookie bounded POST header', async () => {
+  const send = vi.fn<typeof fetch>().mockResolvedValue(response());
+  const auth = { currentUser: { uid: 'owner', getIdToken: async () => 'private-token' } };
+  await createPairingPort(auth, endpoint, send).revoke(pairingId, 'owner');
+  expect(send).toHaveBeenCalledOnce();
+  const [url, options] = send.mock.calls[0];
+  expect(url).toBe(`${endpoint}/revoke`);
+  expect(options).toMatchObject({
+    method: 'POST',
+    redirect: 'error',
+    credentials: 'omit',
+    cache: 'no-store',
+    headers: { authorization: 'Bearer private-token' },
+  });
+  expect(options?.body).toBe(JSON.stringify({ version: 1, pairingId }));
+  expect(options?.signal).toBeInstanceOf(AbortSignal);
+});
+
+it('session change during token acquisition cannot send an approval as the previous owner', async () => {
+  let resolve: (token: string) => void = () => {};
+  const auth: { currentUser: { uid: string; getIdToken(): Promise<string> } | null } = {
+    currentUser: {
+      uid: 'owner',
+      getIdToken: () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    },
+  };
+  const send = vi.fn<typeof fetch>();
+  const port = createPairingPort(auth, endpoint, send);
+  const pending = port.revoke(pairingId, 'owner');
+  auth.currentUser = null;
+  resolve('private-token');
+  await expect(pending).rejects.toMatchObject({ kind: 'denied' });
+  expect(send).not.toHaveBeenCalled();
+  await expect(port.revoke(pairingId, 'other')).rejects.toMatchObject({ kind: 'denied' });
+});
+
+it('oversize or invalid successful responses remain uncertain and error bodies are never displayed', async () => {
+  const auth = { currentUser: { uid: 'owner', getIdToken: async () => 'private-token' } };
+  for (const reply of [
+    new Response('x'.repeat(4097), { headers: { 'content-type': 'application/json' } }),
+    new Response('private server path', { headers: { 'content-type': 'text/plain' } }),
+    new Response('private server path', { status: 503 }),
+  ]) {
+    const port = createPairingPort(auth, endpoint, vi.fn<typeof fetch>().mockResolvedValue(reply));
+    await expect(port.revoke(pairingId, 'owner')).rejects.toMatchObject({ kind: 'uncertain' });
+  }
+  const denied = createPairingPort(
+    auth,
+    endpoint,
+    vi.fn<typeof fetch>().mockResolvedValue(new Response('private server path', { status: 403 }))
+  );
+  await expect(denied.revoke(pairingId, 'owner')).rejects.toMatchObject({ kind: 'denied' });
+});
+
+it.each([
+  [401, 'denied'],
+  [403, 'denied'],
+  [404, 'unavailable'],
+  [409, 'conflict'],
+] as const)(
+  'maps status %s to the distinct %s recovery state without disclosing the body',
+  async (status, kind) => {
+    const auth = { currentUser: { uid: 'owner', getIdToken: async () => 'private-token' } };
+    const port = createPairingPort(
+      auth,
+      endpoint,
+      vi.fn<typeof fetch>().mockResolvedValue(new Response('sensitive server details', { status }))
+    );
+    await expect(port.revoke(pairingId, 'owner')).rejects.toMatchObject({ kind });
+  }
+);

--- a/apps/office/src/pairing/pairing-transport.ts
+++ b/apps/office/src/pairing/pairing-transport.ts
@@ -1,0 +1,111 @@
+import {
+  parseApprovedPairing,
+  parseRevokedPairing,
+  PairingActionError,
+} from './pairing-contract.js';
+import type { PairingPort } from './pairing-contract.js';
+
+/** Deployment configuration is trusted input; pairing links never select an endpoint. */
+export function pairingEndpoint(
+  mode: string,
+  settings: Record<string, unknown>
+): string | undefined {
+  if (mode === 'emulator') return 'http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing';
+  if (
+    mode !== 'cloud' ||
+    settings.VITE_OFFICE_PAIRING_URL === undefined ||
+    settings.VITE_OFFICE_PAIRING_URL === ''
+  )
+    return undefined;
+  const value = settings.VITE_OFFICE_PAIRING_URL;
+  if (typeof value !== 'string') throw new Error('Invalid Office pairing service configuration.');
+  const url = new URL(value);
+  if (
+    url.protocol !== 'https:' ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.href !== value
+  )
+    throw new Error('Invalid Office pairing service configuration.');
+  return url.href.replace(/\/$/, '');
+}
+
+async function responseBody(response: Response): Promise<unknown> {
+  if (
+    !response.headers.get('content-type')?.match(/^application\/json(?:\s*;|$)/i) ||
+    !response.body
+  )
+    throw new PairingActionError('uncertain');
+  const reader = response.body.getReader();
+  const bytes: number[] = [];
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (bytes.length + value.length > 4096) {
+        await reader.cancel();
+        throw new PairingActionError('uncertain');
+      }
+      bytes.push(...value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(new Uint8Array(bytes)));
+}
+
+interface TokenSession {
+  readonly currentUser: { uid: string; getIdToken(): Promise<string> } | null;
+}
+
+export function createPairingPort(
+  auth: TokenSession,
+  endpoint: string,
+  send: typeof fetch = fetch
+): PairingPort {
+  async function post(operation: 'approve' | 'revoke', input: unknown, ownerUid: string) {
+    const user = auth.currentUser;
+    if (!user || user.uid !== ownerUid) throw new PairingActionError('denied');
+    try {
+      const token = await user.getIdToken();
+      if (auth.currentUser !== user) throw new PairingActionError('denied');
+      const response = await send(`${endpoint}/${operation}`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify(input),
+        credentials: 'omit',
+        redirect: 'error',
+        cache: 'no-store',
+        signal: AbortSignal.timeout(10_000),
+      });
+      const failure =
+        auth.currentUser !== user || [400, 401, 403].includes(response.status)
+          ? 'denied'
+          : response.status === 404
+            ? 'unavailable'
+            : response.status === 409
+              ? 'conflict'
+              : response.status !== 200
+                ? 'uncertain'
+                : undefined;
+      if (failure) {
+        await response.body?.cancel();
+        throw new PairingActionError(failure);
+      }
+      return await responseBody(response);
+    } catch (error) {
+      if (error instanceof PairingActionError) throw error;
+      throw new PairingActionError('uncertain');
+    }
+  }
+  return {
+    async approve(request, ownerUid) {
+      return parseApprovedPairing(await post('approve', request, ownerUid), request);
+    },
+    async revoke(pairingId, ownerUid) {
+      parseRevokedPairing(await post('revoke', { version: 1, pairingId }, ownerUid), pairingId);
+    },
+  };
+}

--- a/apps/office/src/pairing/pairing-view.test.tsx
+++ b/apps/office/src/pairing/pairing-view.test.tsx
@@ -1,0 +1,135 @@
+import { Buffer } from 'node:buffer';
+import { createMemoryHistory } from '@tanstack/react-router';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, it, vi } from 'vitest';
+import { createSession } from '../auth/session.js';
+import type { SessionUser } from '../auth/session.js';
+import { createWorldState } from '../worlds/world-state.js';
+import { createOfficeRouter } from '../router.js';
+import { OfficeApp } from '../office-app.js';
+import type { ApprovedPairing, PairingRequest, PairingPort } from './pairing-contract.js';
+import vectors from '../../../../contracts/office/pairing-examples.json' with { type: 'json' };
+
+async function fixture(change: Record<string, unknown> = {}) {
+  const request = { ...vectors.valid[0], ...change } as PairingRequest;
+  const world = { id: request.worldId, name: 'Private studio', ownerUid: 'owner', createdAtMs: 1 };
+  let identity: (user: SessionUser | null) => void = () => {};
+  let admission: (value: boolean) => void = () => {};
+  const session = createSession({
+    observe: (changed) => {
+      identity = changed;
+      changed({ uid: 'owner', displayName: 'Owner' });
+      return () => {};
+    },
+    signIn: async () => {},
+    signOut: async () => identity(null),
+    dispose: async () => {},
+  });
+  const worlds = createWorldState(session, {
+    draft: () => {
+      throw new Error('No world creation in this scenario');
+    },
+    create: async () => {
+      throw new Error('No world creation in this scenario');
+    },
+    watchAdmission: (_uid, changed) => {
+      admission = changed;
+      changed(true);
+      return () => {};
+    },
+    watch: (_id, changed) => {
+      changed(world);
+      return () => {};
+    },
+  });
+  const approved: ApprovedPairing = {
+    ...request,
+    principalUid: 'office-agent:00000000-0000-4000-8000-000000000003',
+    blockId: '00000000-0000-4000-8000-000000000004',
+    expiresAt: 2_000_000_000_000,
+  };
+  const port: PairingPort = { approve: vi.fn(async () => approved), revoke: vi.fn(async () => {}) };
+  const fragment = `tmt-pair=${Buffer.from(JSON.stringify(request)).toString('base64url')}`;
+  const router = createOfficeRouter(
+    createMemoryHistory({ initialEntries: [`/worlds/${world.id}/pair#${fragment}`] })
+  );
+  const view = render(
+    <OfficeApp router={router} session={session} worlds={worlds} pairing={port} />
+  );
+  return {
+    port,
+    approved,
+    router,
+    request,
+    revokeAdmission: () => admission(false),
+    async dispose() {
+      view.unmount();
+      worlds.dispose();
+      await session.dispose();
+    },
+  };
+}
+
+it('requires explicit recognition, renders labels as text and never approves just by viewing', async () => {
+  const f = await fixture({ identityLabel: '<img src=x onerror=alert(1)>' });
+  try {
+    const user = userEvent.setup();
+    const approve = await screen.findByRole('button', { name: 'Approve pairing' });
+    expect((approve as HTMLButtonElement).disabled).toBe(true);
+    expect(f.port.approve).not.toHaveBeenCalled();
+    const region = screen.getByRole('region', { name: 'Agent pairing request' });
+    expect(region.querySelector('img')).toBeNull();
+    expect(region.textContent).toContain('<img src=x onerror=alert(1)>');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(approve);
+    await screen.findByText(/Approved\. Return to the requesting terminal/);
+    expect(f.port.approve).toHaveBeenCalledExactlyOnceWith(f.request, 'owner');
+    await user.click(screen.getByRole('button', { name: 'Revoke request' }));
+    await screen.findByText(/Request revoked\. Existing workspace content is retained/);
+    expect(f.port.revoke).toHaveBeenCalledExactlyOnceWith(f.request.pairingId, 'owner');
+  } finally {
+    await f.dispose();
+  }
+});
+
+it.each(['admission', 'route'] as const)(
+  'a %s change discards the request view and fences pending approval',
+  async (boundary) => {
+    const f = await fixture();
+    try {
+      let finish: (value: ApprovedPairing) => void = () => {};
+      vi.mocked(f.port.approve).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          })
+      );
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole('checkbox'));
+      await user.click(screen.getByRole('button', { name: 'Approve pairing' }));
+      expect(f.port.approve).toHaveBeenCalledOnce();
+      await act(async () => {
+        if (boundary === 'admission') f.revokeAdmission();
+        else await f.router.navigate({ to: '/setup' });
+      });
+      expect(screen.queryByRole('region', { name: 'Agent pairing request' })).toBeNull();
+      await act(async () => finish(f.approved));
+      expect(screen.queryByText(/Approved\. Return/)).toBeNull();
+    } finally {
+      await f.dispose();
+    }
+  }
+);
+
+it('secret-bearing input fails before any approval operation', async () => {
+  const f = await fixture({ secret: 'must-not-be-accepted' });
+  try {
+    await screen.findByText(/Invalid pairing link/);
+    expect(screen.queryByRole('button', { name: 'Approve pairing' })).toBeNull();
+    expect(f.port.approve).not.toHaveBeenCalled();
+    expect(f.port.revoke).not.toHaveBeenCalled();
+  } finally {
+    await f.dispose();
+  }
+});

--- a/apps/office/src/pairing/pairing-view.tsx
+++ b/apps/office/src/pairing/pairing-view.tsx
@@ -1,0 +1,145 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { parsePairingFragment } from './pairing-contract.js';
+import type { PairingRequest, PairingPort } from './pairing-contract.js';
+import { createPairingState } from './pairing-state.js';
+import type { PairingState } from './pairing-state.js';
+import './pairing.css';
+
+export const PairingContext = createContext<PairingPort | undefined>(undefined);
+
+export function PairingPanel({
+  worldId,
+  ownerUid,
+  fragment,
+}: {
+  worldId: string;
+  ownerUid: string;
+  fragment: string;
+}) {
+  const port = useContext(PairingContext);
+  const request = useMemo(() => {
+    try {
+      return parsePairingFragment(fragment, worldId);
+    } catch {
+      return null;
+    }
+  }, [fragment, worldId]);
+  if (!port) return <p role="status">Pairing is not configured for this deployment.</p>;
+  if (!request)
+    return (
+      <p role="alert">Invalid pairing link. Ask for a new link from the requesting installation.</p>
+    );
+  return (
+    <PairingMount
+      key={`${ownerUid}:${fragment}`}
+      port={port}
+      request={request}
+      ownerUid={ownerUid}
+    />
+  );
+}
+
+function PairingMount({
+  port,
+  request,
+  ownerUid,
+}: {
+  port: PairingPort;
+  request: PairingRequest;
+  ownerUid: string;
+}) {
+  const [state, setState] = useState<PairingState>();
+  useEffect(() => {
+    const next = createPairingState(port, request, ownerUid);
+    setState(next);
+    return () => next.dispose();
+  }, [port, request, ownerUid]);
+  return state ? <PairingForm state={state} request={request} /> : null;
+}
+
+export function PairingForm({ state, request }: { state: PairingState; request: PairingRequest }) {
+  const { busy, attempted, approved, revoked, error } = useSyncExternalStore(
+    state.subscribe,
+    state.getSnapshot
+  );
+  const [recognized, setRecognized] = useState(false);
+  return (
+    <section className="pairing-panel" aria-label="Agent pairing request">
+      <p className="eyebrow">INVITE AN AGENT INTO YOUR SPACE</p>
+      <h2>Is this your agent?</h2>
+      <p>
+        Only approve a request you started. Labels are supplied by the requesting installation, not
+        verified identities.
+      </p>
+      <dl className="pairing-details">
+        <dt>Agent</dt>
+        <dd>{request.identityLabel}</dd>
+        <dt>Installation</dt>
+        <dd>{request.installationLabel}</dd>
+        <dt>Identity ID</dt>
+        <dd>
+          <code>{request.identityId}</code>
+        </dd>
+        <dt>Installation ID</dt>
+        <dd>
+          <code>{request.installationId}</code>
+        </dd>
+        <dt>Request code</dt>
+        <dd>
+          <code>{request.pairingId.slice(0, 12)}</code>
+        </dd>
+        <dt>Access</dt>
+        <dd>
+          {request.capabilities.length === 2
+            ? 'Read and arrange one assigned block'
+            : 'Read one assigned block'}
+        </dd>
+      </dl>
+      <p>No notebook, message board, local files or command execution access is granted.</p>
+      {error && <p role="alert">{error}</p>}
+      {approved && (
+        <p role="status">
+          Approved. Return to the requesting terminal before{' '}
+          <time dateTime={new Date(approved.expiresAt).toISOString()}>
+            {new Date(approved.expiresAt).toLocaleString()}
+          </time>
+          . This does not mean the agent is connected.
+        </p>
+      )}
+      {revoked && <p role="status">Request revoked. Existing workspace content is retained.</p>}
+      {!approved && !revoked && (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (recognized) void state.approve();
+          }}
+        >
+          <label className="pairing-consent">
+            <input
+              type="checkbox"
+              checked={recognized}
+              disabled={busy}
+              onChange={(event) => setRecognized(event.target.checked)}
+            />{' '}
+            I recognize this agent and installation.
+          </label>
+          <button disabled={busy || !recognized}>
+            {busy ? 'Confirming…' : attempted ? 'Retry same approval' : 'Approve pairing'}
+          </button>
+        </form>
+      )}
+      {attempted && !revoked && (
+        <button disabled={busy} onClick={() => void state.revoke()}>
+          Revoke request
+        </button>
+      )}
+    </section>
+  );
+}

--- a/apps/office/src/pairing/pairing.css
+++ b/apps/office/src/pairing/pairing.css
@@ -1,0 +1,44 @@
+.pairing-panel {
+  max-width: 52rem;
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid #d4dccf;
+  border-radius: 1rem;
+  background: #fff;
+}
+.pairing-details {
+  display: grid;
+  grid-template-columns: minmax(7rem, 1fr) minmax(0, 3fr);
+  gap: 0.75rem 1rem;
+}
+.pairing-details dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+.pairing-details dt {
+  font-weight: 600;
+}
+.pairing-consent {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.pairing-consent input {
+  width: auto;
+}
+.pairing-panel button {
+  margin: 0.5rem 0.5rem 0 0;
+}
+@media (max-width: 500px) {
+  .pairing-panel {
+    padding: 1rem;
+  }
+  .pairing-details {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.25rem;
+  }
+  .pairing-details dd {
+    margin-bottom: 0.75rem;
+  }
+}

--- a/apps/office/src/router.tsx
+++ b/apps/office/src/router.tsx
@@ -1,9 +1,16 @@
-import { createRootRoute, createRoute, createRouter, Link } from '@tanstack/react-router';
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Link,
+  useLocation,
+} from '@tanstack/react-router';
 import type { RouterHistory } from '@tanstack/react-router';
 import { OfficeShell } from './shell.js';
 import { HomePage } from './pages/home.js';
 import { SetupPage } from './pages/setup.js';
 import { SelectedWorld, WorldGate } from './worlds/world-view.js';
+import { PairingPanel } from './pairing/pairing-view.js';
 
 const rootRoute = createRootRoute({
   component: OfficeShell,
@@ -26,10 +33,32 @@ function WorldPage() {
   return <WorldGate>{(state) => <SelectedWorld state={state} id={worldId} />}</WorldGate>;
 }
 
+const pairingRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/worlds/$worldId/pair',
+  component: PairingPage,
+});
+function PairingPage() {
+  const { worldId } = pairingRoute.useParams();
+  const fragment = useLocation({ select: (location) => location.hash });
+  return (
+    <WorldGate>
+      {(state) => (
+        <SelectedWorld state={state} id={worldId}>
+          {(world) => (
+            <PairingPanel worldId={world.id} ownerUid={world.ownerUid} fragment={fragment} />
+          )}
+        </SelectedWorld>
+      )}
+    </WorldGate>
+  );
+}
+
 const routeTree = rootRoute.addChildren([
   createRoute({ getParentRoute: () => rootRoute, path: '/', component: HomePage }),
   createRoute({ getParentRoute: () => rootRoute, path: '/setup', component: SetupPage }),
   worldRoute,
+  pairingRoute,
 ]);
 
 export function createOfficeRouter(history?: RouterHistory) {

--- a/apps/office/src/shell.tsx
+++ b/apps/office/src/shell.tsx
@@ -12,7 +12,14 @@ export function OfficeShell(): ReactElement {
   const mode = useContext(OfficeModeContext);
   return (
     <div className="office-shell">
-      <a className="skip-link" href="#main">
+      <a
+        className="skip-link"
+        href="#main"
+        onClick={(event) => {
+          event.preventDefault();
+          document.getElementById('main')?.focus();
+        }}
+      >
         Skip to content
       </a>
       <header>
@@ -29,7 +36,7 @@ export function OfficeShell(): ReactElement {
           {session ? (mode === 'cloud' ? 'Private pilot' : 'Local emulator') : 'Local preview'}
         </span>
       </header>
-      <main id="main">
+      <main id="main" tabIndex={-1}>
         <SessionPanel />
         <Outlet />
       </main>

--- a/apps/office/src/worlds/world-view.tsx
+++ b/apps/office/src/worlds/world-view.tsx
@@ -3,6 +3,7 @@ import { Link, Navigate, useNavigate } from '@tanstack/react-router';
 import type { ReactElement, ReactNode } from 'react';
 import type { WorldState } from './world-state.js';
 import { WORLD_ID_PATTERN } from './world-contract.js';
+import type { World } from './world-contract.js';
 import { BlockPanel } from '../blocks/block-view.js';
 
 export const WorldContext = createContext<WorldState | undefined>(undefined);
@@ -88,7 +89,15 @@ export function CreateWorld({ state }: { state: WorldState }): ReactElement {
   );
 }
 
-export function SelectedWorld({ state, id }: { state: WorldState; id: string }): ReactElement {
+export function SelectedWorld({
+  state,
+  id,
+  children,
+}: {
+  state: WorldState;
+  id: string;
+  children?: (world: World) => ReactNode;
+}): ReactElement {
   const { world, loading, error } = useSyncExternalStore(state.subscribe, state.getSnapshot);
   useEffect(() => {
     state.select(id);
@@ -111,7 +120,7 @@ export function SelectedWorld({ state, id }: { state: WorldState; id: string }):
       <p>
         World ID: <code>{world.id}</code>
       </p>
-      <BlockPanel key={world.id} worldId={world.id} />
+      {children ? children(world) : <BlockPanel key={world.id} worldId={world.id} />}
     </section>
   );
 }

--- a/contracts/office/pairing-examples.json
+++ b/contracts/office/pairing-examples.json
@@ -1,0 +1,108 @@
+{
+  "valid": [
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "Alice",
+      "capabilities": ["layout.read", "layout.write"]
+    },
+    {
+      "version": 1,
+      "pairingId": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+      "worldId": "0123456789ABCDEFGHIJ",
+      "installationId": "00000000-0000-4000-8000-000000000011",
+      "identityId": "00000000-0000-4000-8000-000000000012",
+      "installationLabel": "Read-only laptop",
+      "identityLabel": "Review agent",
+      "capabilities": ["layout.read"]
+    }
+  ],
+  "invalid": [
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "Alice",
+      "capabilities": ["layout.read"],
+      "ownerUid": "secret-owner-field"
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "Alice",
+      "capabilities": ["layout.read"],
+      "endpoint": "https://example.invalid/office"
+    },
+    {
+      "version": 1,
+      "pairingId": "not-a-pairing-id",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "Alice",
+      "capabilities": ["layout.read"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "../private-world",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "Alice",
+      "capabilities": ["layout.read"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "pane-1",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "Alice",
+      "capabilities": ["layout.read"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "line\nbreak",
+      "identityLabel": "Alice",
+      "capabilities": ["layout.read"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "Alice",
+      "capabilities": ["layout.write"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "Alice",
+      "capabilities": ["layout.read", "board.write"]
+    }
+  ]
+}

--- a/contracts/office/pairing-v1.md
+++ b/contracts/office/pairing-v1.md
@@ -1,8 +1,8 @@
 # Pairing approval and claim v1
 
-Implementation target for #218. Native commands, browser assignment UI and
-production activation are separate gates; no currently installed command is
-promised by this contract.
+Locally implemented issuer and browser approval protocol. Native commands,
+assignment management and production activation remain separate gates; no
+currently installed command is promised by this contract.
 
 ## Proof and consent
 
@@ -10,8 +10,11 @@ The originating native installation generates 32 cryptographically random bytes.
 The claim secret is their canonical unpadded base64url encoding (43 characters).
 `pairingId` is the lowercase hexadecimal SHA-256 digest of those original bytes.
 Only the public pairing ID and bounded requested binding appear in the browser
-link fragment. Never put the secret, an ID token or a refresh token in a URL,
-ordinary output, log or browser request for owner approval.
+link fragment. Never put secrets or tokens in a URL, ordinary output, log or
+approval request body. The claim secret and refresh token never enter browser
+approval requests. The current owner's ID token is sent only in the
+`Authorization: Bearer` header to the trusted configured HTTPS service (loopback
+HTTP is allowed only for the demo emulator).
 
 There is no unauthenticated durable "begin" write. The admitted human owner must
 approve the exact installation/identity/world and layout capability selection
@@ -21,6 +24,32 @@ also compare the claimed binding with its own expected values before storing
 credentials. A comparison code or copied link alone does not prove possession.
 
 ## HTTP operations
+
+### Browser approval link
+
+The owner approval route is `/worlds/{worldId}/pair` with fragment
+`#tmt-pair={payload}`. Payload is canonical unpadded base64url of a UTF-8 JSON
+approval input (including `version`); decoded input is at most 2048 bytes.
+The route world must match the requested world. Unknown fields, secret/token
+material, invalid Unicode, noncanonical encoding and malformed input reject.
+No endpoint or actor identity comes from this fragment. Display labels are text,
+never markup. A URL visit, login or admission change performs no approval write.
+
+The browser uses its operator-configured pairing service and the current human
+session; only explicit approval/revocation actions send requests. Uncertain
+approval retries preserve the same immutable request and challenge. Session,
+world and route changes dispose the view and fence late action completions,
+without pretending that a submitted remote write was cancelled.
+
+Browser decoding is input feedback and response integrity, not authentication.
+The service remains authoritative. Cross-consumer conformance fixtures pin this
+wire contract instead of adding a shared Firebase/runtime package to the SPA.
+`pairing-examples.json` contains independent literal acceptance/rejection vectors
+used by both browser and service decoders. The browser accepts only an exact
+approval response echo with a valid principal/block and representable expiry;
+unexpected token fields never become view state.
+
+### Service operations
 
 The service accepts JSON POST operations under its explicitly configured base
 URL. Bodies are bounded to 4 KiB, reject unknown fields and use `version: 1`.
@@ -98,5 +127,7 @@ loopback endpoints, never accept unsigned emulator credentials in a real project
 The [local-first M1 acceptance contract](../../DEVELOPMENT.md#personal-office-milestone-acceptance)
 owns verification/cost requirements. Issuer tests must exercise actual emulator
 tokens, transactions, concurrent claims, injected signer failure and downstream
-Rules. They are not evidence of protected native credential storage, usable
-pairing UI, native retirement or the full CLI-to-browser milestone flow.
+Rules. Browser scenarios additionally verify explicit owner consent, lost-response
+retry and logout fencing through the real service. These are not evidence of
+protected native credential storage, native retirement or the full CLI-to-browser
+milestone flow.

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -23,8 +23,8 @@ Rules also implement the [agent grant boundary](../../contracts/office/agent-gra
 trusted per-agent principals can access only an assigned UUID block with matching
 installation/identity claims, live capability/lease and current owner admission.
 Only the owner can revoke a grant; clients cannot issue or enlarge one. This
-does not provide native credentials or pairing UI. Retained UUID blocks use the
-existing layout validator; no parallel layout/ownership document is introduced.
+does not provide native credentials or assignment management. Retained UUID blocks
+use the existing layout validator; no parallel layout/ownership document is introduced.
 
 The current browser edits one owner-only `home` block per admitted world.
 `src/blocks/block-contract.ts` owns client values, catalog and footprint policy;
@@ -116,13 +116,35 @@ No public unauthenticated begin write, alternate block model or work queue exist
 
 The service defaults off outside the strictly configured demo emulators.
 Production activation requires separate ingress/abuse, retention, IAM and cost
-review; instance/concurrency limits are not a billing cap. Native secure storage,
-browser approval UI and the integrated CLI flow remain separate delivery gates.
+review; instance/concurrency limits are not a billing cap. Native secure storage
+and the integrated CLI flow remain separate delivery gates.
 Service unit checks use its own Vitest/Oxlint/Oxfmt configuration. The existing
 browser Docker owner adds Functions and the real-token pairing scenarios; its
 service-owned privileged fixture is test-only. Standalone SPA type checks exclude
 E2E imports; `type:check:e2e` explicitly checks the combined fixture with both
 packages installed. Browser production source never imports the Admin SDK.
+
+### Browser owner approval
+
+`src/pairing` adds explicit owner consent under `/worlds/$worldId/pair`, not an
+agent connection or general assignment manager. `pairing-contract` decodes the
+bounded public fragment and exact response echo; shared literal vectors under
+`contracts/office` verify conformance with the independently authoritative issuer.
+Browser platform base64 APIs and a fatal UTF-8 decoder own encoding primitives.
+
+`pairing-transport` owns only the bounded JSON approval/revocation POST to the
+operator-configured endpoint, with no redirects, cookies or implicit retries.
+The Firebase composition supplies the current token source; tokens stay out of
+view state. Preview has no pairing transport; cloud mode requires an explicit
+HTTPS `VITE_OFFICE_PAIRING_URL`, while emulator mode uses the fixed demo endpoint.
+The request fragment cannot select a service or an actor.
+
+`pairing-state` serializes actions for one mounted immutable request and records
+confirmed or uncertain results, not a second Firestore snapshot cache. The view
+requires explicit recognition before approval. Existing session/admission and
+selected-world owners gate the route; unmount fences late completions without
+claiming to cancel submitted writes. Skip-to-content focuses the main landmark
+without overwriting the request fragment. The browser cannot claim agent tokens.
 
 ## Frontend stack
 

--- a/docs/office/design.md
+++ b/docs/office/design.md
@@ -70,8 +70,8 @@ world subcollections, not unbounded arrays on the root. Those paths currently
 deny all client access except the owner-only `blocks/home` decoration slice
 specified in [block v1](../../contracts/office/block-v1.md) and scoped UUID blocks
 under [agent grant v1](../../contracts/office/agent-grant-v1.md). Grant enforcement
-is complemented by the local [pairing issuer](../../contracts/office/pairing-v1.md),
-not yet native/browser pairing. Invitations and device/work operations below remain
+is complemented by the local [pairing issuer and browser approval](../../contracts/office/pairing-v1.md),
+not yet native pairing. Invitations and device/work operations below remain
 future design; they do not justify a generic backend for ordinary world storage.
 The initial owner-only world does not implement visitor memberships or presence.
 

--- a/services/office/README.md
+++ b/services/office/README.md
@@ -9,8 +9,9 @@ not implied by this implementation. Unspecified paths remain denied.
 Rules also enforce [scoped agent grants](../../contracts/office/agent-grant-v1.md)
 for UUID blocks with live expiry, capability and owner-admission checks. The
 trusted issuer is implemented under `functions/` for emulator verification;
-native pairing and browser approval UI are not implemented. Do not manually enable
-anonymous authentication or create production agent grants to simulate pairing.
+the browser can explicitly approve/revoke, but native pairing is not implemented.
+Do not manually enable anonymous authentication or create production agent grants
+to simulate pairing.
 The current browser continues to edit only the owner's home block.
 
 [Pairing v1](../../contracts/office/pairing-v1.md) defines approval, proof claim,
@@ -48,6 +49,8 @@ follow [Local browser sign-in](../../DEVELOPMENT.md#local-browser-sign-in).
 The default image/Compose service does not install Chromium or start the app.
 It also does not start Functions. The integrated `browser-tests` target builds
 the service and starts its loopback-only Functions emulator on port 5001.
+Its browser scenarios exercise actual owner approval, scoped credential use and
+revocation. No native CLI pairing command is implied by a browser test link.
 Do not mount credentials, host config or repository roots into this service.
 The first image build downloads tools and emulator binaries; later runs use the
 cached image. Rebuild deliberately to update pinned tools, not on every test.
@@ -84,6 +87,16 @@ For a build use `pnpm --filter @tmt/office build --mode cloud`; configure the
 SPA host to rewrite `/worlds/*` to `index.html`. Default builds stay disconnected.
 This pilot currently uses the project's standard `PROJECT.firebaseapp.com`
 Auth domain; custom auth domains need a separately reviewed configuration change.
+
+Browser pairing additionally requires an explicitly reviewed/deployed trusted
+issuer and its HTTPS base URL in `VITE_OFFICE_PAIRING_URL`. Leaving it blank
+disables pairing without disabling ordinary world access. Do not activate or
+deploy the issuer merely to fill this setting; its production review gates remain
+in the pairing contract. The browser accepts only the versioned public link
+defined there, never a secret, token or endpoint supplied by a link. The owner
+must recognize the request and approve explicitly. A lost response keeps the same
+request for retry; **Revoke request** disables its access and retains content.
+Approval is not proof that the native agent has connected.
 
 Deploy the reviewed `firestore.rules` only after explicit authorization, using
 the exact intended project rather than a default alias. A user can then sign

--- a/services/office/functions/test/pairing-conformance.test.ts
+++ b/services/office/functions/test/pairing-conformance.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { parseApproval } from '../src/pairing-contract.js';
+
+interface PairingVectors {
+  valid: unknown[];
+  invalid: unknown[];
+}
+
+const vectors = JSON.parse(
+  readFileSync(
+    new URL('../../../../contracts/office/pairing-examples.json', import.meta.url),
+    'utf8'
+  )
+) as PairingVectors;
+
+describe('pairing request conformance', () => {
+  it('keeps positive and negative vectors instead of passing an empty corpus', () => {
+    expect(vectors.valid.length).toBeGreaterThan(0);
+    expect(vectors.invalid.length).toBeGreaterThan(0);
+  });
+  it.each(vectors.valid)('accepts the literal valid request %#', (request) => {
+    expect(parseApproval(request)).toEqual(request);
+  });
+
+  it.each(vectors.invalid)('rejects the literal invalid request %#', (request) => {
+    expect(() => parseApproval(request)).toThrow('INVALID_ARGUMENT');
+  });
+});


### PR DESCRIPTION
## Outcome

Closes #220. Advances #209 and personal-office M1 under #173; neither parent is complete.

An admitted world owner can inspect a public pairing link, explicitly recognize and approve its installation/identity/layout scope, retry the same request after uncertainty, or revoke it without deleting workspace content. Opening the link, login and admission never approve automatically.

## Architecture and review

- Reuse the existing Firebase composition and session/admission/selected-world lifecycle. The new pairing boundary owns only public wire decoding, bounded approval/revocation transport and mount-owned action state; there is no second remote cache, identity registry or generic request framework.
- Tokens remain in the authenticated transport. The link cannot select an endpoint or actor; exact response decoding excludes token-bearing fields. Disposal fences late UI results without pretending a submitted remote write was cancelled.
- Keep the service authoritative. Independent literal conformance vectors cover browser/service decoding; Node's encoder is the browser decoder's independent test oracle.
- Primary review covered all changed source, callers, tests, fixtures, CSS and documentation. Independent review checked authority, endpoint/token boundaries and stale completion behavior. Findings fixed: outdated browser-pairing documentation, ambiguous header-token wording, incomplete outgoing-body evidence, redundant hand-written base64 primitives, vacuous size/corpus controls and interface ownership. Added a real non-owner route denial and reopened-request recovery control.
- The skip link now focuses the main landmark without destroying the pairing fragment. Desktop/narrow screenshots were visually inspected; keyboard behavior is asserted separately.

## Local verification

- `pnpm check`: passed.
- `pnpm test:run`: 156 tests passed.
- `docker build --target browser-tests -f services/office/Dockerfile -t tmt-office-220:local .`: passed using pinned Node 22; service 30/30, Office 129/129, quality/type checks and preview/emulator/cloud builds.
- `docker run --rm --init --shm-size=256m tmt-office-220:local`: full browser suite 35/35 twice (50.8s and 52.0s).
- Real browser approval -> issuer -> original-proof claim -> cached scoped token -> assigned block write -> revocation denial with retained content. Independent Admin reads corroborate mutations. Actual approval POST body is asserted exactly; no secret in URL/body and only header bearer authentication.
- Lost response, explicit same-request retry, route reopening, non-owner denial and logout before late confirmation are exercised. Unit/DOM tests cover malformed/oversized input, endpoint gating, action serialization, expiry/conflict status and admission/route fencing.
- `git diff --check`: passed. Existing Firebase bundle-size and local Node-engine warnings remain; the supported Node 22 Docker target passes.

The first local late-response test incorrectly waited for a body the signed-out client intentionally discards. Its oracle now observes real intercepted response delivery plus independent durable state and absence of a stale confirmation; no production behavior was weakened. All final tests ran locally before the reviewed push, without paid models, production Firebase, host credentials or billing activation.

## Boundaries

This is browser approval, not native protected credential storage, native pair/renew commands, assignment management, deployment or the complete CLI-to-browser M1 journey. Installed skills do not advertise unimplemented commands. Architecture, canonical protocol, operator guidance and the local-first acceptance guide are updated; no new dependency or CI gate change.
