### PR TITLE
fix(office): release installation lock after verified launch

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,7 +89,8 @@ The optional `rust/crates/tmt-office` executable is independently versioned and
 currently implements only the internal compatibility probe. It depends on core,
 not the CLI, Firebase or SQLite. `tmt-core::office_protocol` owns the fixed typed
 handshake; `tmt-adapters::office_companion` verifies active installation ownership
-and composes the existing bounded subprocess runner under the installer lock.
+and starts the existing bounded subprocess under the installer lock, then waits
+outside that lock and validates the version selected at launch.
 Its contract is [native companion handshake](contracts/office/native-companion.md).
 The public `office` subtree composes installation and this local probe; pairing
 and background connection remain unimplemented.
@@ -232,6 +233,10 @@ remain owned by the existing request contract.
 
 `tmt-adapters::process` is the shared bounded subprocess owner. It enforces
 output caps, monotonic deadlines, process-group cleanup and wait/reap behavior.
+Its owned running-command handle separates launch from wait when a caller needs
+to release a selection lock; synchronous execution uses that same path. The
+original deadline and cleanup ownership survive the split. An abandoned handle
+stops and reaps its child without introducing a second runner or background task.
 `interrupt::Interrupt` owns invocation-local signal callbacks and descriptor
 cleanup. `tmux` uses explicit socket/server evidence, bounded command budgets,
 owned buffers and no ambient host fallback. A failed paste or Enter is an

--- a/contracts/office/native-companion.md
+++ b/contracts/office/native-companion.md
@@ -23,9 +23,12 @@ artifact during pre-activation validation.
 The fixed header identifies this explicit child response, never terminal scrollback.
 
 Only a verified owned release or staged candidate may be probed. The installer
-lock protects that selection during bounded execution; no PATH lookup or
-fallback to another executable is permitted. The existing subprocess owner
-handles deadline, output limits and cleanup. Handshake success says nothing about
+lock protects active-release verification and child launch, not the subsequent
+wait. The result describes the version selected at launch; concurrent upgrade
+or deactivation may change the current installation before completion. A staged
+candidate's pre-activation probe retains the publisher's existing lock scope.
+No PATH lookup or fallback to another executable is permitted. The existing
+subprocess owner handles deadline, output limits and cleanup. Handshake success says nothing about
 pairing, remote availability, granted capabilities or service startup.
 
 `tmt-core::office_protocol` owns request encoding and response validation, with

--- a/rust/crates/tmt-adapters/src/native_install/office_companion_tests.rs
+++ b/rust/crates/tmt-adapters/src/native_install/office_companion_tests.rs
@@ -5,6 +5,54 @@ use crate::{native_install::Product, office_companion::probe_office_companion};
 use std::fs;
 
 #[test]
+fn verified_launch_releases_install_lock_before_waiting_for_the_companion() {
+    let fixture = office_fixture_with_payload(
+        br#"#!/bin/sh
+control="${0%/lib/tmt-office/releases/*}/probe-control"
+if [ -f "$control/block" ]; then
+  printf ready > "$control/ready"
+  while [ ! -f "$control/release" ]; do sleep 0.01; done
+fi
+printf 'TMT-OFFICE/1\n1.2.3\n'
+"#,
+    );
+    let prefix = fixture.directory.path.join("prefix");
+    let report = install_fixture(&fixture, &prefix, Product::Office).unwrap();
+    let active = &report.active_executable;
+    let control = prefix.join("probe-control");
+    fs::create_dir(&control).unwrap();
+    let marker = |suffix: &str| control.join(suffix);
+    let before = fs::read(active).unwrap();
+    fs::write(marker("block"), b"").unwrap();
+    std::thread::scope(|scope| {
+        let probe = scope.spawn(|| probe_office_companion(&report.executable));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while fs::read(marker("ready")).ok().as_deref() != Some(b"ready") {
+            if probe.is_finished() {
+                panic!(
+                    "probe exited before its controlled gate: {:?}",
+                    probe.join().unwrap()
+                );
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "companion did not start"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        // A ready child proves launch happened. Deactivation must acquire the
+        // real installer lock while that same child is still awaiting release.
+        let removed = crate::native_install::uninstall_office(&prefix);
+        fs::write(marker("release"), b"").unwrap();
+        assert!(removed.unwrap());
+        assert_eq!(probe.join().unwrap().unwrap(), "1.2.3");
+    });
+    assert!(!report.executable.exists());
+    assert!(!prefix.join("lib/tmt-office/current").exists());
+    assert_eq!(fs::read(active).unwrap(), before);
+}
+
+#[test]
 fn verified_probe_uses_the_installed_executable_and_preserves_its_receipt() {
     let fixture = office_fixture_with_payload(b"#!/bin/sh\nprintf 'TMT-OFFICE/1\\n1.2.3\\n'\n");
     let prefix = fixture.directory.path.join("prefix");

--- a/rust/crates/tmt-adapters/src/office_companion.rs
+++ b/rust/crates/tmt-adapters/src/office_companion.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     native_install::{self, Product},
-    process::{CommandRequest, CommandRunner, UnixCommandRunner},
+    process::{CommandRequest, RunningCommand, UnixCommandRunner},
 };
 use std::{
     ffi::OsString,
@@ -16,25 +16,36 @@ use tmt_core::office_protocol::{
 
 /// Local compatibility inspection only: does not pair, authenticate or start a service.
 pub fn probe_office_companion(executable: &Path) -> io::Result<String> {
-    native_install::with_active_product(Product::Office, executable, |installed| {
-        probe_candidate(&installed.active_executable, &installed.state.version)
-    })?
+    let (running, version) =
+        native_install::with_active_product(Product::Office, executable, |installed| {
+            start_probe(&installed.active_executable)
+                .map(|running| (running, installed.state.version.clone()))
+        })??;
+    finish_probe(running, &version)
 }
 
 pub(crate) fn probe_candidate(
     executable: &Path,
     expected_version: &semver::Version,
 ) -> io::Result<String> {
+    finish_probe(start_probe(executable)?, expected_version)
+}
+
+fn start_probe(executable: &Path) -> io::Result<RunningCommand> {
     let args = OfficeInvocation::Probe.arguments().map(OsString::from);
-    let output = UnixCommandRunner
-        .execute(CommandRequest {
+    UnixCommandRunner
+        .start(CommandRequest {
             program: executable.as_os_str(),
             args: &args,
             input: &[],
             deadline: Instant::now() + Duration::from_secs(5),
             max_output_bytes: OFFICE_PROTOCOL_OUTPUT_LIMIT,
         })
-        .map_err(io::Error::other)?;
+        .map_err(io::Error::other)
+}
+
+fn finish_probe(running: RunningCommand, expected_version: &semver::Version) -> io::Result<String> {
+    let output = running.wait().map_err(io::Error::other)?;
     if !output.stderr.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/rust/crates/tmt-adapters/src/process.rs
+++ b/rust/crates/tmt-adapters/src/process.rs
@@ -104,6 +104,16 @@ pub struct UnixCommandRunner;
 
 impl CommandRunner for UnixCommandRunner {
     fn execute(&self, request: CommandRequest<'_>) -> Result<CommandOutput, CommandError> {
+        self.start(request)?.wait()
+    }
+}
+
+impl UnixCommandRunner {
+    /// Spawn under a caller's short-lived ownership guard, then wait outside it.
+    pub(crate) fn start(
+        &self,
+        request: CommandRequest<'_>,
+    ) -> Result<RunningCommand, CommandError> {
         remaining(request.deadline)?;
         let job = Exec::cmd(request.program)
             .args(request.args.iter().cloned())
@@ -113,17 +123,32 @@ impl CommandRunner for UnixCommandRunner {
             .setpgid()
             .start()
             .map_err(|cause| CommandError::io(CommandFailure::Spawn, cause))?;
-        let mut owned = OwnedJob {
+        Ok(RunningCommand {
             job,
             finished: false,
-        };
-        match communicate(&mut owned.job, request.deadline, request.max_output_bytes) {
+            deadline: request.deadline,
+            max_output_bytes: request.max_output_bytes,
+        })
+    }
+}
+
+/// Owns the same bounded child from successful spawn through wait or abandonment.
+pub(crate) struct RunningCommand {
+    job: Job,
+    finished: bool,
+    deadline: Instant,
+    max_output_bytes: usize,
+}
+
+impl RunningCommand {
+    pub(crate) fn wait(mut self) -> Result<CommandOutput, CommandError> {
+        match communicate(&mut self.job, self.deadline, self.max_output_bytes) {
             Ok(output) => {
-                owned.finished = true;
+                self.finished = true;
                 Ok(output)
             }
             Err(mut error) => {
-                error.cleanup_error = owned.cleanup().err();
+                error.cleanup_error = self.cleanup().err();
                 Err(error)
             }
         }
@@ -217,12 +242,7 @@ impl Write for CappedOutput {
     }
 }
 
-struct OwnedJob {
-    job: Job,
-    finished: bool,
-}
-
-impl OwnedJob {
+impl RunningCommand {
     fn cleanup(&mut self) -> io::Result<()> {
         let signal = self.job.send_signal_group(Signal::SIGKILL as i32);
         let waited = self.job.wait_timeout(CLEANUP_TIMEOUT);
@@ -269,10 +289,10 @@ fn confirm_group_termination(
     }
 }
 
-impl Drop for OwnedJob {
+impl Drop for RunningCommand {
     fn drop(&mut self) {
         if !self.finished {
-            // Unwind fallback only. Operational paths call cleanup explicitly
+            // Abandonment/unwind fallback. Operational errors clean up explicitly
             // so they can preserve the primary error and expose cleanup failure.
             let _ = self.cleanup();
         }

--- a/rust/crates/tmt-adapters/src/process_tests.rs
+++ b/rust/crates/tmt-adapters/src/process_tests.rs
@@ -20,6 +20,100 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const CLEANUP_WAIT: Duration = Duration::from_secs(2);
 
 #[test]
+fn started_command_retains_the_original_deadline() {
+    let directory = TestDirectory::new();
+    let pid_file = directory.path.join("pid");
+    let mut cleanup = PidCleanup {
+        path: pid_file.clone(),
+        armed: true,
+    };
+    let deadline = Instant::now() + Duration::from_millis(500);
+    let running = {
+        let args = shell_args(
+            "echo $$ > \"$1\"; read -r input; printf '%s' \"$input\"",
+            &[path_arg(&pid_file)],
+        );
+        UnixCommandRunner
+            .start(CommandRequest {
+                program: OsStr::new(SHELL),
+                args: &args,
+                input: b"private input\n",
+                deadline,
+                max_output_bytes: 64,
+            })
+            .unwrap()
+    };
+    let pid = wait_for_pid(&pid_file);
+    // Deliberately consume the original budget before wait. Starting a second
+    // timeout at wait would keep this already-expired child alive.
+    if let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        thread::sleep(remaining);
+    }
+    let error = running.wait().unwrap_err();
+    assert_eq!(error.kind, CommandFailure::Timeout);
+    assert!(!error.cleanup_failed());
+    assert_pid_gone(pid, &mut cleanup);
+}
+
+#[test]
+fn started_command_owns_arguments_and_input_until_wait() {
+    let running = {
+        let args = shell_args(
+            "read -r input; printf '%s:%s' \"$1\" \"$input\"",
+            &[OsString::from("literal !")],
+        );
+        let input = b"private input\n".to_vec();
+        UnixCommandRunner
+            .start(CommandRequest {
+                program: OsStr::new(SHELL),
+                args: &args,
+                input: &input,
+                deadline: Instant::now() + Duration::from_secs(2),
+                max_output_bytes: 64,
+            })
+            .unwrap()
+    };
+    let output = running.wait().unwrap();
+    assert_eq!(output.stdout, b"literal !:private input");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn dropping_or_unwinding_before_wait_reaps_the_started_child() {
+    for unwind in [false, true] {
+        let directory = TestDirectory::new();
+        let pid_file = directory.path.join("pid");
+        let mut cleanup = PidCleanup {
+            path: pid_file.clone(),
+            armed: true,
+        };
+        let args = shell_args("echo $$ > \"$1\"; exec sleep 5", &[path_arg(&pid_file)]);
+        let running = UnixCommandRunner
+            .start(CommandRequest {
+                program: OsStr::new(SHELL),
+                args: &args,
+                input: &[],
+                deadline: Instant::now() + Duration::from_secs(3),
+                max_output_bytes: 64,
+            })
+            .unwrap();
+        let pid = wait_for_pid(&pid_file);
+        if unwind {
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let _owned = running;
+                    panic!("controlled caller unwind");
+                }))
+                .is_err()
+            );
+        } else {
+            drop(running);
+        }
+        assert_pid_gone(pid, &mut cleanup);
+    }
+}
+
+#[test]
 fn nonzero_exit_preserves_bounded_protocol_output_without_formatting_it() {
     let args = shell_args(
         "printf 'private stdout'; printf 'private stderr' >&2; exit 1",


### PR DESCRIPTION
## Outcome

Closes #223, a bounded prerequisite of #222 / #209 / personal-office M1 #173.

The managed Office probe verifies and launches its selected executable under the installation lock, then waits outside that lock. A running probe no longer prevents a concurrent authorized upgrade/deactivation simply because it has not returned. The result describes the version selected at launch, not a promise that installation state stayed unchanged.

## Architecture and review

- Split start/wait in the existing process owner. `RunningCommand` replaces `OwnedJob`; synchronous `execute` delegates to that same path. Original deadlines, literal argv/stdin, independent output caps, failure classification and process-group cleanup remain shared.
- The existing managed-product guard still protects validation and actual launch. Staged pre-activation candidate checks stay inside the publisher's existing lock scope. No new runner, background thread, dependency, protocol or public command.
- Updated architecture and the canonical native companion contract. Pairing, credentials and remote access remain unimplemented.
- Primary reviewed every changed file and its managed-install/process callers. Independent review confirmed ownership and launch-version semantics. Added a direct successful split-input control. A proposed extra lock-test thread was unnecessary: the actual lock is nonblocking; the negative control demonstrates immediate causal failure rather than a hang.

## Verification

- Original implementation negative control in a disposable container: the new concurrent-deactivation test fails with `WouldBlock` in 0.02s. The working tree was not reverted or modified for this check.
- Final Rust fmt/clippy/all tests/MSRV 1.88 build passed in pinned local Rust containers. Rust tests: 436 passed; one pre-existing separately authorized archive-upgrade test ignored, not counted as proof.
- Native CLI process suite: 154/154 passed. Tooling: 156/156 passed. `pnpm check` and `git diff --check` passed.
- Existing `pnpm test:e2e` local network-disabled tmux harness: 170/170 twice (124.41s and 125.49s), plus adapter tests. Its one optional skipped performance benchmark is not acceptance evidence.
- New scenarios prove active-child deactivation with retained executable bytes, original deadline expiry, successful delayed input ownership and PID disappearance after drop/unwind. Existing candidate-integrity, output-cap, descendant and closed-pipe tests remain.

The first local fixture put control files inside the integrity-checked release directory and was correctly rejected. Controls now live outside the managed release; production integrity checks were not weakened. Archive inventory, versions, dependencies and public probe wire format are unchanged; no release artifact, tag, publication, production Firebase or host credential access is claimed or performed. CI starts only after local verification; existing gates remain unchanged.
