### PR TITLE
feat(office): pair native identities with protected credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,13 @@ jobs:
           cargo +1.88.0 build --locked
           cargo build --locked
           cargo build --locked --example storage-probe
+      - name: Build independent native process fixtures
+        working-directory: rust
+        env:
+          CARGO_PROFILE_DEV_DEBUG: 0
+        run: |
+          cargo build --locked -p tmt-office
+          cargo build --locked -p tmt-cli
       - name: Set up Node.js test tooling
         uses: actions/setup-node@v4
         with:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,8 +86,13 @@ module remapping or incomplete discovery. It is a syntactic guard and never
 replaces review of behavior or effects.
 
 The optional `rust/crates/tmt-office` executable is independently versioned and
-currently implements only the internal compatibility probe. It depends on core,
-not the CLI, Firebase or SQLite. `tmt-core::office_protocol` owns the fixed typed
+currently exposes only the internal compatibility probe. It depends on core and
+the existing adapters, not the CLI. Its adapter `office` feature owns validated
+deployment decoding for in-progress pairing; ordinary CLI builds do not enable
+that feature. Serde derives reject duplicate/unknown descriptor fields; the URL
+Standard library matches browser URL interpretation instead of introducing a
+handwritten parser. Neither dependency enters core. The probe acquires no
+credentials or network data. `tmt-core::office_protocol` owns the fixed typed
 handshake; `tmt-adapters::office_companion` verifies active installation ownership
 and starts the existing bounded subprocess under the installer lock, then waits
 outside that lock and validates the version selected at launch.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,6 +110,10 @@ owns pending proof or credentials; no SQLite binding index mirrors it. OS random
 bytes create proofs; explicit Keychain/Secret Service backends fail closed.
 Background connection and resource editing remain unimplemented.
 
+Workspace quality checks cover the unified feature graph. Native process
+fixtures build products separately to retain ordinary CLI feature isolation;
+[Development](DEVELOPMENT.md#rust-checks) owns their symbol/profile selection.
+
 ## Public command boundary
 
 `rust/crates/tmt-cli/src/grammar.rs` is the single syntax/help/completion

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -27,7 +27,8 @@ Rust, test, release script and canonical skill paths remain stable. Read
 [Office architecture](docs/office/architecture.md) for current SPA ownership,
 the chosen React/Vite/TanStack/Jotai stack and the
 [Office design](docs/office/design.md) for planned trust/lifecycle semantics.
-Office must not import local SQLite/process adapters or native test helpers.
+Office runtime code must not import local SQLite/process adapters or native test helpers.
+Its browser E2E may reuse the established test-only process and artifact owners.
 The pairing issuer is implemented for local emulator verification and disabled
 by default outside that environment; it is not deployed. `contracts/office`
 owns the versioned work-handoff schema and fixtures; derived representations must
@@ -53,7 +54,8 @@ pairing issuer under `functions/`, not a deployed backend. Admin operations
 bypass Rules: the issuer explicitly checks verified human authentication, live
 admission, ownership and grant authority in its transaction owner. Signing stays
 outside transactions. Rules enforce the issued grant using the existing UUID
-block validator. Native pairing remains unimplemented. See
+block validator. The native companion consumes this issuer through its optional
+Office adapter feature. See
 [pairing v1](contracts/office/pairing-v1.md) for approval/retry semantics and the
 agent-grant contract for resource leases. Owner-local configuration stays outside Git and Docker. Native tmux,
 Office browser/Rules and bootstrap smoke proofs retain separate fixture owners.
@@ -86,9 +88,10 @@ module remapping or incomplete discovery. It is a syntactic guard and never
 replaces review of behavior or effects.
 
 The optional `rust/crates/tmt-office` executable is independently versioned and
-currently exposes only the internal compatibility probe. It depends on core and
-the existing adapters, not the CLI. Its adapter `office` feature owns validated
-deployment decoding for in-progress pairing; ordinary CLI builds do not enable
+exposes the compatibility probe and typed one-shot pairing/status/inspect operations.
+It depends on core and the existing adapters, not the CLI. Its adapter `office`
+feature owns validated deployment decoding, bounded HTTP, protected pairing
+records and explicit platform credential stores; ordinary CLI builds do not enable
 that feature. Serde derives reject duplicate/unknown descriptor fields; the URL
 Standard library matches browser URL interpretation instead of introducing a
 handwritten parser. Neither dependency enters core. The probe acquires no
@@ -97,8 +100,15 @@ handshake; `tmt-adapters::office_companion` verifies active installation ownersh
 and starts the existing bounded subprocess under the installer lock, then waits
 outside that lock and validates the version selected at launch.
 Its contract is [native companion handshake](contracts/office/native-companion.md).
-The public `office` subtree composes installation and this local probe; pairing
-and background connection remain unimplemented.
+The public `office` subtree composes installation, identity resolution and bounded
+pairing observation, never credentials or HTTP. `office_pairing` separates wire
+values, remote Auth/resource access, vault access, local installation metadata,
+record transitions and one-shot composition. `office_http` shares bounded JSON
+transport with deployment discovery. Existing ConfigPaths, identity storage,
+file locks and process owners remain authoritative. One protected scope record
+owns pending proof or credentials; no SQLite binding index mirrors it. OS random
+bytes create proofs; explicit Keychain/Secret Service backends fail closed.
+Background connection and resource editing remain unimplemented.
 
 ## Public command boundary
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -280,6 +280,22 @@ cargo build --locked --example tmux-probe
 cargo +1.88.0 build --locked
 ```
 
+Before native installation/process tests, build the two product fixtures
+independently, after workspace checks:
+
+```sh
+CARGO_PROFILE_DEV_DEBUG=0 cargo build --locked -p tmt-office
+CARGO_PROFILE_DEV_DEBUG=0 cargo build --locked -p tmt-cli
+```
+
+Workspace builds unify adapter features, so their debug CLI can include Office
+dependency debug information. Package-scoped builds exercise the ordinary CLI
+product without Office features. These fixtures omit debug symbols, not debug
+assertions or runtime checks; installation tests should hash/package executable
+behavior rather than large DWARF payloads. Keep the existing process deadlines
+and assertions. Both binaries remain in `target/debug`, using the established
+selectors. This does not replace optimized release-archive verification.
+
 The architecture guard is included in `cargo test`. A focused offline run is:
 
 ```bash

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -163,7 +163,7 @@ isolation, malformed/expired grants and one-way owner revocation with unchanged
 cached tokens. `pairing-service.spec.ts` adds actual HTTP approval/custom-token
 issuance, concurrent claims and live revocation. Direct service composition with
 an injected signer adds failure/recovery evidence against the same real database.
-This is not evidence of protected native storage or
+Those service scenarios alone are not evidence of protected native storage or
 CLI-to-browser pairing. Service-only scenarios can run with `--network none`
 by overriding the image command to select that spec. Operator fixtures
 also independently inspect saved block layouts. Home-block scenarios cover
@@ -194,6 +194,21 @@ consume the same literal pairing corpus; browser encoding tests use an independe
 Node encoder. Review desktop/narrow screenshots rather than accepting their
 existence as visual proof.
 
+`native-pairing.spec.ts` installs the real compiled CLI/companion through a
+synthetic verified archive, using the existing `test/support` process and artifact
+owners. It resumes a protected proof across CLI processes after Chromium consent,
+then independently checks the issued grant, OS-store record, scoped Firestore
+read, token refresh, expiry, corruption, revocation and same-name replacement.
+The browser target therefore builds Rust and installs the root test-helper
+dependencies with scripts disabled; it does not execute the SQLite oracle or
+import native helpers into the SPA. The standalone app image stays independent.
+`with-test-keyring.sh` owns a disposable D-Bus session and real Linux Secret Service
+with a fixture-only password and private container directories. The scenario
+deletes and verifies absence of its protected entry; container teardown removes
+the disposable store. No host Keychain, credentials or installed CLI is used.
+This is Linux credential-store evidence, not macOS runtime or real release-archive
+acceptance. Reuse the separate native artifact verifier for published artifacts.
+
 For focused service checks use `pnpm office:service:check`,
 `pnpm office:service:test` and `pnpm office:service:build`. `pnpm check` also runs
 the combined `@tmt/office type:check:e2e`; standalone `office:check` deliberately
@@ -220,8 +235,9 @@ tmux where relevant, Playwright Chromium and demo-project Auth/Firestore
 emulators. Extend the existing fixture owners as each feature ships, not a
 parallel mock implementation of TMT. Independent database observations must
 corroborate UI and command results. Separate green layer suites are not proof of
-this integrated flow; the current browser/Rules suite does not yet run native
-pairing or companion operations.
+this integrated flow. The native pairing browser scenario covers acquisition and
+scoped reads; native resource editing and visible browser results remain separate
+milestone work, not implied by successful credential retention.
 
 Automated acceptance must not call a paid model, use provider/host credentials,
 contact production Firebase or require paid runners. Keep the native-only tmux

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -200,6 +200,17 @@ the combined `@tmt/office type:check:e2e`; standalone `office:check` deliberatel
 does not load service dependencies through E2E fixtures. The Docker browser
 target runs both package checks and this explicit E2E type check on Node 22.
 
+For in-progress native deployment discovery, run
+`cargo test --locked --workspace office_deployment` from `rust/` (or select
+`-p tmt-adapters --features office office_deployment`). The optional Office feature
+is not enabled by the native-only tmux fixture. These tests verify literal
+browser/native descriptor conformance, strict URL/JSON validation and bounded
+unauthenticated HTTP; they do not prove native pairing or protected credentials.
+`deployment.spec.ts` checks the actual built emulator descriptor and unavailable
+preview/cloud variants. Issuer scenarios independently compare claim
+`grantExpiresAt` with Firestore, including retries and a shortened grant; approval
+and token expiry must not stand in for that value.
+
 ## Personal-office milestone acceptance
 
 The M1 acceptance target is a causal local flow: actual native CLI and Office

--- a/apps/office/e2e/deployment.spec.ts
+++ b/apps/office/e2e/deployment.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+import deployments from '../../../contracts/office/deployment-examples.json' with { type: 'json' };
+
+test('built emulator serves only the public descriptor; preview and unconfigured cloud do not', async ({
+  request,
+}) => {
+  const path = '/.well-known/tmt-office.json';
+  const response = await request.get(`http://127.0.0.1:4173${path}`, { maxRedirects: 0 });
+  expect(response.status()).toBe(200);
+  expect(response.headers()['content-type']).toContain('application/json');
+  expect(await response.json()).toEqual(deployments.valid[1].descriptor);
+  for (const port of [4174, 4175]) {
+    const unavailable = await request.get(`http://127.0.0.1:${port}${path}`, { maxRedirects: 0 });
+    // Static SPA hosting may rewrite missing assets to index.html. Such a
+    // response is not a descriptor and native discovery must reject its MIME.
+    expect(unavailable.headers()['content-type']).not.toContain('application/json');
+    expect(await unavailable.text()).not.toContain('"pairingUrl"');
+  }
+});

--- a/apps/office/e2e/native-pairing.spec.ts
+++ b/apps/office/e2e/native-pairing.spec.ts
@@ -1,0 +1,299 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { expect } from '@playwright/test';
+import { test, signIn } from './browser-session.js';
+import { setTester } from './firestore-fixture.js';
+import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
+import { createArtifact } from '../../../test/support/native-artifact.js';
+import { runCli, withSandbox } from '../../../test/support/cli-process.js';
+
+test('native pairing resumes its protected proof and a separate process uses the scoped credential', async ({
+  openSession,
+}) => {
+  test.setTimeout(90_000);
+  const admin = createPairingEmulatorFixture();
+  try {
+    await withSandbox(async (sandbox) => {
+      let scopeKey: string | undefined;
+      const vault = async (operation: 'lookup' | 'store' | 'clear', input?: string) => {
+        if (!scopeKey) throw new Error('The scenario has no protected scope yet.');
+        return runCli(
+          { ...sandbox, cli: { executable: '/usr/bin/secret-tool', args: [] } },
+          [
+            operation,
+            ...(operation === 'store' ? ['--label', 'Native pairing fixture'] : []),
+            'service',
+            'org.tmux-team.office.v1',
+            'username',
+            scopeKey,
+          ],
+          input === undefined ? {} : { stdin: input }
+        );
+      };
+      try {
+        const companion = path.resolve('../../rust/target/debug/tmt-office');
+        const fixture = await createArtifact(
+          sandbox,
+          '0.1.0-alpha.1',
+          new Uint8Array(),
+          'office',
+          companion
+        );
+        const prefix = path.join(sandbox.root, 'office-prefix');
+        const installed = await runCli(
+          sandbox,
+          [
+            'office',
+            'install',
+            '--yes',
+            '--prefix',
+            prefix,
+            '--archive',
+            fixture.archive,
+            '--manifest',
+            fixture.manifest,
+            '--json',
+          ],
+          { deadlineMs: 20_000 }
+        );
+        expect(installed.status, installed.stdout).toBe(0);
+        expect(installed.stderr).toBe('');
+        const created = await runCli(sandbox, ['identity', 'create', 'Alice', '--json']);
+        expect(created.status, created.stdout).toBe(0);
+        const worldId = admin.db.collection('worlds').doc().id;
+        const world = `http://127.0.0.1:4173/worlds/${worldId}`;
+        const office = (operation: string, extra: string[] = [], env = sandbox.env) =>
+          runCli(
+            { ...sandbox, env },
+            [
+              'office',
+              operation,
+              '--prefix',
+              prefix,
+              '--world',
+              world,
+              '--identity',
+              'Alice',
+              '--emulator',
+              '--json',
+              ...extra,
+            ],
+            { deadlineMs: 35_000 }
+          );
+        const unpaired = await office('status');
+        expect(unpaired.status).toBe(0);
+        expect(JSON.parse(unpaired.stdout).state).toBe('unpaired');
+        const unpairedRead = await office('inspect');
+        expect(unpairedRead.status).toBe(1);
+        expect(JSON.parse(unpairedRead.stdout).error.code).toBe('OFFICE_NOT_PAIRED');
+        const unavailable = await office('pair', ['--timeout', '5'], {
+          ...sandbox.env,
+          DBUS_SESSION_BUS_ADDRESS: `unix:path=${sandbox.root}/missing-session-bus`,
+        });
+        expect(unavailable.status).toBe(1);
+        expect(JSON.parse(unavailable.stdout).error.code).toBe('OFFICE_CREDENTIALS_UNAVAILABLE');
+        expect(unavailable.stderr).toBe('');
+
+        // End the observer before approval, then resume from another CLI process.
+        // This is an explicit short observer window, not a fixed readiness sleep.
+        const pending = await office('pair', ['--timeout', '5']);
+        expect(pending.status, pending.stdout).toBe(1);
+        expect(JSON.parse(pending.stdout).error.code).toBe('OFFICE_PAIRING_PENDING');
+        const link = pending.stderr.trim();
+        expect(link.startsWith(`${world}/pair#tmt-pair=`)).toBe(true);
+        const consent = JSON.parse(
+          Buffer.from(link.split('#tmt-pair=')[1]!, 'base64url').toString('utf8')
+        ) as Record<string, unknown>;
+        expect(Object.keys(consent).sort()).toEqual(
+          [
+            'capabilities',
+            'identityId',
+            'identityLabel',
+            'installationId',
+            'installationLabel',
+            'pairingId',
+            'version',
+            'worldId',
+          ].sort()
+        );
+        expect(consent.identityLabel).toBe('Alice');
+        expect(consent.capabilities).toEqual(['layout.read', 'layout.write']);
+        const installationId = readFileSync(
+          path.join(sandbox.globalDir, 'office', 'installation-id'),
+          'utf8'
+        );
+        const scopeFile = readdirSync(path.join(sandbox.globalDir, 'office')).find((name) =>
+          /^[0-9a-f]{64}\.lock$/.test(name)
+        );
+        expect(scopeFile).toBeDefined();
+        scopeKey = scopeFile!.slice(0, -'.lock'.length);
+        const protectedPending = await vault('lookup');
+        expect(protectedPending.status).toBe(0);
+        const pendingRecord = JSON.parse(protectedPending.stdout);
+        expect(pendingRecord.phase.state).toBe('pending');
+        const proof: string = pendingRecord.phase.secret;
+        expect(createHash('sha256').update(Buffer.from(proof, 'base64url')).digest('hex')).toBe(
+          consent.pairingId
+        );
+        expect(consent.installationId).toBe(installationId);
+        const pairing = admin.db.collection('officePairings').doc(String(consent.pairingId));
+        expect((await pairing.get()).exists).toBe(false);
+        const changedCapabilities = await office('pair', ['--read-only', '--timeout', '5']);
+        expect(changedCapabilities.status).toBe(1);
+        expect(JSON.parse(changedCapabilities.stdout).error.code).toBe(
+          'OFFICE_CREDENTIALS_INVALID'
+        );
+        expect(changedCapabilities.stderr).toBe('');
+        expect((await vault('lookup')).stdout === protectedPending.stdout).toBe(true);
+
+        const { page } = await openSession(link);
+        await signIn(page, 'NativeOfficeOwner');
+        const uid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+        await admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .set({ version: 1, name: 'Native office', ownerUid: uid, createdAt: new Date() });
+        await setTester(uid, true);
+        await expect(page.getByRole('region', { name: 'Agent pairing request' })).toBeVisible();
+        await page
+          .getByRole('checkbox', { name: 'I recognize this agent and installation.' })
+          .check();
+        await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+        await expect(
+          page.getByRole('status').filter({ hasText: 'Approved. Return' })
+        ).toBeVisible();
+        const resumed = await office('pair', ['--timeout', '25']);
+        expect(resumed.status, resumed.stdout).toBe(0);
+        expect(resumed.stderr.trim()).toBe(link);
+        expect(JSON.parse(resumed.stdout).state).toBe('credential');
+        const remote = (await pairing.get()).data()!;
+        expect(remote.request).toEqual(consent);
+        const grant = admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .collection('agentGrants')
+          .doc(String(remote.principalUid));
+        const savedGrant = (await grant.get()).data()!;
+        expect(savedGrant.identityId).toBe(consent.identityId);
+        expect(savedGrant.installationId).toBe(installationId);
+        expect(savedGrant.blockId).toBe(remote.blockId);
+        const protectedPaired = await vault('lookup');
+        expect(protectedPaired.status).toBe(0);
+        const pairedRecord = JSON.parse(protectedPaired.stdout);
+        expect(pairedRecord.phase.state).toBe('paired');
+        expect('secret' in pairedRecord.phase).toBe(false);
+        expect(pairedRecord.phase.principalUid).toBe(remote.principalUid);
+        expect(pairedRecord.phase.blockId).toBe(savedGrant.blockId);
+        expect(pairedRecord.phase.grantExpiresAt).toBe(savedGrant.expiresAt.toMillis());
+        expect(pairedRecord.approval).toEqual(consent);
+        expect(pairedRecord.expiresAt).toBe(pendingRecord.expiresAt);
+        const secrets: string[] = [
+          proof,
+          pairedRecord.phase.credential.idToken,
+          pairedRecord.phase.credential.refreshToken,
+        ];
+        expect(secrets.every((secret) => typeof secret === 'string' && secret.length > 0)).toBe(
+          true
+        );
+
+        const missingBlock = await office('inspect');
+        expect(missingBlock.status, missingBlock.stdout).toBe(0);
+        expect(JSON.parse(missingBlock.stdout)).toMatchObject({
+          blockExists: false,
+          serverAuthorizationChecked: true,
+        });
+        await admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .collection('blocks')
+          .doc(String(remote.blockId))
+          .set({ version: 1, revision: 1, objects: ['d000'], updatedAt: new Date() });
+        const existingBlock = await office('inspect');
+        expect(existingBlock.status, existingBlock.stdout).toBe(0);
+        expect(JSON.parse(existingBlock.stdout).blockExists).toBe(true);
+
+        // Force the local refresh threshold using the independent OS-store tool;
+        // Auth remains real and refresh must preserve the exact resource lease.
+        pairedRecord.phase.credential.tokenExpiresAt = 0;
+        expect((await vault('store', JSON.stringify(pairedRecord))).status).toBe(0);
+        const refreshed = await office('inspect');
+        expect(refreshed.status, refreshed.stdout).toBe(0);
+        const afterRefresh = JSON.parse((await vault('lookup')).stdout);
+        expect(afterRefresh.phase.credential.tokenExpiresAt > Date.now()).toBe(true);
+        expect(afterRefresh.phase.grantExpiresAt).toBe(savedGrant.expiresAt.toMillis());
+        expect(afterRefresh.phase.blockId).toBe(remote.blockId);
+        const expired = structuredClone(afterRefresh);
+        expired.phase.grantExpiresAt = Date.now() - 1;
+        expect((await vault('store', JSON.stringify(expired))).status).toBe(0);
+        const expiredResult = await office('inspect');
+        expect(expiredResult.status).toBe(1);
+        expect(JSON.parse(expiredResult.stdout).error.code).toBe('OFFICE_PAIRING_EXPIRED');
+        const mismatched = structuredClone(afterRefresh);
+        mismatched.approval.identityId = '00000000-0000-4000-8000-000000000009';
+        expect((await vault('store', JSON.stringify(mismatched))).status).toBe(0);
+        const invalid = await office('status');
+        expect(invalid.status).toBe(1);
+        expect(JSON.parse(invalid.stdout).error.code).toBe('OFFICE_CREDENTIALS_INVALID');
+        expect((await vault('store', JSON.stringify(afterRefresh))).status).toBe(0);
+
+        await grant.update({ enabled: false });
+        const denied = await office('inspect');
+        expect(denied.status).toBe(1);
+        expect(JSON.parse(denied.stdout).error.code).toBe('OFFICE_REMOTE_DENIED');
+        const offline = await office('status');
+        expect(offline.status).toBe(0);
+        expect(JSON.parse(offline.stdout)).toMatchObject({
+          state: 'credential',
+          serverAuthorizationChecked: false,
+        });
+        expect((await pairing.get()).data()?.principalUid).toBe(remote.principalUid);
+        expect(
+          readFileSync(path.join(sandbox.globalDir, 'office', 'installation-id'), 'utf8')
+        ).toBe(installationId);
+        expect(
+          readdirSync(path.join(sandbox.globalDir, 'office')).every(
+            (name) => name === 'installation-id' || name.endsWith('.lock')
+          )
+        ).toBe(true);
+        for (const result of [unpaired, resumed, missingBlock, existingBlock, denied, offline]) {
+          expect(
+            result.stdout.includes('refreshToken') ||
+              result.stdout.includes('idToken') ||
+              result.stdout.includes('customToken')
+          ).toBe(false);
+          expect(
+            secrets.some(
+              (secret) => result.stdout.includes(secret) || result.stderr.includes(secret)
+            )
+          ).toBe(false);
+        }
+        const databaseFiles = readdirSync(path.dirname(sandbox.database))
+          .filter((name) => name.startsWith(path.basename(sandbox.database)))
+          .map((name) => readFileSync(path.join(path.dirname(sandbox.database), name)));
+        expect(
+          secrets.some((secret) =>
+            databaseFiles.some((bytes) => bytes.includes(Buffer.from(secret)))
+          )
+        ).toBe(false);
+        const removed = await runCli(sandbox, ['rm', 'Alice', '--force', '--json']);
+        expect(removed.status, removed.stdout).toBe(0);
+        expect((await runCli(sandbox, ['identity', 'create', 'Alice', '--json'])).status).toBe(0);
+        const replacement = await office('status');
+        expect(replacement.status).toBe(0);
+        expect(JSON.parse(replacement.stdout).state).toBe('unpaired');
+        expect(JSON.parse(replacement.stdout).identityId).not.toBe(consent.identityId);
+        const replacementRead = await office('inspect');
+        expect(replacementRead.status).toBe(1);
+        expect(JSON.parse(replacementRead.stdout).error.code).toBe('OFFICE_NOT_PAIRED');
+      } finally {
+        if (scopeKey) {
+          expect((await vault('clear')).status).toBe(0);
+          expect((await vault('lookup')).status).toBe(1);
+        }
+      }
+    });
+  } finally {
+    await admin.dispose();
+  }
+});

--- a/apps/office/e2e/pairing-service.spec.ts
+++ b/apps/office/e2e/pairing-service.spec.ts
@@ -92,6 +92,13 @@ test('HTTP approval and proof claim produce an actually usable scoped credential
     const principalUid = field(claimed, 'principalUid');
     const blockId = field(claimed, 'blockId');
     expect(principalUid).toBe(approved.body.principalUid);
+    const issuedGrant = (
+      await db.collection('worlds').doc(world.id).collection('agentGrants').doc(principalUid).get()
+    ).data();
+    expect(claimed.grantExpiresAt).toBe(issuedGrant?.expiresAt.toMillis());
+    expect(claimed.expiresAt).toBe(approved.body.expiresAt);
+    expect(claimed.grantExpiresAt).toBeGreaterThan(claimed.expiresAt as number);
+    expect(approved.body).not.toHaveProperty('grantExpiresAt');
     const agent = await fixture.client(false, 'device');
     await signInWithCustomToken(agent.auth, field(claimed, 'customToken'));
     expect(agent.auth.currentUser!.uid).toBe(principalUid);
@@ -271,10 +278,24 @@ test('signer failure and lost-response retries preserve one principal and the or
     now += CLAIM_INTERVAL_MS;
     const recovered = await service.claim({ version: 1, secret });
     expect(recovered.principalUid).toBe(approved.principalUid);
+    expect(recovered.grantExpiresAt).toBe(original?.expiresAt.toMillis());
     now += CLAIM_INTERVAL_MS;
-    expect((await service.claim({ version: 1, secret })).principalUid).toBe(approved.principalUid);
+    expect(await service.claim({ version: 1, secret })).toMatchObject({
+      principalUid: approved.principalUid,
+      expiresAt: approved.expiresAt,
+      grantExpiresAt: recovered.grantExpiresAt,
+    });
     expect((await grants.get()).size).toBe(1);
     expect((await grants.doc(approved.principalUid).get()).data()).toEqual(original);
+    // A trusted operator can shorten a grant. The response must read that live
+    // expiry, not reconstruct a new 24-hour lease from the retry time.
+    const shortenedExpiry = now + 60_000;
+    await grants.doc(approved.principalUid).update({ expiresAt: new Date(shortenedExpiry) });
+    now += CLAIM_INTERVAL_MS;
+    expect((await service.claim({ version: 1, secret })).grantExpiresAt).toBe(shortenedExpiry);
+    expect((await grants.doc(approved.principalUid).get()).data()?.expiresAt.toMillis()).toBe(
+      shortenedExpiry
+    );
     await store.revoke(owner.uid, request.pairingId);
     now += CLAIM_INTERVAL_MS;
     await expect(service.claim({ version: 1, secret })).rejects.toMatchObject({

--- a/apps/office/src/auth/firebase-config.test.ts
+++ b/apps/office/src/auth/firebase-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { officeFirebaseConfig } from './firebase-config.js';
+import { officeDeployment, officeFirebaseConfig } from './firebase-config.js';
+import deployments from '../../../../contracts/office/deployment-examples.json';
 
 const settings = {
   VITE_FIREBASE_API_KEY: 'public-key',
@@ -7,6 +8,44 @@ const settings = {
   VITE_FIREBASE_AUTH_DOMAIN: 'example-office.firebaseapp.com',
   VITE_FIREBASE_APP_ID: 'public-app-id',
 };
+describe('public deployment projection', () => {
+  it('matches independent native fixtures without publishing private settings', () => {
+    expect(deployments.valid).toHaveLength(3);
+    for (const { descriptor, pairingSetting } of deployments.valid) {
+      expect(
+        officeDeployment(descriptor.mode, {
+          ...settings,
+          VITE_FIREBASE_API_KEY: descriptor.apiKey,
+          VITE_OFFICE_PAIRING_URL: pairingSetting ?? descriptor.pairingUrl,
+          PRIVATE_SERVICE_ACCOUNT: 'never-publish',
+          VITE_UNRELATED_SECRET: 'never-publish-either',
+        })
+      ).toEqual(descriptor);
+    }
+  });
+  it('keeps preview and unconfigured cloud unavailable', () => {
+    expect(officeDeployment('production', settings)).toBeUndefined();
+    expect(officeDeployment('cloud')).toBeUndefined();
+    expect(officeDeployment('cloud', settings)).toBeUndefined();
+    expect(officeDeployment('emulator')?.projectId).toBe('demo-tmt-office');
+  });
+  it('rejects configured discovery instead of advertising a mismatched runtime', () => {
+    const configured = {
+      ...settings,
+      VITE_OFFICE_PAIRING_URL: 'https://issuer.example/officePairing',
+    };
+    for (const changes of [
+      { VITE_FIREBASE_PROJECT_ID: 'demo-tmt-office' },
+      { VITE_FIREBASE_AUTH_DOMAIN: 'other.example' },
+      { VITE_FIREBASE_API_KEY: 'key?query' },
+      { VITE_FIREBASE_API_KEY: 'x'.repeat(257) },
+      { VITE_OFFICE_PAIRING_URL: 'https://issuer.example/?token=secret' },
+      { VITE_OFFICE_PAIRING_URL: 'https://issuer.example/officePairing//' },
+      { VITE_OFFICE_PAIRING_URL: `https://issuer.example/${'x'.repeat(2048)}` },
+    ])
+      expect(() => officeDeployment('cloud', { ...configured, ...changes })).toThrow();
+  });
+});
 describe('explicit cloud configuration', () => {
   it('uses only the supplied public configuration in cloud mode', () => {
     expect(officeFirebaseConfig('cloud', 'localhost', settings)).toEqual({

--- a/apps/office/src/auth/firebase-config.ts
+++ b/apps/office/src/auth/firebase-config.ts
@@ -36,3 +36,50 @@ export function officeFirebaseConfig(
   }
   return { apiKey, projectId, authDomain, appId };
 }
+
+/** Public deployment configuration, never selected by an approval fragment. */
+export function pairingEndpoint(
+  mode: string,
+  settings: Record<string, unknown>
+): string | undefined {
+  if (mode === 'emulator') return 'http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing';
+  if (
+    mode !== 'cloud' ||
+    settings.VITE_OFFICE_PAIRING_URL === undefined ||
+    settings.VITE_OFFICE_PAIRING_URL === ''
+  )
+    return undefined;
+  const value = settings.VITE_OFFICE_PAIRING_URL;
+  if (typeof value !== 'string') throw new Error('Invalid Office pairing service configuration.');
+  const url = new URL(value);
+  if (
+    value.length > 2048 ||
+    url.protocol !== 'https:' ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.pathname.endsWith('//') ||
+    url.href !== value
+  )
+    throw new Error('Invalid Office pairing service configuration.');
+  return url.href.replace(/\/$/, '');
+}
+
+/** Only this allowlisted projection is published; settings themselves never are. */
+export function officeDeployment(mode: string, settings: Record<string, unknown> = {}) {
+  if (mode !== 'cloud' && mode !== 'emulator') return undefined;
+  const pairingUrl = pairingEndpoint(mode, settings);
+  if (!pairingUrl) return undefined;
+  const config = officeFirebaseConfig(mode, '127.0.0.1', settings);
+  if (!config) return undefined;
+  if (typeof config.apiKey !== 'string' || !/^[A-Za-z0-9_-]{1,256}$/.test(config.apiKey))
+    throw new Error('Invalid Office public API key.');
+  return {
+    version: 1 as const,
+    mode,
+    projectId: config.projectId,
+    apiKey: config.apiKey,
+    pairingUrl,
+  };
+}

--- a/apps/office/src/auth/firebase-session.ts
+++ b/apps/office/src/auth/firebase-session.ts
@@ -16,11 +16,11 @@ import {
   memoryLocalCache,
   terminate,
 } from 'firebase/firestore';
-import { officeFirebaseConfig } from './firebase-config.js';
+import { officeFirebaseConfig, pairingEndpoint } from './firebase-config.js';
 import { createWorldPort } from '../worlds/firebase-worlds.js';
 import { createWorldState } from '../worlds/world-state.js';
 import { createBlockPort } from '../blocks/firebase-blocks.js';
-import { createPairingPort, pairingEndpoint } from '../pairing/pairing-transport.js';
+import { createPairingPort } from '../pairing/pairing-transport.js';
 
 /** One composition root for both explicit environments, outside React rendering. */
 export function startOfficeRuntime(

--- a/apps/office/src/pairing/pairing-contract.test.ts
+++ b/apps/office/src/pairing/pairing-contract.test.ts
@@ -8,7 +8,7 @@ import {
   type PairingRequest,
 } from './pairing-contract.js';
 
-type PairingVectors = { valid: PairingRequest[]; invalid: unknown[] };
+type PairingVectors = { valid: PairingRequest[]; invalid: unknown[]; invalidJson: string[] };
 const pairingVectors = vectors as PairingVectors;
 const BASE64URL = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
 
@@ -33,6 +33,12 @@ function noncanonical(encoded: string): string {
 }
 
 describe('pairing request vectors', () => {
+  it.each(pairingVectors.invalidJson)('rejects malformed Unicode in raw JSON %#', (input) => {
+    const encoded = Buffer.from(input, 'utf8').toString('base64url');
+    expect(() =>
+      parsePairingFragment(`#tmt-pair=${encoded}`, pairingVectors.valid[0].worldId)
+    ).toThrow('Invalid pairing input.');
+  });
   it('keeps a nonempty positive and negative conformance corpus', () => {
     expect(pairingVectors.valid.length).toBeGreaterThan(0);
     expect(pairingVectors.invalid.length).toBeGreaterThan(0);

--- a/apps/office/src/pairing/pairing-transport.test.ts
+++ b/apps/office/src/pairing/pairing-transport.test.ts
@@ -1,5 +1,6 @@
 import { expect, it, vi } from 'vitest';
-import { createPairingPort, pairingEndpoint } from './pairing-transport.js';
+import { createPairingPort } from './pairing-transport.js';
+import { pairingEndpoint } from '../auth/firebase-config.js';
 
 const pairingId = 'a'.repeat(64);
 const endpoint = 'https://pair.example/officePairing';

--- a/apps/office/src/pairing/pairing-transport.ts
+++ b/apps/office/src/pairing/pairing-transport.ts
@@ -5,33 +5,6 @@ import {
 } from './pairing-contract.js';
 import type { PairingPort } from './pairing-contract.js';
 
-/** Deployment configuration is trusted input; pairing links never select an endpoint. */
-export function pairingEndpoint(
-  mode: string,
-  settings: Record<string, unknown>
-): string | undefined {
-  if (mode === 'emulator') return 'http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing';
-  if (
-    mode !== 'cloud' ||
-    settings.VITE_OFFICE_PAIRING_URL === undefined ||
-    settings.VITE_OFFICE_PAIRING_URL === ''
-  )
-    return undefined;
-  const value = settings.VITE_OFFICE_PAIRING_URL;
-  if (typeof value !== 'string') throw new Error('Invalid Office pairing service configuration.');
-  const url = new URL(value);
-  if (
-    url.protocol !== 'https:' ||
-    url.username ||
-    url.password ||
-    url.search ||
-    url.hash ||
-    url.href !== value
-  )
-    throw new Error('Invalid Office pairing service configuration.');
-  return url.href.replace(/\/$/, '');
-}
-
 async function responseBody(response: Response): Promise<unknown> {
   if (
     !response.headers.get('content-type')?.match(/^application\/json(?:\s*;|$)/i) ||

--- a/apps/office/vite.config.ts
+++ b/apps/office/vite.config.ts
@@ -1,13 +1,37 @@
 import react from '@vitejs/plugin-react';
+import { loadEnv } from 'vite';
 import { defineConfig } from 'vitest/config';
+import { officeDeployment } from './src/auth/firebase-config.js';
 
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    environment: 'jsdom',
-    include: ['src/**/*.test.{ts,tsx}'],
-    setupFiles: ['./src/test-setup.ts'],
-    passWithNoTests: false,
-    restoreMocks: true,
-  },
+export default defineConfig(({ mode }) => {
+  const deployment = officeDeployment(mode, loadEnv(mode, import.meta.dirname, 'VITE_'));
+  const fileName = '.well-known/tmt-office.json';
+  const source = deployment ? `${JSON.stringify(deployment)}\n` : undefined;
+  return {
+    plugins: [
+      react(),
+      {
+        name: 'office-public-deployment',
+        generateBundle() {
+          if (source) this.emitFile({ type: 'asset', fileName, source });
+        },
+        configureServer(server) {
+          server.middlewares.use((request, response, next) => {
+            if (request.url !== `/${fileName}`) return next();
+            response.setHeader('Cache-Control', 'no-store');
+            response.setHeader('Content-Type', 'application/json');
+            response.statusCode = source ? 200 : 404;
+            response.end(source ?? '{"error":"DEPLOYMENT_UNAVAILABLE"}\n');
+          });
+        },
+      },
+    ],
+    test: {
+      environment: 'jsdom',
+      include: ['src/**/*.test.{ts,tsx}'],
+      setupFiles: ['./src/test-setup.ts'],
+      passWithNoTests: false,
+      restoreMocks: true,
+    },
+  };
 });

--- a/contracts/office/README.md
+++ b/contracts/office/README.md
@@ -7,6 +7,8 @@ The [agent resource grant v1](agent-grant-v1.md) adds server-enforced access to
 assigned UUID blocks. [Pairing approval and claim v1](pairing-v1.md) defines the
 locally tested trusted issuer. Native pairing and the agent-block UI remain
 separate work; the browser currently edits only the owner's home block.
+The [native pairing contract](native-pairing.md) defines deployment discovery and
+the in-progress command/credential boundary, not shipped command guidance.
 
 The separately versioned [private world document v1](private-world.md) is the
 direct-Firestore contract. It uses native Firestore timestamps and Rules,

--- a/contracts/office/deployment-examples.json
+++ b/contracts/office/deployment-examples.json
@@ -1,0 +1,35 @@
+{
+  "valid": [
+    {
+      "worldUrl": "https://office.example/worlds/abcdefghijklmnopqrst",
+      "descriptor": {
+        "version": 1,
+        "mode": "cloud",
+        "projectId": "example-office",
+        "apiKey": "public-web-api-key",
+        "pairingUrl": "https://issuer.example/officePairing"
+      }
+    },
+    {
+      "worldUrl": "http://127.0.0.1:4174/worlds/ABCDEFGHIJKLMNOPQRST",
+      "descriptor": {
+        "version": 1,
+        "mode": "emulator",
+        "projectId": "demo-tmt-office",
+        "apiKey": "demo-tmt-office",
+        "pairingUrl": "http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing"
+      }
+    },
+    {
+      "worldUrl": "https://office.example/worlds/abcdefghijklmnopqrst",
+      "pairingSetting": "https://issuer.example/",
+      "descriptor": {
+        "version": 1,
+        "mode": "cloud",
+        "projectId": "example-office",
+        "apiKey": "public-web-api-key",
+        "pairingUrl": "https://issuer.example"
+      }
+    }
+  ]
+}

--- a/contracts/office/native-companion.md
+++ b/contracts/office/native-companion.md
@@ -3,12 +3,13 @@
 This internal local protocol is separate from the proposed remote work-handoff
 schema. It grants no Office access and does not replace pairing.
 
-The core-owned `OfficeInvocation` currently has one operation: `Probe`. Its exact
-argument vector is `__tmt-office`, `1`, `probe`. Unknown versions, operations,
+The core-owned `OfficeInvocation` has exact operations `probe`, `pair-begin`,
+`pair-poll`, `pair-status` and `inspect`. Its argument vector is
+`__tmt-office`, `1`, `<operation>`. Unknown versions, operations,
 extra arguments and non-UTF-8 arguments fail with exit 1, empty stdout and a brief
 stderr diagnostic. There is no arbitrary argv forwarding or shell evaluation.
 
-Successful output is exactly two LF-terminated UTF-8 lines:
+Successful probe output is exactly two LF-terminated UTF-8 lines:
 
 ```text
 TMT-OFFICE/1
@@ -40,5 +41,21 @@ available; no public release has been published. Synthetic archive process tests
 exercise the real compiled companion. The independent native artifact verifier
 separately checks actual Office archives; neither constitutes public publication.
 
-Future operations require a reviewed typed contract before implementation.
-Do not reuse this probe response as a generic payload or remote authentication.
+## Pairing operations
+
+Non-probe operations consume one bounded JSON object on stdin (4096 bytes):
+`world`, `identityId`, `emulator` and `readOnly`, with no unknown or duplicate
+fields. Selectors contain no credentials. The adapter accepts at most 4096 bytes
+per output stream and uses the existing subprocess deadline/cleanup owner.
+The companion receives at most 25 seconds for a single operation; the public
+observer's shorter deadline still wins. A successful process emits only a public
+JSON result: local `state`, pending `state` plus `approvalUrl`, `blockExists`, or
+a known `error` code. Stderr must be empty. Credentials and provider diagnostics
+never cross this boundary. Public CLI output uses its existing error envelope.
+
+The adapter validates this allowlist; the CLI additionally checks that the result
+belongs to the requested operation. The protected state machine and HTTP/vault
+adapters stay in the Office feature, not the CLI or core. See
+[native pairing](native-pairing.md) for scope, deadlines and server authority.
+Future operations require a reviewed typed contract before implementation;
+the probe response is never a generic payload or remote authentication.

--- a/contracts/office/native-companion.md
+++ b/contracts/office/native-companion.md
@@ -32,8 +32,10 @@ subprocess owner handles deadline, output limits and cleanup. Handshake success 
 pairing, remote availability, granted capabilities or service startup.
 
 `tmt-core::office_protocol` owns request encoding and response validation, with
-literal positive/negative test vectors. The separate `tmt-office` executable has
-no Firebase, SQLite or networking dependency. Local cargo-dist packaging is
+literal positive/negative test vectors. The separate `tmt-office` executable
+depends on core and the shared adapters, with Office-specific deployment decoding
+enabled only for that consumer. Its probe performs no Firebase, SQLite, network
+or credential-store operations. Local cargo-dist packaging is
 available; no public release has been published. Synthetic archive process tests
 exercise the real compiled companion. The independent native artifact verifier
 separately checks actual Office archives; neither constitutes public publication.

--- a/contracts/office/native-pairing.md
+++ b/contracts/office/native-pairing.md
@@ -1,0 +1,89 @@
+# Native pairing v1
+
+Implementation contract for #222. Deployment discovery is implemented;
+public pairing and protected credential use are not yet shipped.
+[Approval and claim](pairing-v1.md) owns remote proof/consent semantics.
+
+## Deployment discovery
+
+The caller selects a canonical world URL:
+`https://office.example/worlds/abcdefghijklmnopqrst`. Discovery reads only that
+origin's `/.well-known/tmt-office.json`, without redirects or credentials.
+The descriptor is JSON, at most 4096 UTF-8 bytes, with exactly these fields:
+
+```json
+{
+  "version": 1,
+  "mode": "cloud",
+  "projectId": "example-office",
+  "apiKey": "public-web-api-key",
+  "pairingUrl": "https://issuer.example/officePairing"
+}
+```
+
+The SPA derives this allowlisted projection from its existing validated Firebase
+and pairing configuration, not a second settings file. Preview and cloud without
+an issuer publish no usable descriptor. Invalid configured deployments fail the
+build. Publishing metadata does not activate the issuer or grant world authority.
+No private environment values, credentials or identity data are included.
+
+Project IDs use the existing Firebase format and exclude `demo-` in cloud mode.
+API keys are 1..256 ASCII alphanumeric, hyphen or underscore characters. URLs are
+canonical absolute HTTPS, at most 2048 bytes, with no user information, query or
+fragment. The browser's configured URL may have one trailing slash; its descriptor
+and operation base omit that slash. The literal corpus includes an origin-only
+issuer to pin this projection. Native URL interpretation uses
+the URL Standard, matching the browser; normalization cannot change a target.
+Auth and Firestore endpoints come from the fixed Firebase API contract, never
+arbitrary descriptor fields. Unknown and duplicate JSON fields reject.
+
+Explicit emulator selection accepts only a canonical `http://127.0.0.1:<port>`
+world origin, `demo-tmt-office` project/key, and the fixed issuer
+`http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing`. Auth and Firestore
+remain fixed loopback demo services. Cloud and emulator descriptors cannot be
+interchanged. This is not a general insecure-HTTP switch.
+
+The website origin and complete descriptor become part of the credential scope.
+Local status and credential reuse do not rediscover endpoints. A changed
+deployment cannot retarget an existing proof or credential. Discovery has a
+10-second budget within the command deadline; reject redirects, non-JSON responses
+and oversized headers/bodies before use.
+
+## Planned command and credential contract
+
+```sh
+tmt office pair --world <url> [--identity <name>] [--read-only] [--timeout <seconds>]
+tmt office status --world <url> [--identity <name>]
+tmt office inspect --world <url> [--identity <name>]
+```
+
+These retain existing Office prefix/output conventions. Names resolve through the
+existing active identity UUID owner; omission requires a verified bound pane.
+No folder guessing, same-name inheritance or temporary-identity promotion.
+Explicit `--emulator` selects the fixed local environment on each operation.
+Pair requests layout read/write unless `--read-only`. Timeout is integer seconds
+1..300, default 300; retries retain the original proof/deadline and five-second
+poll floor. Human mode prints the public approval URL before polling. JSON mode
+puts that URL on stderr and one final object on stdout. No secret enters output
+or argv. Unqualified status retains installation-only behavior; world-qualified
+status is local-only. Inspect reads the assigned block, not a world-wide index.
+
+A stable installation UUID is independent of release receipts. Nonsecret binding
+metadata lives under ConfigPaths, not a second identity registry. Protected
+records bind origin, descriptor, world, installation and identity UUID, validated
+on every read. Store the pending proof before exposing an approval link. No token
+belongs in config, SQLite or logs. Missing/locked storage fails closed; no sample
+or plaintext fallback. OS storage and metadata are not one atomic transaction.
+
+Office failures use the existing envelope and exit 1:
+`OFFICE_DEPLOYMENT_INVALID`, `OFFICE_DEPLOYMENT_CHANGED`,
+`OFFICE_CREDENTIALS_UNAVAILABLE`, `OFFICE_CREDENTIALS_INVALID`,
+`OFFICE_NOT_PAIRED`, `OFFICE_PAIRING_PENDING`, `OFFICE_PAIRING_EXPIRED`,
+`OFFICE_REMOTE_DENIED`, `OFFICE_REMOTE_UNCERTAIN`. Interruption uses
+`OFFICE_INTERRUPTED`, exit 130. Existing identity/grammar errors retain their
+owners. An unavailable claim cannot distinguish absent from denied approval.
+
+Renewal preserving resources, reassignment and temporary retirement/offline
+revocation remain #209 requirements. Token refresh never extends a grant lease.
+Actual native/browser/isolated-vault evidence is required by the
+[local-first acceptance contract](../../DEVELOPMENT.md#personal-office-milestone-acceptance).

--- a/contracts/office/native-pairing.md
+++ b/contracts/office/native-pairing.md
@@ -1,7 +1,7 @@
 # Native pairing v1
 
-Implementation contract for #222. Deployment discovery is implemented;
-public pairing and protected credential use are not yet shipped.
+Implementation contract for #222. Source builds implement deployment discovery,
+pairing and protected credential use; no public Office release is published.
 [Approval and claim](pairing-v1.md) owns remote proof/consent semantics.
 
 ## Deployment discovery
@@ -49,7 +49,7 @@ deployment cannot retarget an existing proof or credential. Discovery has a
 10-second budget within the command deadline; reject redirects, non-JSON responses
 and oversized headers/bodies before use.
 
-## Planned command and credential contract
+## Command and credential contract
 
 ```sh
 tmt office pair --world <url> [--identity <name>] [--read-only] [--timeout <seconds>]
@@ -66,17 +66,38 @@ Pair requests layout read/write unless `--read-only`. Timeout is integer seconds
 poll floor. Human mode prints the public approval URL before polling. JSON mode
 puts that URL on stderr and one final object on stdout. No secret enters output
 or argv. Unqualified status retains installation-only behavior; world-qualified
-status is local-only. Inspect reads the assigned block, not a world-wide index.
+status is local-only and returns `unpaired`, `pending`, `credential` or `expired`,
+with `serverAuthorizationChecked: false`. Inspect performs a server-authorized
+read of the assigned block, not a world-wide index. Its result is
+`blockExists: true|false` with `serverAuthorizationChecked: true`; it does not
+return or interpret layout contents. Missing pairing fails `OFFICE_NOT_PAIRED`.
 
-A stable installation UUID is independent of release receipts. Nonsecret binding
-metadata lives under ConfigPaths, not a second identity registry. Protected
-records bind origin, descriptor, world, installation and identity UUID, validated
+A stable installation UUID is independent of release receipts and binary prefixes:
+one logical installation per ConfigPaths root. Only that public UUID and scope
+locks live in its `office/` directory; there is no disk binding index or second
+identity registry. Missing or corrupt metadata is not automatically regenerated
+inside an existing installation. One protected record per origin/world/mode/
+installation/identity UUID pins the complete descriptor, immutable approval and
+pending proof/deadline/cadence or paired credential/resource lease, validated
 on every read. Store the pending proof before exposing an approval link. No token
 belongs in config, SQLite or logs. Missing/locked storage fails closed; no sample
-or plaintext fallback. OS storage and metadata are not one atomic transaction.
+or plaintext fallback. Linux uses Secret Service on the session bus; macOS uses
+the user Keychain. Each write requires exact readback before reporting success.
+The per-scope lock serializes mutation; local status reads one protected snapshot
+without creating locks. OS storage and metadata are not one atomic transaction.
+Uncertain claim or publication retains the original scope for retry. Expired
+pending records and grants fail closed without silently requesting another grant;
+explicit renewal/recovery remains part of #209. Do not delete local state as a
+substitute for server revocation.
+
+Auth exchange and refresh use fixed Firebase endpoints. ID-token payload checks
+detect inconsistent scope but are not signature verification or authorization;
+Firestore Rules enforce every resource request. Token refresh preserves the
+original resource assignment and grant expiry. Identity names resolve once to an
+active UUID and are rechecked before protected publication and resource use.
 
 Office failures use the existing envelope and exit 1:
-`OFFICE_DEPLOYMENT_INVALID`, `OFFICE_DEPLOYMENT_CHANGED`,
+`OFFICE_DEPLOYMENT_INVALID`,
 `OFFICE_CREDENTIALS_UNAVAILABLE`, `OFFICE_CREDENTIALS_INVALID`,
 `OFFICE_NOT_PAIRED`, `OFFICE_PAIRING_PENDING`, `OFFICE_PAIRING_EXPIRED`,
 `OFFICE_REMOTE_DENIED`, `OFFICE_REMOTE_UNCERTAIN`. Interruption uses

--- a/contracts/office/pairing-examples.json
+++ b/contracts/office/pairing-examples.json
@@ -19,6 +19,26 @@
       "installationLabel": "Read-only laptop",
       "identityLabel": "Review agent",
       "capabilities": ["layout.read"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "Café 🤖",
+      "capabilities": ["layout.read", "layout.write"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖",
+      "capabilities": ["layout.read", "layout.write"]
     }
   ],
   "invalid": [
@@ -103,6 +123,59 @@
       "installationLabel": "Office workstation",
       "identityLabel": "Alice",
       "capabilities": ["layout.read", "board.write"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖",
+      "capabilities": ["layout.read", "layout.write"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "﻿",
+      "capabilities": ["layout.read", "layout.write"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "  ",
+      "capabilities": ["layout.read", "layout.write"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "\u0001agent",
+      "capabilities": ["layout.read", "layout.write"]
+    },
+    {
+      "version": 1,
+      "pairingId": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "worldId": "AbCdEfGhIjKlMnOpQrSt",
+      "installationId": "00000000-0000-4000-8000-000000000001",
+      "identityId": "00000000-0000-4000-8000-000000000002",
+      "installationLabel": "Office workstation",
+      "identityLabel": "agent",
+      "capabilities": ["layout.read", "layout.write"]
     }
+  ],
+  "invalidJson": [
+    "{\"version\":1,\"pairingId\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\",\"worldId\":\"AbCdEfGhIjKlMnOpQrSt\",\"installationId\":\"00000000-0000-4000-8000-000000000001\",\"identityId\":\"00000000-0000-4000-8000-000000000002\",\"installationLabel\":\"Office workstation\",\"identityLabel\":\"\\ud800\",\"capabilities\":[\"layout.read\",\"layout.write\"]}"
   ]
 }

--- a/contracts/office/pairing-v1.md
+++ b/contracts/office/pairing-v1.md
@@ -72,6 +72,12 @@ without control characters. Capabilities are exactly the ordered layout lists
 in [agent grant v1](agent-grant-v1.md). No arbitrary paths or additional resource
 permissions are accepted.
 
+Claim responses retain the exact approved binding and approval `expiresAt`, and
+add `customToken` plus `grantExpiresAt` from the validated resource grant. Approval
+expiry, grant expiry and Firebase token expiry are separate clocks. A retry reads
+the existing grant expiry; it never computes a new lease or extends one. Approval
+responses do not contain `grantExpiresAt` because no grant has been issued yet.
+
 Missing/invalid human authentication is `401 UNAUTHENTICATED`; invalid input is
 `400 INVALID_ARGUMENT`; unauthorized approval/revocation is `403 PERMISSION_DENIED`.
 Claims with wrong/unknown proof, expired/disabled approval or lost owner/grant

--- a/contracts/office/pairing-v1.md
+++ b/contracts/office/pairing-v1.md
@@ -1,8 +1,9 @@
 # Pairing approval and claim v1
 
-Locally implemented issuer and browser approval protocol. Native commands,
-assignment management and production activation remain separate gates; no
-currently installed command is promised by this contract.
+Locally implemented issuer and browser approval protocol. The
+[native pairing contract](native-pairing.md) defines its source-build consumer.
+Assignment management and production activation remain separate gates; no
+public Office distribution is promised by this contract.
 
 ## Proof and consent
 
@@ -45,7 +46,10 @@ Browser decoding is input feedback and response integrity, not authentication.
 The service remains authoritative. Cross-consumer conformance fixtures pin this
 wire contract instead of adding a shared Firebase/runtime package to the SPA.
 `pairing-examples.json` contains independent literal acceptance/rejection vectors
-used by both browser and service decoders. The browser accepts only an exact
+used by browser, service and native decoders. Unicode labels and escaped invalid
+surrogates are technical fixture data for cross-language scalar/whitespace
+boundaries; invalid raw JSON stays in `invalidJson`, not imported JSON values.
+The browser accepts only an exact
 approval response echo with a valid principal/block and representable expiry;
 unexpected token fields never become view state.
 

--- a/docs/native-release-verification.md
+++ b/docs/native-release-verification.md
@@ -183,6 +183,11 @@ evidence does not replace real cargo-dist archive and distribution acceptance.
 
 ### Office archives
 
+The local Linux artifact Dockerfile accepts `--build-arg PRODUCT=office` with
+the matching `TARGET_TRIPLE`. Pass `--product office` and the corresponding
+Office archive to its verifier entrypoint. The default remains CLI; both use
+the same generator, notice owner and independent verification path.
+
 Generate an actual matching-host Office archive with the same toolchain and
 target policy, selecting Office's runtime dependency notices:
 

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -23,7 +23,8 @@ Rules also implement the [agent grant boundary](../../contracts/office/agent-gra
 trusted per-agent principals can access only an assigned UUID block with matching
 installation/identity claims, live capability/lease and current owner admission.
 Only the owner can revoke a grant; clients cannot issue or enlarge one. This
-does not provide native credentials or assignment management. Retained UUID blocks
+does not provide assignment management. Native credential consumption is owned
+by the optional companion described below. Retained UUID blocks
 use the existing layout validator; no parallel layout/ownership document is introduced.
 
 The current browser edits one owner-only `home` block per admitted world.
@@ -89,9 +90,10 @@ Firebase setup is implied.
 
 There is no work connector, deployed service or shared browser runtime package yet.
 The independently versioned native `tmt-office` companion currently implements
-only the [internal local handshake](../../contracts/office/native-companion.md).
-Its optional adapter feature prepares validated deployment discovery; no public
-command consumes credentials yet. It has no public distribution. The CLI's explicit `office`
+the [typed local protocol](../../contracts/office/native-companion.md), including
+pairing, local status and an authorized assigned-block existence check.
+Its optional adapter feature owns discovery, Auth exchange/refresh and protected
+scope records. It has no public distribution. The CLI's explicit `office`
 subtree installs, inspects, updates and deactivates it through existing native
 owners; other CLI operations do not execute or probe it. Shared native protocol
 values remain in the existing core.

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -90,7 +90,8 @@ Firebase setup is implied.
 There is no work connector, deployed service or shared browser runtime package yet.
 The independently versioned native `tmt-office` companion currently implements
 only the [internal local handshake](../../contracts/office/native-companion.md).
-It has no cloud access or public distribution. The CLI's explicit `office`
+Its optional adapter feature prepares validated deployment discovery; no public
+command consumes credentials yet. It has no public distribution. The CLI's explicit `office`
 subtree installs, inspects, updates and deactivates it through existing native
 owners; other CLI operations do not execute or probe it. Shared native protocol
 values remain in the existing core.
@@ -145,6 +146,18 @@ requires explicit recognition before approval. Existing session/admission and
 selected-world owners gate the route; unmount fences late completions without
 claiming to cancel submitted writes. Skip-to-content focuses the main landmark
 without overwriting the request fragment. The browser cannot claim agent tokens.
+
+### Public deployment discovery
+
+`auth/firebase-config.ts` owns Firebase configuration and issuer selection.
+Vite publishes only the allowlisted
+[native deployment descriptor](../../contracts/office/native-pairing.md) at
+`/.well-known/tmt-office.json`; private environment values are never spread into
+it. Preview and unconfigured cloud publish no usable descriptor. Invalid
+configured deployments fail the build. Browser transport consumes this same
+configuration owner, not a second deployment registry or settings file.
+Literal fixtures verify generator/native-decoder conformance. This metadata does
+not prove world ownership, activate the issuer or complete native pairing.
 
 ## Frontend stack
 

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -34,6 +34,8 @@ installation; repeat explicit uninstall to finish before reinstalling.
 ## Planned connected commands
 
 The following connected behaviors are proposals, not installed instructions.
+The [native pairing contract](../../contracts/office/native-pairing.md) refines
+the in-progress pair/status/inspect inputs, outputs and deployment trust boundary.
 
 | Command                                                    | Planned behavior                                                                                        |
 | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
@@ -41,7 +43,7 @@ The following connected behaviors are proposals, not installed instructions.
 | `tmt office install --yes`                                 | Explicitly acquire and verify the official extension; `--yes` consents to installation only             |
 | `tmt office upgrade`                                       | Explicit verified extension update, with compatibility checks and rollback-safe activation              |
 | `tmt office status --json`                                 | Local extension/pairing/connector status; no network or automatic update check                          |
-| `tmt office pair --world <https-origin/world-id>`          | Explicit bounded pairing and capability confirmation with the selected deployment                       |
+| `tmt office pair --world <https-origin/worlds/world-id>`   | Explicit bounded pairing and capability confirmation with the selected deployment                       |
 | `tmt office run`                                           | Run the connector in the foreground; Ctrl-C stops it without cancelling native work                     |
 | `tmt office publish <identity> --capability review`        | Publish an explicitly selected identity UUID and allowed capability; no implicit all-agent publication  |
 | `tmt office unpublish <identity>`                          | Reject new work for that published identity, without deleting local identity or retained exchanges      |

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -26,10 +26,38 @@ success. `tmt upgrade` continues to update only the CLI and its managed skills.
 `status --json` returns `installed`, `version`, `protocolVersion` and `executable`
 after local ownership/integrity and handshake verification. It never checks cloud
 availability. Plain `tmt office` currently reports `OFFICE_NOT_PAIRED` after a
-successful probe; world opening and pairing are not implemented. Uninstall
+successful probe; automatic world opening is not implemented. Uninstall
 requires explicit consent and removes verified activation links only. Release
 files and unrelated data remain. A partial removal reports an invalid
 installation; repeat explicit uninstall to finish before reinstalling.
+
+## Native pairing (source builds)
+
+Pairing requires an installed compatible companion and an unlocked OS credential
+store (macOS Keychain or Linux Secret Service). No public Office release is
+published yet. Select a world and an existing identity explicitly outside tmux:
+
+```sh
+tmt office pair --world https://office.example/worlds/abcdefghijklmnopqrst --identity Alice
+tmt office status --world https://office.example/worlds/abcdefghijklmnopqrst --identity Alice --json
+tmt office inspect --world https://office.example/worlds/abcdefghijklmnopqrst --identity Alice --json
+```
+
+Open the printed approval link, sign in as the admitted world owner, recognize
+the identity/installation and approve. `pair` waits up to 300 seconds; use
+`--timeout 30` for a shorter observer and repeat the same command to resume the
+original pending request. `--read-only` requests only layout read access. Omit
+`--identity` only with verified pane context. Temporary identities are accepted
+without promoting them to saved identities.
+
+World-qualified `status` reports local retained state, not live authority.
+`inspect` checks server access and reports only whether the assigned block exists;
+it does not expose layouts or list other agents. Revocation can therefore leave
+local status `credential` while inspect fails `OFFICE_REMOTE_DENIED`. A same-name
+replacement has a different UUID and cannot inherit the pairing. Expiry never
+silently creates a replacement grant; renewal and unpair remain planned.
+The [native pairing contract](../../contracts/office/native-pairing.md) owns exact
+scope, output, errors and emulator restrictions.
 
 ## Planned connected commands
 
@@ -43,7 +71,6 @@ the in-progress pair/status/inspect inputs, outputs and deployment trust boundar
 | `tmt office install --yes`                                 | Explicitly acquire and verify the official extension; `--yes` consents to installation only             |
 | `tmt office upgrade`                                       | Explicit verified extension update, with compatibility checks and rollback-safe activation              |
 | `tmt office status --json`                                 | Local extension/pairing/connector status; no network or automatic update check                          |
-| `tmt office pair --world <https-origin/worlds/world-id>`   | Explicit bounded pairing and capability confirmation with the selected deployment                       |
 | `tmt office run`                                           | Run the connector in the foreground; Ctrl-C stops it without cancelling native work                     |
 | `tmt office publish <identity> --capability review`        | Publish an explicitly selected identity UUID and allowed capability; no implicit all-agent publication  |
 | `tmt office unpublish <identity>`                          | Reject new work for that published identity, without deleting local identity or retained exchanges      |
@@ -61,7 +88,6 @@ provision a Firebase project or deploy a website.
 | Proposed command                                                                         | Result                                                                              |
 | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `tmt office --help`                                                                      | Core-owned help, available without an installed extension                           |
-| `tmt office inspect --json`                                                              | Selected world, effective allowed capabilities and observation freshness            |
 | `tmt office map --json`                                                                  | Bounded permitted spatial projection, not unrestricted world enumeration            |
 | `tmt office block ls --json`                                                             | Allowed blocks and assignments, without guessing IDs                                |
 | `tmt office block show <block-id> --json`                                                | Canonical layout and revision                                                       |

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,10 +9,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b350bfd03649e07aa05c0a81b3e15934374e585c98204a57e20b9d49f49bb9a"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -52,6 +74,143 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -102,6 +261,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +293,15 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -134,6 +324,16 @@ name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -171,6 +371,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "combine"
 version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +385,21 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -195,6 +416,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -215,12 +442,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -256,7 +498,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "ctutils",
 ]
 
 [[package]]
@@ -268,6 +512,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.5",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -287,6 +558,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +588,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
@@ -342,6 +639,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -386,6 +714,36 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -553,6 +911,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +987,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +1019,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +1041,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -698,12 +1090,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -719,6 +1134,27 @@ version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -753,6 +1189,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,10 +1217,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -786,6 +1263,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -876,6 +1362,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -977,6 +1476,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5107b24b91445dd2aa449a258a1807b63240942157292354dc5bfdbeb8bc6db8"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hkdf",
+ "hybrid-array",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1565,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1192,6 +1721,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,8 +1798,11 @@ dependencies = [
 name = "tmt-adapters"
 version = "5.0.0-alpha.2"
 dependencies = [
+ "apple-native-keyring-store",
  "base64 0.22.1",
  "flate2",
+ "getrandom 0.4.3",
+ "keyring-core",
  "nix",
  "rcgen",
  "rusqlite",
@@ -1273,6 +1818,7 @@ dependencies = [
  "ureq",
  "url",
  "uuid",
+ "zbus-secret-service-keyring-store",
 ]
 
 [[package]]
@@ -1309,10 +1855,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.15+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1340ea94a5856333492c9064b02c778b191dd2c853778d9609debdcdfea3a614"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1393,6 +2011,7 @@ checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -1601,6 +2220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +2283,87 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74801d001b9e7729adb4f1825b67b398185fed424749aa3d8bacf70417137d9a"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1724,3 +2433,44 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.5",
+ "winnow",
+]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -327,6 +327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +519,27 @@ dependencies = [
  "zerofrom",
  "zerotrie",
  "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1233,6 +1263,7 @@ dependencies = [
  "rusqlite",
  "rustls",
  "semver",
+ "serde",
  "serde_json",
  "sha2",
  "signal-hook",
@@ -1240,6 +1271,7 @@ dependencies = [
  "tar",
  "tmt-core",
  "ureq",
+ "url",
  "uuid",
 ]
 
@@ -1272,6 +1304,7 @@ dependencies = [
 name = "tmt-office"
 version = "0.1.0-alpha.1"
 dependencies = [
+ "tmt-adapters",
  "tmt-core",
 ]
 
@@ -1326,6 +1359,18 @@ dependencies = [
  "http",
  "httparse",
  "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,10 @@ publish = false
 repository = "https://github.com/wkh237/tmux-team"
 
 [workspace.dependencies]
+getrandom = "=0.4.3"
+keyring-core = "=1.0.0"
+zbus-secret-service-keyring-store = { version = "=1.0.1", default-features = false, features = ["rt-async-io-crypto-rust"] }
+apple-native-keyring-store = { version = "=1.0.2", default-features = false, features = ["keychain"] }
 serde = { version = "=1.0.229", features = ["derive"] }
 url = "=2.5.8"
 unicode-width = { version = "=0.2.2", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,8 @@ publish = false
 repository = "https://github.com/wkh237/tmux-team"
 
 [workspace.dependencies]
+serde = { version = "=1.0.229", features = ["derive"] }
+url = "=2.5.8"
 unicode-width = { version = "=0.2.2", default-features = false }
 ureq = { version = "=3.4.0", default-features = false, features = ["rustls", "platform-verifier"] }
 rustls = { version = "=0.23.44", default-features = false, features = ["std", "ring", "tls12"] }

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -6,7 +6,12 @@ rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
 
+[features]
+office = ["dep:serde", "dep:url"]
+
 [dependencies]
+serde = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
 ureq.workspace = true
 tmt-core.workspace = true
 rusqlite.workspace = true

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -7,9 +7,11 @@ license.workspace = true
 publish.workspace = true
 
 [features]
-office = ["dep:serde", "dep:url"]
+office = ["dep:serde", "dep:url", "dep:getrandom", "dep:keyring-core", "dep:zbus-secret-service-keyring-store", "dep:apple-native-keyring-store"]
 
 [dependencies]
+getrandom = { workspace = true, optional = true }
+keyring-core = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 ureq.workspace = true
@@ -27,6 +29,12 @@ flate2.workspace = true
 subprocess.workspace = true
 nix.workspace = true
 signal-hook.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus-secret-service-keyring-store = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 rustls.workspace = true

--- a/rust/crates/tmt-adapters/src/config/paths.rs
+++ b/rust/crates/tmt-adapters/src/config/paths.rs
@@ -14,6 +14,10 @@ pub struct ConfigPaths {
 }
 
 impl ConfigPaths {
+    pub fn office_directory(&self) -> PathBuf {
+        self.global_dir.join("office")
+    }
+
     pub fn discover() -> Result<Self, ConfigError> {
         let cwd = env::current_dir().map_err(|error| ConfigError::internal(error.to_string()))?;
         let home = env::home_dir()

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -15,6 +15,10 @@ pub mod native_install;
 pub mod office_companion;
 #[cfg(feature = "office")]
 pub mod office_deployment;
+#[cfg(feature = "office")]
+mod office_http;
+#[cfg(feature = "office")]
+pub mod office_pairing;
 #[cfg(unix)]
 pub mod process;
 #[cfg(unix)]

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -13,6 +13,8 @@ mod json_document;
 pub mod native_install;
 #[cfg(unix)]
 pub mod office_companion;
+#[cfg(feature = "office")]
+pub mod office_deployment;
 #[cfg(unix)]
 pub mod process;
 #[cfg(unix)]

--- a/rust/crates/tmt-adapters/src/office_companion.rs
+++ b/rust/crates/tmt-adapters/src/office_companion.rs
@@ -11,8 +11,96 @@ use std::{
     time::{Duration, Instant},
 };
 use tmt_core::office_protocol::{
-    OFFICE_PROTOCOL_OUTPUT_LIMIT, OfficeInvocation, decode_office_probe,
+    OFFICE_PROTOCOL_OUTPUT_LIMIT, OfficeError, OfficeInvocation, decode_office_probe,
 };
+
+pub struct PairingCall<'a> {
+    pub world: &'a str,
+    pub identity_id: &'a str,
+    pub emulator: bool,
+    pub read_only: bool,
+}
+
+pub enum PairingReply {
+    Inspected(bool),
+    Pending(String),
+    State(String),
+    Error(OfficeError),
+}
+
+/// Launch selection is short; all remote/vault work happens after releasing
+/// the installer lock. Only nonsecret scope selectors cross stdin.
+pub fn invoke_office_pairing(
+    executable: &Path,
+    operation: OfficeInvocation,
+    call: &PairingCall<'_>,
+    deadline: Instant,
+) -> io::Result<PairingReply> {
+    if operation == OfficeInvocation::Probe {
+        return Err(invalid_pairing());
+    }
+    let input = serde_json::to_vec(
+        &serde_json::json!({"world":call.world,"identityId":call.identity_id,"emulator":call.emulator,"readOnly":call.read_only}),
+    )?;
+    if input.len() > 4096 {
+        return Err(invalid_pairing());
+    }
+    let args = operation.arguments().map(OsString::from);
+    let running = native_install::with_active_product(Product::Office, executable, |installed| {
+        UnixCommandRunner
+            .start(CommandRequest {
+                program: installed.active_executable.as_os_str(),
+                args: &args,
+                input: &input,
+                deadline,
+                max_output_bytes: 4096,
+            })
+            .map_err(io::Error::other)
+    })??;
+    let output = running.wait().map_err(io::Error::other)?;
+    if !output.stderr.is_empty() {
+        return Err(invalid_pairing());
+    }
+    decode_pairing_reply(&output.stdout, call.world)
+}
+
+fn decode_pairing_reply(bytes: &[u8], world: &str) -> io::Result<PairingReply> {
+    if bytes.len() > 4096 {
+        return Err(invalid_pairing());
+    }
+    let value: serde_json::Value = serde_json::from_slice(bytes).map_err(|_| invalid_pairing())?;
+    let object = value.as_object().ok_or_else(invalid_pairing)?;
+    if object.len() == 1 {
+        if let Some(exists) = value["blockExists"].as_bool() {
+            return Ok(PairingReply::Inspected(exists));
+        }
+        if let Some(error) = value["error"].as_str().and_then(OfficeError::parse) {
+            return Ok(PairingReply::Error(error));
+        }
+        if let Some(state @ ("unpaired" | "pending" | "credential" | "expired")) =
+            value["state"].as_str()
+        {
+            return Ok(PairingReply::State(state.into()));
+        }
+    }
+    if object.len() == 2
+        && value["state"] == "pending"
+        && let Some(link) = value["approvalUrl"].as_str().filter(|link| {
+            link.starts_with(&format!("{world}/pair#tmt-pair="))
+                && !link.chars().any(char::is_control)
+        })
+    {
+        return Ok(PairingReply::Pending(link.into()));
+    }
+    Err(invalid_pairing())
+}
+
+fn invalid_pairing() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "Invalid Office pairing response.",
+    )
+}
 
 /// Local compatibility inspection only: does not pair, authenticate or start a service.
 pub fn probe_office_companion(executable: &Path) -> io::Result<String> {
@@ -61,4 +149,43 @@ fn finish_probe(running: RunningCommand, expected_version: &semver::Version) -> 
         ));
     }
     Ok(version.to_string())
+}
+
+#[cfg(test)]
+mod pairing_tests {
+    use super::*;
+
+    #[test]
+    fn pairing_response_accepts_only_public_fields_and_the_selected_world() {
+        let world = "https://office.example/worlds/abcdefghijklmnopqrst";
+        assert!(
+            matches!(decode_pairing_reply(br#"{"state":"unpaired"}"#, world), Ok(PairingReply::State(state)) if state == "unpaired")
+        );
+        assert!(matches!(
+            decode_pairing_reply(br#"{"blockExists":false}"#, world),
+            Ok(PairingReply::Inspected(false))
+        ));
+        assert!(matches!(
+            decode_pairing_reply(br#"{"error":"OFFICE_NOT_PAIRED"}"#, world),
+            Ok(PairingReply::Error(OfficeError::NotPaired))
+        ));
+        let link = format!("{world}/pair#tmt-pair=e30");
+        let pending = serde_json::json!({"state":"pending","approvalUrl":link});
+        assert!(
+            matches!(decode_pairing_reply(pending.to_string().as_bytes(), world), Ok(PairingReply::Pending(value)) if value == link)
+        );
+        for value in [
+            serde_json::json!({"state":"credential","refreshToken":"private"}),
+            serde_json::json!({"state":"unknown"}),
+            serde_json::json!({"error":"arbitrary-provider-diagnostic"}),
+            serde_json::json!({"blockExists":"false"}),
+            serde_json::json!({"state":"pending","approvalUrl":"https://other.example/pair#tmt-pair=e30"}),
+            serde_json::json!({"state":"pending","approvalUrl":format!("{link}\n")}),
+            serde_json::json!([]),
+        ] {
+            assert!(decode_pairing_reply(value.to_string().as_bytes(), world).is_err());
+        }
+        assert!(decode_pairing_reply(b"\xff", world).is_err());
+        assert!(decode_pairing_reply(&vec![b' '; 4097], world).is_err());
+    }
 }

--- a/rust/crates/tmt-adapters/src/office_deployment.rs
+++ b/rust/crates/tmt-adapters/src/office_deployment.rs
@@ -1,0 +1,261 @@
+//! Public Office deployment decoding. These values select scope, not authority.
+
+use serde::Deserialize;
+use std::{
+    fmt, io,
+    time::{Duration, Instant},
+};
+use ureq::{
+    Agent,
+    tls::{RootCerts, TlsConfig},
+};
+use url::Url;
+
+pub const DEPLOYMENT_PATH: &str = "/.well-known/tmt-office.json";
+pub const DEPLOYMENT_LIMIT: usize = 4096;
+const URL_LIMIT: usize = 2048;
+const DEMO_PROJECT: &str = "demo-tmt-office";
+const DEMO_ISSUER: &str = "http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeploymentMode {
+    Cloud,
+    Emulator,
+}
+
+/// Error messages deliberately exclude untrusted document or URL contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidDeployment;
+
+impl fmt::Display for InvalidDeployment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Invalid Office deployment configuration or world URL.")
+    }
+}
+
+impl std::error::Error for InvalidDeployment {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorldTarget {
+    origin: String,
+    world_id: String,
+    mode: DeploymentMode,
+}
+
+impl WorldTarget {
+    pub fn parse(value: &str, mode: DeploymentMode) -> Result<Self, InvalidDeployment> {
+        let url = canonical_url(value)?;
+        let world_id = url
+            .path()
+            .strip_prefix("/worlds/")
+            .ok_or(InvalidDeployment)?;
+        if world_id.len() != 20 || !world_id.bytes().all(|byte| byte.is_ascii_alphanumeric()) {
+            return Err(InvalidDeployment);
+        }
+        match mode {
+            DeploymentMode::Cloud if url.scheme() == "https" => {}
+            DeploymentMode::Emulator
+                if url.scheme() == "http"
+                    && url.host_str() == Some("127.0.0.1")
+                    && url.port().is_some_and(|port| port != 0) => {}
+            _ => return Err(InvalidDeployment),
+        }
+        Ok(Self {
+            origin: url.origin().ascii_serialization(),
+            world_id: world_id.to_owned(),
+            mode,
+        })
+    }
+
+    pub fn origin(&self) -> &str {
+        &self.origin
+    }
+
+    pub fn world_id(&self) -> &str {
+        &self.world_id
+    }
+
+    pub fn discovery_url(&self) -> String {
+        format!("{}{DEPLOYMENT_PATH}", self.origin)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Descriptor {
+    version: u8,
+    mode: DeploymentMode,
+    project_id: String,
+    api_key: String,
+    pairing_url: String,
+}
+
+/// Immutable validated deployment. Private fields prevent bypassing the decoder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OfficeDeployment {
+    target: WorldTarget,
+    project_id: String,
+    api_key: String,
+    pairing_url: String,
+}
+
+impl OfficeDeployment {
+    /// Unauthenticated acquisition from the explicitly selected website only.
+    pub fn discover(target: WorldTarget, deadline: Instant) -> io::Result<Self> {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::TimedOut, "Office discovery timed out."))?
+            .min(Duration::from_secs(10));
+        let agent = Agent::new_with_config(
+            Agent::config_builder()
+                .https_only(target.mode == DeploymentMode::Cloud)
+                .max_redirects(0)
+                .max_response_header_size(16 * 1024)
+                .timeout_global(Some(remaining))
+                .tls_config(
+                    TlsConfig::builder()
+                        .root_certs(RootCerts::PlatformVerifier)
+                        .build(),
+                )
+                .build(),
+        );
+        let mut response = agent
+            .get(target.discovery_url())
+            .header("Accept", "application/json")
+            .header("Cache-Control", "no-store")
+            .call()
+            .map_err(discovery_failure)?;
+        if response.status().as_u16() != 200
+            || !response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| {
+                    value
+                        .split(';')
+                        .next()
+                        .is_some_and(|mime| mime.trim().eq_ignore_ascii_case("application/json"))
+                })
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                InvalidDeployment,
+            ));
+        }
+        let bytes = response
+            .body_mut()
+            .with_config()
+            .limit((DEPLOYMENT_LIMIT + 1) as u64)
+            .read_to_vec()
+            .map_err(discovery_failure)?;
+        Self::decode(target, &bytes)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
+
+    pub fn decode(target: WorldTarget, bytes: &[u8]) -> Result<Self, InvalidDeployment> {
+        if bytes.len() > DEPLOYMENT_LIMIT {
+            return Err(InvalidDeployment);
+        }
+        // Deserialize the typed object directly: a Value round trip would discard
+        // duplicate keys before Serde can reject them.
+        let descriptor: Descriptor =
+            serde_json::from_slice(bytes).map_err(|_| InvalidDeployment)?;
+        if descriptor.version != 1
+            || descriptor.mode != target.mode
+            || descriptor.api_key.is_empty()
+            || descriptor.api_key.len() > 256
+            || !descriptor
+                .api_key
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b"_-".contains(&b))
+            || descriptor.pairing_url.ends_with('/')
+        {
+            return Err(InvalidDeployment);
+        }
+        // An origin-only issuer base omits the URL Standard's implicit slash.
+        let issuer = parsed_url(&descriptor.pairing_url)?;
+        if issuer.as_str().trim_end_matches('/') != descriptor.pairing_url {
+            return Err(InvalidDeployment);
+        }
+        match descriptor.mode {
+            DeploymentMode::Cloud
+                if issuer.scheme() == "https"
+                    && valid_project(&descriptor.project_id)
+                    && !descriptor.project_id.starts_with("demo-") => {}
+            DeploymentMode::Emulator
+                if descriptor.project_id == DEMO_PROJECT
+                    && descriptor.api_key == DEMO_PROJECT
+                    && descriptor.pairing_url == DEMO_ISSUER => {}
+            _ => return Err(InvalidDeployment),
+        }
+        Ok(Self {
+            target,
+            project_id: descriptor.project_id,
+            api_key: descriptor.api_key,
+            pairing_url: descriptor.pairing_url,
+        })
+    }
+
+    pub fn target(&self) -> &WorldTarget {
+        &self.target
+    }
+
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+
+    pub fn api_key(&self) -> &str {
+        &self.api_key
+    }
+
+    pub fn claim_url(&self) -> String {
+        format!("{}/claim", self.pairing_url)
+    }
+}
+
+fn canonical_url(value: &str) -> Result<Url, InvalidDeployment> {
+    let url = parsed_url(value)?;
+    if url.as_str() != value {
+        return Err(InvalidDeployment);
+    }
+    Ok(url)
+}
+
+fn parsed_url(value: &str) -> Result<Url, InvalidDeployment> {
+    if value.len() > URL_LIMIT {
+        return Err(InvalidDeployment);
+    }
+    let url = Url::parse(value).map_err(|_| InvalidDeployment)?;
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(InvalidDeployment);
+    }
+    Ok(url)
+}
+
+fn valid_project(value: &str) -> bool {
+    (6..=30).contains(&value.len())
+        && value.as_bytes()[0].is_ascii_lowercase()
+        && value.as_bytes()[value.len() - 1].is_ascii_alphanumeric()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn discovery_failure(error: ureq::Error) -> io::Error {
+    let kind = match error {
+        ureq::Error::Timeout(_) => io::ErrorKind::TimedOut,
+        ureq::Error::BodyExceedsLimit(_) => io::ErrorKind::InvalidData,
+        _ => io::ErrorKind::Other,
+    };
+    io::Error::new(kind, "Office deployment discovery could not be confirmed.")
+}
+
+#[cfg(test)]
+#[path = "office_deployment_tests.rs"]
+mod tests;

--- a/rust/crates/tmt-adapters/src/office_deployment.rs
+++ b/rust/crates/tmt-adapters/src/office_deployment.rs
@@ -1,14 +1,8 @@
 //! Public Office deployment decoding. These values select scope, not authority.
 
-use serde::Deserialize;
-use std::{
-    fmt, io,
-    time::{Duration, Instant},
-};
-use ureq::{
-    Agent,
-    tls::{RootCerts, TlsConfig},
-};
+use crate::office_http;
+use serde::{Deserialize, Serialize};
+use std::{fmt, io, time::Instant};
 use url::Url;
 
 pub const DEPLOYMENT_PATH: &str = "/.well-known/tmt-office.json";
@@ -17,7 +11,7 @@ const URL_LIMIT: usize = 2048;
 const DEMO_PROJECT: &str = "demo-tmt-office";
 const DEMO_ISSUER: &str = "http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DeploymentMode {
     Cloud,
@@ -76,12 +70,16 @@ impl WorldTarget {
         &self.world_id
     }
 
+    pub fn mode(&self) -> DeploymentMode {
+        self.mode
+    }
+
     pub fn discovery_url(&self) -> String {
         format!("{}{DEPLOYMENT_PATH}", self.origin)
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct Descriptor {
     version: u8,
@@ -103,53 +101,25 @@ pub struct OfficeDeployment {
 impl OfficeDeployment {
     /// Unauthenticated acquisition from the explicitly selected website only.
     pub fn discover(target: WorldTarget, deadline: Instant) -> io::Result<Self> {
-        let remaining = deadline
-            .checked_duration_since(Instant::now())
-            .filter(|remaining| !remaining.is_zero())
-            .ok_or_else(|| io::Error::new(io::ErrorKind::TimedOut, "Office discovery timed out."))?
-            .min(Duration::from_secs(10));
-        let agent = Agent::new_with_config(
-            Agent::config_builder()
-                .https_only(target.mode == DeploymentMode::Cloud)
-                .max_redirects(0)
-                .max_response_header_size(16 * 1024)
-                .timeout_global(Some(remaining))
-                .tls_config(
-                    TlsConfig::builder()
-                        .root_certs(RootCerts::PlatformVerifier)
-                        .build(),
-                )
-                .build(),
-        );
+        let agent = office_http::agent(target.mode, deadline)?;
         let mut response = agent
             .get(target.discovery_url())
             .header("Accept", "application/json")
             .header("Cache-Control", "no-store")
             .call()
-            .map_err(discovery_failure)?;
-        if response.status().as_u16() != 200
-            || !response
-                .headers()
-                .get("content-type")
-                .and_then(|value| value.to_str().ok())
-                .is_some_and(|value| {
-                    value
-                        .split(';')
-                        .next()
-                        .is_some_and(|mime| mime.trim().eq_ignore_ascii_case("application/json"))
-                })
-        {
+            .map_err(office_http::failure)?;
+        if response.status().is_server_error() || response.status().is_client_error() {
+            return Err(io::Error::other(
+                "Office deployment discovery could not be confirmed.",
+            ));
+        }
+        if response.status().as_u16() != 200 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 InvalidDeployment,
             ));
         }
-        let bytes = response
-            .body_mut()
-            .with_config()
-            .limit((DEPLOYMENT_LIMIT + 1) as u64)
-            .read_to_vec()
-            .map_err(discovery_failure)?;
+        let bytes = office_http::json_body(&mut response, DEPLOYMENT_LIMIT)?;
         Self::decode(target, &bytes)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
     }
@@ -210,6 +180,17 @@ impl OfficeDeployment {
         &self.api_key
     }
 
+    pub fn encode_descriptor(&self) -> Vec<u8> {
+        serde_json::to_vec(&Descriptor {
+            version: 1,
+            mode: self.target.mode,
+            project_id: self.project_id.clone(),
+            api_key: self.api_key.clone(),
+            pairing_url: self.pairing_url.clone(),
+        })
+        .expect("validated deployment contains only JSON scalar values")
+    }
+
     pub fn claim_url(&self) -> String {
         format!("{}/claim", self.pairing_url)
     }
@@ -245,15 +226,6 @@ fn valid_project(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
-}
-
-fn discovery_failure(error: ureq::Error) -> io::Error {
-    let kind = match error {
-        ureq::Error::Timeout(_) => io::ErrorKind::TimedOut,
-        ureq::Error::BodyExceedsLimit(_) => io::ErrorKind::InvalidData,
-        _ => io::ErrorKind::Other,
-    };
-    io::Error::new(kind, "Office deployment discovery could not be confirmed.")
 }
 
 #[cfg(test)]

--- a/rust/crates/tmt-adapters/src/office_deployment_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_deployment_tests.rs
@@ -1,9 +1,10 @@
 use super::*;
+use crate::office_http::tests::with_http_response;
 use serde_json::{Value, json};
 use std::{
-    io::{Read, Write},
+    io,
     net::TcpListener,
-    thread,
+    time::{Duration, Instant},
 };
 
 fn cloud() -> WorldTarget {
@@ -203,53 +204,6 @@ fn emulator_requires_explicit_mode_and_exact_demo_endpoints() {
     }
 }
 
-fn serve_discovery(response: Vec<u8>) -> (io::Result<OfficeDeployment>, String) {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.set_nonblocking(true).unwrap();
-    let target = WorldTarget::parse(
-        &format!(
-            "http://{}/worlds/abcdefghijklmnopqrst",
-            listener.local_addr().unwrap()
-        ),
-        DeploymentMode::Emulator,
-    )
-    .unwrap();
-    thread::scope(|scope| {
-        let server = scope.spawn(move || {
-            let deadline = Instant::now() + Duration::from_secs(3);
-            let mut stream = loop {
-                match listener.accept() {
-                    Ok((stream, _)) => break stream,
-                    Err(error)
-                        if error.kind() == io::ErrorKind::WouldBlock
-                            && Instant::now() < deadline =>
-                    {
-                        thread::sleep(Duration::from_millis(5))
-                    }
-                    Err(error) => panic!("fixture accept failed: {error}"),
-                }
-            };
-            stream
-                .set_read_timeout(Some(Duration::from_secs(2)))
-                .unwrap();
-            stream
-                .set_write_timeout(Some(Duration::from_secs(2)))
-                .unwrap();
-            let mut request = Vec::new();
-            while !request.ends_with(b"\r\n\r\n") {
-                assert!(request.len() < 16 * 1024);
-                let mut byte = [0];
-                stream.read_exact(&mut byte).unwrap();
-                request.push(byte[0]);
-            }
-            stream.write_all(&response).unwrap();
-            String::from_utf8(request).unwrap()
-        });
-        let result = OfficeDeployment::discover(target, Instant::now() + Duration::from_secs(2));
-        (result, server.join().unwrap())
-    })
-}
-
 #[test]
 fn real_discovery_uses_exact_unauthenticated_path_and_bounds_response() {
     let body = json!({"version":1,"mode":"emulator","projectId":DEMO_PROJECT,"apiKey":DEMO_PROJECT,"pairingUrl":DEMO_ISSUER}).to_string();
@@ -257,7 +211,14 @@ fn real_discovery_uses_exact_unauthenticated_path_and_bounds_response() {
         "HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len()
     );
-    let (result, request) = serve_discovery(response.into_bytes());
+    let (result, request) = with_http_response(response.into_bytes(), |origin| {
+        let target = WorldTarget::parse(
+            &format!("{origin}/worlds/abcdefghijklmnopqrst"),
+            DeploymentMode::Emulator,
+        )
+        .unwrap();
+        OfficeDeployment::discover(target, Instant::now() + Duration::from_secs(2))
+    });
     assert_eq!(result.unwrap().project_id(), DEMO_PROJECT);
     assert!(request.starts_with("GET /.well-known/tmt-office.json HTTP/1.1\r\n"));
     let lower = request.to_ascii_lowercase();
@@ -270,7 +231,14 @@ fn real_discovery_uses_exact_unauthenticated_path_and_bounds_response() {
         (format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 4097\r\n\r\n{}", " ".repeat(4097)), io::ErrorKind::InvalidData),
         ("HTTP/1.1 503 Unavailable\r\nContent-Type: application/json\r\nContent-Length: 16\r\n\r\nprivate-material".to_owned(), io::ErrorKind::Other),
     ] {
-        let (result, _) = serve_discovery(response.into_bytes());
+        let (result, _) = with_http_response(response.into_bytes(), |origin| {
+            let target = WorldTarget::parse(
+                &format!("{origin}/worlds/abcdefghijklmnopqrst"),
+                DeploymentMode::Emulator,
+            )
+            .unwrap();
+            OfficeDeployment::discover(target, Instant::now() + Duration::from_secs(2))
+        });
         let error = result.unwrap_err();
         assert_eq!(error.kind(), kind);
         assert!(!error.to_string().contains("private-material"));

--- a/rust/crates/tmt-adapters/src/office_deployment_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_deployment_tests.rs
@@ -1,0 +1,299 @@
+use super::*;
+use serde_json::{Value, json};
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    thread,
+};
+
+fn cloud() -> WorldTarget {
+    WorldTarget::parse(
+        "https://office.example/worlds/abcdefghijklmnopqrst",
+        DeploymentMode::Cloud,
+    )
+    .unwrap()
+}
+
+fn descriptor() -> Value {
+    json!({"version":1,"mode":"cloud","projectId":"example-office", "apiKey":"public-web-api-key", "pairingUrl":"https://issuer.example/officePairing"})
+}
+
+#[test]
+fn literal_browser_deployments_pin_origin_and_exact_claim_target() {
+    let corpus: Value = serde_json::from_str(include_str!(
+        "../../../../contracts/office/deployment-examples.json"
+    ))
+    .unwrap();
+    let examples = corpus["valid"].as_array().unwrap();
+    assert_eq!(examples.len(), 3);
+    for example in examples {
+        let mode = serde_json::from_value(example["descriptor"]["mode"].clone()).unwrap();
+        let target = WorldTarget::parse(example["worldUrl"].as_str().unwrap(), mode).unwrap();
+        let deployment = OfficeDeployment::decode(
+            target.clone(),
+            &serde_json::to_vec(&example["descriptor"]).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(deployment.target(), &target);
+        assert_eq!(deployment.project_id(), example["descriptor"]["projectId"]);
+        assert_eq!(deployment.api_key(), example["descriptor"]["apiKey"]);
+        assert_eq!(
+            deployment.claim_url(),
+            format!(
+                "{}/claim",
+                example["descriptor"]["pairingUrl"].as_str().unwrap()
+            )
+        );
+    }
+    assert_eq!(
+        cloud().discovery_url(),
+        "https://office.example/.well-known/tmt-office.json"
+    );
+}
+
+#[test]
+fn world_selection_rejects_credentials_normalization_and_extra_routes() {
+    for value in [
+        "http://office.example/worlds/abcdefghijklmnopqrst",
+        "https://user:secret@office.example/worlds/abcdefghijklmnopqrst",
+        "https://office.example/worlds/abcdefghijklmnopqrst?token=secret",
+        "https://office.example/worlds/abcdefghijklmnopqrst#secret",
+        "https://office.example/a/../worlds/abcdefghijklmnopqrst",
+        "https://OFFICE.example/worlds/abcdefghijklmnopqrst",
+        "https://office.example/worlds/abcdefghijklmnopqrst/",
+        "https://office.example/worlds/abcdefghijklmnopqrst/pair",
+        "https://office.example/worlds/%61bcdefghijklmnopqrst",
+        "https://office.example/worlds/abc",
+        "https://office.example:443/worlds/abcdefghijklmnopqrst",
+        "https://office.example\\worlds/abcdefghijklmnopqrst",
+    ] {
+        assert_eq!(
+            WorldTarget::parse(value, DeploymentMode::Cloud),
+            Err(InvalidDeployment),
+            "{value}"
+        );
+    }
+}
+
+#[test]
+fn malformed_unknown_duplicate_and_oversize_documents_fail_closed() {
+    let bytes = serde_json::to_vec(&descriptor()).unwrap();
+    let mut exact_bound = bytes.clone();
+    exact_bound.resize(DEPLOYMENT_LIMIT, b' ');
+    assert!(OfficeDeployment::decode(cloud(), &exact_bound).is_ok());
+    exact_bound.push(b' ');
+    assert_eq!(
+        OfficeDeployment::decode(cloud(), &exact_bound),
+        Err(InvalidDeployment)
+    );
+    for key in ["version", "mode", "projectId", "apiKey", "pairingUrl"] {
+        let mut missing = descriptor();
+        let removed = missing.as_object_mut().unwrap().remove(key).unwrap();
+        assert!(OfficeDeployment::decode(cloud(), &serde_json::to_vec(&missing).unwrap()).is_err());
+        let duplicate = format!(
+            "{{\"{key}\":{removed},{}",
+            String::from_utf8(bytes.clone())
+                .unwrap()
+                .strip_prefix('{')
+                .unwrap()
+        );
+        assert!(
+            OfficeDeployment::decode(cloud(), duplicate.as_bytes()).is_err(),
+            "duplicate {key}"
+        );
+    }
+    for input in [
+        b"[]".as_slice(),
+        b"{}",
+        b"\xff",
+        b"null",
+        b"{\"apiKey\":\"\\ud800\"}",
+    ] {
+        assert!(OfficeDeployment::decode(cloud(), input).is_err());
+    }
+    let mut unknown = descriptor();
+    unknown["authUrl"] = json!("https://evil.example/token");
+    assert!(OfficeDeployment::decode(cloud(), &serde_json::to_vec(&unknown).unwrap()).is_err());
+}
+
+#[test]
+fn cloud_descriptor_rejects_retargeting_and_invalid_config_fields() {
+    for (key, value) in [
+        ("version", json!(2)),
+        ("version", json!(1.0)),
+        ("mode", json!("emulator")),
+        ("mode", json!("other")),
+        ("projectId", json!("demo-tmt-office")),
+        ("projectId", json!("EXAMPLE-office")),
+        ("apiKey", json!("secret?query")),
+        ("apiKey", json!("")),
+        ("apiKey", json!("a".repeat(257))),
+        ("pairingUrl", json!("http://issuer.example/officePairing")),
+        ("pairingUrl", json!("https://issuer.example/officePairing/")),
+        (
+            "pairingUrl",
+            json!("https://issuer.example/a/../officePairing"),
+        ),
+        (
+            "pairingUrl",
+            json!("https://issuer.example/officePairing?token=x"),
+        ),
+        (
+            "pairingUrl",
+            json!("https://issuer.example/officePairing#x"),
+        ),
+        (
+            "pairingUrl",
+            json!("https://secret@issuer.example/officePairing"),
+        ),
+    ] {
+        let mut input = descriptor();
+        input[key] = value;
+        assert!(
+            OfficeDeployment::decode(cloud(), &serde_json::to_vec(&input).unwrap()).is_err(),
+            "{key}: {input}"
+        );
+    }
+    let mut root_issuer = descriptor();
+    root_issuer["pairingUrl"] = json!("https://issuer.example");
+    assert_eq!(
+        OfficeDeployment::decode(cloud(), &serde_json::to_vec(&root_issuer).unwrap())
+            .unwrap()
+            .claim_url(),
+        "https://issuer.example/claim"
+    );
+}
+
+#[test]
+fn emulator_requires_explicit_mode_and_exact_demo_endpoints() {
+    let world = "http://127.0.0.1:4174/worlds/abcdefghijklmnopqrst";
+    assert!(WorldTarget::parse(world, DeploymentMode::Cloud).is_err());
+    for host in [
+        "localhost:4174",
+        "127.0.0.2:4174",
+        "[::1]:4174",
+        "127.0.0.1:0",
+        "127.0.0.1",
+    ] {
+        assert!(
+            WorldTarget::parse(
+                &format!("http://{host}/worlds/abcdefghijklmnopqrst"),
+                DeploymentMode::Emulator
+            )
+            .is_err()
+        );
+    }
+    let target = WorldTarget::parse(world, DeploymentMode::Emulator).unwrap();
+    let mut input = json!({"version":1,"mode":"emulator","projectId":DEMO_PROJECT,"apiKey":DEMO_PROJECT,"pairingUrl":DEMO_ISSUER});
+    assert!(OfficeDeployment::decode(target.clone(), &serde_json::to_vec(&input).unwrap()).is_ok());
+    for (key, value) in [
+        ("projectId", "real-project"),
+        ("apiKey", "other-key"),
+        (
+            "pairingUrl",
+            "http://127.0.0.1:5002/demo-tmt-office/us-central1/officePairing",
+        ),
+    ] {
+        let original = input[key].clone();
+        input[key] = json!(value);
+        assert!(
+            OfficeDeployment::decode(target.clone(), &serde_json::to_vec(&input).unwrap()).is_err()
+        );
+        input[key] = original;
+    }
+}
+
+fn serve_discovery(response: Vec<u8>) -> (io::Result<OfficeDeployment>, String) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let target = WorldTarget::parse(
+        &format!(
+            "http://{}/worlds/abcdefghijklmnopqrst",
+            listener.local_addr().unwrap()
+        ),
+        DeploymentMode::Emulator,
+    )
+    .unwrap();
+    thread::scope(|scope| {
+        let server = scope.spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(3);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(error)
+                        if error.kind() == io::ErrorKind::WouldBlock
+                            && Instant::now() < deadline =>
+                    {
+                        thread::sleep(Duration::from_millis(5))
+                    }
+                    Err(error) => panic!("fixture accept failed: {error}"),
+                }
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            stream
+                .set_write_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                assert!(request.len() < 16 * 1024);
+                let mut byte = [0];
+                stream.read_exact(&mut byte).unwrap();
+                request.push(byte[0]);
+            }
+            stream.write_all(&response).unwrap();
+            String::from_utf8(request).unwrap()
+        });
+        let result = OfficeDeployment::discover(target, Instant::now() + Duration::from_secs(2));
+        (result, server.join().unwrap())
+    })
+}
+
+#[test]
+fn real_discovery_uses_exact_unauthenticated_path_and_bounds_response() {
+    let body = json!({"version":1,"mode":"emulator","projectId":DEMO_PROJECT,"apiKey":DEMO_PROJECT,"pairingUrl":DEMO_ISSUER}).to_string();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let (result, request) = serve_discovery(response.into_bytes());
+    assert_eq!(result.unwrap().project_id(), DEMO_PROJECT);
+    assert!(request.starts_with("GET /.well-known/tmt-office.json HTTP/1.1\r\n"));
+    let lower = request.to_ascii_lowercase();
+    assert!(!lower.contains("authorization:"));
+    assert!(!lower.contains("cookie:"));
+    assert!(lower.contains("accept: application/json\r\n"));
+    for (response, kind) in [
+        ("HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:1/credential-target\r\nContent-Length: 0\r\n\r\n".to_owned(), io::ErrorKind::InvalidData),
+        ("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 2\r\n\r\n{}".to_owned(), io::ErrorKind::InvalidData),
+        (format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 4097\r\n\r\n{}", " ".repeat(4097)), io::ErrorKind::InvalidData),
+        ("HTTP/1.1 503 Unavailable\r\nContent-Type: application/json\r\nContent-Length: 16\r\n\r\nprivate-material".to_owned(), io::ErrorKind::Other),
+    ] {
+        let (result, _) = serve_discovery(response.into_bytes());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), kind);
+        assert!(!error.to_string().contains("private-material"));
+        assert!(!error.to_string().contains("credential-target"));
+    }
+}
+
+#[test]
+fn exhausted_discovery_deadline_does_not_connect() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let target = WorldTarget::parse(
+        &format!(
+            "http://{}/worlds/abcdefghijklmnopqrst",
+            listener.local_addr().unwrap()
+        ),
+        DeploymentMode::Emulator,
+    )
+    .unwrap();
+    let error = OfficeDeployment::discover(target, Instant::now()).unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(
+        listener.accept().unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+}

--- a/rust/crates/tmt-adapters/src/office_http.rs
+++ b/rust/crates/tmt-adapters/src/office_http.rs
@@ -1,0 +1,79 @@
+//! Shared bounded Office transport. Callers select fixed validated endpoints.
+
+use crate::office_deployment::DeploymentMode;
+use std::{
+    io,
+    time::{Duration, Instant},
+};
+use ureq::{
+    Agent, Body,
+    http::Response,
+    tls::{RootCerts, TlsConfig},
+};
+
+pub(crate) fn agent(mode: DeploymentMode, deadline: Instant) -> io::Result<Agent> {
+    let remaining = deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::TimedOut, "Office operation timed out."))?
+        .min(Duration::from_secs(10));
+    Ok(Agent::new_with_config(
+        Agent::config_builder()
+            .https_only(mode == DeploymentMode::Cloud)
+            .http_status_as_error(false)
+            .max_redirects(0)
+            .max_response_header_size(16 * 1024)
+            .timeout_global(Some(remaining))
+            .tls_config(
+                TlsConfig::builder()
+                    .root_certs(RootCerts::PlatformVerifier)
+                    .build(),
+            )
+            .build(),
+    ))
+}
+
+pub(crate) fn json_body(response: &mut Response<Body>, limit: usize) -> io::Result<Vec<u8>> {
+    if !response
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(';')
+                .next()
+                .is_some_and(|mime| mime.trim().eq_ignore_ascii_case("application/json"))
+        })
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Invalid Office response.",
+        ));
+    }
+    let bytes = response
+        .body_mut()
+        .with_config()
+        .limit((limit + 1) as u64)
+        .read_to_vec()
+        .map_err(failure)?;
+    if bytes.len() > limit {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Office response exceeds its bound.",
+        ));
+    }
+    Ok(bytes)
+}
+
+pub(crate) fn failure(error: ureq::Error) -> io::Error {
+    let kind = match error {
+        ureq::Error::Timeout(_) => io::ErrorKind::TimedOut,
+        ureq::Error::BodyExceedsLimit(_) => io::ErrorKind::InvalidData,
+        _ => io::ErrorKind::Other,
+    };
+    io::Error::new(kind, "Office request could not be confirmed.")
+}
+
+#[cfg(test)]
+#[path = "office_http_tests.rs"]
+pub(crate) mod tests;

--- a/rust/crates/tmt-adapters/src/office_http_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_http_tests.rs
@@ -1,0 +1,68 @@
+use std::{
+    io::{self, Read, Write},
+    net::TcpListener,
+    thread,
+    time::{Duration, Instant},
+};
+
+/// Serve one bounded plain-HTTP response and return the request headers seen.
+///
+/// This is shared by discovery and remote transport tests so they exercise the
+/// same one-shot listener/read/write behavior without introducing a second
+/// server implementation.
+pub(crate) fn with_http_response<T>(
+    response: Vec<u8>,
+    operation: impl FnOnce(String) -> T,
+) -> (T, String) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let origin = format!("http://{}", listener.local_addr().unwrap());
+    thread::scope(|scope| {
+        let server = scope.spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(3);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(error)
+                        if error.kind() == io::ErrorKind::WouldBlock
+                            && Instant::now() < deadline =>
+                    {
+                        thread::sleep(Duration::from_millis(5))
+                    }
+                    Err(error) => panic!("fixture accept failed: {error}"),
+                }
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            stream
+                .set_write_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                assert!(request.len() < 16 * 1024);
+                let mut byte = [0];
+                stream.read_exact(&mut byte).unwrap();
+                request.push(byte[0]);
+            }
+            // Drain a bounded POST body before closing the socket. Closing with
+            // unread request bytes can reset TCP and disguise a valid response
+            // as the truncation failure that another scenario intends to test.
+            let headers = String::from_utf8(request).unwrap();
+            let length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().unwrap())
+                })
+                .unwrap_or(0);
+            assert!(length <= 16 * 1024);
+            stream.read_exact(&mut vec![0; length]).unwrap();
+            stream.write_all(&response).unwrap();
+            headers
+        });
+        let result = operation(origin);
+        (result, server.join().unwrap())
+    })
+}

--- a/rust/crates/tmt-adapters/src/office_pairing.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing.rs
@@ -1,0 +1,16 @@
+//! Native approval/proof codec. Secret-bearing values deliberately have no Debug.
+
+mod invocation;
+mod local;
+mod record;
+mod remote;
+mod vault;
+mod wire;
+
+pub use invocation::execute;
+pub use local::OfficeInstallation;
+pub use record::PairingRecord;
+pub use remote::{AgentCredential, claim_pairing};
+pub use tmt_core::office_protocol::OfficeError;
+pub use vault::ProtectedEntry;
+pub use wire::{Approval, Claim, Proof};

--- a/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
@@ -1,0 +1,170 @@
+//! One-shot companion composition. Only allowlisted public data leaves this owner.
+
+use super::{
+    AgentCredential, Approval, OfficeError, OfficeInstallation, PairingRecord, Proof,
+    ProtectedEntry, claim_pairing,
+};
+use crate::{
+    config::ConfigPaths,
+    office_deployment::{DeploymentMode, OfficeDeployment, WorldTarget},
+    storage::Storage,
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tmt_core::{identity::Identity, office_protocol::OfficeInvocation};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Request {
+    world: String,
+    identity_id: String,
+    emulator: bool,
+    read_only: bool,
+}
+
+pub fn execute(operation: OfficeInvocation, bytes: &[u8]) -> Vec<u8> {
+    let result = run(operation, bytes);
+    let value = result.unwrap_or_else(|error| json!({"error":error.code()}));
+    serde_json::to_vec(&value).expect("public Office result is JSON data")
+}
+
+fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> {
+    if bytes.len() > 4096 || operation == OfficeInvocation::Probe {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    let request: Request =
+        serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+    let mode = if request.emulator {
+        DeploymentMode::Emulator
+    } else {
+        DeploymentMode::Cloud
+    };
+    let target =
+        WorldTarget::parse(&request.world, mode).map_err(|_| OfficeError::DeploymentInvalid)?;
+    let paths = ConfigPaths::discover().map_err(|_| OfficeError::CredentialsUnavailable)?;
+    let identity = active_identity(&paths, &request.identity_id)?;
+    let create = operation == OfficeInvocation::PairBegin;
+    let Some(installation) = OfficeInstallation::open(&paths, create)? else {
+        return if operation == OfficeInvocation::PairStatus {
+            Ok(json!({"state":"unpaired"}))
+        } else {
+            Err(OfficeError::NotPaired)
+        };
+    };
+    let deadline = Instant::now() + Duration::from_secs(25);
+    let operate = |key: &str| {
+        let entry = ProtectedEntry::open(key)?;
+        let existing = entry
+            .read()?
+            .map(|bytes| PairingRecord::decode(&bytes, &target, installation.id(), &identity.id))
+            .transpose()?;
+        match operation {
+            OfficeInvocation::Inspect => {
+                let mut record = existing.ok_or(OfficeError::NotPaired)?;
+                if record.refresh_if_needed(&target, now_ms()?, deadline)? {
+                    active_identity(&paths, &identity.id)?;
+                    entry.write(&record.encode()?)?;
+                }
+                active_identity(&paths, &identity.id)?;
+                let exists = record.inspect(&target, now_ms()?, deadline)?;
+                Ok(json!({"blockExists":exists}))
+            }
+            OfficeInvocation::PairStatus => {
+                let now = now_ms()?;
+                Ok(
+                    json!({"state":existing.as_ref().map_or("unpaired", |record| record.local_state(now))}),
+                )
+            }
+            OfficeInvocation::PairBegin => {
+                let record = match existing {
+                    Some(record) => {
+                        if record.approval().read_only() != request.read_only {
+                            return Err(OfficeError::CredentialsInvalid);
+                        }
+                        record
+                    }
+                    None => {
+                        let deployment = OfficeDeployment::discover(target.clone(), deadline)
+                            .map_err(|error| {
+                                if error.kind() == std::io::ErrorKind::InvalidData {
+                                    OfficeError::DeploymentInvalid
+                                } else {
+                                    OfficeError::RemoteUncertain
+                                }
+                            })?;
+                        let proof = Proof::generate()?;
+                        let approval = Approval::new(
+                            &target,
+                            installation.id(),
+                            &identity.id,
+                            &identity.name,
+                            request.read_only,
+                            &proof,
+                        )?;
+                        let record =
+                            PairingRecord::pending(&deployment, approval, proof, now_ms()?)?;
+                        active_identity(&paths, &identity.id)?;
+                        entry.write(&record.encode()?)?;
+                        record
+                    }
+                };
+                match record.local_state(now_ms()?) {
+                    "pending" => Ok(
+                        json!({"state":"pending","approvalUrl":record.approval().approval_url(&target)?}),
+                    ),
+                    "credential" => Ok(json!({"state":"credential"})),
+                    _ => Err(OfficeError::PairingExpired),
+                }
+            }
+            OfficeInvocation::PairPoll => {
+                let mut record = existing.ok_or(OfficeError::NotPaired)?;
+                if record.local_state(now_ms()?) == "credential" {
+                    return Ok(json!({"state":"credential"}));
+                }
+                let proof = record.reserve_claim(now_ms()?)?;
+                entry.write(&record.encode()?)?;
+                active_identity(&paths, &identity.id)?;
+                let deployment = record.deployment(&target)?;
+                let claim =
+                    claim_pairing(&deployment, &proof, record.approval(), now_ms()?, deadline)?;
+                let credential = AgentCredential::exchange(
+                    &deployment,
+                    record.approval(),
+                    &claim,
+                    now_ms()?,
+                    deadline,
+                )?;
+                active_identity(&paths, &identity.id)?;
+                record.complete(claim, credential, &target)?;
+                entry.write(&record.encode()?)?;
+                active_identity(&paths, &identity.id)?;
+                Ok(json!({"state":"credential"}))
+            }
+            OfficeInvocation::Probe => Err(OfficeError::CredentialsInvalid),
+        }
+    };
+    if operation == OfficeInvocation::PairStatus {
+        operate(&installation.scope_key(&target, &identity.id)?)
+    } else {
+        installation.with_scope(&target, &identity.id, operate)
+    }
+}
+
+fn active_identity(paths: &ConfigPaths, id: &str) -> Result<Identity, OfficeError> {
+    let storage =
+        Storage::open(&paths.database).map_err(|_| OfficeError::CredentialsUnavailable)?;
+    storage
+        .find_active_identity_by_id(id)
+        .map_err(|_| OfficeError::CredentialsUnavailable)?
+        .ok_or(OfficeError::NotPaired)
+}
+
+fn now_ms() -> Result<u64, OfficeError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| OfficeError::CredentialsUnavailable)?
+        .as_millis()
+        .try_into()
+        .map_err(|_| OfficeError::CredentialsUnavailable)
+}

--- a/rust/crates/tmt-adapters/src/office_pairing/local.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/local.rs
@@ -1,0 +1,254 @@
+//! Nonsecret stable installation identity. Binding/secret state belongs to the vault.
+
+use super::{OfficeError, wire::valid_uuid};
+use crate::{
+    bounded_file::{self, FileReadError},
+    config::ConfigPaths,
+    content_digest::sha256,
+    file_lock,
+    office_deployment::WorldTarget,
+};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{self, Write},
+    os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt},
+    path::PathBuf,
+};
+
+pub struct OfficeInstallation {
+    directory: PathBuf,
+    id: String,
+}
+
+impl OfficeInstallation {
+    pub fn open(paths: &ConfigPaths, create: bool) -> Result<Option<Self>, OfficeError> {
+        let directory = paths.office_directory();
+        let mut created = false;
+        if create {
+            fs::create_dir_all(&paths.global_dir).map_err(unavailable)?;
+            match fs::DirBuilder::new().mode(0o700).create(&directory) {
+                Ok(()) => {
+                    created = true;
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(unavailable(error)),
+            }
+        }
+        match fs::symlink_metadata(&directory) {
+            Ok(metadata) if metadata.is_dir() && metadata.permissions().mode() & 0o077 == 0 => {}
+            Err(error) if !create && error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            _ => return Err(OfficeError::CredentialsUnavailable),
+        }
+        // Read-only operations do not create missing metadata or lock files.
+        if !create {
+            let id = read_id(&directory)?.ok_or(OfficeError::CredentialsInvalid)?;
+            return Ok(Some(Self { directory, id }));
+        }
+        let _lock =
+            file_lock::exclusive(&directory.join("installation.lock")).map_err(unavailable)?;
+        let id = match read_id(&directory)? {
+            Some(id) => id,
+            None => {
+                if !created {
+                    // Missing metadata in an existing installation is not
+                    // permission to orphan its protected entries under a new ID.
+                    return Err(OfficeError::CredentialsInvalid);
+                }
+                let id = uuid::Uuid::new_v4().to_string();
+                let staging = directory.join(format!(".installation-{}.tmp", uuid::Uuid::new_v4()));
+                let mut file = OpenOptions::new()
+                    .create_new(true)
+                    .write(true)
+                    .mode(0o600)
+                    .open(&staging)
+                    .map_err(unavailable)?;
+                let result = file
+                    .write_all(id.as_bytes())
+                    .and_then(|()| file.sync_all())
+                    .and_then(|()| fs::rename(&staging, directory.join("installation-id")))
+                    .and_then(|()| File::open(&directory)?.sync_all());
+                if result.is_err() && staging.exists() {
+                    // This unique path belongs to this invocation, never a glob.
+                    fs::remove_file(&staging).map_err(unavailable)?;
+                }
+                result.map_err(unavailable)?;
+                id
+            }
+        };
+        Ok(Some(Self { directory, id }))
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn with_scope<T>(
+        &self,
+        target: &WorldTarget,
+        identity_id: &str,
+        operation: impl FnOnce(&str) -> Result<T, OfficeError>,
+    ) -> Result<T, OfficeError> {
+        let key = self.scope_key(target, identity_id)?;
+        let _lock = file_lock::exclusive(&self.directory.join(format!("{key}.lock")))
+            .map_err(unavailable)?;
+        operation(&key)
+    }
+
+    pub fn scope_key(
+        &self,
+        target: &WorldTarget,
+        identity_id: &str,
+    ) -> Result<String, OfficeError> {
+        if !valid_uuid(identity_id) {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let key = sha256(
+            &serde_json::to_vec(&(
+                target.origin(),
+                target.world_id(),
+                target.mode(),
+                &self.id,
+                identity_id,
+            ))
+            .map_err(|_| OfficeError::CredentialsInvalid)?,
+        );
+        Ok(key)
+    }
+}
+
+fn read_id(directory: &std::path::Path) -> Result<Option<String>, OfficeError> {
+    let bytes = match bounded_file::read_no_follow(&directory.join("installation-id"), 36) {
+        Ok(bytes) => bytes,
+        Err(FileReadError::Io(error)) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(None);
+        }
+        Err(_) => return Err(OfficeError::CredentialsInvalid),
+    };
+    let id = String::from_utf8(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+    if !valid_uuid(&id) {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    Ok(Some(id))
+}
+
+fn unavailable(_: io::Error) -> OfficeError {
+    OfficeError::CredentialsUnavailable
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{office_deployment::DeploymentMode, test_support::TestDirectory};
+
+    fn paths(root: &TestDirectory) -> ConfigPaths {
+        ConfigPaths::resolve(&root.path, &root.path, Some(&root.path.join("app")), None)
+    }
+
+    #[test]
+    fn missing_status_is_read_only_and_stable_id_survives_reopen() {
+        let root = TestDirectory::new();
+        let paths = paths(&root);
+        assert!(OfficeInstallation::open(&paths, false).unwrap().is_none());
+        assert!(!paths.global_dir.exists());
+        let created = OfficeInstallation::open(&paths, true).unwrap().unwrap();
+        let bytes = fs::read(paths.office_directory().join("installation-id")).unwrap();
+        assert_eq!(bytes, created.id().as_bytes());
+        assert_eq!(
+            OfficeInstallation::open(&paths, false)
+                .unwrap()
+                .unwrap()
+                .id(),
+            created.id()
+        );
+        assert_eq!(
+            OfficeInstallation::open(&paths, true)
+                .unwrap()
+                .unwrap()
+                .id(),
+            created.id()
+        );
+        assert!(!paths.database.exists());
+    }
+
+    #[test]
+    fn missing_installation_id_is_not_regenerated() {
+        let root = TestDirectory::new();
+        let paths = paths(&root);
+        OfficeInstallation::open(&paths, true).unwrap();
+        let id_path = paths.office_directory().join("installation-id");
+        fs::remove_file(&id_path).unwrap();
+        assert!(matches!(
+            OfficeInstallation::open(&paths, false),
+            Err(OfficeError::CredentialsInvalid)
+        ));
+        assert!(matches!(
+            OfficeInstallation::open(&paths, true),
+            Err(OfficeError::CredentialsInvalid)
+        ));
+        assert!(!id_path.exists());
+    }
+
+    #[test]
+    fn malformed_metadata_and_symlinks_are_never_replaced() {
+        let root = TestDirectory::new();
+        let paths = paths(&root);
+        OfficeInstallation::open(&paths, true).unwrap();
+        let id_path = paths.office_directory().join("installation-id");
+        fs::write(&id_path, b"malformed").unwrap();
+        assert!(matches!(
+            OfficeInstallation::open(&paths, true),
+            Err(OfficeError::CredentialsInvalid)
+        ));
+        assert_eq!(fs::read(&id_path).unwrap(), b"malformed");
+        fs::remove_file(&id_path).unwrap();
+        std::os::unix::fs::symlink(root.path.join("outside"), &id_path).unwrap();
+        assert!(matches!(
+            OfficeInstallation::open(&paths, true),
+            Err(OfficeError::CredentialsInvalid)
+        ));
+        assert!(
+            fs::symlink_metadata(&id_path)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(!root.path.join("outside").exists());
+    }
+
+    #[test]
+    fn scope_is_stable_isolated_and_exclusively_locked() {
+        let root = TestDirectory::new();
+        let installation = OfficeInstallation::open(&paths(&root), true)
+            .unwrap()
+            .unwrap();
+        let target = WorldTarget::parse(
+            "https://office.example/worlds/abcdefghijklmnopqrst",
+            DeploymentMode::Cloud,
+        )
+        .unwrap();
+        let identity = "00000000-0000-4000-8000-000000000001";
+        let first = installation
+            .with_scope(&target, identity, |key| {
+                assert_eq!(
+                    installation.with_scope(&target, identity, |_| Ok(())),
+                    Err(OfficeError::CredentialsUnavailable)
+                );
+                Ok(key.to_string())
+            })
+            .unwrap();
+        assert_eq!(
+            installation
+                .with_scope(&target, identity, |key| Ok(key.to_string()))
+                .unwrap(),
+            first
+        );
+        assert_ne!(
+            installation
+                .with_scope(&target, "00000000-0000-4000-8000-000000000002", |key| Ok(
+                    key.to_string()
+                ))
+                .unwrap(),
+            first
+        );
+    }
+}

--- a/rust/crates/tmt-adapters/src/office_pairing/record.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/record.rs
@@ -1,0 +1,264 @@
+//! One protected binding record. No second disk index or secret-file fallback.
+
+use super::{
+    AgentCredential, Approval, Claim, OfficeError, Proof, vault::RECORD_LIMIT, wire::valid_uuid,
+};
+use crate::office_deployment::{DeploymentMode, OfficeDeployment, WorldTarget};
+use serde::{Deserialize, Serialize};
+
+const APPROVAL_MS: u64 = 300_000;
+const CLAIM_INTERVAL_MS: u64 = 5000;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PairingRecord {
+    version: u8,
+    origin: String,
+    mode: DeploymentMode,
+    descriptor: String,
+    approval: Approval,
+    created_at: u64,
+    expires_at: u64,
+    phase: Phase,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(
+    tag = "state",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+enum Phase {
+    Pending {
+        secret: String,
+        next_claim_at: u64,
+    },
+    Paired {
+        principal_uid: String,
+        block_id: String,
+        grant_expires_at: u64,
+        credential: AgentCredential,
+    },
+}
+
+impl PairingRecord {
+    pub fn refresh_if_needed(
+        &mut self,
+        target: &WorldTarget,
+        now_ms: u64,
+        deadline: std::time::Instant,
+    ) -> Result<bool, OfficeError> {
+        let deployment = self.deployment(target)?;
+        match &mut self.phase {
+            Phase::Paired {
+                principal_uid,
+                grant_expires_at,
+                credential,
+                ..
+            } => {
+                if now_ms >= *grant_expires_at {
+                    return Err(OfficeError::PairingExpired);
+                }
+                if credential.token_expires_at() > now_ms.saturating_add(30_000) {
+                    return Ok(false);
+                }
+                *credential = credential.refresh(
+                    &deployment,
+                    &self.approval,
+                    principal_uid,
+                    now_ms,
+                    deadline,
+                )?;
+                Ok(true)
+            }
+            Phase::Pending { .. } => Err(OfficeError::NotPaired),
+        }
+    }
+
+    pub fn inspect(
+        &self,
+        target: &WorldTarget,
+        now_ms: u64,
+        deadline: std::time::Instant,
+    ) -> Result<bool, OfficeError> {
+        match &self.phase {
+            Phase::Paired {
+                grant_expires_at,
+                block_id,
+                credential,
+                ..
+            } => {
+                if now_ms >= *grant_expires_at {
+                    return Err(OfficeError::PairingExpired);
+                }
+                credential.inspect_block(&self.deployment(target)?, block_id, deadline)
+            }
+            Phase::Pending { .. } => Err(OfficeError::NotPaired),
+        }
+    }
+
+    pub fn pending(
+        deployment: &OfficeDeployment,
+        approval: Approval,
+        proof: Proof,
+        now_ms: u64,
+    ) -> Result<Self, OfficeError> {
+        if approval.pairing_id() != proof.challenge() {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        // This also validates the approval world before any protected publication.
+        approval.approval_url(deployment.target())?;
+        Ok(Self {
+            version: 1,
+            origin: deployment.target().origin().into(),
+            mode: deployment.target().mode(),
+            descriptor: String::from_utf8(deployment.encode_descriptor())
+                .map_err(|_| OfficeError::CredentialsInvalid)?,
+            approval,
+            created_at: now_ms,
+            expires_at: now_ms
+                .checked_add(APPROVAL_MS)
+                .ok_or(OfficeError::CredentialsInvalid)?,
+            phase: Phase::Pending {
+                secret: proof.secret(),
+                next_claim_at: now_ms,
+            },
+        })
+    }
+
+    pub fn decode(
+        bytes: &[u8],
+        target: &WorldTarget,
+        installation_id: &str,
+        identity_id: &str,
+    ) -> Result<Self, OfficeError> {
+        if bytes.len() > RECORD_LIMIT {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let value: Self =
+            serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+        if value.version != 1
+            || value.origin != target.origin()
+            || value.mode != target.mode()
+            || value.approval.installation_id() != installation_id
+            || value.approval.identity_id() != identity_id
+            || value.expires_at > 8_640_000_000_000_000
+            || value.created_at.checked_add(APPROVAL_MS) != Some(value.expires_at)
+        {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        value.approval.approval_url(target)?;
+        let deployment = value.deployment(target)?;
+        match &value.phase {
+            Phase::Pending {
+                secret,
+                next_claim_at,
+            } => {
+                if Proof::decode(secret)?.challenge() != value.approval.pairing_id()
+                    || *next_claim_at < value.created_at
+                    || *next_claim_at > value.expires_at + CLAIM_INTERVAL_MS
+                {
+                    return Err(OfficeError::CredentialsInvalid);
+                }
+            }
+            Phase::Paired {
+                principal_uid,
+                block_id,
+                grant_expires_at,
+                credential,
+            } => {
+                if !principal_uid
+                    .strip_prefix("office-agent:")
+                    .is_some_and(valid_uuid)
+                    || !valid_uuid(block_id)
+                    || *grant_expires_at <= value.created_at
+                    || *grant_expires_at > 8_640_000_000_000_000
+                {
+                    return Err(OfficeError::CredentialsInvalid);
+                }
+                credential.validate(&deployment, &value.approval, principal_uid)?;
+            }
+        }
+        Ok(value)
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, OfficeError> {
+        let bytes = serde_json::to_vec(self).map_err(|_| OfficeError::CredentialsInvalid)?;
+        if bytes.len() > RECORD_LIMIT {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        Ok(bytes)
+    }
+
+    pub fn deployment(&self, target: &WorldTarget) -> Result<OfficeDeployment, OfficeError> {
+        OfficeDeployment::decode(target.clone(), self.descriptor.as_bytes())
+            .map_err(|_| OfficeError::CredentialsInvalid)
+    }
+
+    pub fn approval(&self) -> &Approval {
+        &self.approval
+    }
+
+    /// Persist the returned record before submitting the returned proof. This
+    /// reserves cadence across crashes and concurrent invocations, not just sleeps.
+    pub fn reserve_claim(&mut self, now_ms: u64) -> Result<Proof, OfficeError> {
+        if now_ms >= self.expires_at {
+            return Err(OfficeError::PairingExpired);
+        }
+        match &mut self.phase {
+            Phase::Pending {
+                secret,
+                next_claim_at,
+            } => {
+                if now_ms < *next_claim_at {
+                    return Err(OfficeError::PairingPending);
+                }
+                *next_claim_at = now_ms
+                    .checked_add(CLAIM_INTERVAL_MS)
+                    .ok_or(OfficeError::CredentialsInvalid)?;
+                Proof::decode(secret)
+            }
+            Phase::Paired { .. } => Err(OfficeError::CredentialsInvalid),
+        }
+    }
+
+    /// Replacing this complete record is the only transition. The old protected
+    /// proof remains recoverable until the replacement write is confirmed.
+    pub fn complete(
+        &mut self,
+        claim: Claim,
+        credential: AgentCredential,
+        target: &WorldTarget,
+    ) -> Result<(), OfficeError> {
+        if !matches!(self.phase, Phase::Pending { .. }) {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        credential.validate(
+            &self.deployment(target)?,
+            &self.approval,
+            &claim.principal_uid,
+        )?;
+        self.phase = Phase::Paired {
+            principal_uid: claim.principal_uid,
+            block_id: claim.block_id,
+            grant_expires_at: claim.grant_expires_at,
+            credential,
+        };
+        Ok(())
+    }
+
+    pub fn local_state(&self, now_ms: u64) -> &'static str {
+        match &self.phase {
+            Phase::Pending { .. } if now_ms < self.expires_at => "pending",
+            Phase::Paired {
+                grant_expires_at, ..
+            } if now_ms < *grant_expires_at => "credential",
+            _ => "expired",
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "record_tests.rs"]
+mod tests;

--- a/rust/crates/tmt-adapters/src/office_pairing/record_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/record_tests.rs
@@ -1,0 +1,108 @@
+use super::*;
+use serde_json::json;
+
+const INSTALLATION: &str = "00000000-0000-4000-8000-000000000001";
+const IDENTITY: &str = "00000000-0000-4000-8000-000000000002";
+
+fn fixture() -> (WorldTarget, PairingRecord) {
+    let target = WorldTarget::parse(
+        "https://office.example/worlds/abcdefghijklmnopqrst",
+        DeploymentMode::Cloud,
+    )
+    .unwrap();
+    let deployment = OfficeDeployment::decode(target.clone(), br#"{"version":1,"mode":"cloud","projectId":"example-office","apiKey":"public-key","pairingUrl":"https://issuer.example"}"#).unwrap();
+    let proof = Proof::generate().unwrap();
+    let approval = Approval::new(&target, INSTALLATION, IDENTITY, "Alice", false, &proof).unwrap();
+    let record = PairingRecord::pending(&deployment, approval, proof, 1000).unwrap();
+    (target, record)
+}
+
+#[test]
+fn protected_record_round_trip_preserves_proof_deadline_and_full_deployment() {
+    let (target, mut original) = fixture();
+    let proof = original.reserve_claim(1000).unwrap();
+    let bytes = original.encode().unwrap();
+    let mut resumed = PairingRecord::decode(&bytes, &target, INSTALLATION, IDENTITY).unwrap();
+    assert_eq!(resumed.expires_at, 301_000);
+    assert_eq!(
+        resumed.deployment(&target).unwrap(),
+        original.deployment(&target).unwrap()
+    );
+    assert_eq!(resumed.approval(), original.approval());
+    assert!(matches!(
+        resumed.reserve_claim(5999),
+        Err(OfficeError::PairingPending)
+    ));
+    assert_eq!(
+        resumed.reserve_claim(6000).unwrap().secret(),
+        proof.secret()
+    );
+    assert_eq!(resumed.expires_at, 301_000);
+    assert_eq!(resumed.local_state(300_999), "pending");
+    assert_eq!(resumed.local_state(301_000), "expired");
+    assert!(matches!(
+        resumed.reserve_claim(301_000),
+        Err(OfficeError::PairingExpired)
+    ));
+}
+
+#[test]
+fn wrong_scope_replacement_and_corrupt_records_fail_closed() {
+    let (target, record) = fixture();
+    let bytes = record.encode().unwrap();
+    let other_origin = WorldTarget::parse(
+        "https://other.example/worlds/abcdefghijklmnopqrst",
+        DeploymentMode::Cloud,
+    )
+    .unwrap();
+    let other_world = WorldTarget::parse(
+        "https://office.example/worlds/AbCdEfGhIjKlMnOpQrSt",
+        DeploymentMode::Cloud,
+    )
+    .unwrap();
+    for (selected, installation, identity) in [
+        (&other_origin, INSTALLATION, IDENTITY),
+        (&other_world, INSTALLATION, IDENTITY),
+        (&target, IDENTITY, IDENTITY),
+        (&target, INSTALLATION, INSTALLATION),
+    ] {
+        assert!(PairingRecord::decode(&bytes, selected, installation, identity).is_err());
+    }
+    for (key, value) in [
+        ("version", json!(2)),
+        ("mode", json!("emulator")),
+        ("descriptor", json!("{}")),
+        ("expiresAt", json!(u64::MAX)),
+        (
+            "phase",
+            json!({"state":"pending","secret":"invalid","nextClaimAt":1000}),
+        ),
+        ("customToken", json!("must-not-persist")),
+    ] {
+        let mut changed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        changed[key] = value;
+        assert!(
+            PairingRecord::decode(
+                &serde_json::to_vec(&changed).unwrap(),
+                &target,
+                INSTALLATION,
+                IDENTITY
+            )
+            .is_err(),
+            "{key}"
+        );
+    }
+    let duplicate = String::from_utf8(bytes)
+        .unwrap()
+        .replacen('{', "{\"version\":1,", 1);
+    assert!(PairingRecord::decode(duplicate.as_bytes(), &target, INSTALLATION, IDENTITY).is_err());
+    assert!(
+        PairingRecord::decode(
+            &vec![b' '; RECORD_LIMIT + 1],
+            &target,
+            INSTALLATION,
+            IDENTITY
+        )
+        .is_err()
+    );
+}

--- a/rust/crates/tmt-adapters/src/office_pairing/remote.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/remote.rs
@@ -1,0 +1,297 @@
+//! Fixed Firebase REST operations; no caller-provided credential destination.
+
+use super::{
+    Approval, Claim, OfficeError, Proof,
+    wire::{RESPONSE_LIMIT, valid_token},
+};
+use crate::{
+    office_deployment::{DeploymentMode, OfficeDeployment},
+    office_http,
+};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+use std::time::Instant;
+
+pub fn claim_pairing(
+    deployment: &OfficeDeployment,
+    proof: &Proof,
+    approval: &Approval,
+    now_ms: u64,
+    deadline: Instant,
+) -> Result<Claim, OfficeError> {
+    if proof.challenge() != approval.pairing_id() {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    let bytes = post(
+        deployment,
+        &deployment.claim_url(),
+        &serde_json::json!({"version":1,"secret":proof.secret()}).to_string(),
+        "application/json",
+        deadline,
+        true,
+    )?;
+    Claim::decode(&bytes, approval, now_ms)
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AgentCredential {
+    id_token: String,
+    refresh_token: String,
+    token_expires_at: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Exchanged {
+    id_token: String,
+    refresh_token: String,
+    expires_in: String,
+}
+
+#[derive(Deserialize)]
+struct Refreshed {
+    id_token: String,
+    refresh_token: String,
+    expires_in: String,
+    token_type: String,
+    user_id: String,
+}
+
+#[derive(Deserialize)]
+struct TokenBinding {
+    aud: String,
+    iss: String,
+    sub: String,
+    #[serde(rename = "tmtOfficeAgent")]
+    agent: bool,
+    #[serde(rename = "tmtInstallationId")]
+    installation_id: String,
+    #[serde(rename = "tmtIdentityId")]
+    identity_id: String,
+}
+
+impl AgentCredential {
+    pub fn inspect_block(
+        &self,
+        deployment: &OfficeDeployment,
+        block_id: &str,
+        deadline: Instant,
+    ) -> Result<bool, OfficeError> {
+        if !super::wire::valid_uuid(block_id) || !valid_token(&self.id_token) {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let base = match deployment.target().mode() {
+            DeploymentMode::Cloud => "https://firestore.googleapis.com",
+            DeploymentMode::Emulator => "http://127.0.0.1:8080",
+        };
+        let name = format!(
+            "projects/{}/databases/(default)/documents/worlds/{}/blocks/{block_id}",
+            deployment.project_id(),
+            deployment.target().world_id()
+        );
+        let agent = office_http::agent(deployment.target().mode(), deadline)
+            .map_err(|_| OfficeError::RemoteUncertain)?;
+        let mut response = agent
+            .get(format!("{base}/v1/{name}"))
+            .header("Authorization", &format!("Bearer {}", self.id_token))
+            .header("Accept", "application/json")
+            .header("Cache-Control", "no-store")
+            .call()
+            .map_err(|_| OfficeError::RemoteUncertain)?;
+        match response.status().as_u16() {
+            200 => {
+                let bytes = office_http::json_body(&mut response, RESPONSE_LIMIT)
+                    .map_err(|_| OfficeError::RemoteUncertain)?;
+                #[derive(Deserialize)]
+                struct Document {
+                    name: String,
+                }
+                let document: Document =
+                    serde_json::from_slice(&bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+                if document.name != name {
+                    return Err(OfficeError::CredentialsInvalid);
+                }
+                // Existence only: no parallel layout codec or unchecked fields.
+                Ok(true)
+            }
+            404 => Ok(false),
+            401 | 403 => Err(OfficeError::RemoteDenied),
+            300..=399 => Err(OfficeError::CredentialsInvalid),
+            _ => Err(OfficeError::RemoteUncertain),
+        }
+    }
+
+    pub fn exchange(
+        deployment: &OfficeDeployment,
+        approval: &Approval,
+        claim: &Claim,
+        now_ms: u64,
+        deadline: Instant,
+    ) -> Result<Self, OfficeError> {
+        let url = auth_url(deployment, "accounts:signInWithCustomToken");
+        let bytes = post(
+            deployment,
+            &url,
+            &serde_json::json!({"token":claim.custom_token,"returnSecureToken":true}).to_string(),
+            "application/json",
+            deadline,
+            false,
+        )?;
+        let response: Exchanged =
+            serde_json::from_slice(&bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+        let value = Self::from_response(
+            response.id_token,
+            response.refresh_token,
+            &response.expires_in,
+            now_ms,
+        )?;
+        value.validate(deployment, approval, &claim.principal_uid)?;
+        Ok(value)
+    }
+
+    pub fn refresh(
+        &self,
+        deployment: &OfficeDeployment,
+        approval: &Approval,
+        principal_uid: &str,
+        now_ms: u64,
+        deadline: Instant,
+    ) -> Result<Self, OfficeError> {
+        self.validate(deployment, approval, principal_uid)?;
+        let base = match deployment.target().mode() {
+            DeploymentMode::Cloud => "https://securetoken.googleapis.com/v1/token",
+            DeploymentMode::Emulator => "http://127.0.0.1:9099/securetoken.googleapis.com/v1/token",
+        };
+        let url = format!("{base}?key={}", deployment.api_key());
+        let body = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("grant_type", "refresh_token")
+            .append_pair("refresh_token", &self.refresh_token)
+            .finish();
+        let bytes = post(
+            deployment,
+            &url,
+            &body,
+            "application/x-www-form-urlencoded",
+            deadline,
+            false,
+        )?;
+        let response: Refreshed =
+            serde_json::from_slice(&bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+        if response.token_type != "Bearer" || response.user_id != principal_uid {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let value = Self::from_response(
+            response.id_token,
+            response.refresh_token,
+            &response.expires_in,
+            now_ms,
+        )?;
+        value.validate(deployment, approval, principal_uid)?;
+        Ok(value)
+    }
+
+    fn from_response(
+        id_token: String,
+        refresh_token: String,
+        expires_in: &str,
+        now_ms: u64,
+    ) -> Result<Self, OfficeError> {
+        let seconds: u64 = expires_in
+            .parse()
+            .map_err(|_| OfficeError::CredentialsInvalid)?;
+        if !(1..=3600).contains(&seconds) || seconds.to_string() != expires_in {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let token_expires_at = now_ms
+            .checked_add(seconds * 1000)
+            .ok_or(OfficeError::CredentialsInvalid)?;
+        Ok(Self {
+            id_token,
+            refresh_token,
+            token_expires_at,
+        })
+    }
+
+    pub fn validate(
+        &self,
+        deployment: &OfficeDeployment,
+        approval: &Approval,
+        principal_uid: &str,
+    ) -> Result<(), OfficeError> {
+        if !valid_token(&self.id_token) || !valid_token(&self.refresh_token) {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let segments = self.id_token.split('.').collect::<Vec<_>>();
+        if segments.len() != 3 {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        // This is response/binding consistency, not JWT signature verification
+        // or authorization. Fixed HTTPS Auth issued the token; live Firestore
+        // Rules authenticate it on every resource operation. Emulator mode is
+        // explicitly isolated and never accepted as cloud authority.
+        let payload = URL_SAFE_NO_PAD
+            .decode(segments[1])
+            .map_err(|_| OfficeError::CredentialsInvalid)?;
+        let binding: TokenBinding =
+            serde_json::from_slice(&payload).map_err(|_| OfficeError::CredentialsInvalid)?;
+        if binding.aud != deployment.project_id()
+            || binding.iss != format!("https://securetoken.google.com/{}", deployment.project_id())
+            || binding.sub != principal_uid
+            || !binding.agent
+            || binding.installation_id != approval.installation_id()
+            || binding.identity_id != approval.identity_id()
+        {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        Ok(())
+    }
+
+    pub fn token_expires_at(&self) -> u64 {
+        self.token_expires_at
+    }
+}
+
+fn auth_url(deployment: &OfficeDeployment, operation: &str) -> String {
+    let base = match deployment.target().mode() {
+        DeploymentMode::Cloud => "https://identitytoolkit.googleapis.com/v1",
+        DeploymentMode::Emulator => "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1",
+    };
+    format!("{base}/{operation}?key={}", deployment.api_key())
+}
+
+fn post(
+    deployment: &OfficeDeployment,
+    url: &str,
+    body: &str,
+    content_type: &str,
+    deadline: Instant,
+    claim: bool,
+) -> Result<Vec<u8>, OfficeError> {
+    let agent = office_http::agent(deployment.target().mode(), deadline)
+        .map_err(|_| OfficeError::RemoteUncertain)?;
+    let mut response = agent
+        .post(url)
+        .header("Content-Type", content_type)
+        .header("Accept", "application/json")
+        .header("Cache-Control", "no-store")
+        .send(body)
+        .map_err(|_| OfficeError::RemoteUncertain)?;
+    match response.status().as_u16() {
+        200 => office_http::json_body(&mut response, RESPONSE_LIMIT).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::InvalidData {
+                OfficeError::CredentialsInvalid
+            } else {
+                OfficeError::RemoteUncertain
+            }
+        }),
+        404 | 429 if claim => Err(OfficeError::PairingPending),
+        400 | 401 | 403 if !claim => Err(OfficeError::RemoteDenied),
+        300..=399 => Err(OfficeError::CredentialsInvalid),
+        _ => Err(OfficeError::RemoteUncertain),
+    }
+}
+
+#[cfg(test)]
+#[path = "remote_tests.rs"]
+mod tests;

--- a/rust/crates/tmt-adapters/src/office_pairing/remote_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/remote_tests.rs
@@ -1,0 +1,286 @@
+use super::*;
+use crate::office_deployment::WorldTarget;
+use crate::office_http::tests::with_http_response;
+use serde_json::{Value, json};
+use std::time::{Duration, Instant};
+
+fn scope() -> (OfficeDeployment, Approval) {
+    let target = WorldTarget::parse(
+        "https://office.example/worlds/abcdefghijklmnopqrst",
+        DeploymentMode::Cloud,
+    )
+    .unwrap();
+    let approval = Approval::new(
+        &target,
+        "00000000-0000-4000-8000-000000000001",
+        "00000000-0000-4000-8000-000000000002",
+        "Alice",
+        false,
+        &Proof::generate().unwrap(),
+    )
+    .unwrap();
+    let deployment = OfficeDeployment::decode(target, br#"{"version":1,"mode":"cloud","projectId":"example-office","apiKey":"public-key","pairingUrl":"https://issuer.example"}"#).unwrap();
+    (deployment, approval)
+}
+
+const PRINCIPAL: &str = "office-agent:00000000-0000-4000-8000-000000000003";
+
+fn claims() -> Value {
+    json!({"aud":"example-office","iss":"https://securetoken.google.com/example-office","sub":PRINCIPAL,
+        "tmtOfficeAgent":true,"tmtInstallationId":"00000000-0000-4000-8000-000000000001",
+        "tmtIdentityId":"00000000-0000-4000-8000-000000000002"})
+}
+
+fn credential(payload: &Value) -> AgentCredential {
+    // Unsigned fixture tokens prove consistency validation, never authentication.
+    let id_token = format!("e30.{}.", URL_SAFE_NO_PAD.encode(payload.to_string()));
+    AgentCredential::from_response(id_token, "private-refresh-token".into(), "3600", 1000).unwrap()
+}
+
+fn emulator_deployment() -> OfficeDeployment {
+    let target = WorldTarget::parse(
+        "http://127.0.0.1:4174/worlds/abcdefghijklmnopqrst",
+        DeploymentMode::Emulator,
+    )
+    .unwrap();
+    OfficeDeployment::decode(
+        target,
+        br#"{"version":1,"mode":"emulator","projectId":"demo-tmt-office","apiKey":"demo-tmt-office","pairingUrl":"http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing"}"#,
+    )
+    .unwrap()
+}
+
+fn http_response(
+    status: u16,
+    headers: &[(&str, &str)],
+    body: &[u8],
+    declared_length: Option<usize>,
+) -> Vec<u8> {
+    let mut response = format!("HTTP/1.1 {status} Test\r\n").into_bytes();
+    if (300..=399).contains(&status) {
+        response.extend_from_slice(b"Location: http://127.0.0.1:1/credential-target\r\n");
+    }
+    for (name, value) in headers {
+        response.extend_from_slice(format!("{name}: {value}\r\n").as_bytes());
+    }
+    if let Some(length) = declared_length {
+        response.extend_from_slice(format!("Content-Length: {length}\r\n").as_bytes());
+    }
+    response.extend_from_slice(b"Connection: close\r\n\r\n");
+    response.extend_from_slice(body);
+    response
+}
+
+fn post_fixture(
+    deployment: &OfficeDeployment,
+    response: Vec<u8>,
+    claim: bool,
+) -> (Result<Vec<u8>, OfficeError>, String) {
+    with_http_response(response, |origin| {
+        post(
+            deployment,
+            &format!("{origin}/claim"),
+            "{\"version\":1}",
+            "application/json",
+            Instant::now() + Duration::from_secs(2),
+            claim,
+        )
+    })
+}
+
+#[test]
+fn bounded_post_statuses_preserve_claim_auth_and_uncertain_meanings() {
+    let deployment = emulator_deployment();
+    let json = br#"{}"#;
+    for (status, claim, expected) in [
+        (404, true, OfficeError::PairingPending),
+        (429, true, OfficeError::PairingPending),
+        (400, false, OfficeError::RemoteDenied),
+        (401, false, OfficeError::RemoteDenied),
+        (403, false, OfficeError::RemoteDenied),
+        (503, false, OfficeError::RemoteUncertain),
+        (302, false, OfficeError::CredentialsInvalid),
+    ] {
+        let response = http_response(
+            status,
+            &[("Content-Type", "application/json")],
+            json,
+            Some(json.len()),
+        );
+        let (result, request) = post_fixture(&deployment, response, claim);
+        assert_eq!(result, Err(expected), "status {status}, claim {claim}");
+        assert!(request.starts_with("POST /claim HTTP/1.1"));
+        let lower = request.to_ascii_lowercase();
+        assert!(lower.contains("content-type: application/json\r\n"));
+        assert!(lower.contains("accept: application/json\r\n"));
+    }
+}
+
+#[test]
+fn bounded_post_body_failures_distinguish_exact_invalid_from_transport_uncertainty() {
+    let deployment = emulator_deployment();
+    let exact = br#"{"version":1}"#;
+    let (result, _) = post_fixture(
+        &deployment,
+        http_response(
+            200,
+            &[("Content-Type", "application/json; charset=utf-8")],
+            exact,
+            Some(exact.len()),
+        ),
+        false,
+    );
+    assert_eq!(result, Ok(exact.to_vec()));
+
+    let truncated = br#"{}"#;
+    let (result, _) = post_fixture(
+        &deployment,
+        http_response(
+            200,
+            &[("Content-Type", "application/json")],
+            truncated,
+            Some(truncated.len() + 4),
+        ),
+        false,
+    );
+    assert_eq!(result, Err(OfficeError::RemoteUncertain));
+
+    let oversized = vec![b'a'; RESPONSE_LIMIT + 1];
+    let (result, _) = post_fixture(
+        &deployment,
+        http_response(
+            200,
+            &[("Content-Type", "application/json")],
+            &oversized,
+            Some(oversized.len()),
+        ),
+        false,
+    );
+    assert_eq!(result, Err(OfficeError::CredentialsInvalid));
+
+    let non_json = br#"{}"#;
+    let (result, _) = post_fixture(
+        &deployment,
+        http_response(
+            200,
+            &[("Content-Type", "text/plain")],
+            non_json,
+            Some(non_json.len()),
+        ),
+        false,
+    );
+    assert_eq!(result, Err(OfficeError::CredentialsInvalid));
+}
+
+#[test]
+fn token_consistency_rejects_every_wrong_scope_and_malformed_payload() {
+    let (deployment, approval) = scope();
+    credential(&claims())
+        .validate(&deployment, &approval, PRINCIPAL)
+        .unwrap();
+    for (field, value) in [
+        ("aud", json!("other-project")),
+        ("iss", json!("https://issuer.example")),
+        ("sub", json!("human-owner")),
+        ("tmtOfficeAgent", json!(false)),
+        (
+            "tmtInstallationId",
+            json!("00000000-0000-4000-8000-000000000009"),
+        ),
+        (
+            "tmtIdentityId",
+            json!("00000000-0000-4000-8000-000000000009"),
+        ),
+    ] {
+        let mut changed = claims();
+        changed[field] = value;
+        assert_eq!(
+            credential(&changed).validate(&deployment, &approval, PRINCIPAL),
+            Err(OfficeError::CredentialsInvalid),
+            "{field}"
+        );
+        changed.as_object_mut().unwrap().remove(field);
+        assert!(
+            credential(&changed)
+                .validate(&deployment, &approval, PRINCIPAL)
+                .is_err()
+        );
+    }
+    for token in [
+        "",
+        "private-token",
+        "a.!!!!.b",
+        "a.e30.b.extra",
+        "a.e30.b\n",
+    ] {
+        let mut value = credential(&claims());
+        value.id_token = token.into();
+        assert_eq!(
+            value.validate(&deployment, &approval, PRINCIPAL),
+            Err(OfficeError::CredentialsInvalid)
+        );
+    }
+    let duplicate = claims()
+        .to_string()
+        .replacen('{', "{\"aud\":\"other-project\",", 1);
+    let mut value = credential(&claims());
+    value.id_token = format!("e30.{}.", URL_SAFE_NO_PAD.encode(duplicate));
+    assert!(value.validate(&deployment, &approval, PRINCIPAL).is_err());
+}
+
+#[test]
+fn bounded_token_clock_and_secret_record_do_not_accept_missing_or_extra_fields() {
+    let value = credential(&claims());
+    assert_eq!(value.token_expires_at(), 3_601_000);
+    for seconds in [
+        "0",
+        "3601",
+        "-1",
+        "01",
+        "1.0",
+        "1e3",
+        "",
+        "18446744073709551615",
+    ] {
+        assert!(
+            AgentCredential::from_response("token".into(), "refresh".into(), seconds, 1000)
+                .is_err()
+        );
+    }
+    assert!(
+        AgentCredential::from_response("token".into(), "refresh".into(), "3600", u64::MAX).is_err()
+    );
+    let serialized = serde_json::to_vec(&value).unwrap();
+    let decoded: AgentCredential = serde_json::from_slice(&serialized).unwrap();
+    assert_eq!(decoded.refresh_token, "private-refresh-token");
+    for key in ["idToken", "refreshToken", "tokenExpiresAt"] {
+        let mut input = serde_json::to_value(&value).unwrap();
+        input.as_object_mut().unwrap().remove(key);
+        assert!(serde_json::from_value::<AgentCredential>(input).is_err());
+    }
+    let extra = String::from_utf8(serialized).unwrap().replacen(
+        '{',
+        "{\"customToken\":\"not-durable\",",
+        1,
+    );
+    assert!(serde_json::from_str::<AgentCredential>(&extra).is_err());
+}
+
+#[test]
+fn fixed_auth_endpoints_do_not_come_from_issuer_or_browser_link() {
+    let (deployment, _) = scope();
+    assert_eq!(
+        auth_url(&deployment, "accounts:signInWithCustomToken"),
+        "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=public-key"
+    );
+    let target = WorldTarget::parse(
+        "http://127.0.0.1:4174/worlds/abcdefghijklmnopqrst",
+        DeploymentMode::Emulator,
+    )
+    .unwrap();
+    let deployment = OfficeDeployment::decode(target, br#"{"version":1,"mode":"emulator","projectId":"demo-tmt-office","apiKey":"demo-tmt-office","pairingUrl":"http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing"}"#).unwrap();
+    assert_eq!(
+        auth_url(&deployment, "accounts:signInWithCustomToken"),
+        "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=demo-tmt-office"
+    );
+}

--- a/rust/crates/tmt-adapters/src/office_pairing/vault.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/vault.rs
@@ -1,0 +1,91 @@
+//! Explicit OS-store selection. No global default, plaintext or mock fallback.
+
+use super::OfficeError;
+use keyring_core::{Entry, Error, api::CredentialStoreApi};
+
+const SERVICE: &str = "org.tmux-team.office.v1";
+pub(super) const RECORD_LIMIT: usize = 32 * 1024;
+
+/// Call only inside the parent's bounded companion process. Platform providers
+/// can block on a locked collection or an OS prompt; they own no TMT daemon.
+pub struct ProtectedEntry(Entry);
+
+impl ProtectedEntry {
+    pub fn open(scope: &str) -> Result<Self, OfficeError> {
+        if !crate::content_digest::is_sha256(scope) {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        #[cfg(target_os = "linux")]
+        let store = zbus_secret_service_keyring_store::Store::new().map_err(failure)?;
+        #[cfg(target_os = "macos")]
+        let store = apple_native_keyring_store::keychain::Store::new().map_err(failure)?;
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        return store.build(SERVICE, scope, None).map(Self).map_err(failure);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        Err(OfficeError::CredentialsUnavailable)
+    }
+
+    pub fn read(&self) -> Result<Option<Vec<u8>>, OfficeError> {
+        match self.0.get_secret() {
+            Ok(bytes) if bytes.len() <= RECORD_LIMIT => Ok(Some(bytes)),
+            Ok(_) => Err(OfficeError::CredentialsInvalid),
+            Err(Error::NoEntry) => Ok(None),
+            Err(error) => Err(failure(error)),
+        }
+    }
+
+    pub fn write(&self, bytes: &[u8]) -> Result<(), OfficeError> {
+        if bytes.is_empty() || bytes.len() > RECORD_LIMIT {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        self.0.set_secret(bytes).map_err(failure)?;
+        // Do not report publication from a successful write alone. A later
+        // uncertain failure retains the same scope for explicit recovery.
+        if self.read()?.as_deref() != Some(bytes) {
+            return Err(OfficeError::CredentialsUnavailable);
+        }
+        Ok(())
+    }
+}
+
+fn failure(error: Error) -> OfficeError {
+    // Provider errors may embed secret bytes or identifying attributes.
+    // Never retain them as an output/source error or format them for diagnostics.
+    match error {
+        Error::BadEncoding(_) | Error::BadDataFormat(_, _) | Error::Ambiguous(_) => {
+            OfficeError::CredentialsInvalid
+        }
+        _ => OfficeError::CredentialsUnavailable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_scope_is_rejected_before_opening_any_platform_store() {
+        for scope in ["", "secret-user-value", "../path", &"A".repeat(64)] {
+            assert!(matches!(
+                ProtectedEntry::open(scope),
+                Err(OfficeError::CredentialsInvalid)
+            ));
+        }
+    }
+
+    #[test]
+    fn provider_errors_never_retain_or_format_secret_material() {
+        assert_eq!(
+            failure(Error::BadEncoding(b"private-material".to_vec())).to_string(),
+            "OFFICE_CREDENTIALS_INVALID"
+        );
+        assert_eq!(
+            failure(Error::Invalid(
+                "private-account".into(),
+                "private-material".into()
+            ))
+            .to_string(),
+            "OFFICE_CREDENTIALS_UNAVAILABLE"
+        );
+    }
+}

--- a/rust/crates/tmt-adapters/src/office_pairing/wire.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/wire.rs
@@ -1,0 +1,230 @@
+use super::OfficeError;
+use crate::content_digest::{is_sha256, sha256};
+use crate::office_deployment::WorldTarget;
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+
+const APPROVAL_LIMIT: usize = 2048;
+pub(super) const RESPONSE_LIMIT: usize = 16 * 1024;
+const MAX_TIMESTAMP: u64 = 8_640_000_000_000_000;
+
+/// Public consent only. Serialize this allowlisted value, never a secret record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Approval {
+    version: u8,
+    pairing_id: String,
+    world_id: String,
+    installation_id: String,
+    identity_id: String,
+    installation_label: String,
+    identity_label: String,
+    capabilities: Vec<String>,
+}
+
+impl Approval {
+    pub fn new(
+        target: &WorldTarget,
+        installation_id: &str,
+        identity_id: &str,
+        identity_label: &str,
+        read_only: bool,
+        proof: &Proof,
+    ) -> Result<Self, OfficeError> {
+        let value = Self {
+            version: 1,
+            pairing_id: proof.challenge(),
+            world_id: target.world_id().into(),
+            installation_id: installation_id.into(),
+            identity_id: identity_id.into(),
+            installation_label: "TMT installation".into(),
+            identity_label: identity_label.into(),
+            capabilities: if read_only {
+                vec!["layout.read".into()]
+            } else {
+                vec!["layout.read".into(), "layout.write".into()]
+            },
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, OfficeError> {
+        if bytes.len() > APPROVAL_LIMIT {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let value: Self =
+            serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+        value.validate()?;
+        Ok(value)
+    }
+
+    fn validate(&self) -> Result<(), OfficeError> {
+        if self.version != 1
+            || !is_sha256(&self.pairing_id)
+            || self.world_id.len() != 20
+            || !self.world_id.bytes().all(|b| b.is_ascii_alphanumeric())
+            || !valid_uuid(&self.installation_id)
+            || !valid_uuid(&self.identity_id)
+            || !valid_label(&self.installation_label)
+            || !valid_label(&self.identity_label)
+            || !(self.capabilities == ["layout.read"]
+                || self.capabilities == ["layout.read", "layout.write"])
+        {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        Ok(())
+    }
+
+    pub fn approval_url(&self, target: &WorldTarget) -> Result<String, OfficeError> {
+        self.validate()?;
+        if self.world_id != target.world_id() {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let bytes = serde_json::to_vec(self).map_err(|_| OfficeError::CredentialsInvalid)?;
+        if bytes.len() > APPROVAL_LIMIT {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        Ok(format!(
+            "{}/worlds/{}/pair#tmt-pair={}",
+            target.origin(),
+            self.world_id,
+            URL_SAFE_NO_PAD.encode(bytes)
+        ))
+    }
+
+    pub fn pairing_id(&self) -> &str {
+        &self.pairing_id
+    }
+    pub fn installation_id(&self) -> &str {
+        &self.installation_id
+    }
+    pub fn identity_id(&self) -> &str {
+        &self.identity_id
+    }
+
+    pub fn read_only(&self) -> bool {
+        self.capabilities.len() == 1
+    }
+}
+
+/// Entropy comes directly from the OS, not a UUID or a noncryptographic PRNG.
+pub struct Proof([u8; 32]);
+
+impl Proof {
+    pub fn generate() -> Result<Self, OfficeError> {
+        let mut bytes = [0; 32];
+        getrandom::fill(&mut bytes).map_err(|_| OfficeError::CredentialsUnavailable)?;
+        Ok(Self(bytes))
+    }
+
+    pub fn decode(secret: &str) -> Result<Self, OfficeError> {
+        if secret.len() != 43 {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let bytes: [u8; 32] = URL_SAFE_NO_PAD
+            .decode(secret)
+            .map_err(|_| OfficeError::CredentialsInvalid)?
+            .try_into()
+            .map_err(|_| OfficeError::CredentialsInvalid)?;
+        if URL_SAFE_NO_PAD.encode(bytes) != secret {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        Ok(Self(bytes))
+    }
+
+    pub fn challenge(&self) -> String {
+        sha256(&self.0)
+    }
+    pub fn secret(&self) -> String {
+        URL_SAFE_NO_PAD.encode(self.0)
+    }
+}
+
+/// Deserialize the exact flat issuer wire object before comparing any authority.
+/// Do not use serde(flatten): it weakens duplicate/unknown field rejection.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ClaimWire {
+    version: u8,
+    pairing_id: String,
+    world_id: String,
+    installation_id: String,
+    identity_id: String,
+    installation_label: String,
+    identity_label: String,
+    capabilities: Vec<String>,
+    principal_uid: String,
+    block_id: String,
+    expires_at: u64,
+    grant_expires_at: u64,
+    custom_token: String,
+}
+
+pub struct Claim {
+    pub principal_uid: String,
+    pub block_id: String,
+    pub grant_expires_at: u64,
+    pub(super) custom_token: String,
+}
+
+impl Claim {
+    pub fn decode(bytes: &[u8], expected: &Approval, now_ms: u64) -> Result<Self, OfficeError> {
+        if bytes.len() > RESPONSE_LIMIT {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        expected.validate()?;
+        let wire: ClaimWire =
+            serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+        let approval = Approval {
+            version: wire.version,
+            pairing_id: wire.pairing_id,
+            world_id: wire.world_id,
+            installation_id: wire.installation_id,
+            identity_id: wire.identity_id,
+            installation_label: wire.installation_label,
+            identity_label: wire.identity_label,
+            capabilities: wire.capabilities,
+        };
+        if &approval != expected
+            || !wire
+                .principal_uid
+                .strip_prefix("office-agent:")
+                .is_some_and(valid_uuid)
+            || !valid_uuid(&wire.block_id)
+            || !(now_ms < wire.expires_at && wire.expires_at <= MAX_TIMESTAMP)
+            || !(now_ms < wire.grant_expires_at && wire.grant_expires_at <= MAX_TIMESTAMP)
+            || !valid_token(&wire.custom_token)
+        {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        Ok(Self {
+            principal_uid: wire.principal_uid,
+            block_id: wire.block_id,
+            grant_expires_at: wire.grant_expires_at,
+            custom_token: wire.custom_token,
+        })
+    }
+}
+
+pub(super) fn valid_token(value: &str) -> bool {
+    !value.is_empty() && value.len() <= 8192 && value.bytes().all(|b| b.is_ascii_graphic())
+}
+
+pub(super) fn valid_uuid(value: &str) -> bool {
+    uuid::Uuid::parse_str(value).is_ok_and(|id| id.hyphenated().to_string() == value)
+}
+
+fn valid_label(value: &str) -> bool {
+    // Rust strings cannot contain surrogate scalars. Match ECMAScript trim's
+    // BOM exception as well as whitespace, rather than accepting a blank label.
+    value.chars().count() <= 80
+        && !value
+            .trim_matches(|c: char| c.is_whitespace() || c == '\u{feff}')
+            .is_empty()
+        && !value.chars().any(char::is_control)
+}
+
+#[cfg(test)]
+#[path = "wire_tests.rs"]
+mod tests;

--- a/rust/crates/tmt-adapters/src/office_pairing/wire_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/wire_tests.rs
@@ -1,0 +1,173 @@
+use super::*;
+use crate::office_deployment::DeploymentMode;
+use serde_json::{Value, json};
+
+fn examples() -> Value {
+    serde_json::from_str(include_str!(
+        "../../../../../contracts/office/pairing-examples.json"
+    ))
+    .unwrap()
+}
+
+fn expected() -> Approval {
+    Approval::decode(&serde_json::to_vec(&examples()["valid"][0]).unwrap()).unwrap()
+}
+
+fn claim() -> Value {
+    let mut value = examples()["valid"][0].clone();
+    value["principalUid"] = json!("office-agent:00000000-0000-4000-8000-000000000003");
+    value["blockId"] = json!("00000000-0000-4000-8000-000000000004");
+    value["expiresAt"] = json!(301_000);
+    value["grantExpiresAt"] = json!(86_401_000);
+    value["customToken"] = json!("private-custom-token");
+    value
+}
+
+#[test]
+fn native_decoder_conforms_to_independent_browser_and_service_literals() {
+    let corpus = examples();
+    for raw in corpus["invalidJson"].as_array().unwrap() {
+        assert!(Approval::decode(raw.as_str().unwrap().as_bytes()).is_err());
+    }
+    for value in corpus["valid"].as_array().unwrap() {
+        let decoded = Approval::decode(&serde_json::to_vec(value).unwrap()).unwrap();
+        assert_eq!(serde_json::to_value(decoded).unwrap(), *value);
+    }
+    for value in corpus["invalid"].as_array().unwrap() {
+        assert!(
+            Approval::decode(&serde_json::to_vec(value).unwrap()).is_err(),
+            "{value}"
+        );
+    }
+    let text = serde_json::to_string(&corpus["valid"][0]).unwrap();
+    assert!(Approval::decode(text.replacen('{', "{\"version\":1,", 1).as_bytes()).is_err());
+    let mut padded = text.clone();
+    padded.extend(std::iter::repeat_n(' ', APPROVAL_LIMIT - text.len()));
+    assert!(Approval::decode(padded.as_bytes()).is_ok());
+    padded.push(' ');
+    assert!(Approval::decode(padded.as_bytes()).is_err());
+}
+
+#[test]
+fn proof_uses_full_entropy_and_canonical_encoding_with_independent_digest() {
+    // SHA-256 of 32 zero bytes, independent of the implementation's encoder.
+    let proof = Proof::decode("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
+    assert_eq!(
+        proof.challenge(),
+        "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"
+    );
+    assert_eq!(
+        proof.secret(),
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    );
+    for input in [
+        "",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+",
+    ] {
+        assert!(Proof::decode(input).is_err());
+    }
+    let first = Proof::generate().unwrap();
+    let second = Proof::generate().unwrap();
+    assert_ne!(first.challenge(), second.challenge());
+    assert_eq!(
+        Proof::decode(&first.secret()).unwrap().challenge(),
+        first.challenge()
+    );
+}
+
+#[test]
+fn public_link_contains_only_exact_consent_and_never_the_proof() {
+    let target = WorldTarget::parse(
+        "https://office.example/worlds/AbCdEfGhIjKlMnOpQrSt",
+        DeploymentMode::Cloud,
+    )
+    .unwrap();
+    let proof = Proof::generate().unwrap();
+    let approval = Approval::new(
+        &target,
+        expected().installation_id(),
+        expected().identity_id(),
+        "Alice",
+        false,
+        &proof,
+    )
+    .unwrap();
+    let link = approval.approval_url(&target).unwrap();
+    assert!(link.starts_with("https://office.example/worlds/AbCdEfGhIjKlMnOpQrSt/pair#tmt-pair="));
+    assert!(!link.contains(&proof.secret()));
+    let bytes = URL_SAFE_NO_PAD
+        .decode(link.split_once("#tmt-pair=").unwrap().1)
+        .unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json.as_object().unwrap().len(), 8);
+    assert_eq!(json["pairingId"], proof.challenge());
+    assert!(
+        !String::from_utf8(bytes.clone())
+            .unwrap()
+            .contains(&proof.secret())
+    );
+    assert_eq!(Approval::decode(&bytes).unwrap(), approval);
+    let other = WorldTarget::parse(
+        "https://office.example/worlds/abcdefghijklmnopqrst",
+        DeploymentMode::Cloud,
+    )
+    .unwrap();
+    assert_eq!(
+        approval.approval_url(&other),
+        Err(OfficeError::CredentialsInvalid)
+    );
+}
+
+#[test]
+fn claim_requires_complete_echo_and_keeps_grant_clock_separate() {
+    let input = claim();
+    let accepted = Claim::decode(&serde_json::to_vec(&input).unwrap(), &expected(), 1000).unwrap();
+    assert_eq!(accepted.principal_uid, input["principalUid"]);
+    assert_eq!(accepted.block_id, input["blockId"]);
+    assert_eq!(accepted.grant_expires_at, 86_401_000);
+    assert_eq!(accepted.custom_token, "private-custom-token");
+    for (key, value) in [
+        ("version", json!(2)),
+        ("pairingId", json!("f".repeat(64))),
+        ("worldId", json!("abcdefghijklmnopqrst")),
+        (
+            "installationId",
+            json!("00000000-0000-4000-8000-000000000009"),
+        ),
+        ("identityId", json!("00000000-0000-4000-8000-000000000009")),
+        ("installationLabel", json!("Different installation")),
+        ("identityLabel", json!("Other")),
+        ("capabilities", json!(["layout.read"])),
+        ("principalUid", json!("human-owner")),
+        ("blockId", json!("home")),
+        ("expiresAt", json!(1000)),
+        ("grantExpiresAt", json!(1000)),
+        ("grantExpiresAt", json!(MAX_TIMESTAMP + 1)),
+        ("customToken", json!("private\nmaterial")),
+        ("customToken", json!("")),
+        ("unknown", json!("private-material")),
+    ] {
+        let mut changed = input.clone();
+        changed[key] = value;
+        let error = Claim::decode(&serde_json::to_vec(&changed).unwrap(), &expected(), 1000)
+            .err()
+            .unwrap();
+        assert_eq!(error, OfficeError::CredentialsInvalid, "{key}");
+        assert!(!error.to_string().contains("private"));
+    }
+    for key in input.as_object().unwrap().keys() {
+        let mut missing = input.clone();
+        missing.as_object_mut().unwrap().remove(key);
+        assert!(
+            Claim::decode(&serde_json::to_vec(&missing).unwrap(), &expected(), 1000).is_err(),
+            "{key}"
+        );
+    }
+    let duplicate = input
+        .to_string()
+        .replacen('{', "{\"customToken\":\"other\",", 1);
+    assert!(Claim::decode(duplicate.as_bytes(), &expected(), 1000).is_err());
+    assert!(Claim::decode(&vec![b' '; RESPONSE_LIMIT + 1], &expected(), 1000).is_err());
+}

--- a/rust/crates/tmt-adapters/src/storage/identities.rs
+++ b/rust/crates/tmt-adapters/src/storage/identities.rs
@@ -92,6 +92,21 @@ impl IdentityReader for Storage {
     }
 }
 
+impl Storage {
+    /// Office revalidates the originally selected UUID across separate calls;
+    /// a same-name replacement must never inherit a pending proof or credential.
+    pub fn find_active_identity_by_id(&self, id: &str) -> Result<Option<Identity>, StorageError> {
+        self.connection()?
+            .query_row(
+                &format!("SELECT {COLUMNS} FROM identities WHERE id = ? AND retired_at_ms IS NULL"),
+                [id],
+                identity_row,
+            )
+            .optional()
+            .map_err(|error| classify(error, "Find active identity by ID"))
+    }
+}
+
 impl IdentityRepository for Storage {
     fn with_identity_transaction<T>(
         &mut self,

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -270,7 +270,37 @@ fn office(name: &'static str, about: &'static str) -> Command {
 
 fn office_commands() -> Command {
     office("office", "Manage the optional Office companion")
-        .subcommand(office("status", "Inspect the local Office installation"))
+        .subcommand(office_scope(
+            office(
+                "inspect",
+                "Check access to the paired identity's assigned block",
+            ),
+            true,
+        ))
+        .subcommand(office_scope(
+            office("status", "Inspect installation or local pairing state"),
+            false,
+        ))
+        .subcommand(
+            office_scope(
+                office(
+                    "pair",
+                    "Pair an existing identity with a private Office world",
+                ),
+                true,
+            )
+            .arg(
+                Arg::new("read-only")
+                    .long("read-only")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("timeout")
+                    .long("timeout")
+                    .default_value("300")
+                    .value_parser(clap::value_parser!(u64).range(1..=300)),
+            ),
+        )
         .subcommand(
             office("install", "Explicitly install the Office companion")
                 .arg(Arg::new("yes").long("yes").action(ArgAction::SetTrue))
@@ -293,6 +323,18 @@ fn office_commands() -> Command {
                 "Deactivate Office without deleting retained data",
             )
             .arg(Arg::new("yes").long("yes").action(ArgAction::SetTrue)),
+        )
+}
+
+fn office_scope(command: Command, required: bool) -> Command {
+    command
+        .arg(Arg::new("world").long("world").required(required))
+        .arg(option("identity").requires("world"))
+        .arg(
+            Arg::new("emulator")
+                .long("emulator")
+                .requires("world")
+                .action(ArgAction::SetTrue),
         )
 }
 

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -79,6 +79,23 @@ pub enum Invocation {
 pub enum OfficeOperation {
     Open,
     Status,
+    Inspect {
+        world: String,
+        identity: Option<String>,
+        emulator: bool,
+    },
+    Pair {
+        world: String,
+        identity: Option<String>,
+        emulator: bool,
+        read_only: bool,
+        timeout_seconds: u64,
+    },
+    PairStatus {
+        world: String,
+        identity: Option<String>,
+        emulator: bool,
+    },
     Install {
         yes: bool,
         archive: Option<String>,

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -14,6 +14,7 @@ mod invocation;
 mod native_install_command;
 mod native_upgrade_command;
 mod office_command;
+mod office_pairing_command;
 mod output;
 mod parser;
 mod profile_command;

--- a/rust/crates/tmt-cli/src/office_command.rs
+++ b/rust/crates/tmt-cli/src/office_command.rs
@@ -210,6 +210,14 @@ fn run(
     }
     let executable = prefix.join("bin/tmt-office");
     match operation {
+        OfficeOperation::Pair { .. }
+        | OfficeOperation::PairStatus { .. }
+        | OfficeOperation::Inspect { .. } => {
+            if !installed(&executable)? {
+                return Err(Failure::new("OFFICE_NOT_INSTALLED", INSTALL_HINT, 1));
+            }
+            crate::office_pairing_command::run(&executable, operation, mode)
+        }
         OfficeOperation::Status | OfficeOperation::Open => {
             if !installed(&executable)? {
                 if matches!(operation, OfficeOperation::Status)

--- a/rust/crates/tmt-cli/src/office_pairing_command.rs
+++ b/rust/crates/tmt-cli/src/office_pairing_command.rs
@@ -1,0 +1,171 @@
+//! Public pairing composition; no credentials, HTTP or OS-store dependencies.
+
+use crate::{
+    identity_context,
+    invocation::{OfficeOperation, OutputMode},
+    output::Failure,
+};
+use std::{
+    io::{self, Write},
+    path::Path,
+    time::{Duration, Instant},
+};
+use tmt_adapters::{
+    config::ConfigPaths,
+    interrupt::Interrupt,
+    office_companion::{PairingCall, PairingReply, invoke_office_pairing},
+    storage::Storage,
+};
+use tmt_core::office_protocol::{OfficeError, OfficeInvocation};
+
+pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> Result<u8, Failure> {
+    let inspect = matches!(&operation, OfficeOperation::Inspect { .. });
+    let (world, identity, emulator, read_only, timeout, pair) = match operation {
+        OfficeOperation::Pair {
+            world,
+            identity,
+            emulator,
+            read_only,
+            timeout_seconds,
+        } => (world, identity, emulator, read_only, timeout_seconds, true),
+        OfficeOperation::PairStatus {
+            world,
+            identity,
+            emulator,
+        } => (world, identity, emulator, false, 30, false),
+        OfficeOperation::Inspect {
+            world,
+            identity,
+            emulator,
+        } => (world, identity, emulator, false, 30, false),
+        _ => {
+            return Err(Failure::new(
+                "USAGE_ERROR",
+                "Expected an Office pairing operation.",
+                1,
+            ));
+        }
+    };
+    let selector = identity_context::required(identity.as_deref())?;
+    let paths = ConfigPaths::discover().map_err(unavailable)?;
+    let mut storage = Storage::open(paths.database).map_err(unavailable)?;
+    let identity = identity_context::resolve(&mut storage, selector)?;
+    storage.close().map_err(unavailable)?;
+    let call = PairingCall {
+        world: &world,
+        identity_id: &identity.id,
+        emulator,
+        read_only,
+    };
+    let interrupt = Interrupt::install().map_err(unavailable)?;
+    let deadline = Instant::now() + Duration::from_secs(timeout);
+    let mut operation = if pair {
+        OfficeInvocation::PairBegin
+    } else if inspect {
+        OfficeInvocation::Inspect
+    } else {
+        OfficeInvocation::PairStatus
+    };
+    loop {
+        if interrupt.is_interrupted() {
+            return Err(interrupted());
+        }
+        if Instant::now() >= deadline {
+            return Err(pairing_error(OfficeError::PairingPending));
+        }
+        let result = invoke_office_pairing(
+            executable,
+            operation,
+            &call,
+            deadline.min(Instant::now() + Duration::from_secs(30)),
+        );
+        if interrupt.is_interrupted() {
+            return Err(interrupted());
+        }
+        let reply = result.map_err(|_| Failure::new("OFFICE_REMOTE_UNCERTAIN", "Office did not confirm the operation. Retry the same pairing; no new approval was requested.", 1))?;
+        match reply {
+            PairingReply::Inspected(exists) if inspect => {
+                let value = serde_json::json!({"blockExists":exists,"identityId":identity.id,"world":world,"serverAuthorizationChecked":true});
+                writeln!(
+                    io::stdout().lock(),
+                    "{}",
+                    if mode.json {
+                        value.to_string()
+                    } else {
+                        format!("Office access confirmed. Assigned block exists: {exists}.")
+                    }
+                )
+                .map_err(unavailable)?;
+                return Ok(0);
+            }
+            PairingReply::Inspected(_) => {
+                return Err(pairing_error(OfficeError::CredentialsInvalid));
+            }
+            PairingReply::Pending(link) if pair => {
+                if mode.json {
+                    writeln!(io::stderr().lock(), "{link}")
+                        .and_then(|()| io::stderr().flush())
+                        .map_err(unavailable)?;
+                } else {
+                    writeln!(
+                        io::stdout().lock(),
+                        "Approve this identity in your browser:\n{link}"
+                    )
+                    .and_then(|()| io::stdout().flush())
+                    .map_err(unavailable)?;
+                }
+            }
+            PairingReply::State(state) if !inspect && (!pair || state == "credential") => {
+                let value = serde_json::json!({"state":state,"identityId":identity.id,"world":world,"serverAuthorizationChecked":false});
+                writeln!(io::stdout().lock(), "{}", if mode.json { value.to_string() } else { format!("Office pairing: {state}. Server authorization is checked when accessing a resource.") }).map_err(unavailable)?;
+                return Ok(0);
+            }
+            PairingReply::Error(OfficeError::PairingPending | OfficeError::RemoteUncertain)
+                if pair && operation == OfficeInvocation::PairPoll => {}
+            PairingReply::Error(error) => return Err(pairing_error(error)),
+            PairingReply::Pending(_) | PairingReply::State(_) => {
+                return Err(pairing_error(OfficeError::CredentialsInvalid));
+            }
+        }
+        operation = OfficeInvocation::PairPoll;
+        interrupt
+            .wait_until(deadline.min(Instant::now() + Duration::from_secs(5)))
+            .map_err(unavailable)?;
+    }
+}
+
+fn pairing_error(error: OfficeError) -> Failure {
+    let message = match error {
+        OfficeError::PairingPending => {
+            "Pairing is not yet confirmed. Retry the same command within the original approval window."
+        }
+        OfficeError::CredentialsUnavailable => {
+            "The OS credential store or local Office state is unavailable. Unlock or configure your OS credential store before pairing."
+        }
+        OfficeError::PairingExpired => {
+            "The retained pairing or grant has expired. No new pairing was created."
+        }
+        OfficeError::NotPaired => "This active identity has no Office pairing.",
+        _ => {
+            "Office could not validate the operation. Retained pairing state was not intentionally deleted."
+        }
+    };
+    Failure::new(error.code(), message, 1)
+}
+
+fn unavailable(error: impl std::error::Error + 'static) -> Failure {
+    Failure::new(
+        "OFFICE_IO_ERROR",
+        "Could not access local Office state or output.",
+        1,
+    )
+    .caused_by(error)
+}
+
+fn interrupted() -> Failure {
+    Failure::new(
+        "OFFICE_INTERRUPTED",
+        "Office pairing interrupted. Retry the same command to inspect or resume retained state.",
+        130,
+    )
+}

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -149,12 +149,35 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
         },
         ["office"]
         | ["office", "status"]
+        | ["office", "pair"]
+        | ["office", "inspect"]
         | ["office", "install"]
         | ["office", "upgrade"]
         | ["office", "uninstall"] => Invocation::Office {
             prefix: text(m, "prefix"),
             operation: match path.last().copied() {
-                Some("status") => OfficeOperation::Status,
+                Some("inspect") => OfficeOperation::Inspect {
+                    world: required(m, "world"),
+                    identity: text(m, "identity"),
+                    emulator: flag(m, "emulator"),
+                },
+                Some("status") => match text(m, "world") {
+                    Some(world) => OfficeOperation::PairStatus {
+                        world,
+                        identity: text(m, "identity"),
+                        emulator: flag(m, "emulator"),
+                    },
+                    None => OfficeOperation::Status,
+                },
+                Some("pair") => OfficeOperation::Pair {
+                    world: required(m, "world"),
+                    identity: text(m, "identity"),
+                    emulator: flag(m, "emulator"),
+                    read_only: flag(m, "read-only"),
+                    timeout_seconds: *m
+                        .get_one::<u64>("timeout")
+                        .expect("grammar supplies pairing timeout"),
+                },
                 Some("install") => OfficeOperation::Install {
                     yes: flag(m, "yes"),
                     archive: text(m, "archive"),

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -10,6 +10,72 @@ fn args(values: &[&str]) -> Vec<OsString> {
 }
 
 #[test]
+fn office_pairing_has_bounded_typed_options_and_retains_unqualified_status() {
+    use crate::invocation::OfficeOperation;
+    let world = "https://office.example/worlds/abcdefghijklmnopqrst";
+    assert_eq!(
+        parsed(&[
+            "office",
+            "pair",
+            "--world",
+            world,
+            "--identity",
+            "Alice",
+            "--read-only",
+            "--timeout",
+            "12"
+        ])
+        .invocation,
+        Invocation::Office {
+            prefix: None,
+            operation: OfficeOperation::Pair {
+                world: world.into(),
+                identity: Some("Alice".into()),
+                emulator: false,
+                read_only: true,
+                timeout_seconds: 12
+            }
+        }
+    );
+    assert_eq!(
+        parsed(&["office", "status", "--world", world]).invocation,
+        Invocation::Office {
+            prefix: None,
+            operation: OfficeOperation::PairStatus {
+                world: world.into(),
+                identity: None,
+                emulator: false
+            }
+        }
+    );
+    assert_eq!(
+        parsed(&["office", "inspect", "--world", world, "--emulator"]).invocation,
+        Invocation::Office {
+            prefix: None,
+            operation: OfficeOperation::Inspect {
+                world: world.into(),
+                identity: None,
+                emulator: true
+            }
+        }
+    );
+    for timeout in ["0", "301", "1.5", "1s", "-1", "NaN"] {
+        assert_eq!(
+            parse_error(&["office", "pair", "--world", world, "--timeout", timeout]).code,
+            "USAGE_ERROR"
+        );
+    }
+    for input in [
+        vec!["office", "status", "--identity", "Alice"],
+        vec!["office", "status", "--emulator"],
+        vec!["office", "inspect"],
+        vec!["office", "status", "--world", world, "--read-only"],
+    ] {
+        assert_eq!(parse_error(&input).code, "USAGE_ERROR");
+    }
+}
+
+#[test]
 fn office_prefix_is_scoped_to_its_subtree_and_file_inputs_are_paired() {
     use crate::invocation::OfficeOperation;
     for input in [

--- a/rust/crates/tmt-cli/tests/architecture/cases.rs
+++ b/rust/crates/tmt-cli/tests/architecture/cases.rs
@@ -423,15 +423,18 @@ fn dependency_policy_rejects_unknown_workspace_packages() {
 }
 
 #[test]
-fn companion_reuses_core_without_cli_or_storage_dependencies() {
+fn companion_reuses_core_and_adapters_without_direct_cli_or_effect_libraries() {
     assert!(
         policy::dependency_violations(&package(
             "tmt-office",
-            vec![dependency("tmt-core", "normal", None, None)]
+            vec![
+                dependency("tmt-core", "normal", None, None),
+                dependency("tmt-adapters", "normal", None, None)
+            ]
         ))
         .is_empty()
     );
-    for name in ["tmt-cli", "tmt-adapters", "rusqlite", "ureq"] {
+    for name in ["tmt-cli", "rusqlite", "ureq", "url", "serde"] {
         assert_eq!(
             policy::dependency_violations(&package(
                 "tmt-office",

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -22,6 +22,8 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
             "sha2",
         ],
         "tmt-adapters" => &[
+            "serde",
+            "url",
             "ureq",
             "semver",
             "tar",
@@ -36,7 +38,7 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
             "signal-hook",
             "sha2",
         ],
-        "tmt-office" => &["tmt-core"],
+        "tmt-office" => &["tmt-core", "tmt-adapters"],
         "tmt-cli" => &[
             "unicode-width",
             "tmt-core",

--- a/rust/crates/tmt-cli/tests/architecture/policy.rs
+++ b/rust/crates/tmt-cli/tests/architecture/policy.rs
@@ -22,6 +22,10 @@ pub fn dependency_violations(package: &Value) -> Vec<String> {
             "sha2",
         ],
         "tmt-adapters" => &[
+            "getrandom",
+            "keyring-core",
+            "zbus-secret-service-keyring-store",
+            "apple-native-keyring-store",
             "serde",
             "url",
             "ureq",

--- a/rust/crates/tmt-core/src/office_protocol.rs
+++ b/rust/crates/tmt-core/src/office_protocol.rs
@@ -6,23 +6,85 @@ pub const OFFICE_PROTOCOL_VERSION: &str = "1";
 pub const OFFICE_PROTOCOL_OUTPUT_LIMIT: usize = 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OfficeError {
+    DeploymentInvalid,
+    CredentialsUnavailable,
+    CredentialsInvalid,
+    NotPaired,
+    PairingPending,
+    PairingExpired,
+    RemoteDenied,
+    RemoteUncertain,
+}
+
+impl OfficeError {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::DeploymentInvalid => "OFFICE_DEPLOYMENT_INVALID",
+            Self::CredentialsUnavailable => "OFFICE_CREDENTIALS_UNAVAILABLE",
+            Self::CredentialsInvalid => "OFFICE_CREDENTIALS_INVALID",
+            Self::NotPaired => "OFFICE_NOT_PAIRED",
+            Self::PairingPending => "OFFICE_PAIRING_PENDING",
+            Self::PairingExpired => "OFFICE_PAIRING_EXPIRED",
+            Self::RemoteDenied => "OFFICE_REMOTE_DENIED",
+            Self::RemoteUncertain => "OFFICE_REMOTE_UNCERTAIN",
+        }
+    }
+
+    pub fn parse(code: &str) -> Option<Self> {
+        [
+            Self::DeploymentInvalid,
+            Self::CredentialsUnavailable,
+            Self::CredentialsInvalid,
+            Self::NotPaired,
+            Self::PairingPending,
+            Self::PairingExpired,
+            Self::RemoteDenied,
+            Self::RemoteUncertain,
+        ]
+        .into_iter()
+        .find(|value| value.code() == code)
+    }
+}
+
+impl std::fmt::Display for OfficeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.code())
+    }
+}
+impl std::error::Error for OfficeError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OfficeInvocation {
     Probe,
+    PairBegin,
+    PairPoll,
+    PairStatus,
+    Inspect,
 }
 
 impl OfficeInvocation {
     pub fn arguments(self) -> [&'static str; 3] {
         match self {
             Self::Probe => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "probe"],
+            Self::PairBegin => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "pair-begin"],
+            Self::PairPoll => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "pair-poll"],
+            Self::PairStatus => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "pair-status"],
+            Self::Inspect => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "inspect"],
         }
     }
 
     pub fn parse(arguments: &[&str]) -> Result<Self, &'static str> {
-        if arguments == Self::Probe.arguments() {
-            Ok(Self::Probe)
-        } else {
-            Err("Unsupported Office invocation or protocol version.")
-        }
+        [
+            Self::Probe,
+            Self::PairBegin,
+            Self::PairPoll,
+            Self::PairStatus,
+            Self::Inspect,
+        ]
+        .into_iter()
+        .find(|operation| arguments == operation.arguments())
+        .ok_or("Unsupported Office invocation or protocol version.")
     }
 }
 
@@ -68,6 +130,24 @@ mod tests {
             decode_office_probe(b"TMT-OFFICE/1\n0.1.0-alpha.1\n"),
             Ok(version)
         );
+    }
+
+    #[test]
+    fn pairing_operations_have_exact_versioned_arguments() {
+        for (name, operation) in [
+            ("pair-begin", OfficeInvocation::PairBegin),
+            ("pair-poll", OfficeInvocation::PairPoll),
+            ("pair-status", OfficeInvocation::PairStatus),
+            ("inspect", OfficeInvocation::Inspect),
+        ] {
+            assert_eq!(operation.arguments(), ["__tmt-office", "1", name]);
+            assert_eq!(
+                OfficeInvocation::parse(&["__tmt-office", "1", name]),
+                Ok(operation)
+            );
+            assert!(OfficeInvocation::parse(&["__tmt-office", "2", name]).is_err());
+            assert!(OfficeInvocation::parse(&["__tmt-office", "1", name, "extra"]).is_err());
+        }
     }
 
     #[test]

--- a/rust/crates/tmt-office/Cargo.toml
+++ b/rust/crates/tmt-office/Cargo.toml
@@ -12,6 +12,7 @@ dist = true
 
 [dependencies]
 tmt-core.workspace = true
+tmt-adapters = { workspace = true, features = ["office"] }
 
 [lints]
 workspace = true

--- a/rust/crates/tmt-office/src/main.rs
+++ b/rust/crates/tmt-office/src/main.rs
@@ -1,7 +1,7 @@
 //! Internal optional companion entrypoint. No implicit authentication or service.
 
 use std::{
-    io::{self, Write},
+    io::{self, Read, Write},
     process::ExitCode,
 };
 use tmt_core::office_protocol::{OfficeInvocation, encode_office_probe};
@@ -24,6 +24,15 @@ fn main() -> ExitCode {
             io::stdout()
                 .lock()
                 .write_all(encode_office_probe(&version).as_bytes())
+        }
+        Ok(operation) => {
+            let mut input = Vec::new();
+            match io::stdin().lock().take(4097).read_to_end(&mut input) {
+                Ok(_) => io::stdout()
+                    .lock()
+                    .write_all(&tmt_adapters::office_pairing::execute(operation, &input)),
+                Err(error) => Err(error),
+            }
         }
         Err(message) => {
             let _ = writeln!(io::stderr().lock(), "{message}");

--- a/services/office/Dockerfile
+++ b/services/office/Dockerfile
@@ -1,4 +1,11 @@
 # Local emulators only; never mount host Firebase credentials into this image.
+FROM rust:1.97.0-bookworm@sha256:8fa55b2f3ddf97471ab6a767bfa3f37e6bad0986ba823e75fea57e2a2a5c3073 AS native-office
+WORKDIR /workspace
+COPY rust rust
+COPY skills skills
+COPY contracts contracts
+RUN cd rust && cargo +1.97.0 build --locked --workspace --release
+
 FROM eclipse-temurin:21-jre-jammy@sha256:54b382c9d790d3201004d4e3921f4eff7dc7d67e1ce21a2da8d8faaaf63c85fc AS java
 FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS emulator-tools
 COPY --from=java /opt/java/openjdk /opt/java/openjdk
@@ -19,6 +26,7 @@ CMD ["firebase", "emulators:start", "--only", "auth,firestore", "--project", "de
 # Opt-in browser proof reuses the emulator owner; no host credentials or volumes.
 FROM emulator-tools AS browser-tests
 USER root
+RUN apt-get update && apt-get install -y --no-install-recommends dbus gnome-keyring libglib2.0-bin libsecret-tools && rm -rf /var/lib/apt/lists/*
 RUN npm install --global pnpm@10.33.0 && mkdir -p /workspace/apps/office && chown -R node:node /workspace
 WORKDIR /workspace
 COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -27,6 +35,9 @@ COPY --chown=node:node services/office/functions/package.json services/office/fu
 USER node
 RUN pnpm office:install && test ! -e node_modules/better-sqlite3 && test ! -e /node_modules
 RUN cd services/office/functions && pnpm install --ignore-workspace --lockfile-dir "$PWD/../../.." --frozen-lockfile
+# Combined native/browser acceptance uses root-owned process/archive helpers.
+# The independent SQLite oracle is not built or executed by this browser image.
+RUN pnpm --filter tmux-team install --frozen-lockfile --ignore-scripts
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 USER root
 RUN pnpm --filter @tmt/office exec playwright install --with-deps chromium
@@ -34,8 +45,12 @@ USER node
 COPY --from=emulators --chown=node:node /home/node/office/ /home/node/office/
 COPY --chown=node:node apps/office apps/office
 COPY --chown=node:node contracts/office contracts/office
+COPY --chown=node:node test/support test/support
+COPY --from=native-office --chown=node:node /workspace/rust/target/release/tmt /workspace/rust/target/debug/tmt
+COPY --from=native-office --chown=node:node /workspace/rust/target/release/tmt-office /workspace/rust/target/debug/tmt-office
 COPY --chown=node:node services/office/functions services/office/functions
 COPY --chown=node:node services/office/firebase.json services/office/firestore.rules services/office/
+COPY --chown=node:node services/office/with-test-keyring.sh services/office/with-test-keyring.sh
 RUN --network=none pnpm --filter @tmt/office-service check \
   && pnpm --filter @tmt/office-service test && pnpm --filter @tmt/office-service build
 RUN --network=none pnpm office:check && pnpm office:test \
@@ -43,7 +58,7 @@ RUN --network=none pnpm office:check && pnpm office:test \
   && pnpm --filter @tmt/office exec vite build --outDir dist-preview \
   && pnpm --filter @tmt/office exec vite build --mode emulator \
   && pnpm --filter @tmt/office exec vite build --mode cloud --outDir dist-cloud
-CMD ["firebase", "emulators:exec", "--only", "auth,firestore,functions", "--project", "demo-tmt-office", "--config", "/workspace/services/office/firebase.json", "--non-interactive", "pnpm --filter @tmt/office test:browser"]
+CMD ["sh", "/workspace/services/office/with-test-keyring.sh", "firebase", "emulators:exec", "--only", "auth,firestore,functions", "--project", "demo-tmt-office", "--config", "/workspace/services/office/firebase.json", "--non-interactive", "pnpm --filter @tmt/office test:browser"]
 
 # Keep the existing default build and compose behavior lightweight.
 FROM emulators AS default

--- a/services/office/functions/src/pairing-store.ts
+++ b/services/office/functions/src/pairing-store.ts
@@ -31,6 +31,10 @@ export interface ApprovedBinding extends Approval {
   expiresAt: number;
 }
 
+export interface ClaimedBinding extends ApprovedBinding {
+  grantExpiresAt: number;
+}
+
 function unavailable(): never {
   throw new PairingError('PAIRING_UNAVAILABLE');
 }
@@ -105,7 +109,7 @@ function sameRequest(left: Approval, right: Approval): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
-function validGrant(input: unknown, pairing: Pairing, now: number): void {
+function validGrant(input: unknown, pairing: Pairing, now: number): number {
   try {
     const value = object(input);
     exact(value, [
@@ -135,6 +139,7 @@ function validGrant(input: unknown, pairing: Pairing, now: number): void {
       value.expiresAt.toMillis() - value.createdAt.toMillis() > GRANT_MS
     )
       unavailable();
+    return value.expiresAt.toMillis();
   } catch {
     unavailable();
   }
@@ -203,14 +208,16 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
       });
     },
 
-    async reserveClaim(id: string): Promise<ApprovedBinding> {
+    async reserveClaim(id: string): Promise<ClaimedBinding> {
       return db.runTransaction(async (tx) => {
         const now = clock();
         const pairing = await current(tx, id, now);
         if (pairing.nextClaimAt.toMillis() > now) throw new PairingError('RETRY_LATER');
         const grant = await tx.get(grantRef(pairing));
-        if (pairing.claimed) validGrant(grant.data(), pairing, now);
-        else {
+        const grantExpiresAt = pairing.claimed
+          ? validGrant(grant.data(), pairing, now)
+          : now + GRANT_MS;
+        if (!pairing.claimed) {
           if (grant.exists) unavailable();
           tx.create(grantRef(pairing), {
             version: 1,
@@ -221,14 +228,14 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
             capabilities: pairing.request.capabilities,
             enabled: true,
             createdAt: Timestamp.fromMillis(now),
-            expiresAt: Timestamp.fromMillis(now + GRANT_MS),
+            expiresAt: Timestamp.fromMillis(grantExpiresAt),
           });
         }
         tx.update(pairingRef(id), {
           claimed: true,
           nextClaimAt: Timestamp.fromMillis(now + CLAIM_INTERVAL_MS),
         });
-        return view(pairing);
+        return { ...view(pairing), grantExpiresAt };
       });
     },
 

--- a/services/office/functions/test/pairing-conformance.test.ts
+++ b/services/office/functions/test/pairing-conformance.test.ts
@@ -5,6 +5,7 @@ import { parseApproval } from '../src/pairing-contract.js';
 interface PairingVectors {
   valid: unknown[];
   invalid: unknown[];
+  invalidJson: string[];
 }
 
 const vectors = JSON.parse(
@@ -15,6 +16,9 @@ const vectors = JSON.parse(
 ) as PairingVectors;
 
 describe('pairing request conformance', () => {
+  it.each(vectors.invalidJson)('rejects malformed Unicode in raw JSON %#', (input) => {
+    expect(() => parseApproval(JSON.parse(input))).toThrow('INVALID_ARGUMENT');
+  });
   it('keeps positive and negative vectors instead of passing an empty corpus', () => {
     expect(vectors.valid.length).toBeGreaterThan(0);
     expect(vectors.invalid.length).toBeGreaterThan(0);

--- a/services/office/with-test-keyring.sh
+++ b/services/office/with-test-keyring.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Container-only real Secret Service fixture; never select a host credential store.
+set -eu
+test -e /.dockerenv
+test "${GCLOUD_PROJECT:-}" = demo-tmt-office
+if test "${1:-}" != --session; then
+  exec dbus-run-session -- sh "$0" --session "$@"
+fi
+shift
+vault_dir=$(mktemp -d /tmp/tmt-office-test-keyring.XXXXXXXX)
+mkdir "$vault_dir/home" "$vault_dir/runtime" "$vault_dir/control"
+chmod 700 "$vault_dir" "$vault_dir/home" "$vault_dir/runtime" "$vault_dir/control"
+export XDG_RUNTIME_DIR="$vault_dir/runtime"
+export GNOME_KEYRING_CONTROL="$vault_dir/control"
+printf '%s' 'isolated-test-keyring-password' |
+  HOME="$vault_dir/home" gnome-keyring-daemon --foreground --unlock --components=secrets --control-directory="$GNOME_KEYRING_CONTROL" > "$vault_dir/environment" 2> "$vault_dir/diagnostics" &
+vault_pid=$!
+cleanup() {
+  kill "$vault_pid" 2>/dev/null || true
+  wait "$vault_pid" 2>/dev/null || true
+  case "$vault_dir" in /tmp/tmt-office-test-keyring.*) rm -rf -- "$vault_dir" ;; *) exit 1 ;; esac
+}
+trap cleanup EXIT
+gdbus wait --session --timeout=10 org.freedesktop.secrets
+"$@"

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -443,10 +443,34 @@ accepts paired `--archive <file> --manifest <file>` inputs on `office install`.
 retains release files, CLI installation, skills and application data.
 Noninteractive/JSON invocations never prompt or install implicitly. Interactive
 `tmt office` offers a default-No installation prompt. The installed root command
-currently returns `OFFICE_NOT_PAIRED`: pairing, world opening, decoration and
+currently returns `OFFICE_NOT_PAIRED`; automatic world opening, decoration and
 notebooks are not available through this CLI yet. Do not guess their commands.
-After any failed mutation, inspect `office status` before retrying; failure can
+After any failed installation mutation, inspect `office status` before retrying; failure can
 occur after activation. Ordinary TMT commands do not probe Office.
+
+Compatible source builds support explicit pairing:
+
+```sh
+tmt office pair --world <world-url> --identity <name> --timeout 30
+tmt office status --world <world-url> --identity <name> --json
+tmt office inspect --world <world-url> --identity <name> --json
+```
+
+The world URL is canonical HTTPS `/worlds/<world-id>`. Omit `--identity` only
+with verified pane context. Pairing requires an unlocked macOS Keychain or Linux
+Secret Service. Give the user the public approval link; never approve on their
+behalf or expose credentials. JSON mode puts the link on stderr and the final
+result on stdout. Retry the same command within the original five-minute window
+after an observer timeout; do not replace the identity or delete pairing state.
+`--read-only` requests layout read only; otherwise pair requests read/write.
+
+World-qualified status is local retained state, not live authorization. Inspect
+checks server access and returns `blockExists`; it does not read layouts or list
+agents. A revoked grant can still have local status `credential`. Same-name
+replacement never inherits the old identity UUID's pairing. Expired pairing or
+grants require recovery/renewal that is not implemented yet; stop and report the
+error rather than silently creating another grant. Uninstall does not revoke
+remote grants. Do not use proposed connector or resource-edit commands.
 
 ## Configuration safety
 

--- a/test/native/artifact.Dockerfile
+++ b/test/native/artifact.Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y musl-tools \
 RUN cargo install cargo-dist --version 0.32.0 --locked \
   && cargo install cargo-about --version 0.9.2 --locked --features cli
 ARG TARGET_TRIPLE
+ARG PRODUCT=cli
 RUN test -n "$TARGET_TRIPLE" && rustup target add "$TARGET_TRIPLE"
 WORKDIR /workspace
 COPY rust/ rust/
@@ -12,7 +13,7 @@ COPY skills/ skills/
 COPY scripts/native-cargo.sh scripts/build-native-artifact.sh scripts/
 COPY dist-workspace.toml LICENSE NATIVE-INSTALL.md ./
 RUN cd rust && cargo fetch --locked
-RUN scripts/build-native-artifact.sh "$TARGET_TRIPLE" > native-manifest.json
+RUN scripts/build-native-artifact.sh "$TARGET_TRIPLE" "$PRODUCT" > native-manifest.json
 
 FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
 RUN apt-get update && apt-get install --no-install-recommends -y binutils \

--- a/test/native/native-installation.test.ts
+++ b/test/native/native-installation.test.ts
@@ -1,7 +1,4 @@
-import { createHash } from 'node:crypto';
 import {
-  chmodSync,
-  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -13,7 +10,6 @@ import {
 } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import * as tar from 'tar';
 import {
   expectError,
   parseWholeStdout,
@@ -21,8 +17,8 @@ import {
   withSandbox,
   type Sandbox,
 } from '../support/cli-process.js';
+import { createArtifact, type ArtifactFixture } from '../support/native-artifact.js';
 
-const REQUIRED_FILES = ['tmt', 'LICENSE', 'NATIVE-INSTALL.md', 'THIRD-PARTY-NOTICES.txt'];
 // Debug payload hashing/decompression and fsync are installation work, not the
 // ordinary command-startup budget. Keep a separate finite process deadline.
 const INSTALL_PROCESS_BUDGET_MS = 15_000;
@@ -32,79 +28,6 @@ type InstallResult = {
   readonly version: string;
   readonly changed: boolean;
 };
-
-type ArtifactFixture = {
-  readonly archive: string;
-  readonly manifest: string;
-  readonly version: string;
-  readonly target: string;
-};
-
-function nativeTarget(): string {
-  const architecture =
-    process.arch === 'arm64' ? 'aarch64' : process.arch === 'x64' ? 'x86_64' : null;
-  const platform =
-    process.platform === 'darwin'
-      ? 'apple-darwin'
-      : process.platform === 'linux'
-        ? 'unknown-linux-musl'
-        : null;
-  if (architecture === null || platform === null)
-    throw new Error(`Unsupported native test target: ${process.arch}-${process.platform}`);
-  return `${architecture}-${platform}`;
-}
-
-async function createArtifact(
-  sandbox: Sandbox,
-  version: string,
-  executableSuffix: Uint8Array = new Uint8Array(),
-  product: 'cli' | 'office' = 'cli'
-): Promise<ArtifactFixture> {
-  const target = nativeTarget();
-  const name = `${product}-${version}-${target}.tar.gz`;
-  const fixtureRoot = path.join(sandbox.root, 'native archive inputs with spaces', product);
-  const tree = path.join(fixtureRoot, 'tree');
-  const root = path.join(tree, name.slice(0, -'.tar.gz'.length));
-  const archive = path.join(fixtureRoot, name);
-  const manifest = path.join(fixtureRoot, 'manifest.json');
-  mkdirSync(root, { recursive: true });
-  const executableName = product === 'cli' ? 'tmt' : 'tmt-office';
-  // Office is built independently. Never substitute the CLI for a missing companion.
-  const source =
-    product === 'cli' ? sandbox.cli.executable : path.resolve('rust/target/debug/tmt-office');
-  copyFileSync(source, path.join(root, executableName));
-  const executable = path.join(root, executableName);
-  chmodSync(executable, 0o755);
-  if (executableSuffix.byteLength > 0)
-    writeFileSync(executable, Buffer.concat([readFileSync(executable), executableSuffix]));
-  writeFileSync(path.join(root, 'LICENSE'), 'MIT\n');
-  writeFileSync(path.join(root, 'NATIVE-INSTALL.md'), 'Native local installation fixture.\n');
-  writeFileSync(path.join(root, 'THIRD-PARTY-NOTICES.txt'), 'Synthetic test notice fixture.\n');
-  await tar.c({ cwd: tree, file: archive, gzip: true }, [path.basename(root)]);
-  const checksum = createHash('sha256').update(readFileSync(archive)).digest('hex');
-  writeFileSync(
-    manifest,
-    `${JSON.stringify({
-      artifacts: {
-        [name]: {
-          kind: 'executable-zip',
-          name,
-          target_triples: [target],
-          checksums: { sha256: checksum },
-          assets: REQUIRED_FILES.map((file) => ({ path: file === 'tmt' ? executableName : file })),
-        },
-      },
-      releases: [
-        {
-          app_name: product === 'cli' ? 'tmt-cli' : 'tmt-office',
-          app_version: version,
-          artifacts: [name],
-        },
-      ],
-    })}\n`
-  );
-  return { archive, manifest, version, target };
-}
 
 function installPrefix(sandbox: Sandbox): string {
   return path.join(sandbox.root, 'native install prefix with spaces');

--- a/test/support/cli-process.ts
+++ b/test/support/cli-process.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'node:child_process';
+import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { expect } from 'vitest';
 import { resolveCliExecutables, type CliExecutable } from './cli-executable.mjs';
 
 const lifecycleKey = Symbol('sandbox process lifetime');
@@ -272,29 +272,30 @@ function startRun(sandbox: Sandbox, args: readonly string[], options: CliRunOpti
 }
 
 export function parseWholeStdout(result: CliResult): JsonDocument {
-  expect(result.signal).toBeNull();
-  expect(result.stderr).toBe('');
-  expect(result.stdout.trim()).not.toBe('');
+  assert.equal(result.signal, null);
+  assert.equal(result.stderr, '');
+  assert.notEqual(result.stdout.trim(), '');
   // Parse the complete stream. Parsing only the final line would allow human
   // output or a second JSON document to leak into JSON mode unnoticed.
   const document = JSON.parse(result.stdout) as unknown;
-  expect(document).toBeTypeOf('object');
-  expect(document).not.toBeNull();
+  assert.equal(typeof document, 'object');
+  assert.notEqual(document, null);
   return document as JsonDocument;
 }
 
 export function expectError(result: CliResult, code: string, message?: string): JsonDocument {
   const document = parseWholeStdout(result);
-  expect(document.error).toMatchObject({ code });
-  expect(document.error).toHaveProperty('message', expect.any(String));
-  expect((document.error as { message: string }).message.length).toBeGreaterThan(0);
-  if (message !== undefined) expect((document.error as { message: string }).message).toBe(message);
+  const error = document.error as { code?: unknown; message?: unknown } | undefined;
+  assert.equal(error?.code, code);
+  assert.equal(typeof error?.message, 'string');
+  assert.ok((error?.message as string).length > 0);
+  if (message !== undefined) assert.equal(error?.message, message);
   return document;
 }
 
 export function expectJsonSuccess(result: CliResult, value: JsonDocument): void {
-  expect(result.status).toBe(0);
-  expect(parseWholeStdout(result)).toEqual(value);
+  assert.equal(result.status, 0);
+  assert.deepEqual(parseWholeStdout(result), value);
 }
 
 export function fileSnapshot(root: string): Record<string, string> {

--- a/test/support/cli-process.ts
+++ b/test/support/cli-process.ts
@@ -286,10 +286,11 @@ export function parseWholeStdout(result: CliResult): JsonDocument {
 export function expectError(result: CliResult, code: string, message?: string): JsonDocument {
   const document = parseWholeStdout(result);
   const error = document.error as { code?: unknown; message?: unknown } | undefined;
-  assert.equal(error?.code, code);
-  assert.equal(typeof error?.message, 'string');
-  assert.ok((error?.message as string).length > 0);
-  if (message !== undefined) assert.equal(error?.message, message);
+  assert.ok(error);
+  assert.equal(error.code, code);
+  assert.ok(typeof error.message === 'string');
+  assert.ok(error.message.length > 0);
+  if (message !== undefined) assert.equal(error.message, message);
   return document;
 }
 

--- a/test/support/native-artifact.ts
+++ b/test/support/native-artifact.ts
@@ -1,0 +1,85 @@
+import { createHash } from 'node:crypto';
+import { chmodSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import * as tar from 'tar';
+
+const REQUIRED_FILES = ['tmt', 'LICENSE', 'NATIVE-INSTALL.md', 'THIRD-PARTY-NOTICES.txt'];
+
+export type ArtifactFixture = {
+  readonly archive: string;
+  readonly manifest: string;
+  readonly version: string;
+  readonly target: string;
+};
+
+export type ArtifactSources = {
+  readonly root: string;
+  readonly cli?: { readonly executable: string };
+};
+
+export function nativeTarget(): string {
+  const architecture =
+    process.arch === 'arm64' ? 'aarch64' : process.arch === 'x64' ? 'x86_64' : null;
+  const platform =
+    process.platform === 'darwin'
+      ? 'apple-darwin'
+      : process.platform === 'linux'
+        ? 'unknown-linux-musl'
+        : null;
+  if (architecture === null || platform === null)
+    throw new Error(`Unsupported native test target: ${process.arch}-${process.platform}`);
+  return `${architecture}-${platform}`;
+}
+
+export async function createArtifact(
+  sources: ArtifactSources,
+  version: string,
+  executableSuffix: Uint8Array = new Uint8Array(),
+  product: 'cli' | 'office' = 'cli',
+  companionExecutable = path.resolve('rust/target/debug/tmt-office')
+): Promise<ArtifactFixture> {
+  const target = nativeTarget();
+  const name = `${product}-${version}-${target}.tar.gz`;
+  const fixtureRoot = path.join(sources.root, 'native archive inputs with spaces', product);
+  const tree = path.join(fixtureRoot, 'tree');
+  const root = path.join(tree, name.slice(0, -'.tar.gz'.length));
+  const archive = path.join(fixtureRoot, name);
+  const manifest = path.join(fixtureRoot, 'manifest.json');
+  mkdirSync(root, { recursive: true });
+  const executableName = product === 'cli' ? 'tmt' : 'tmt-office';
+  // Office is built independently. Never substitute the CLI for a missing companion.
+  const source = product === 'cli' ? sources.cli?.executable : companionExecutable;
+  if (source === undefined) throw new Error(`Missing ${product} executable for artifact fixture.`);
+  copyFileSync(source, path.join(root, executableName));
+  const executable = path.join(root, executableName);
+  chmodSync(executable, 0o755);
+  if (executableSuffix.byteLength > 0)
+    writeFileSync(executable, Buffer.concat([readFileSync(executable), executableSuffix]));
+  writeFileSync(path.join(root, 'LICENSE'), 'MIT\n');
+  writeFileSync(path.join(root, 'NATIVE-INSTALL.md'), 'Native local installation fixture.\n');
+  writeFileSync(path.join(root, 'THIRD-PARTY-NOTICES.txt'), 'Synthetic test notice fixture.\n');
+  await tar.c({ cwd: tree, file: archive, gzip: true }, [path.basename(root)]);
+  const checksum = createHash('sha256').update(readFileSync(archive)).digest('hex');
+  writeFileSync(
+    manifest,
+    `${JSON.stringify({
+      artifacts: {
+        [name]: {
+          kind: 'executable-zip',
+          name,
+          target_triples: [target],
+          checksums: { sha256: checksum },
+          assets: REQUIRED_FILES.map((file) => ({ path: file === 'tmt' ? executableName : file })),
+        },
+      },
+      releases: [
+        {
+          app_name: product === 'cli' ? 'tmt-cli' : 'tmt-office',
+          app_version: version,
+          artifacts: [name],
+        },
+      ],
+    })}\n`
+  );
+  return { archive, manifest, version, target };
+}


### PR DESCRIPTION
## Summary

Closes #222. Parent #209 and personal-office milestone #173 remain open.

- Add typed `office pair`, world-qualified local `status`, and server-authorized
  assigned-block `inspect`, preserving existing installation-only status.
- Keep stable installation identity independent of binary releases. Retain one
  protected scope record through pending proof, claim, Auth exchange and refresh.
- Use explicit macOS Keychain/Linux Secret Service backends with no plaintext or
  mock fallback. Ordinary CLI builds do not enable Office-only dependencies.
- Exercise real CLI/companion -> Chromium consent -> issuer/Auth -> protected
  credential reuse in the existing demo emulator/browser owner.
- Update canonical contracts, architecture, developer guidance and installed skill.

## Behavior and boundaries

`pair --world <url> --identity Alice` prints a public approval URL and observes
the original request for a bounded time. A retry reuses its proof, deadline and
scope; changing capabilities does not rewrite a pending request. Only an
admitted world owner can approve. Credentials never enter argv, ordinary config,
SQLite, public JSON or the approval fragment.

World-qualified status reports retained local state and explicitly does not claim
current server authority. Inspect checks the assigned resource through Rules and
returns only `blockExists`. Revocation denies access with a retained local
credential. Same-name replacement cannot inherit another UUID's pairing.

This does not publish/deploy Office, implement a connector, edit layouts or close
resource-preserving renewal, reassignment, temporary retirement/offline revocation
or notebooks. Expired records fail closed instead of silently minting a new grant.
Linux protected-store/runtime acceptance is real; macOS Keychain runtime and
production IAM remain separate pilot evidence, not implied by emulator success.

## Architecture review

Primary-reviewed head: `9891677` (implementation `31a7ec4`, prerequisite `ac1784a`). Reviewed the
grammar/parser/CLI composition, versioned companion/process boundary, deployment
and Auth transport, wire/record validation, UUID revalidation, scope locking,
platform vault access, Cargo feature graph, browser/service conformance and all
changed fixtures/callers. Independent review supplemented primary ownership.

The companion owns credentials/network; core owns pure operation/error values;
CLI owns selectors/output/observation. Existing ConfigPaths, storage, file lock,
subprocess, artifact and HTTP owners are reused. No parallel identity registry,
SQLite pairing index, layout codec or process runner was introduced. Runtime
Office code does not import native test helpers; combined E2E explicitly may.

Findings corrected: damaged installation metadata mislabeled unpaired,
operation-incompatible success results, inaccurate remote error classifications,
scope revalidation around credential publication, WAL leak-check omission and
unasserted default capability semantics. Shared TCP fixtures drain bounded POST
input so TCP reset artifacts cannot falsely prove truncation handling.

The verified companion emits JSON through serde; the parent applies a small
public allowlist and operation-specific validation. Its Value-based decoder does
not independently reject duplicate keys; unlike untrusted network/vault input,
this input is from the owned verified executable. No new ordinary-CLI serde
dependency was introduced solely for that defense-in-depth case.

## Local verification

- `pnpm check`: passed (host Node 26 emits the expected service Node 22 warning;
  browser Docker also runs Office/service checks on pinned Node 22).
- Tooling 156, Office 140, service 38 tests passed.
- `cargo +1.97.0 test --locked --workspace`: 463 passed; one existing ignored
  actual old/new archive-upgrade acceptance. fmt and workspace all-target Clippy
  with denied warnings passed; workspace build passed.
- Rust 1.88 workspace build and 21 architecture checks passed. CLI-only runtime
  dependency tree excludes the Office vault/URL/async dependency graph.
- Full native process suite on Node 22: 154 passed. Initial fixture lacked zsh
  and an explicit storage probe; both prerequisites were supplied, not skipped.
- Network-isolated real-tmux lifecycle: two complete passes, 170 tests each;
  one existing optional scenario skipped. Adapter tests: 314 passed, one ignored.
- Latest Chromium/Auth/Firestore/Functions/real Secret Service integration image:
  two complete passes, 37 tests each, with no retries or paid model calls.
- Native scenario independently checks proof hash, consent/capabilities,
  approval/grant/OS-store binding, same-request resumption, refresh without lease
  extension, denied/expired/corrupt scope, unavailable vault before approval,
  same-name replacement, no output/SQLite+sidecar secrets, and deleted vault entry.
- Actual cargo-dist Office archive for matching aarch64 Linux musl: generated
  target-filtered notices and independent archive/linkage/handshake/no-state
  verification passed. This is not a synthetic archive or publication claim.
- Canonical installed skill validator and native managed-skill tests passed.

All heavy checks run locally before a reviewed CI candidate push. Merge requires
the required checks on this exact reviewed head; no protection bypass.

### CI fixture refinement

The first candidate passed all other jobs but exposed a 15-second subprocess
timeout in the existing pin/unpin installation scenario. Recorded CI output does
not identify which install phase timed out; this was not treated as proof of a
particular product operation failing. Native contracts took 231 seconds overall.

Local native arm64, one-CPU comparisons on the same scenario showed workspace
debug CLI 123,704,872 bytes / 23.13 seconds; independent CLI 80,087,600 bytes /
15.49 seconds; only debug sections removed 20,746,880 bytes / 4.19 seconds.
This is comparative fixture evidence, not a claim of identical GitHub x64 timing.

The new fixture step preserves all workspace quality/MSRV builds, then builds
Office and CLI independently with `CARGO_PROFILE_DEV_DEBUG=0`. Ordinary CLI
feature isolation is restored; debug assertions, executable behavior, file bounds
and existing timeouts stay intact. DWARF is not the installation contract under
test. Both outputs retain the established selectors; no Cargo output is manually
overwritten or runtime mocked. Architecture/verification guidance documents this
boundary, and release-archive acceptance remains separate.

Final local verification of this exact fixture mode, including the explicitly
narrowed error assertion: full native suite 154/154 twice under one CPU (~46s
each); helper tests 32/32; tooling 156/156; full quality checks have zero lint
warnings/errors (only the known host Node engine warning). No test timeout or
assertion was relaxed. Later source changes are limited to this fixture policy,
the shared error assertion and their documentation; production pairing is unchanged.
