### PR TITLE
feat(office): renew scoped grants without re-pairing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,7 +103,10 @@ Its contract is [native companion handshake](contracts/office/native-companion.m
 The public `office` subtree composes installation, identity resolution and bounded
 pairing observation, never credentials or HTTP. `office_pairing` separates wire
 values, remote Auth/resource access, vault access, local installation metadata,
-record transitions and one-shot composition. `office_http` shares bounded JSON
+record transitions and one-shot composition. Resource access refreshes Auth and
+performs bounded lease renewal separately; only an exact authenticated issuer
+readback can replace the local expiry. No timer or background process renews
+grants, and local status stays network-free. `office_http` shares bounded JSON
 transport with deployment discovery. Existing ConfigPaths, identity storage,
 file locks and process owners remain authoritative. One protected scope record
 owns pending proof or credentials; no SQLite binding index mirrors it. OS random

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -198,7 +198,8 @@ existence as visual proof.
 synthetic verified archive, using the existing `test/support` process and artifact
 owners. It resumes a protected proof across CLI processes after Chromium consent,
 then independently checks the issued grant, OS-store record, scoped Firestore
-read, token refresh, expiry, corruption, revocation and same-name replacement.
+read, token refresh, expired server/native lease renewal, simulated lost-response readback,
+unchanged resources, corruption, revocation and same-name replacement.
 The browser target therefore builds Rust and installs the root test-helper
 dependencies with scripts disabled; it does not execute the SQLite oracle or
 import native helpers into the SPA. The standalone app image stays independent.

--- a/NATIVE-INSTALL.md
+++ b/NATIVE-INSTALL.md
@@ -3,9 +3,10 @@
 For an optional `tmt-office` archive, use an installed native CLI:
 `tmt office install --yes --archive <archive.tar.gz> --manifest <dist-manifest.json>`.
 Then run `tmt office status`. Add the same `--prefix <folder>` to both commands
-for a custom installation. Office is independently versioned and currently only
-provides a local compatibility probe; installation does not pair, open a world
-or start a service. No public Office release is available yet.
+for a custom installation. Office is independently versioned. Source builds
+support compatibility probes, explicit pairing and renewable scoped access;
+installation alone does not pair, open a world or start a service.
+No public Office release is available yet.
 
 The remaining instructions apply to the core `tmt` archive.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ failure handling, or `tmt help` for command options.
 ## Development
 
 Office is an optional work in progress. Its CLI installation/status commands are
-implemented, but pairing and a public Office release are not available yet. See
+implemented; source builds also support pairing and scoped access with renewable
+leases. No public Office release is available yet. See
 [Office commands](docs/office/commands.md); ordinary TMT use does not require it.
 
 Contributor-only requirements and checks are in [development](DEVELOPMENT.md).

--- a/apps/office/e2e/native-pairing.spec.ts
+++ b/apps/office/e2e/native-pairing.spec.ts
@@ -227,17 +227,69 @@ test('native pairing resumes its protected proof and a separate process uses the
         expired.phase.grantExpiresAt = Date.now() - 1;
         expect((await vault('store', JSON.stringify(expired))).status).toBe(0);
         const expiredResult = await office('inspect');
-        expect(expiredResult.status).toBe(1);
-        expect(JSON.parse(expiredResult.stdout).error.code).toBe('OFFICE_PAIRING_EXPIRED');
+        expect(expiredResult.status, expiredResult.stdout).toBe(0);
+        const recovered = JSON.parse((await vault('lookup')).stdout);
+        expect(recovered.phase.grantExpiresAt).toBe(savedGrant.expiresAt.toMillis());
+        expect((await grant.get()).data()!.expiresAt.toMillis()).toBe(
+          savedGrant.expiresAt.toMillis()
+        );
+
+        // Expire the actual server lease as well as its native copy. Readback
+        // of a still-live server lease above is not renewal evidence.
+        const pastExpiry = Date.now() - 1;
+        await grant.update({
+          createdAt: new Date(pastExpiry - 1000),
+          expiresAt: new Date(pastExpiry),
+        });
+        recovered.phase.grantExpiresAt = pastExpiry;
+        recovered.phase.credential.tokenExpiresAt = 0;
+        expect((await vault('store', JSON.stringify(recovered))).status).toBe(0);
+        const block = grant.parent.parent!.collection('blocks').doc(String(remote.blockId));
+        const beforeRenewalBlock = (await block.get()).data();
+        const renewed = await office('inspect');
+        expect(renewed.status, renewed.stdout).toBe(0);
+        expect(JSON.parse(renewed.stdout).blockExists).toBe(true);
+        const renewedGrant = (await grant.get()).data()!;
+        const renewedRecord = JSON.parse((await vault('lookup')).stdout);
+        secrets.push(
+          afterRefresh.phase.credential.idToken,
+          afterRefresh.phase.credential.refreshToken,
+          renewedRecord.phase.credential.idToken,
+          renewedRecord.phase.credential.refreshToken
+        );
+        expect(renewedGrant.expiresAt.toMillis()).toBeGreaterThan(Date.now());
+        expect(renewedGrant.expiresAt.toMillis() - renewedGrant.createdAt.toMillis()).toBe(
+          24 * 60 * 60_000
+        );
+        expect(renewedRecord.phase.grantExpiresAt).toBe(renewedGrant.expiresAt.toMillis());
+        expect(renewedRecord.phase.principalUid).toBe(remote.principalUid);
+        expect(renewedRecord.phase.blockId).toBe(remote.blockId);
+        expect(renewedGrant.capabilities).toEqual(savedGrant.capabilities);
+        expect((await block.get()).data()).toEqual(beforeRenewalBlock);
+
+        // Simulate a lost renewal response by restoring only the old local
+        // record. Retry must learn the same lease, never extend it again.
+        expect((await vault('store', JSON.stringify(recovered))).status).toBe(0);
+        expect((await office('inspect')).status).toBe(0);
+        expect((await grant.get()).data()).toEqual(renewedGrant);
+        const invalidRefresh = structuredClone(renewedRecord);
+        invalidRefresh.phase.credential.tokenExpiresAt = 0;
+        invalidRefresh.phase.credential.refreshToken = 'invalid-refresh-token';
+        expect((await vault('store', JSON.stringify(invalidRefresh))).status).toBe(0);
+        const refreshDenied = await office('inspect');
+        expect(refreshDenied.status).toBe(1);
+        expect(JSON.parse(refreshDenied.stdout).error.code).toBe('OFFICE_REMOTE_DENIED');
+        expect((await grant.get()).data()).toEqual(renewedGrant);
         const mismatched = structuredClone(afterRefresh);
         mismatched.approval.identityId = '00000000-0000-4000-8000-000000000009';
         expect((await vault('store', JSON.stringify(mismatched))).status).toBe(0);
         const invalid = await office('status');
         expect(invalid.status).toBe(1);
         expect(JSON.parse(invalid.stdout).error.code).toBe('OFFICE_CREDENTIALS_INVALID');
-        expect((await vault('store', JSON.stringify(afterRefresh))).status).toBe(0);
+        expect((await vault('store', JSON.stringify(renewedRecord))).status).toBe(0);
 
         await grant.update({ enabled: false });
+        const revokedGrant = (await grant.get()).data();
         const denied = await office('inspect');
         expect(denied.status).toBe(1);
         expect(JSON.parse(denied.stdout).error.code).toBe('OFFICE_REMOTE_DENIED');
@@ -247,6 +299,13 @@ test('native pairing resumes its protected proof and a separate process uses the
           state: 'credential',
           serverAuthorizationChecked: false,
         });
+        expect((await vault('store', JSON.stringify(recovered))).status).toBe(0);
+        const deniedRenewal = await office('inspect');
+        expect(deniedRenewal.status).toBe(1);
+        expect(JSON.parse(deniedRenewal.stdout).error.code).toBe('OFFICE_REMOTE_DENIED');
+        expect((await grant.get()).data()!.enabled).toBe(false);
+        expect((await grant.get()).data()).toEqual(revokedGrant);
+        expect(JSON.parse((await vault('lookup')).stdout).phase.grantExpiresAt).toBe(pastExpiry);
         expect((await pairing.get()).data()?.principalUid).toBe(remote.principalUid);
         expect(
           readFileSync(path.join(sandbox.globalDir, 'office', 'installation-id'), 'utf8')
@@ -256,7 +315,16 @@ test('native pairing resumes its protected proof and a separate process uses the
             (name) => name === 'installation-id' || name.endsWith('.lock')
           )
         ).toBe(true);
-        for (const result of [unpaired, resumed, missingBlock, existingBlock, denied, offline]) {
+        for (const result of [
+          unpaired,
+          resumed,
+          missingBlock,
+          existingBlock,
+          renewed,
+          deniedRenewal,
+          denied,
+          offline,
+        ]) {
           expect(
             result.stdout.includes('refreshToken') ||
               result.stdout.includes('idToken') ||

--- a/apps/office/e2e/pairing-service.spec.ts
+++ b/apps/office/e2e/pairing-service.spec.ts
@@ -133,6 +133,91 @@ test('HTTP approval and proof claim produce an actually usable scoped credential
   });
 });
 
+test('authenticated renewal converges across concurrent callers and never revives revoked authority', async () => {
+  await withPairing(async ({ fixture, db, auth, world, secret, request, token }) => {
+    expect((await post('approve', request, token)).status).toBe(200);
+    const claimed = await post('claim', { version: 1, secret });
+    expect(claimed.status).toBe(200);
+    const principal = field(claimed.body, 'principalUid');
+    const blockId = field(claimed.body, 'blockId');
+    const agent = await fixture.client(false, 'device');
+    await signInWithCustomToken(agent.auth, field(claimed.body, 'customToken'));
+    const agentToken = await agent.auth.currentUser!.getIdToken();
+    const grant = db.collection('worlds').doc(world.id).collection('agentGrants').doc(principal);
+    const original = (await grant.get()).data()!;
+    const expiredAt = Date.now() - 1000;
+    await grant.update({ createdAt: new Date(expiredAt - 1000), expiresAt: new Date(expiredAt) });
+    const renewal = { version: 1, pairingId: request.pairingId, grantExpiresAt: expiredAt };
+    expect((await post('renew', renewal)).status).toBe(401);
+    expect((await post('renew', renewal, token)).status).toBe(403);
+    const wrong = await fixture.client(false, 'device');
+    await signInWithCustomToken(
+      wrong.auth,
+      await auth.createCustomToken('office-agent:00000000-0000-4000-8000-000000000099', {
+        tmtOfficeAgent: true,
+        tmtInstallationId: request.installationId,
+        tmtIdentityId: request.identityId,
+      })
+    );
+    expect((await post('renew', renewal, await wrong.auth.currentUser!.getIdToken())).status).toBe(
+      404
+    );
+    expect((await grant.get()).data()!.expiresAt.toMillis()).toBe(expiredAt);
+    const results = await Promise.all([
+      post('renew', renewal, agentToken),
+      post('renew', renewal, agentToken),
+    ]);
+    expect(results[0].status).toBe(200);
+    expect(results[1]).toEqual(results[0]);
+    const renewed = (await grant.get()).data()!;
+    expect(results[0].body).toEqual({
+      version: 1,
+      pairingId: request.pairingId,
+      worldId: world.id,
+      installationId: request.installationId,
+      identityId: request.identityId,
+      principalUid: principal,
+      blockId,
+      capabilities: request.capabilities,
+      grantExpiresAt: renewed.expiresAt.toMillis(),
+    });
+    expect(renewed).toEqual({
+      ...original,
+      createdAt: renewed.createdAt,
+      expiresAt: renewed.expiresAt,
+    });
+    expect(renewed.expiresAt.toMillis() - renewed.createdAt.toMillis()).toBe(24 * 60 * 60_000);
+    expect(await post('renew', renewal, agentToken)).toEqual(results[0]);
+    expect((await grant.get()).data()).toEqual(renewed);
+
+    // Real competing transactions must leave revocation terminal in either
+    // ordering. A successful renewal response is not subsequent access authority.
+    await grant.delete();
+    expect((await post('renew', renewal, agentToken)).status).toBe(404);
+    expect((await grant.get()).exists).toBe(false);
+    // Restore only through the privileged test oracle, then make a real lease
+    // mutation compete with revoke (not a no-op read of a long-lived lease).
+    const raceExpiry = Date.now() + 1000;
+    await grant.set({
+      ...renewed,
+      createdAt: new Date(raceExpiry - 1000),
+      expiresAt: new Date(raceExpiry),
+    });
+    const current = { ...renewal, grantExpiresAt: raceExpiry };
+    const [raced, revoked] = await Promise.all([
+      post('renew', current, agentToken),
+      post('revoke', { version: 1, pairingId: request.pairingId }, token),
+    ]);
+    expect([200, 404]).toContain(raced.status);
+    expect(revoked.status).toBe(200);
+    expect((await grant.get()).data()!.enabled).toBe(false);
+    expect((await post('renew', current, agentToken)).status).toBe(404);
+    await expect(
+      getDocFromServer(doc(agent.db, 'worlds', world.id, 'blocks', blockId))
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+  });
+});
+
 test('HTTP auth, input and proof failures cannot allocate credentials or cross owner scope', async () => {
   await withPairing(async ({ fixture, db, request, secret, token, owner }) => {
     expect((await post('approve', request)).status).toBe(401);

--- a/apps/office/src/pairing/pairing-view.test.tsx
+++ b/apps/office/src/pairing/pairing-view.test.tsx
@@ -81,6 +81,9 @@ it('requires explicit recognition, renders labels as text and never approves jus
     const region = screen.getByRole('region', { name: 'Agent pairing request' });
     expect(region.querySelector('img')).toBeNull();
     expect(region.textContent).toContain('<img src=x onerror=alert(1)>');
+    expect(region.textContent).toContain(
+      'renew its access in leases of up to 24 hours until you revoke it'
+    );
     await user.click(screen.getByRole('checkbox'));
     await user.click(approve);
     await screen.findByText(/Approved\. Return to the requesting terminal/);

--- a/apps/office/src/pairing/pairing-view.tsx
+++ b/apps/office/src/pairing/pairing-view.tsx
@@ -103,6 +103,10 @@ export function PairingForm({ state, request }: { state: PairingState; request: 
         </dd>
       </dl>
       <p>No notebook, message board, local files or command execution access is granted.</p>
+      <p>
+        This identity may renew its access in leases of up to 24 hours until you revoke it. Renewal
+        keeps the same block and permissions; it does not require daily approval.
+      </p>
       {error && <p role="alert">{error}</p>}
       {approved && (
         <p role="status">

--- a/contracts/office/agent-grant-v1.md
+++ b/contracts/office/agent-grant-v1.md
@@ -1,7 +1,7 @@
 # Agent resource grant v1
 
-Implemented Rules boundary for future pairing, not a shipped credential issuer,
-assignment UI or native command. Automated evidence uses isolated Auth/Firestore
+Implemented Rules boundary with a locally verified pairing/renewal issuer,
+not a public distribution or assignment UI. Automated evidence uses isolated Auth/Firestore
 emulators. No production activation or human credential sharing is implied.
 
 ## Principal and document
@@ -15,17 +15,17 @@ Display names, folders and pane IDs are neither credentials nor lookup keys.
 
 `worlds/{worldId}/agentGrants/{principalUid}` contains exactly:
 
-| Field            | Value                                                                        |
-| ---------------- | ---------------------------------------------------------------------------- |
-| `version`        | Integer `1`                                                                  |
-| `ownerUid`       | String matching the immutable world's human owner                            |
-| `installationId` | Lowercase hyphenated UUID of the originating installation                    |
-| `identityId`     | Existing local identity UUID, lowercase and hyphenated                       |
-| `blockId`        | Independent lowercase hyphenated UUID, never `home`                          |
-| `capabilities`   | Exactly `['layout.read']` or `['layout.read', 'layout.write']` in that order |
-| `enabled`        | Boolean; only `true` grants access                                           |
-| `createdAt`      | Firestore timestamp, not later than the server request time                  |
-| `expiresAt`      | Firestore timestamp, after creation and at most 24 hours later               |
+| Field            | Value                                                                            |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `version`        | Integer `1`                                                                      |
+| `ownerUid`       | String matching the immutable world's human owner                                |
+| `installationId` | Lowercase hyphenated UUID of the originating installation                        |
+| `identityId`     | Existing local identity UUID, lowercase and hyphenated                           |
+| `blockId`        | Independent lowercase hyphenated UUID, never `home`                              |
+| `capabilities`   | Exactly `['layout.read']` or `['layout.read', 'layout.write']` in that order     |
+| `enabled`        | Boolean; only `true` grants access                                               |
+| `createdAt`      | Current lease start as a Firestore timestamp, not later than server request time |
+| `expiresAt`      | Firestore timestamp, after creation and at most 24 hours later                   |
 
 Access requires `createdAt <= request.time < expiresAt`, valid schema, current
 owner tester admission and matching authenticated principal/installation/identity.
@@ -71,9 +71,9 @@ by these Rules:
   token; no anonymous-provider enablement or browser-minted credentials.
 - Use a 24-hour default and maximum resource lease. Renewal must recheck current
   owner admission, the exact approved binding and its non-revoked state. Token
-  refresh alone cannot extend a lease or reactivate a revoked grant. Whether
-  native renewal is automatic belongs to the credential-lifecycle slice, not
-  a mandatory daily human prompt implied by these Rules.
+  refresh alone cannot extend a lease or reactivate a revoked grant. Native
+  renewal is defined by the [native pairing contract](native-pairing.md#invocation-owned-renewal):
+  scoped access renews near expiry without a daily human prompt.
   Re-pairing after revocation creates a new principal.
   The issuer must enforce these transitions itself: Admin writes bypass Rules.
 - Store agent refresh credentials through a native protected-store adapter,

--- a/contracts/office/native-pairing.md
+++ b/contracts/office/native-pairing.md
@@ -1,6 +1,6 @@
 # Native pairing v1
 
-Implementation contract for #222. Source builds implement deployment discovery,
+Implementation contract for #222 and renewal slice #227. Source builds implement deployment discovery,
 pairing and protected credential use; no public Office release is published.
 [Approval and claim](pairing-v1.md) owns remote proof/consent semantics.
 
@@ -86,13 +86,13 @@ the user Keychain. Each write requires exact readback before reporting success.
 The per-scope lock serializes mutation; local status reads one protected snapshot
 without creating locks. OS storage and metadata are not one atomic transaction.
 Uncertain claim or publication retains the original scope for retry. Expired
-pending records and grants fail closed without silently requesting another grant;
-explicit renewal/recovery remains part of #209. Do not delete local state as a
+pending approvals fail closed without silently requesting another grant;
+paired resource access can renew its existing lease as described below. Do not delete local state as a
 substitute for server revocation.
 
 Auth exchange and refresh use fixed Firebase endpoints. ID-token payload checks
 detect inconsistent scope but are not signature verification or authorization;
-Firestore Rules enforce every resource request. Token refresh preserves the
+Firestore Rules enforce every resource request. Token refresh alone preserves the
 original resource assignment and grant expiry. Identity names resolve once to an
 active UUID and are rechecked before protected publication and resource use.
 
@@ -104,7 +104,27 @@ Office failures use the existing envelope and exit 1:
 `OFFICE_INTERRUPTED`, exit 130. Existing identity/grammar errors retain their
 owners. An unavailable claim cannot distinguish absent from denied approval.
 
-Renewal preserving resources, reassignment and temporary retirement/offline
+Reassignment, lost-credential recovery and temporary retirement/offline
 revocation remain #209 requirements. Token refresh never extends a grant lease.
 Actual native/browser/isolated-vault evidence is required by the
 [local-first acceptance contract](../../DEVELOPMENT.md#personal-office-milestone-acceptance).
+
+## Invocation-owned renewal
+
+`inspect` refreshes Auth when necessary, then renews a paired lease with five
+minutes or less remaining (including expiry) through the authenticated issuer
+operation in [pairing v1](pairing-v1.md#lease-renewal). There is no scheduler,
+new approval link or daily browser prompt. Local `status` never renews or makes
+a network request. `pair` retains its existing acquisition behavior.
+
+The native request supplies the protected record's exact last grant expiry.
+Readback must match version, pairing, world, installation, identity, principal,
+block and capabilities, and cannot roll the expiry backward. Unknown/duplicate
+fields reject. The service owns lease bounds; native never computes a new expiry.
+Only the validated server value is written back through the existing protected
+record and readback owner. A lost response retains the old lease for retry;
+another caller's newer lease is recovered without extending it again. If that
+recovered lease has itself expired, resource use still fails expired; a later
+invocation can renew using the recovered expiry. Each invocation is bounded,
+not an automatic retry loop. Denied, malformed or uncertain renewal never
+authorizes resource use or creates a replacement pairing.

--- a/contracts/office/pairing-v1.md
+++ b/contracts/office/pairing-v1.md
@@ -126,6 +126,41 @@ The service keeps expired/disabled records as tombstones in this slice: no TTL
 or cleanup silently permits reuse of a pairing ID. Bounded retention and public
 endpoint abuse controls must be reviewed before production activation.
 
+## Lease renewal
+
+Owner approval permits the selected agent to renew the same resource lease until
+revoked; the browser discloses this before consent. Each lease is at most 24 hours.
+The consumer is defined in [native pairing](native-pairing.md#invocation-owned-renewal).
+No background process or fresh daily human approval is required.
+
+`POST /renew` accepts exactly `{version:1, pairingId, grantExpiresAt}`. The expiry
+is the positive representable integer timestamp last observed by the caller,
+not a requested extension. Authentication is a verified, non-revoked Firebase
+agent ID token in the bearer header, never the original claim secret, an
+unverified JWT payload or a human token. Its UID, agent flag, installation and
+identity claims must match the stored pairing and grant.
+
+The transaction rechecks current owner admission, enabled/claimed pairing,
+original approval shape, matching resource scope and a complete enabled grant.
+The five-minute approval window remains closed: renewal does not call claim,
+mint another principal, reconstruct a missing grant or reactivate a disabled one.
+An expired resource lease can renew; expiry is not revocation.
+
+When the expected expiry matches the current lease and it has at most five
+minutes remaining, replace only the lease timestamps with server `now` and
+`now + 24h`. A still-long-lived lease is returned unchanged. A lower expected
+expiry returns the existing newer lease unchanged, even if it too has expired;
+a higher expected expiry conflicts. This comparison makes lost-response retries
+and concurrent requests converge without another extension. Transactions
+serialize renewal against revocation; a committed renewal never undoes a later
+revocation. Rules remain authoritative for subsequent resource access.
+
+Success is exactly `{version:1,pairingId,worldId,installationId,identityId,
+principalUid,blockId,capabilities,grantExpiresAt}` with server-authoritative
+expiry and no credentials. Existing authentication, invalid-input, permission,
+unavailable-pairing, conflict and unavailable-service errors retain their
+HTTP mappings. No browser receives agent tokens or direct grant-read authority.
+
 ## Deployment and verification boundary
 
 This slice is locally verified against Auth/Firestore emulators. Functions are

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -92,7 +92,8 @@ There is no work connector, deployed service or shared browser runtime package y
 The independently versioned native `tmt-office` companion currently implements
 the [typed local protocol](../../contracts/office/native-companion.md), including
 pairing, local status and an authorized assigned-block existence check.
-Its optional adapter feature owns discovery, Auth exchange/refresh and protected
+Its optional adapter feature owns discovery, Auth exchange/refresh, invocation-owned
+resource-lease renewal and protected
 scope records. It has no public distribution. The CLI's explicit `office`
 subtree installs, inspects, updates and deactivates it through existing native
 owners; other CLI operations do not execute or probe it. Shared native protocol
@@ -110,8 +111,9 @@ database client is introduced. Its [pairing contract](../../contracts/office/pai
 owns the wire format and recovery policy.
 
 `pairing-contract` owns bounded value decoding; `pairing-store` owns transactional
-approval/grant state and live owner admission. `pairing-service` composes human
-authentication and external signing, with a final authority recheck before token
+approval/grant state, compare-expiry lease renewal and live owner admission.
+`pairing-service` verifies human approval/revocation or bound-agent renewal
+authentication and composes external signing, with a final authority recheck before token
 delivery. `pairing-http` maps transport/error results; `index` alone initializes
 SDKs and exposes the function. Admin bypasses Rules, so server validation is an
 independent trust boundary, not a substitute for downstream Rules enforcement.

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -54,8 +54,11 @@ World-qualified `status` reports local retained state, not live authority.
 `inspect` checks server access and reports only whether the assigned block exists;
 it does not expose layouts or list other agents. Revocation can therefore leave
 local status `credential` while inspect fails `OFFICE_REMOTE_DENIED`. A same-name
-replacement has a different UUID and cannot inherit the pairing. Expiry never
-silently creates a replacement grant; renewal and unpair remain planned.
+replacement has a different UUID and cannot inherit the pairing. `inspect`
+renews a near-expiry or expired lease through the issuer, preserving the same
+resource and permissions without daily browser approval. Local status does not
+renew. Revoked or missing grants cannot be renewed; expired pending approvals
+and lost credentials still need recovery work. Unpair remains planned.
 The [native pairing contract](../../contracts/office/native-pairing.md) owns exact
 scope, output, errors and emulator restrictions.
 

--- a/rust/crates/tmt-adapters/src/office_deployment.rs
+++ b/rust/crates/tmt-adapters/src/office_deployment.rs
@@ -194,6 +194,10 @@ impl OfficeDeployment {
     pub fn claim_url(&self) -> String {
         format!("{}/claim", self.pairing_url)
     }
+
+    pub fn renewal_url(&self) -> String {
+        format!("{}/renew", self.pairing_url)
+    }
 }
 
 fn canonical_url(value: &str) -> Result<Url, InvalidDeployment> {

--- a/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
@@ -67,6 +67,11 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
                     entry.write(&record.encode()?)?;
                 }
                 active_identity(&paths, &identity.id)?;
+                if record.renew_if_needed(&target, now_ms()?, deadline)? {
+                    active_identity(&paths, &identity.id)?;
+                    entry.write(&record.encode()?)?;
+                }
+                active_identity(&paths, &identity.id)?;
                 let exists = record.inspect(&target, now_ms()?, deadline)?;
                 Ok(json!({"blockExists":exists}))
             }

--- a/rust/crates/tmt-adapters/src/office_pairing/record.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/record.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 const APPROVAL_MS: u64 = 300_000;
 const CLAIM_INTERVAL_MS: u64 = 5000;
+const RENEWAL_WINDOW_MS: u64 = 300_000;
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -53,13 +54,9 @@ impl PairingRecord {
         match &mut self.phase {
             Phase::Paired {
                 principal_uid,
-                grant_expires_at,
                 credential,
                 ..
             } => {
-                if now_ms >= *grant_expires_at {
-                    return Err(OfficeError::PairingExpired);
-                }
                 if credential.token_expires_at() > now_ms.saturating_add(30_000) {
                     return Ok(false);
                 }
@@ -71,6 +68,44 @@ impl PairingRecord {
                     deadline,
                 )?;
                 Ok(true)
+            }
+            Phase::Pending { .. } => Err(OfficeError::NotPaired),
+        }
+    }
+
+    pub fn renew_if_needed(
+        &mut self,
+        target: &WorldTarget,
+        now_ms: u64,
+        deadline: std::time::Instant,
+    ) -> Result<bool, OfficeError> {
+        let deployment = self.deployment(target)?;
+        match &mut self.phase {
+            Phase::Paired {
+                principal_uid,
+                block_id,
+                grant_expires_at,
+                credential,
+            } => {
+                if *grant_expires_at > now_ms.saturating_add(RENEWAL_WINDOW_MS) {
+                    return Ok(false);
+                }
+                let bytes = credential.renew_grant(
+                    &deployment,
+                    &self.approval,
+                    deadline,
+                    *grant_expires_at,
+                )?;
+                let expiry = super::wire::Renewal::decode(
+                    &bytes,
+                    &self.approval,
+                    principal_uid,
+                    block_id,
+                    *grant_expires_at,
+                )?;
+                let changed = expiry != *grant_expires_at;
+                *grant_expires_at = expiry;
+                Ok(changed)
             }
             Phase::Pending { .. } => Err(OfficeError::NotPaired),
         }

--- a/rust/crates/tmt-adapters/src/office_pairing/remote.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/remote.rs
@@ -28,7 +28,7 @@ pub fn claim_pairing(
         &serde_json::json!({"version":1,"secret":proof.secret()}).to_string(),
         "application/json",
         deadline,
-        true,
+        PostPurpose::Claim,
     )?;
     Claim::decode(&bytes, approval, now_ms)
 }
@@ -72,6 +72,26 @@ struct TokenBinding {
 }
 
 impl AgentCredential {
+    pub fn renew_grant(
+        &self,
+        deployment: &OfficeDeployment,
+        approval: &Approval,
+        deadline: Instant,
+        expected_expiry: u64,
+    ) -> Result<Vec<u8>, OfficeError> {
+        if !valid_token(&self.id_token) {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        post(
+            deployment,
+            &deployment.renewal_url(),
+            &serde_json::json!({"version":1,"pairingId":approval.pairing_id(),"grantExpiresAt":expected_expiry}).to_string(),
+            "application/json",
+            deadline,
+            PostPurpose::Renewal(&self.id_token),
+        )
+    }
+
     pub fn inspect_block(
         &self,
         deployment: &OfficeDeployment,
@@ -136,7 +156,7 @@ impl AgentCredential {
             &serde_json::json!({"token":claim.custom_token,"returnSecureToken":true}).to_string(),
             "application/json",
             deadline,
-            false,
+            PostPurpose::Auth,
         )?;
         let response: Exchanged =
             serde_json::from_slice(&bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
@@ -174,7 +194,7 @@ impl AgentCredential {
             &body,
             "application/x-www-form-urlencoded",
             deadline,
-            false,
+            PostPurpose::Auth,
         )?;
         let response: Refreshed =
             serde_json::from_slice(&bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
@@ -260,21 +280,31 @@ fn auth_url(deployment: &OfficeDeployment, operation: &str) -> String {
     format!("{base}/{operation}?key={}", deployment.api_key())
 }
 
+enum PostPurpose<'a> {
+    Auth,
+    Claim,
+    Renewal(&'a str),
+}
+
 fn post(
     deployment: &OfficeDeployment,
     url: &str,
     body: &str,
     content_type: &str,
     deadline: Instant,
-    claim: bool,
+    purpose: PostPurpose<'_>,
 ) -> Result<Vec<u8>, OfficeError> {
     let agent = office_http::agent(deployment.target().mode(), deadline)
         .map_err(|_| OfficeError::RemoteUncertain)?;
-    let mut response = agent
+    let mut request = agent
         .post(url)
         .header("Content-Type", content_type)
         .header("Accept", "application/json")
-        .header("Cache-Control", "no-store")
+        .header("Cache-Control", "no-store");
+    if let PostPurpose::Renewal(token) = purpose {
+        request = request.header("Authorization", &format!("Bearer {token}"));
+    }
+    let mut response = request
         .send(body)
         .map_err(|_| OfficeError::RemoteUncertain)?;
     match response.status().as_u16() {
@@ -285,8 +315,10 @@ fn post(
                 OfficeError::RemoteUncertain
             }
         }),
-        404 | 429 if claim => Err(OfficeError::PairingPending),
-        400 | 401 | 403 if !claim => Err(OfficeError::RemoteDenied),
+        404 | 429 if matches!(purpose, PostPurpose::Claim) => Err(OfficeError::PairingPending),
+        400 | 401 | 403 | 404 | 409 if !matches!(purpose, PostPurpose::Claim) => {
+            Err(OfficeError::RemoteDenied)
+        }
         300..=399 => Err(OfficeError::CredentialsInvalid),
         _ => Err(OfficeError::RemoteUncertain),
     }

--- a/rust/crates/tmt-adapters/src/office_pairing/remote_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/remote_tests.rs
@@ -83,7 +83,11 @@ fn post_fixture(
             "{\"version\":1}",
             "application/json",
             Instant::now() + Duration::from_secs(2),
-            claim,
+            if claim {
+                PostPurpose::Claim
+            } else {
+                PostPurpose::Auth
+            },
         )
     })
 }
@@ -98,6 +102,7 @@ fn bounded_post_statuses_preserve_claim_auth_and_uncertain_meanings() {
         (400, false, OfficeError::RemoteDenied),
         (401, false, OfficeError::RemoteDenied),
         (403, false, OfficeError::RemoteDenied),
+        (409, false, OfficeError::RemoteDenied),
         (503, false, OfficeError::RemoteUncertain),
         (302, false, OfficeError::CredentialsInvalid),
     ] {

--- a/rust/crates/tmt-adapters/src/office_pairing/wire.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/wire.rs
@@ -168,6 +168,51 @@ pub struct Claim {
     pub(super) custom_token: String,
 }
 
+/// An authenticated lease readback, not a new approval or credential.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct Renewal {
+    version: u8,
+    pairing_id: String,
+    world_id: String,
+    installation_id: String,
+    identity_id: String,
+    principal_uid: String,
+    block_id: String,
+    capabilities: Vec<String>,
+    grant_expires_at: u64,
+}
+
+impl Renewal {
+    pub fn decode(
+        bytes: &[u8],
+        approval: &Approval,
+        principal: &str,
+        block: &str,
+        expected_expiry: u64,
+    ) -> Result<u64, OfficeError> {
+        if bytes.len() > RESPONSE_LIMIT {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let value: Self =
+            serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+        if value.version != 1
+            || value.pairing_id != approval.pairing_id
+            || value.world_id != approval.world_id
+            || value.installation_id != approval.installation_id
+            || value.identity_id != approval.identity_id
+            || value.capabilities != approval.capabilities
+            || value.principal_uid != principal
+            || value.block_id != block
+            || value.grant_expires_at < expected_expiry
+            || value.grant_expires_at > MAX_TIMESTAMP
+        {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        Ok(value.grant_expires_at)
+    }
+}
+
 impl Claim {
     pub fn decode(bytes: &[u8], expected: &Approval, now_ms: u64) -> Result<Self, OfficeError> {
         if bytes.len() > RESPONSE_LIMIT {

--- a/rust/crates/tmt-adapters/src/office_pairing/wire_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/wire_tests.rs
@@ -24,6 +24,60 @@ fn claim() -> Value {
 }
 
 #[test]
+fn renewal_readback_preserves_scope_and_rejects_rollback_or_ambiguous_json() {
+    let mut value = claim();
+    let fields = value.as_object_mut().unwrap();
+    for key in [
+        "installationLabel",
+        "identityLabel",
+        "expiresAt",
+        "customToken",
+    ] {
+        fields.remove(key);
+    }
+    let principal = value["principalUid"].as_str().unwrap().to_owned();
+    let block = value["blockId"].as_str().unwrap().to_owned();
+    let decode = |bytes: &[u8]| Renewal::decode(bytes, &expected(), &principal, &block, 1000);
+    assert_eq!(
+        decode(&serde_json::to_vec(&value).unwrap()).unwrap(),
+        86_401_000
+    );
+    for (key, invalid) in [
+        ("version", json!(2)),
+        ("pairingId", json!("0".repeat(64))),
+        ("worldId", json!("abcdefghijklmnopqrst")),
+        (
+            "installationId",
+            json!("00000000-0000-4000-8000-000000000009"),
+        ),
+        ("identityId", json!("00000000-0000-4000-8000-000000000009")),
+        (
+            "principalUid",
+            json!("office-agent:00000000-0000-4000-8000-000000000009"),
+        ),
+        ("blockId", json!("00000000-0000-4000-8000-000000000009")),
+        ("capabilities", json!(["layout.read", "notebook.write"])),
+        ("grantExpiresAt", json!(999)),
+        ("grantExpiresAt", json!(MAX_TIMESTAMP + 1)),
+        ("customToken", json!("unexpected-token")),
+    ] {
+        let mut changed = value.clone();
+        changed[key] = invalid;
+        assert!(
+            decode(&serde_json::to_vec(&changed).unwrap()).is_err(),
+            "{key}"
+        );
+    }
+    let text = serde_json::to_string(&value).unwrap();
+    assert!(decode(text.replacen('{', "{\"version\":1,", 1).as_bytes()).is_err());
+    assert!(decode(&vec![b' '; RESPONSE_LIMIT + 1]).is_err());
+    // A stale request may read back another caller's already-expired lease;
+    // the record persists it, but resource use still requires a live lease.
+    value["grantExpiresAt"] = json!(1000);
+    assert_eq!(decode(&serde_json::to_vec(&value).unwrap()).unwrap(), 1000);
+}
+
+#[test]
 fn native_decoder_conforms_to_independent_browser_and_service_literals() {
     let corpus = examples();
     for raw in corpus["invalidJson"].as_array().unwrap() {

--- a/services/office/functions/src/pairing-contract.ts
+++ b/services/office/functions/src/pairing-contract.ts
@@ -26,11 +26,19 @@ export interface Approval {
   capabilities: ['layout.read'] | ['layout.read', 'layout.write'];
 }
 
+export interface Renewal {
+  version: 1;
+  pairingId: string;
+  grantExpiresAt: number;
+}
+
 export const APPROVAL_MS = 5 * 60_000;
 export const GRANT_MS = 24 * 60 * 60_000;
+export const RENEWAL_WINDOW_MS = 5 * 60_000;
 export const CLAIM_INTERVAL_MS = 5000;
 export const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 export const PAIRING_ID = /^[0-9a-f]{64}$/;
+export const MAX_TIMESTAMP_MS = 8_640_000_000_000_000;
 
 export function object(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value))
@@ -45,6 +53,15 @@ export function exact(value: Record<string, unknown>, keys: string[]): void {
 
 function matches(value: unknown, pattern: RegExp): value is string {
   return typeof value === 'string' && pattern.test(value);
+}
+
+export function isTimestampMillis(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value > 0 &&
+    value <= MAX_TIMESTAMP_MS
+  );
 }
 
 function label(value: unknown): value is string {
@@ -106,6 +123,22 @@ export function parseClaim(input: unknown): string {
   if (bytes.length !== 32 || bytes.toString('base64url') !== value.secret)
     throw new PairingError('INVALID_ARGUMENT');
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+export function parseRenewal(input: unknown): Renewal {
+  const value = object(input);
+  exact(value, ['version', 'pairingId', 'grantExpiresAt']);
+  if (
+    value.version !== 1 ||
+    !matches(value.pairingId, PAIRING_ID) ||
+    !isTimestampMillis(value.grantExpiresAt)
+  )
+    throw new PairingError('INVALID_ARGUMENT');
+  return {
+    version: 1,
+    pairingId: value.pairingId,
+    grantExpiresAt: value.grantExpiresAt,
+  };
 }
 
 export function parseRevocation(input: unknown): string {

--- a/services/office/functions/src/pairing-http.ts
+++ b/services/office/functions/src/pairing-http.ts
@@ -44,6 +44,8 @@ export function createPairingHandler(
           return { status: 200, body: await service.approve(request.body, request.authorization) };
         case '/claim':
           return { status: 200, body: await service.claim(request.body) };
+        case '/renew':
+          return { status: 200, body: await service.renew(request.body, request.authorization) };
         case '/revoke':
           return { status: 200, body: await service.revoke(request.body, request.authorization) };
         default:

--- a/services/office/functions/src/pairing-service.ts
+++ b/services/office/functions/src/pairing-service.ts
@@ -1,6 +1,13 @@
 import type { DecodedIdToken } from 'firebase-admin/auth';
-import { PairingError, parseApproval, parseClaim, parseRevocation } from './pairing-contract.js';
-import type { PairingStore } from './pairing-store.js';
+import {
+  PairingError,
+  UUID,
+  parseApproval,
+  parseClaim,
+  parseRenewal,
+  parseRevocation,
+} from './pairing-contract.js';
+import type { AgentIdentity, PairingStore } from './pairing-store.js';
 
 export interface PairingAuthentication {
   verifyIdToken(token: string, checkRevoked: boolean): Promise<DecodedIdToken>;
@@ -8,18 +15,38 @@ export interface PairingAuthentication {
 }
 
 export function createPairingService(store: PairingStore, auth: PairingAuthentication) {
-  async function human(authorization: string | undefined): Promise<string> {
+  async function verified(authorization: string | undefined): Promise<DecodedIdToken> {
     if (!authorization || authorization.length > 8192 || !/^Bearer \S+$/.test(authorization))
       throw new PairingError('UNAUTHENTICATED');
-    let token: DecodedIdToken;
     try {
-      token = await auth.verifyIdToken(authorization.slice(7), true);
+      return await auth.verifyIdToken(authorization.slice(7), true);
     } catch {
       throw new PairingError('UNAUTHENTICATED');
     }
+  }
+
+  async function human(authorization: string | undefined): Promise<string> {
+    const token = await verified(authorization);
     if (token.firebase.sign_in_provider !== 'google.com' || token.email_verified !== true)
       throw new PairingError('PERMISSION_DENIED');
     return token.uid;
+  }
+
+  async function agent(authorization: string | undefined): Promise<AgentIdentity> {
+    const token = await verified(authorization);
+    if (
+      token.tmtOfficeAgent !== true ||
+      typeof token.tmtInstallationId !== 'string' ||
+      !UUID.test(token.tmtInstallationId) ||
+      typeof token.tmtIdentityId !== 'string' ||
+      !UUID.test(token.tmtIdentityId)
+    )
+      throw new PairingError('PERMISSION_DENIED');
+    return {
+      uid: token.uid,
+      installationId: token.tmtInstallationId,
+      identityId: token.tmtIdentityId,
+    };
   }
 
   return {
@@ -42,6 +69,15 @@ export function createPairingService(store: PairingStore, auth: PairingAuthentic
       }
       await store.confirmClaim(id);
       return { ...binding, customToken };
+    },
+    async renew(input: unknown, authorization?: string) {
+      const renewal = parseRenewal(input);
+      const binding = await store.renew(
+        await agent(authorization),
+        renewal.pairingId,
+        renewal.grantExpiresAt
+      );
+      return binding;
     },
     async revoke(input: unknown, authorization?: string) {
       const id = parseRevocation(input);

--- a/services/office/functions/src/pairing-store.ts
+++ b/services/office/functions/src/pairing-store.ts
@@ -5,6 +5,9 @@ import {
   APPROVAL_MS,
   CLAIM_INTERVAL_MS,
   GRANT_MS,
+  isTimestampMillis,
+  MAX_TIMESTAMP_MS,
+  RENEWAL_WINDOW_MS,
   UUID,
   PairingError,
   exact,
@@ -32,6 +35,24 @@ export interface ApprovedBinding extends Approval {
 }
 
 export interface ClaimedBinding extends ApprovedBinding {
+  grantExpiresAt: number;
+}
+
+export interface AgentIdentity {
+  uid: string;
+  installationId: string;
+  identityId: string;
+}
+
+export interface RenewedBinding {
+  version: 1;
+  pairingId: string;
+  worldId: string;
+  installationId: string;
+  identityId: string;
+  principalUid: string;
+  blockId: string;
+  capabilities: Approval['capabilities'];
   grantExpiresAt: number;
 }
 
@@ -86,12 +107,22 @@ function decode(input: unknown, id: string): Pairing {
   }
 }
 
-function active(pairing: Pairing, now: number): void {
+function timestampMillis(value: Timestamp): number {
+  if (value.nanoseconds % 1_000_000 !== 0) unavailable();
+  const millis = value.toMillis();
+  if (!isTimestampMillis(millis)) unavailable();
+  return millis;
+}
+
+function validApproval(pairing: Pairing, now: number, temporal: 'active' | 'renewal'): void {
+  const createdAt = timestampMillis(pairing.createdAt);
+  const expiresAt = timestampMillis(pairing.expiresAt);
+  timestampMillis(pairing.nextClaimAt);
   if (
     !pairing.enabled ||
-    pairing.createdAt.toMillis() > now ||
-    pairing.expiresAt.toMillis() <= now ||
-    pairing.expiresAt.toMillis() - pairing.createdAt.toMillis() !== APPROVAL_MS
+    createdAt > now ||
+    expiresAt - createdAt !== APPROVAL_MS ||
+    (temporal === 'active' && expiresAt <= now)
   )
     unavailable();
 }
@@ -109,7 +140,12 @@ function sameRequest(left: Approval, right: Approval): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
-function validGrant(input: unknown, pairing: Pairing, now: number): number {
+function validGrant(
+  input: unknown,
+  pairing: Pairing,
+  now: number,
+  temporal: 'active' | 'renewal' = 'active'
+): number {
   try {
     const value = object(input);
     exact(value, [
@@ -123,6 +159,10 @@ function validGrant(input: unknown, pairing: Pairing, now: number): number {
       'createdAt',
       'expiresAt',
     ]);
+    const createdAt =
+      value.createdAt instanceof Timestamp ? timestampMillis(value.createdAt) : unavailable();
+    const expiresAt =
+      value.expiresAt instanceof Timestamp ? timestampMillis(value.expiresAt) : unavailable();
     if (
       value.version !== 1 ||
       value.ownerUid !== pairing.ownerUid ||
@@ -131,18 +171,30 @@ function validGrant(input: unknown, pairing: Pairing, now: number): number {
       value.blockId !== pairing.blockId ||
       JSON.stringify(value.capabilities) !== JSON.stringify(pairing.request.capabilities) ||
       value.enabled !== true ||
-      !(value.createdAt instanceof Timestamp) ||
-      !(value.expiresAt instanceof Timestamp) ||
-      value.createdAt.toMillis() > now ||
-      value.expiresAt.toMillis() <= now ||
-      value.expiresAt.toMillis() <= value.createdAt.toMillis() ||
-      value.expiresAt.toMillis() - value.createdAt.toMillis() > GRANT_MS
+      createdAt > now ||
+      (temporal === 'active' && expiresAt <= now) ||
+      expiresAt <= createdAt ||
+      expiresAt - createdAt > GRANT_MS
     )
       unavailable();
-    return value.expiresAt.toMillis();
+    return expiresAt;
   } catch {
     unavailable();
   }
+}
+
+function renewed(pairing: Pairing, grantExpiresAt: number): RenewedBinding {
+  return {
+    version: 1,
+    pairingId: pairing.request.pairingId,
+    worldId: pairing.request.worldId,
+    installationId: pairing.request.installationId,
+    identityId: pairing.request.identityId,
+    principalUid: pairing.principalUid,
+    blockId: pairing.blockId,
+    capabilities: pairing.request.capabilities,
+    grantExpiresAt,
+  };
 }
 
 export function createPairingStore(db: Firestore, clock: () => number = Date.now) {
@@ -169,7 +221,7 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
 
   async function current(tx: Transaction, id: string, now: number): Promise<Pairing> {
     const pairing = decode((await tx.get(pairingRef(id))).data(), id);
-    active(pairing, now);
+    validApproval(pairing, now, 'active');
     if (!(await ownsWorld(tx, pairing.ownerUid, pairing.request.worldId))) unavailable();
     return pairing;
   }
@@ -188,7 +240,7 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
           const pairing = decode(existing.data(), request.pairingId);
           if (pairing.ownerUid !== uid || !sameRequest(pairing.request, request))
             throw new PairingError('PAIRING_CONFLICT');
-          active(pairing, now);
+          validApproval(pairing, now, 'active');
           if (pairing.claimed) validGrant((await tx.get(grantRef(pairing))).data(), pairing, now);
           return view(pairing);
         }
@@ -245,6 +297,44 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
         const pairing = await current(tx, id, now);
         if (!pairing.claimed) unavailable();
         validGrant((await tx.get(grantRef(pairing))).data(), pairing, now);
+      });
+    },
+
+    async renew(
+      agent: AgentIdentity,
+      id: string,
+      expectedGrantExpiresAt: number
+    ): Promise<RenewedBinding> {
+      return db.runTransaction(async (tx) => {
+        const now = clock();
+        if (!isTimestampMillis(now) || !isTimestampMillis(expectedGrantExpiresAt)) unavailable();
+        const pairing = decode((await tx.get(pairingRef(id))).data(), id);
+        validApproval(pairing, now, 'renewal');
+        if (!pairing.claimed || !(await ownsWorld(tx, pairing.ownerUid, pairing.request.worldId)))
+          unavailable();
+        if (
+          pairing.principalUid !== agent.uid ||
+          pairing.request.installationId !== agent.installationId ||
+          pairing.request.identityId !== agent.identityId
+        )
+          unavailable();
+
+        const grant = await tx.get(grantRef(pairing));
+        const currentGrantExpiresAt = validGrant(grant.data(), pairing, now, 'renewal');
+        if (expectedGrantExpiresAt > currentGrantExpiresAt)
+          throw new PairingError('PAIRING_CONFLICT');
+        const withinRenewalWindow =
+          currentGrantExpiresAt <= now || currentGrantExpiresAt - now <= RENEWAL_WINDOW_MS;
+        if (expectedGrantExpiresAt < currentGrantExpiresAt || !withinRenewalWindow)
+          return renewed(pairing, currentGrantExpiresAt);
+
+        if (now > MAX_TIMESTAMP_MS - GRANT_MS) unavailable();
+        const grantExpiresAt = now + GRANT_MS;
+        tx.update(grant.ref, {
+          createdAt: Timestamp.fromMillis(now),
+          expiresAt: Timestamp.fromMillis(grantExpiresAt),
+        });
+        return renewed(pairing, grantExpiresAt);
       });
     },
 

--- a/services/office/functions/test/pairing-contract.test.ts
+++ b/services/office/functions/test/pairing-contract.test.ts
@@ -1,6 +1,11 @@
 import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
-import { parseApproval, parseClaim, parseRevocation } from '../src/pairing-contract.js';
+import {
+  parseApproval,
+  parseClaim,
+  parseRenewal,
+  parseRevocation,
+} from '../src/pairing-contract.js';
 import { serviceEnvironment } from '../src/firebase-environment.js';
 
 const approval = {
@@ -21,6 +26,14 @@ describe('pairing input contract', () => {
       'layout.read',
     ]);
     expect(parseRevocation({ version: 1, pairingId: approval.pairingId })).toBe(approval.pairingId);
+    expect(parseRenewal({ version: 1, pairingId: approval.pairingId, grantExpiresAt: 1 })).toEqual({
+      version: 1,
+      pairingId: approval.pairingId,
+      grantExpiresAt: 1,
+    });
+    expect(() =>
+      parseRenewal({ version: 1, pairingId: approval.pairingId, grantExpiresAt: 1, extra: true })
+    ).toThrow('INVALID_ARGUMENT');
   });
   it.each([
     { ownerUid: 'self-grant' },
@@ -49,6 +62,14 @@ describe('pairing input contract', () => {
     for (const value of [null, [], Object.create(approval)])
       expect(() => parseApproval(value)).toThrow('INVALID_ARGUMENT');
   });
+  it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER, 8_640_000_000_000_001])(
+    'rejects an invalid renewal expiry %s',
+    (grantExpiresAt) => {
+      expect(() =>
+        parseRenewal({ version: 1, pairingId: approval.pairingId, grantExpiresAt })
+      ).toThrow('INVALID_ARGUMENT');
+    }
+  );
   it('hashes original proof bytes and rejects noncanonical or oversized secrets', () => {
     const bytes = Buffer.alloc(32, 1);
     const secret = bytes.toString('base64url');

--- a/services/office/functions/test/pairing-renewal.test.ts
+++ b/services/office/functions/test/pairing-renewal.test.ts
@@ -1,0 +1,340 @@
+import { Timestamp } from 'firebase-admin/firestore';
+import type { DecodedIdToken } from 'firebase-admin/auth';
+import type { Firestore } from 'firebase-admin/firestore';
+import { describe, expect, it } from 'vitest';
+import { APPROVAL_MS, GRANT_MS, RENEWAL_WINDOW_MS } from '../src/pairing-contract.js';
+import { createPairingStore } from '../src/pairing-store.js';
+import type { PairingAuthentication } from '../src/pairing-service.js';
+import { createPairingService } from '../src/pairing-service.js';
+import type { PairingStore } from '../src/pairing-store.js';
+
+const OWNER = 'owner-uid';
+const WORLD = 'abcdefghijklmnopqrst';
+const PAIRING = 'a'.repeat(64);
+const PRINCIPAL = 'office-agent:00000000-0000-4000-8000-000000000001';
+const INSTALLATION = '00000000-0000-4000-8000-000000000002';
+const IDENTITY = '00000000-0000-4000-8000-000000000003';
+const BLOCK = '00000000-0000-4000-8000-000000000004';
+const NOW = 1_700_000_000_000;
+
+type Ref = { path: string; id: string; collection(name: string): Ref; doc(id: string): Ref };
+
+function reference(path: string): Ref {
+  const parts = path.split('/');
+  const ref = {
+    path,
+    id: parts.at(-1)!,
+    collection(name: string) {
+      return reference(`${path}/${name}`);
+    },
+    doc(id: string) {
+      return reference(`${path}/${id}`);
+    },
+  };
+  return ref;
+}
+
+function fakeFirestore(initial: Record<string, unknown>) {
+  const values = new Map(Object.entries(initial));
+  const updates: Array<{ path: string; value: Record<string, unknown> }> = [];
+  const snapshot = (ref: Ref) => ({
+    ref,
+    exists: values.has(ref.path),
+    data: () => values.get(ref.path),
+  });
+  const db = {
+    collection: (name: string) => reference(name),
+    runTransaction: async (operation: (transaction: unknown) => Promise<unknown>) =>
+      operation({
+        get: async (ref: Ref) => snapshot(ref),
+        getAll: async (...refs: Ref[]) => refs.map((ref) => snapshot(ref)),
+        update: (ref: Ref, value: Record<string, unknown>) => {
+          const current = values.get(ref.path);
+          values.set(ref.path, { ...(current as Record<string, unknown>), ...value });
+          updates.push({ path: ref.path, value });
+        },
+      }),
+  };
+  return { db: db as unknown as Firestore, values, updates };
+}
+
+function seed(
+  grantExpiresAt: number,
+  options: {
+    pairingEnabled?: boolean;
+    claimed?: boolean;
+    ownerAdmitted?: boolean;
+    requestPatch?: Record<string, unknown>;
+    pairingPatch?: Record<string, unknown>;
+    grant?: Record<string, unknown>;
+    missingGrant?: boolean;
+  } = {}
+) {
+  const pairing = {
+    request: {
+      version: 1 as const,
+      pairingId: PAIRING,
+      worldId: WORLD,
+      installationId: INSTALLATION,
+      identityId: IDENTITY,
+      installationLabel: 'Installation',
+      identityLabel: 'Alice',
+      capabilities: ['layout.read', 'layout.write'] as ['layout.read', 'layout.write'],
+      ...options.requestPatch,
+    },
+    ownerUid: OWNER,
+    principalUid: PRINCIPAL,
+    blockId: BLOCK,
+    createdAt: Timestamp.fromMillis(NOW - APPROVAL_MS),
+    expiresAt: Timestamp.fromMillis(NOW),
+    enabled: options.pairingEnabled ?? true,
+    claimed: options.claimed ?? true,
+    nextClaimAt: Timestamp.fromMillis(NOW),
+    ...options.pairingPatch,
+  };
+  const grant = {
+    version: 1,
+    ownerUid: OWNER,
+    installationId: INSTALLATION,
+    identityId: IDENTITY,
+    blockId: BLOCK,
+    capabilities: ['layout.read', 'layout.write'],
+    enabled: true,
+    createdAt: Timestamp.fromMillis(grantExpiresAt - GRANT_MS),
+    expiresAt: Timestamp.fromMillis(grantExpiresAt),
+    ...options.grant,
+  };
+  const initial: Record<string, unknown> = {
+    [`officePairings/${PAIRING}`]: pairing,
+    [`worlds/${WORLD}`]: { ownerUid: OWNER },
+  };
+  if (options.ownerAdmitted !== false) initial[`testers/${OWNER}`] = { enabled: true };
+  if (!options.missingGrant) initial[`worlds/${WORLD}/agentGrants/${PRINCIPAL}`] = grant;
+  return fakeFirestore(initial);
+}
+
+const agent = { uid: PRINCIPAL, installationId: INSTALLATION, identityId: IDENTITY };
+
+describe('renewal authentication', () => {
+  it('requires a checked agent token and returns only the exact public lease view', async () => {
+    let observed: unknown[] | undefined;
+    const response = {
+      version: 1 as const,
+      pairingId: PAIRING,
+      worldId: WORLD,
+      installationId: INSTALLATION,
+      identityId: IDENTITY,
+      principalUid: PRINCIPAL,
+      blockId: BLOCK,
+      capabilities: ['layout.read'] as ['layout.read'],
+      grantExpiresAt: NOW + GRANT_MS,
+    };
+    const auth: PairingAuthentication = {
+      verifyIdToken: async (token, checkRevoked) => {
+        expect(token).toBe('agent-token');
+        expect(checkRevoked).toBe(true);
+        return {
+          uid: PRINCIPAL,
+          tmtOfficeAgent: true,
+          tmtInstallationId: INSTALLATION,
+          tmtIdentityId: IDENTITY,
+        } as unknown as DecodedIdToken;
+      },
+      createCustomToken: async () => 'unused',
+    };
+    const store = {
+      renew: async (...args: unknown[]) => {
+        observed = args;
+        return response;
+      },
+    } as unknown as PairingStore;
+    const service = createPairingService(store, auth);
+
+    await expect(
+      service.renew({ version: 1, pairingId: PAIRING, grantExpiresAt: NOW }, 'Bearer agent-token')
+    ).resolves.toEqual(response);
+    expect(observed).toEqual([
+      { uid: PRINCIPAL, installationId: INSTALLATION, identityId: IDENTITY },
+      PAIRING,
+      NOW,
+    ]);
+  });
+
+  it.each([
+    { tmtOfficeAgent: false },
+    { tmtInstallationId: 'not-a-uuid' },
+    { tmtIdentityId: 'not-a-uuid' },
+  ])('rejects a non-agent or malformed custom claim %j', async (claims) => {
+    const auth: PairingAuthentication = {
+      verifyIdToken: async () =>
+        ({
+          uid: PRINCIPAL,
+          tmtOfficeAgent: true,
+          tmtInstallationId: INSTALLATION,
+          tmtIdentityId: IDENTITY,
+          ...claims,
+        }) as unknown as DecodedIdToken,
+      createCustomToken: async () => 'unused',
+    };
+    const store = { renew: async () => responseForTest() } as unknown as PairingStore;
+
+    await expect(
+      createPairingService(store, auth).renew(
+        { version: 1, pairingId: PAIRING, grantExpiresAt: NOW },
+        'Bearer agent-token'
+      )
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+});
+
+function responseForTest() {
+  return {
+    version: 1 as const,
+    pairingId: PAIRING,
+    worldId: WORLD,
+    installationId: INSTALLATION,
+    identityId: IDENTITY,
+    principalUid: PRINCIPAL,
+    blockId: BLOCK,
+    capabilities: ['layout.read'] as ['layout.read'],
+    grantExpiresAt: NOW + GRANT_MS,
+  };
+}
+
+describe('renewal store', () => {
+  it.each([0, Number.MAX_SAFE_INTEGER])('rejects an impossible renewal clock %s', async (now) => {
+    const fixture = seed(NOW - 1);
+    const store = createPairingStore(fixture.db, () => now);
+
+    await expect(store.renew(agent, PAIRING, NOW - 1)).rejects.toMatchObject({
+      code: 'PAIRING_UNAVAILABLE',
+    });
+    expect(fixture.updates).toHaveLength(0);
+  });
+
+  it('renews an expired lease without changing its resource binding', async () => {
+    const fixture = seed(NOW - 1);
+    const store = createPairingStore(fixture.db, () => NOW);
+
+    const renewed = await store.renew(agent, PAIRING, NOW - 1);
+
+    expect(renewed).toEqual({
+      version: 1,
+      pairingId: PAIRING,
+      worldId: WORLD,
+      installationId: INSTALLATION,
+      identityId: IDENTITY,
+      principalUid: PRINCIPAL,
+      blockId: BLOCK,
+      capabilities: ['layout.read', 'layout.write'],
+      grantExpiresAt: NOW + GRANT_MS,
+    });
+    expect(fixture.updates).toHaveLength(1);
+    expect(fixture.values.get(`worlds/${WORLD}/agentGrants/${PRINCIPAL}`)).toMatchObject({
+      ownerUid: OWNER,
+      installationId: INSTALLATION,
+      identityId: IDENTITY,
+      blockId: BLOCK,
+      capabilities: ['layout.read', 'layout.write'],
+      createdAt: Timestamp.fromMillis(NOW),
+      expiresAt: Timestamp.fromMillis(NOW + GRANT_MS),
+    });
+  });
+
+  it('returns a newer live lease for stale expectations without extending it', async () => {
+    const current = NOW + 60_000;
+    const fixture = seed(current);
+    const store = createPairingStore(fixture.db, () => NOW);
+
+    await expect(store.renew(agent, PAIRING, NOW - 1)).resolves.toMatchObject({
+      grantExpiresAt: current,
+    });
+    expect(fixture.updates).toHaveLength(0);
+  });
+
+  it('returns an expired current lease for a stale retry instead of extending it', async () => {
+    const current = NOW - 1;
+    const fixture = seed(current);
+    const store = createPairingStore(fixture.db, () => NOW);
+
+    await expect(store.renew(agent, PAIRING, NOW - 2)).resolves.toMatchObject({
+      grantExpiresAt: current,
+    });
+    expect(fixture.updates).toHaveLength(0);
+  });
+
+  it.each([
+    [RENEWAL_WINDOW_MS, 1],
+    [RENEWAL_WINDOW_MS + 1, 0],
+  ])(
+    'renews only when an equal expectation is within the five-minute window (%s)',
+    async (offset, updates) => {
+      const current = NOW + offset;
+      const fixture = seed(current);
+      const store = createPairingStore(fixture.db, () => NOW);
+
+      await store.renew(agent, PAIRING, current);
+
+      expect(fixture.updates).toHaveLength(updates);
+    }
+  );
+
+  it('rejects higher expectations and mismatched agent claims', async () => {
+    const fixture = seed(NOW - 1);
+    const store = createPairingStore(fixture.db, () => NOW);
+    await expect(store.renew(agent, PAIRING, NOW + 1)).rejects.toMatchObject({
+      code: 'PAIRING_CONFLICT',
+    });
+    for (const mismatch of [
+      { ...agent, uid: `${PRINCIPAL}-other` },
+      { ...agent, installationId: IDENTITY },
+      { ...agent, identityId: INSTALLATION },
+    ]) {
+      await expect(store.renew(mismatch, PAIRING, NOW - 1)).rejects.toMatchObject({
+        code: 'PAIRING_UNAVAILABLE',
+      });
+    }
+  });
+
+  it.each([
+    ['disabled pairing', { pairingEnabled: false }],
+    ['unclaimed approval', { claimed: false }],
+    ['owner admission removed', { ownerAdmitted: false }],
+    ['malformed approval', { requestPatch: { worldId: 'bad-world' } }],
+    ['disabled grant', { grant: { enabled: false } }],
+    ['missing grant', { missingGrant: true }],
+    ['malformed grant', { grant: { extra: true } }],
+    [
+      'fractional grant timestamp',
+      {
+        grant: {
+          createdAt: new Timestamp(
+            Timestamp.fromMillis(NOW - GRANT_MS).seconds,
+            Timestamp.fromMillis(NOW - GRANT_MS).nanoseconds + 1
+          ),
+        },
+      },
+    ],
+    [
+      'fractional approval timestamp',
+      {
+        pairingPatch: {
+          createdAt: new Timestamp(
+            Timestamp.fromMillis(NOW - APPROVAL_MS).seconds,
+            Timestamp.fromMillis(NOW - APPROVAL_MS).nanoseconds + 1
+          ),
+        },
+      },
+    ],
+  ])('%s cannot be renewed or recreated', async (_name, options) => {
+    const fixture = seed(NOW - 1, options);
+    const hasGrant = !('missingGrant' in options && options.missingGrant);
+    const store = createPairingStore(fixture.db, () => NOW);
+
+    await expect(store.renew(agent, PAIRING, NOW - 1)).rejects.toMatchObject({
+      code: 'PAIRING_UNAVAILABLE',
+    });
+    expect(fixture.updates).toHaveLength(0);
+    expect(fixture.values.has(`worlds/${WORLD}/agentGrants/${PRINCIPAL}`)).toBe(hasGrant);
+  });
+});

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -467,9 +467,16 @@ after an observer timeout; do not replace the identity or delete pairing state.
 World-qualified status is local retained state, not live authorization. Inspect
 checks server access and returns `blockExists`; it does not read layouts or list
 agents. A revoked grant can still have local status `credential`. Same-name
-replacement never inherits the old identity UUID's pairing. Expired pairing or
-grants require recovery/renewal that is not implemented yet; stop and report the
-error rather than silently creating another grant. Uninstall does not revoke
+replacement never inherits the old identity UUID's pairing. `inspect` renews a
+paired lease with five minutes or less remaining, including expiry, after
+server authentication and authority checks. Renewal preserves the assigned block
+and capabilities; owner consent permits it until revoked, without daily browser
+approval. Local status never renews. A lost response can be retried without
+extending an already-renewed lease again. If an expired newer lease is recovered,
+the current inspect fails expired; a later invocation can renew it. Do not loop
+on failures. Disabled/missing grants, expired pending approvals and lost
+credentials cannot be repaired by silently creating another grant. Report those
+errors; never delete state to bypass revocation. Uninstall does not revoke
 remote grants. Do not use proposed connector or resource-edit commands.
 
 ## Configuration safety


### PR DESCRIPTION
## Summary

Closes #227. Continues #209 toward the personal-office milestone in #173.

- Renew the same admitted agent's finite resource lease during scoped Office access, without daily browser approval, a new principal/block, or broader capabilities.
- Authenticate renewal with checked Firebase agent credentials; validate current owner admission and exact enabled pairing/grant scope in the existing transaction owner.
- Compare the caller's last expiry with the authoritative lease so concurrent callers and stale-response retries converge without repeated extensions. Revocation remains terminal.
- Keep Auth refresh, resource renewal, local status, and actual Rules-authorized reads distinct. Persist only exact bound-server lease readback through the existing protected record.
- Disclose renewable consent in the browser and update canonical installed guidance and current documentation. No new command, dependency, daemon, registry, or alternate persistence layer.

## User behavior

`office inspect --world <url> --identity <name>` renews when a paired lease has at most five minutes remaining, including expiry. Each server lease lasts at most 24 hours. Local `office status` remains network-free; pairing acquisition still has its original five-minute claim window.

Disabled/missing grants and lost owner admission fail closed. A same-name replacement cannot inherit the old UUID's credentials. Retired local identities are rejected by the existing identity checks; remote retirement/offline revocation orchestration, expired pending-approval recovery, reassignment and lost-credential recovery remain separate #209 work.

## Architecture review

Primary reviewed the changed source, callers, tests and contracts. Renewal extends the existing pairing store/service/HTTP boundary and native wire/remote/record/invocation owners. Core protocol shapes and ordinary CLI dependency isolation are unchanged. The grant's timestamps describe its current lease; stable resource ownership is unchanged. Shared validation distinguishes active access from renewal without duplicating the grant decoder.

Review findings addressed: isolate disabled-pairing versus missing-grant tests, cover owner-admission loss and exact window boundaries, reject sub-millisecond stored timestamps before floating-point conversion, assert full revoked-grant preservation, and label simulated lost-response evidence accurately. Actual native-to-issuer integration exercises the renewal path, bearer authentication and exact request contract; no arbitrary-endpoint production seam was added solely for unit tests.

## Verification

Reviewed head: `43a3e106d07c5a827ace3cffea30f3910140db32`.

- Host `pnpm check`: passed (known host Node 26 versus package Node 22 engine notices only).
- Isolated Rust formatting, Office-feature Clippy with warnings denied, workspace tests and locked builds: passed; 464 tests passed, one ignored. Final HTTP 409 denial assertion rerun: 1/1 passed.
- Rust 1.88 minimum-supported-version build passed; architecture gate 21/21 passed.
- Service quality checks and tests: passed; 64 tests across three files.
- Browser/emulator lifecycle suite: two complete runs, 38 Playwright tests passed each.
- Independent native process suite: 154 tests across 15 files passed; embedded installed-skill bytes matched exactly.
- Test-image production, test and skill source hashes match the reviewed commit. The pre-commit image differs only in Markdown table alignment in `agent-grant-v1.md`; the final host documentation check passed.
- `git diff --check` passed. Required exact-head GitHub CI remains the merge gate.

## Evidence limits

Restoring an old protected record simulates a lost renewal response and proves stale-expectation convergence. It is not an injected TCP interruption or OS-store write/readback failure. Unit fake Firestore tests prove policy, not transaction isolation; emulator concurrent renewal/revocation scenarios supply the latter evidence. A 409 lease conflict intentionally maps to the existing coarse native `OFFICE_REMOTE_DENIED`, with no automatic replay.

All cloud behavior remains local-emulator verified. No production Firebase deployment, paid model call, public Office release, host credential use or host CLI replacement is performed. The temporary-list report #226 remains independent and open.
