### PR TITLE
feat: connect identity retirement hooks to Office revocation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,7 +88,7 @@ module remapping or incomplete discovery. It is a syntactic guard and never
 replaces review of behavior or effects.
 
 The optional `rust/crates/tmt-office` executable is independently versioned and
-exposes the compatibility probe and typed one-shot pairing/status/inspect operations.
+exposes the compatibility probe and typed one-shot pairing/status/inspect/sync operations.
 It depends on core and the existing adapters, not the CLI. Its adapter `office`
 feature owns validated deployment decoding, bounded HTTP, protected pairing
 records and explicit platform credential stores; ordinary CLI builds do not enable
@@ -109,9 +109,23 @@ readback can replace the local expiry. No timer or background process renews
 grants, and local status stays network-free. `office_http` shares bounded JSON
 transport with deployment discovery. Existing ConfigPaths, identity storage,
 file locks and process owners remain authoritative. One protected scope record
-owns pending proof or credentials; no SQLite binding index mirrors it. OS random
+owns pending proof or credentials; SQLite hooks contain only its opaque scope
+reference, never a duplicate credential or grant. OS random
 bytes create proofs; explicit Keychain/Secret Service backends fail closed.
 Background connection and resource editing remain unimplemented.
+
+Identity retirement remains the existing binding transaction's responsibility.
+`tmt-core::identity_hooks` owns typed subscriptions and delivery state;
+`storage::identity_hooks` registers subscriptions and atomically queues retirement
+notifications from that same transaction. It has no Office dependency. Consumers
+run after commit: `office_pairing::hooks` uses the existing protected-record and
+per-scope lock owners to revoke, retain a secret-free receipt, then acknowledge.
+No SQL transaction spans remote work. Office pair/inspect and explicit `office
+sync` consume bounded batches; ordinary identity commands only enqueue locally.
+No background or punctual remote cleanup is implied. The
+[native pairing lifecycle contract](contracts/office/native-pairing.md#identity-retirement-hooks)
+owns delivery order, retries and compatibility limitations. This is a retirement
+hook, not an arbitrary executable event bus.
 
 Workspace quality checks cover the unified feature graph. Native process
 fixtures build products separately to retain ordinary CLI feature isolation;
@@ -206,7 +220,7 @@ an exact reply/body transformation or the receipt decoder's policy.
 ### SQLite and durable exchanges
 
 `tmt-adapters::storage` owns one private synchronous `rusqlite` connection,
-schema migrations 1 through 9, WAL/foreign-key/FTS5 setup, busy and transaction
+schema migrations 1 through 10, WAL/foreign-key/FTS5 setup, busy and transaction
 boundaries, and close/checkpoint cleanup. Historical schemas and frozen fixture
 provenance are evidence, not a second implementation. The adapter keeps raw
 connections private and exposes narrow ports to core services.
@@ -215,6 +229,9 @@ promotes existing identities to saved without changing UUIDs; unsupported custom
 identity-table definitions are rejected rather than silently rebuilt. Old
 schema-8 writers cannot share the migrated database. Frozen inputs retain their
 own provenance in `test/fixtures/storage-history`, not in this architecture map.
+Schema 10 adds identity hook subscriptions and terminal delivery receipts;
+registration after retirement queues immediately, and delivered subscriptions
+cannot be resurrected by registration retries.
 
 `tmt-core::request::RequestService` owns preparation, delivery-state
 transitions, exact final submission, waiter release, attention revisions and

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -201,14 +201,27 @@ then independently checks the issued grant, OS-store record, scoped Firestore
 read, token refresh, expired server/native lease renewal, simulated lost-response readback,
 unchanged resources, corruption, revocation and same-name replacement.
 The browser target therefore builds Rust and installs the root test-helper
-dependencies with scripts disabled; it does not execute the SQLite oracle or
-import native helpers into the SPA. The standalone app image stays independent.
+dependencies with scripts disabled; native helpers never enter the SPA. The
+standalone app image stays independent.
 `with-test-keyring.sh` owns a disposable D-Bus session and real Linux Secret Service
 with a fixture-only password and private container directories. The scenario
 deletes and verifies absence of its protected entry; container teardown removes
 the disposable store. No host Keychain, credentials or installed CLI is used.
 This is Linux credential-store evidence, not macOS runtime or real release-archive
 acceptance. Reuse the separate native artifact verifier for published artifacts.
+
+`native-hooks.spec.ts` adds the causal retirement path using a private real tmux
+server and the container's `sqlite3` tool as an independent state observer.
+Verify local retirement plus pending notification before any remote cleanup,
+then disabled pairing/grant, retained block and denial of a previously usable
+cached token. A missing session bus or vault entry must retain pending work.
+An unknown pending proof stays retryable and later cancels a known approval
+without claiming credentials or creating a grant. A test-only SQLite
+acknowledgment trigger separates remote/vault success from local completion;
+retry must consume the protected revoked receipt without restoring credentials.
+Neither hook registration unit tests nor service-only revocation proves this
+chain. Run the Office browser target and tmux lifecycle suite twice after changes
+to these cleanup boundaries, with verified private-server/vault cleanup.
 
 For focused service checks use `pnpm office:service:check`,
 `pnpm office:service:test` and `pnpm office:service:build`. `pnpm check` also runs

--- a/NATIVE-INSTALL.md
+++ b/NATIVE-INSTALL.md
@@ -18,7 +18,7 @@ where required. A sender can run outside tmux; recipients still need live panes.
 Use the installer asset from a published release; the README
 supplies the verified version URL when one is available.
 
-Native schema 9 is forward-only: the TypeScript runtime cannot reopen it.
+Native schema migrations are forward-only: the TypeScript runtime cannot reopen native state.
 Installing or replacing a native binary does not migrate, delete or downgrade
 application data. Stop older TMT writers before switching, and do not run the
 native runtime against a database that the TypeScript runtime still uses.
@@ -156,4 +156,4 @@ makes recoverable backups; bootstrap never silently forces. Skill failure return
 nonzero after binary installation, without claiming rollback. Reload the agent
 or ask it to read the complete `tmt learn --skill`. No historical-session
 continuity or SQLite downgrade is promised; never use the old TypeScript writer
-on a schema-9 database.
+on a native database.

--- a/REQUEST-RESPONSE.md
+++ b/REQUEST-RESPONSE.md
@@ -159,10 +159,10 @@ key-order and duplicate-key-last-value behavior. Retained finals remain sufficie
 for retry after attempt removal; expiry and conflicts never renew them. Tests
 execute original TS-generated v1 receipts against migrated frozen schema-8
 fixtures, including in-flight and orphan finals. This proves service handoff,
-not simultaneous TS/schema-8 access to native/schema-9 state.
+not simultaneous TS/schema-8 access to current native state.
 
 Both receipt versions work without tmux or current config. Old schema-8 inputs
-may migrate through native reply; simultaneous old writers after schema-9
+may migrate through native reply; simultaneous old writers after native
 migration are unsupported.
 
 ## Talk completion

--- a/RUST-REWRITE.md
+++ b/RUST-REWRITE.md
@@ -15,7 +15,7 @@ and verification commands in [Development](DEVELOPMENT.md).
   Local receipts correlate recorded requests and endpoints; they are not remote
   authentication. [Request/response](REQUEST-RESPONSE.md) owns the wire and
   attention contracts.
-- Native schema 9 is forward-only from supported historical schemas. Old
+- Native schema migrations are forward-only from supported historical schemas. Old
   TypeScript/schema-8 writers must stop before migration and cannot reopen
   native state. Binary rollback does not imply database downgrade.
 - The native installer does not migrate or delete application data. Existing

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -30,7 +30,7 @@ Native `name` and `add` bindings are temporary by default. Add `-s`/`--save`
 to preserve an identity, and use `tmt rm <name>` to retire a temporary identity
 (`--force` is required for a saved identity). Switching from npm or pnpm is a
 fresh installation: stop old writers first; no configuration, database or
-historical exchange is migrated or deleted. Native schema 9 is forward-only,
+historical exchange is migrated or deleted. Native schema migrations are forward-only,
 so never use the old TypeScript writer on a native database.
 
 ## Name panes and inspect presence

--- a/apps/office/e2e/native-hooks.spec.ts
+++ b/apps/office/e2e/native-hooks.spec.ts
@@ -1,0 +1,329 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { expect } from '@playwright/test';
+import { test, signIn } from './browser-session.js';
+import { setTester } from './firestore-fixture.js';
+import { installNativeOffice, protectedOfficeRecord } from './native-office-fixture.js';
+import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
+import { withE2EFixture } from '../../../test/e2e/harness.js';
+import { runCli, withSandbox, type Sandbox } from '../../../test/support/cli-process.js';
+
+// An independent SQLite CLI observes state without invoking product housekeeping.
+async function sql(sandbox: Sandbox, statement: string, write = false) {
+  const result = await runCli({ ...sandbox, cli: { executable: '/usr/bin/sqlite3', args: [] } }, [
+    ...(write ? [] : ['-readonly']),
+    '-json',
+    sandbox.database,
+    statement,
+  ]);
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout ? JSON.parse(result.stdout) : [];
+}
+
+test('retired pending proof stays retryable until a known approval can be cancelled', async ({
+  openSession,
+}) => {
+  test.setTimeout(90_000);
+  const admin = createPairingEmulatorFixture();
+  try {
+    await withSandbox(async (sandbox) => {
+      const prefix = await installNativeOffice(sandbox);
+      expect((await runCli(sandbox, ['identity', 'create', 'PendingHooks', '--json'])).status).toBe(
+        0
+      );
+      const worldId = admin.db.collection('worlds').doc().id;
+      const world = `http://127.0.0.1:4173/worlds/${worldId}`;
+      const pending = await runCli(
+        sandbox,
+        [
+          'office',
+          'pair',
+          '--prefix',
+          prefix,
+          '--world',
+          world,
+          '--identity',
+          'PendingHooks',
+          '--emulator',
+          '--timeout',
+          '5',
+          '--json',
+        ],
+        { deadlineMs: 15_000 }
+      );
+      expect(pending.status).toBe(1);
+      expect(JSON.parse(pending.stdout).error.code).toBe('OFFICE_PAIRING_PENDING');
+      const link = pending.stderr.trim();
+      expect(link.startsWith(`${world}/pair#tmt-pair=`)).toBe(true);
+      const approval = JSON.parse(
+        Buffer.from(link.split('#tmt-pair=')[1]!, 'base64url').toString('utf8')
+      );
+      const scopeFile = readdirSync(path.join(sandbox.globalDir, 'office')).find((name) =>
+        /^[0-9a-f]{64}\.lock$/.test(name)
+      );
+      expect(scopeFile).toBeDefined();
+      const key = scopeFile!.slice(0, -'.lock'.length);
+      const sync = () =>
+        runCli(sandbox, ['office', 'sync', '--prefix', prefix, '--json'], { deadlineMs: 35_000 });
+      const pairing = admin.db.collection('officePairings').doc(approval.pairingId);
+      try {
+        const proof = await protectedOfficeRecord(sandbox, key, 'lookup');
+        expect(proof.status).toBe(0);
+        expect(JSON.parse(proof.stdout).phase.state).toBe('pending');
+        expect((await runCli(sandbox, ['rm', 'PendingHooks', '--force', '--json'])).status).toBe(0);
+        const unknown = await sync();
+        expect(unknown.status).toBe(1);
+        expect(JSON.parse(unknown.stdout)).toEqual({
+          completed: 0,
+          failed: 1,
+          pending: 1,
+          failureCode: 'OFFICE_REMOTE_DENIED',
+        });
+        expect((await pairing.get()).exists).toBe(false);
+        expect((await protectedOfficeRecord(sandbox, key, 'lookup')).stdout).toBe(proof.stdout);
+
+        // A browser may still hold the old public link. No native claim/token is
+        // needed to reduce this subsequently approved scope using its proof.
+        const { page } = await openSession(link);
+        await signIn(page, 'PendingHooksOwner');
+        const uid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+        await admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .set({ version: 1, name: 'Pending hook', ownerUid: uid, createdAt: new Date() });
+        await setTester(uid, true);
+        await page
+          .getByRole('checkbox', { name: 'I recognize this agent and installation.' })
+          .check();
+        await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+        await expect(
+          page.getByRole('status').filter({ hasText: 'Approved. Return' })
+        ).toBeVisible();
+        const approved = (await pairing.get()).data()!;
+        expect(approved.enabled).toBe(true);
+        expect(approved.claimed).toBe(false);
+        const cancelled = await sync();
+        expect(cancelled.status, cancelled.stdout).toBe(0);
+        expect(JSON.parse(cancelled.stdout)).toEqual({
+          completed: 1,
+          failed: 0,
+          pending: 0,
+          failureCode: null,
+        });
+        expect((await pairing.get()).data()).toEqual({ ...approved, enabled: false });
+        const grants = await admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .collection('agentGrants')
+          .get();
+        expect(grants.empty).toBe(true);
+        expect(await sql(sandbox, 'SELECT state, attempt_count FROM identity_hooks')).toEqual([
+          { state: 'delivered', attempt_count: 2 },
+        ]);
+        expect(
+          JSON.parse((await protectedOfficeRecord(sandbox, key, 'lookup')).stdout).phase
+        ).toEqual({ state: 'revoked' });
+      } finally {
+        expect((await protectedOfficeRecord(sandbox, key, 'clear')).status).toBe(0);
+        expect((await protectedOfficeRecord(sandbox, key, 'lookup')).status).toBe(1);
+      }
+    });
+  } finally {
+    await admin.dispose();
+  }
+});
+
+test('retirement delivers Office hooks and recovers after vault and acknowledgment failures', async ({
+  openSession,
+}) => {
+  test.setTimeout(120_000);
+  const admin = createPairingEmulatorFixture();
+  try {
+    await withSandbox(async (sandbox) => {
+      await withE2EFixture(
+        async (fixture) => {
+          const prefix = await installNativeOffice(sandbox);
+          const pane = await fixture.createMockPane('temporary-hooks');
+          const added = await fixture.runJsonCli<{ id: string; lifetime: string }>([
+            'add',
+            pane.pane,
+            'TemporaryHooks',
+          ]);
+          expect(added.code, added.stderr).toBe(0);
+          expect(added.json?.lifetime).toBe('temporary');
+          const identityId = added.json!.id;
+          expect(identityId).toMatch(/^[0-9a-f-]{36}$/);
+          const worldId = admin.db.collection('worlds').doc().id;
+          const world = `http://127.0.0.1:4173/worlds/${worldId}`;
+          const office = (operation: string, extra: string[] = [], env = sandbox.env) =>
+            runCli(
+              { ...sandbox, env },
+              ['office', operation, '--prefix', prefix, '--json', ...extra],
+              { deadlineMs: 35_000 }
+            );
+          const scope = ['--world', world, '--identity', 'TemporaryHooks', '--emulator'];
+          const pending = await office('pair', [...scope, '--timeout', '5']);
+          expect(pending.status).toBe(1);
+          expect(JSON.parse(pending.stdout).error.code).toBe('OFFICE_PAIRING_PENDING');
+          const link = pending.stderr.trim();
+          expect(link.startsWith(`${world}/pair#tmt-pair=`)).toBe(true);
+          const approval = JSON.parse(
+            Buffer.from(link.split('#tmt-pair=')[1]!, 'base64url').toString('utf8')
+          );
+          expect(approval.identityId).toBe(identityId);
+          expect(approval.worldId).toBe(worldId);
+          const hook = () =>
+            sql(
+              sandbox,
+              `SELECT state, attempt_count FROM identity_hooks WHERE consumer = 'tmt-office' AND identity_id = '${identityId}'`
+            );
+          expect(await hook()).toEqual([{ state: 'registered', attempt_count: 0 }]);
+          const scopeFile = readdirSync(path.join(sandbox.globalDir, 'office')).find((name) =>
+            /^[0-9a-f]{64}\.lock$/.test(name)
+          );
+          expect(scopeFile).toBeDefined();
+          const key = scopeFile!.slice(0, -'.lock'.length);
+          const vault = (operation: 'lookup' | 'store' | 'clear', input?: string) =>
+            protectedOfficeRecord(sandbox, key, operation, input);
+          try {
+            const { page } = await openSession(link);
+            await signIn(page, 'NativeIdentityHooksOwner');
+            const uid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+            await admin.db
+              .collection('worlds')
+              .doc(worldId)
+              .set({ version: 1, name: 'Identity hooks', ownerUid: uid, createdAt: new Date() });
+            await setTester(uid, true);
+            await page
+              .getByRole('checkbox', { name: 'I recognize this agent and installation.' })
+              .check();
+            await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+            await expect(
+              page.getByRole('status').filter({ hasText: 'Approved. Return' })
+            ).toBeVisible();
+            const resumed = await office('pair', [...scope, '--timeout', '25']);
+            expect(resumed.status, resumed.stdout).toBe(0);
+            expect(JSON.parse(resumed.stdout).state).toBe('credential');
+            const pairing = admin.db.collection('officePairings').doc(approval.pairingId);
+            const remote = (await pairing.get()).data()!;
+            const grant = admin.db
+              .collection('worlds')
+              .doc(worldId)
+              .collection('agentGrants')
+              .doc(remote.principalUid);
+            const savedGrant = (await grant.get()).data()!;
+            const block = admin.db
+              .collection('worlds')
+              .doc(worldId)
+              .collection('blocks')
+              .doc(remote.blockId);
+            await block.set({ version: 1, revision: 1, objects: ['d000'], updatedAt: new Date() });
+            const savedBlock = (await block.get()).data();
+            const stored = await vault('lookup');
+            expect(stored.status).toBe(0);
+            const record = JSON.parse(stored.stdout);
+            const token = record.phase.credential.idToken;
+            const blockUrl = `http://127.0.0.1:8080/v1/projects/demo-tmt-office/databases/(default)/documents/worlds/${worldId}/blocks/${remote.blockId}`;
+            const readBlock = () =>
+              fetch(blockUrl, {
+                headers: { authorization: `Bearer ${token}` },
+                signal: AbortSignal.timeout(10_000),
+              });
+            expect((await readBlock()).status).toBe(200);
+            // Require a real Auth refresh after retirement, solely for reduction.
+            record.phase.credential.tokenExpiresAt = 0;
+            expect((await vault('store', JSON.stringify(record))).status).toBe(0);
+
+            fixture.tmux(['kill-pane', '-t', pane.pane]);
+            expect(
+              fixture.tmux(['list-panes', '-a', '-F', '#{pane_id}']).trim().split('\n')
+            ).not.toContain(pane.pane);
+            const listed = await fixture.runJsonCli<{ identities: Array<{ id: string }> }>(['ls']);
+            expect(listed.code, listed.stderr).toBe(0);
+            expect(listed.json!.identities.some((identity) => identity.id === identityId)).toBe(
+              false
+            );
+            expect(await hook()).toEqual([{ state: 'pending', attempt_count: 0 }]);
+            expect((await grant.get()).data()).toEqual(savedGrant);
+            expect((await pairing.get()).data()).toEqual(remote);
+            expect((await readBlock()).status).toBe(200);
+
+            const unavailable = await office('sync', [], {
+              ...sandbox.env,
+              DBUS_SESSION_BUS_ADDRESS: `unix:path=${sandbox.root}/missing-session-bus`,
+            });
+            expect(unavailable.status).toBe(1);
+            expect(JSON.parse(unavailable.stdout)).toEqual({
+              completed: 0,
+              failed: 1,
+              pending: 1,
+              failureCode: 'OFFICE_CREDENTIALS_UNAVAILABLE',
+            });
+            expect(await hook()).toEqual([{ state: 'pending', attempt_count: 1 }]);
+            expect((await grant.get()).data()).toEqual(savedGrant);
+
+            // A deleted vault entry is missing evidence, not proof of revocation.
+            expect((await vault('clear')).status).toBe(0);
+            const missing = await office('sync');
+            expect(missing.status).toBe(1);
+            expect(JSON.parse(missing.stdout)).toEqual(JSON.parse(unavailable.stdout));
+            expect(await hook()).toEqual([{ state: 'pending', attempt_count: 2 }]);
+            expect((await grant.get()).data()).toEqual(savedGrant);
+            expect((await vault('store', JSON.stringify(record))).status).toBe(0);
+
+            await sql(
+              sandbox,
+              "CREATE TRIGGER reject_office_hook_ack BEFORE UPDATE OF state ON identity_hooks WHEN NEW.state = 'delivered' BEGIN SELECT RAISE(ABORT, 'fixture acknowledgment failure'); END",
+              true
+            );
+            const unacknowledged = await office('sync');
+            expect(unacknowledged.status).toBe(1);
+            expect(JSON.parse(unacknowledged.stdout)).toEqual({
+              completed: 0,
+              failed: 1,
+              pending: 1,
+              failureCode: 'OFFICE_CREDENTIALS_UNAVAILABLE',
+            });
+            expect(await hook()).toEqual([{ state: 'pending', attempt_count: 3 }]);
+            expect((await grant.get()).data()).toEqual({ ...savedGrant, enabled: false });
+            expect((await pairing.get()).data()).toEqual({ ...remote, enabled: false });
+            expect((await block.get()).data()).toEqual(savedBlock);
+            const tombstone = await vault('lookup');
+            expect(tombstone.status).toBe(0);
+            expect(JSON.parse(tombstone.stdout).phase).toEqual({ state: 'revoked' });
+            expect((await readBlock()).status).toBe(403);
+
+            await sql(sandbox, 'DROP TRIGGER reject_office_hook_ack', true);
+            const retried = await office('sync');
+            expect(retried.status, retried.stdout).toBe(0);
+            expect(JSON.parse(retried.stdout)).toEqual({
+              completed: 1,
+              failed: 0,
+              pending: 0,
+              failureCode: null,
+            });
+            expect(await hook()).toEqual([{ state: 'delivered', attempt_count: 4 }]);
+            expect((await vault('lookup')).stdout).toBe(tombstone.stdout);
+            const repeated = await office('sync');
+            expect(repeated.status).toBe(0);
+            expect(JSON.parse(repeated.stdout)).toEqual({
+              completed: 0,
+              failed: 0,
+              pending: 0,
+              failureCode: null,
+            });
+            expect(await hook()).toEqual([{ state: 'delivered', attempt_count: 4 }]);
+            expect((await grant.get()).data()).toEqual({ ...savedGrant, enabled: false });
+            expect((await block.get()).data()).toEqual(savedBlock);
+          } finally {
+            expect((await vault('clear')).status).toBe(0);
+            expect((await vault('lookup')).status).toBe(1);
+          }
+        },
+        { globalDir: sandbox.globalDir }
+      );
+    });
+  } finally {
+    await admin.dispose();
+  }
+});

--- a/apps/office/e2e/native-office-fixture.ts
+++ b/apps/office/e2e/native-office-fixture.ts
@@ -1,0 +1,54 @@
+import path from 'node:path';
+import { expect } from '@playwright/test';
+import { createArtifact } from '../../../test/support/native-artifact.js';
+import { runCli, type Sandbox } from '../../../test/support/cli-process.js';
+
+export async function installNativeOffice(sandbox: Sandbox): Promise<string> {
+  const artifact = await createArtifact(
+    sandbox,
+    '0.1.0-alpha.1',
+    new Uint8Array(),
+    'office',
+    path.resolve('../../rust/target/debug/tmt-office')
+  );
+  const prefix = path.join(sandbox.root, 'office-prefix');
+  const installed = await runCli(
+    sandbox,
+    [
+      'office',
+      'install',
+      '--yes',
+      '--prefix',
+      prefix,
+      '--archive',
+      artifact.archive,
+      '--manifest',
+      artifact.manifest,
+      '--json',
+    ],
+    { deadlineMs: 20_000 }
+  );
+  expect(installed.status, installed.stdout).toBe(0);
+  expect(installed.stderr).toBe('');
+  return prefix;
+}
+
+export function protectedOfficeRecord(
+  sandbox: Sandbox,
+  scopeKey: string,
+  operation: 'lookup' | 'store' | 'clear',
+  input?: string
+) {
+  return runCli(
+    { ...sandbox, cli: { executable: '/usr/bin/secret-tool', args: [] } },
+    [
+      operation,
+      ...(operation === 'store' ? ['--label', 'Native Office fixture'] : []),
+      'service',
+      'org.tmux-team.office.v1',
+      'username',
+      scopeKey,
+    ],
+    input === undefined ? {} : { stdin: input }
+  );
+}

--- a/apps/office/e2e/native-pairing.spec.ts
+++ b/apps/office/e2e/native-pairing.spec.ts
@@ -5,8 +5,8 @@ import { expect } from '@playwright/test';
 import { test, signIn } from './browser-session.js';
 import { setTester } from './firestore-fixture.js';
 import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
-import { createArtifact } from '../../../test/support/native-artifact.js';
 import { runCli, withSandbox } from '../../../test/support/cli-process.js';
+import { installNativeOffice, protectedOfficeRecord } from './native-office-fixture.js';
 
 test('native pairing resumes its protected proof and a separate process uses the scoped credential', async ({
   openSession,
@@ -18,47 +18,10 @@ test('native pairing resumes its protected proof and a separate process uses the
       let scopeKey: string | undefined;
       const vault = async (operation: 'lookup' | 'store' | 'clear', input?: string) => {
         if (!scopeKey) throw new Error('The scenario has no protected scope yet.');
-        return runCli(
-          { ...sandbox, cli: { executable: '/usr/bin/secret-tool', args: [] } },
-          [
-            operation,
-            ...(operation === 'store' ? ['--label', 'Native pairing fixture'] : []),
-            'service',
-            'org.tmux-team.office.v1',
-            'username',
-            scopeKey,
-          ],
-          input === undefined ? {} : { stdin: input }
-        );
+        return protectedOfficeRecord(sandbox, scopeKey, operation, input);
       };
       try {
-        const companion = path.resolve('../../rust/target/debug/tmt-office');
-        const fixture = await createArtifact(
-          sandbox,
-          '0.1.0-alpha.1',
-          new Uint8Array(),
-          'office',
-          companion
-        );
-        const prefix = path.join(sandbox.root, 'office-prefix');
-        const installed = await runCli(
-          sandbox,
-          [
-            'office',
-            'install',
-            '--yes',
-            '--prefix',
-            prefix,
-            '--archive',
-            fixture.archive,
-            '--manifest',
-            fixture.manifest,
-            '--json',
-          ],
-          { deadlineMs: 20_000 }
-        );
-        expect(installed.status, installed.stdout).toBe(0);
-        expect(installed.stderr).toBe('');
+        const prefix = await installNativeOffice(sandbox);
         const created = await runCli(sandbox, ['identity', 'create', 'Alice', '--json']);
         expect(created.status, created.stdout).toBe(0);
         const worldId = admin.db.collection('worlds').doc().id;
@@ -354,6 +317,11 @@ test('native pairing resumes its protected proof and a separate process uses the
         const replacementRead = await office('inspect');
         expect(replacementRead.status).toBe(1);
         expect(JSON.parse(replacementRead.stdout).error.code).toBe('OFFICE_NOT_PAIRED');
+        expect(replacementRead.stderr).toBe('');
+        // The shared online boundary drains the old UUID before independently
+        // refusing resource access to its unpaired same-name replacement.
+        expect(JSON.parse((await vault('lookup')).stdout).phase).toEqual({ state: 'revoked' });
+        expect((await pairing.get()).data()!.enabled).toBe(false);
       } finally {
         if (scopeKey) {
           expect((await vault('clear')).status).toBe(0);

--- a/apps/office/e2e/pairing-service.spec.ts
+++ b/apps/office/e2e/pairing-service.spec.ts
@@ -133,7 +133,7 @@ test('HTTP approval and proof claim produce an actually usable scoped credential
   });
 });
 
-test('authenticated renewal converges across concurrent callers and never revives revoked authority', async () => {
+test('authenticated renewal converges across concurrent callers and never revives self-revoked authority', async () => {
   await withPairing(async ({ fixture, db, auth, world, secret, request, token }) => {
     expect((await post('approve', request, token)).status).toBe(200);
     const claimed = await post('claim', { version: 1, secret });
@@ -143,6 +143,16 @@ test('authenticated renewal converges across concurrent callers and never revive
     const agent = await fixture.client(false, 'device');
     await signInWithCustomToken(agent.auth, field(claimed.body, 'customToken'));
     const agentToken = await agent.auth.currentUser!.getIdToken();
+    const target = doc(agent.db, 'worlds', world.id, 'blocks', blockId);
+    await setDoc(target, {
+      version: 1,
+      revision: 1,
+      objects: ['d000'],
+      updatedAt: serverTimestamp(),
+    });
+    const block = db.collection('worlds').doc(world.id).collection('blocks').doc(blockId);
+    const stored = (await block.get()).data();
+    expect((await getDocFromServer(target)).data()?.objects).toEqual(['d000']);
     const grant = db.collection('worlds').doc(world.id).collection('agentGrants').doc(principal);
     const original = (await grant.get()).data()!;
     const expiredAt = Date.now() - 1000;
@@ -206,17 +216,165 @@ test('authenticated renewal converges across concurrent callers and never revive
     const current = { ...renewal, grantExpiresAt: raceExpiry };
     const [raced, revoked] = await Promise.all([
       post('renew', current, agentToken),
-      post('revoke', { version: 1, pairingId: request.pairingId }, token),
+      post('revoke', { version: 1, pairingId: request.pairingId }, agentToken),
     ]);
     expect([200, 404]).toContain(raced.status);
     expect(revoked.status).toBe(200);
     expect((await grant.get()).data()!.enabled).toBe(false);
+    expect(
+      (await db.collection('officePairings').doc(request.pairingId).get()).data()?.enabled
+    ).toBe(false);
+    expect((await block.get()).data()).toEqual(stored);
     expect((await post('renew', current, agentToken)).status).toBe(404);
     await expect(
       getDocFromServer(doc(agent.db, 'worlds', world.id, 'blocks', blockId))
     ).rejects.toMatchObject({ code: 'permission-denied' });
   });
 });
+
+test('only the exact issued agent can relinquish its claimed scope after admission loss', async () => {
+  await withPairing(async ({ fixture, db, auth, owner, world, secret, request, token }) => {
+    expect((await post('approve', request, token)).status).toBe(200);
+    const claimed = await post('claim', { version: 1, secret });
+    expect(claimed.status).toBe(200);
+    const principalUid = field(claimed.body, 'principalUid');
+    const record = db.collection('officePairings').doc(request.pairingId);
+    const grant = db.collection('worlds').doc(world.id).collection('agentGrants').doc(principalUid);
+    const beforePairing = (await record.get()).data();
+    const beforeGrant = (await grant.get()).data();
+    const agent = await fixture.client(false, 'device');
+    await signInWithCustomToken(agent.auth, field(claimed.body, 'customToken'));
+    const agentToken = await agent.auth.currentUser!.getIdToken();
+    const target = doc(agent.db, 'worlds', world.id, 'blocks', field(claimed.body, 'blockId'));
+    await setDoc(target, {
+      version: 1,
+      revision: 1,
+      objects: ['d000'],
+      updatedAt: serverTimestamp(),
+    });
+    const block = db
+      .collection('worlds')
+      .doc(world.id)
+      .collection('blocks')
+      .doc(field(claimed.body, 'blockId'));
+    const stored = (await block.get()).data();
+    expect((await getDocFromServer(target)).data()?.objects).toEqual(['d000']);
+    for (const mismatch of [
+      {
+        uid: `office-agent:${crypto.randomUUID()}`,
+        installationId: request.installationId,
+        identityId: request.identityId,
+      },
+      { uid: principalUid, installationId: crypto.randomUUID(), identityId: request.identityId },
+      {
+        uid: principalUid,
+        installationId: request.installationId,
+        identityId: crypto.randomUUID(),
+      },
+    ]) {
+      const wrong = await fixture.client(false, 'device');
+      await signInWithCustomToken(
+        wrong.auth,
+        await auth.createCustomToken(mismatch.uid, {
+          tmtOfficeAgent: true,
+          tmtInstallationId: mismatch.installationId,
+          tmtIdentityId: mismatch.identityId,
+        })
+      );
+      expect(
+        await post(
+          'revoke',
+          { version: 1, pairingId: request.pairingId },
+          await wrong.auth.currentUser!.getIdToken()
+        )
+      ).toEqual({ status: 404, body: { error: { code: 'PAIRING_UNAVAILABLE' } } });
+      expect((await record.get()).data()).toEqual(beforePairing);
+      expect((await grant.get()).data()).toEqual(beforeGrant);
+    }
+    await setTester(owner.uid, false);
+    expect((await post('revoke', { version: 1, pairingId: request.pairingId }, token)).status).toBe(
+      403
+    );
+    const expected = {
+      status: 200,
+      body: { version: 1, pairingId: request.pairingId, revoked: true },
+    };
+    expect(await post('revoke', { version: 1, pairingId: request.pairingId }, agentToken)).toEqual(
+      expected
+    );
+    expect(await post('revoke', { version: 1, pairingId: request.pairingId }, agentToken)).toEqual(
+      expected
+    );
+    expect((await record.get()).data()).toEqual({ ...beforePairing, enabled: false });
+    expect((await grant.get()).data()).toEqual({ ...beforeGrant, enabled: false });
+    // Restore admission to prove the retained disabled grant itself denies use.
+    await setTester(owner.uid, true);
+    await expect(getDocFromServer(target)).rejects.toMatchObject({ code: 'permission-denied' });
+    expect(
+      (
+        await post(
+          'renew',
+          { version: 1, pairingId: request.pairingId, grantExpiresAt: claimed.body.grantExpiresAt },
+          agentToken
+        )
+      ).status
+    ).toBe(404);
+    expect((await block.get()).data()).toEqual(stored);
+  });
+});
+
+for (const claimed of [false, true]) {
+  test(`original proof cancels an expired ${claimed ? 'reserved claim' : 'unclaimed approval'} without reconstructing authority`, async () => {
+    await withPairing(async ({ db, owner, secret, request, token }) => {
+      const proof = { version: 1, secret };
+      const record = db.collection('officePairings').doc(request.pairingId);
+      expect(await post('revoke', proof)).toEqual({
+        status: 404,
+        body: { error: { code: 'PAIRING_UNAVAILABLE' } },
+      });
+      expect((await record.get()).exists).toBe(false);
+      expect((await post('approve', request, token)).status).toBe(200);
+      if (claimed) {
+        // Reserve without signing/delivery: the original proof must also clean
+        // up an issued grant whose credential response was never received.
+        await createPairingStore(db).reserveClaim(request.pairingId);
+      }
+      const expiredAt = Date.now() - 1000;
+      await record.update({
+        createdAt: new Date(expiredAt - APPROVAL_MS),
+        expiresAt: new Date(expiredAt),
+      });
+      const beforePairing = (await record.get()).data()!;
+      const grant = db
+        .collection('worlds')
+        .doc(request.worldId)
+        .collection('agentGrants')
+        .doc(beforePairing.principalUid);
+      const beforeGrant = (await grant.get()).data();
+      await setTester(owner.uid, false);
+      for (const [input, header] of [
+        [{ ...proof, pairingId: request.pairingId }, undefined],
+        [proof, token],
+      ] as const) {
+        expect((await post('revoke', input, header)).status).toBe(400);
+        expect((await record.get()).data()).toEqual(beforePairing);
+        expect((await grant.get()).data()).toEqual(beforeGrant);
+      }
+      const expected = {
+        status: 200,
+        body: { version: 1, pairingId: request.pairingId, revoked: true },
+      };
+      expect(await post('revoke', proof)).toEqual(expected);
+      expect(await post('revoke', proof)).toEqual(expected);
+      expect((await record.get()).data()).toEqual({ ...beforePairing, enabled: false });
+      expect((await grant.get()).exists).toBe(claimed);
+      if (claimed) expect((await grant.get()).data()).toEqual({ ...beforeGrant, enabled: false });
+      await setTester(owner.uid, true);
+      expect((await post('claim', proof)).status).toBe(404);
+      expect((await post('approve', request, token)).status).toBe(404);
+    });
+  });
+}
 
 test('HTTP auth, input and proof failures cannot allocate credentials or cross owner scope', async () => {
   await withPairing(async ({ fixture, db, request, secret, token, owner }) => {
@@ -277,13 +435,15 @@ test('expired approval remains revocable and a missing issued grant is never rec
     });
     expect((await grant.get()).exists).toBe(false);
     now += APPROVAL_MS;
-    await store.revoke(owner.uid, request.pairingId);
-    await store.revoke(owner.uid, request.pairingId);
+    await store.revoke({ kind: 'owner', uid: owner.uid }, request.pairingId);
+    await store.revoke({ kind: 'owner', uid: owner.uid }, request.pairingId);
     expect(
       (await db.collection('officePairings').doc(request.pairingId).get()).data()?.enabled
     ).toBe(false);
     expect((await grant.get()).exists).toBe(false);
-    await expect(store.revoke(owner.uid, '0'.repeat(64))).rejects.toMatchObject({
+    await expect(
+      store.revoke({ kind: 'owner', uid: owner.uid }, '0'.repeat(64))
+    ).rejects.toMatchObject({
       code: 'PERMISSION_DENIED',
     });
     const later = await store.approve(owner.uid, { ...input, pairingId: '1'.repeat(64) });
@@ -292,7 +452,7 @@ test('expired approval remains revocable and a missing issued grant is never rec
     const before = (await retained.get()).data();
     expect(before?.enabled).toBe(true);
     now += APPROVAL_MS;
-    await store.revoke(owner.uid, later.pairingId);
+    await store.revoke({ kind: 'owner', uid: owner.uid }, later.pairingId);
     expect((await retained.get()).data()).toEqual({ ...before, enabled: false });
   });
 });
@@ -381,7 +541,7 @@ test('signer failure and lost-response retries preserve one principal and the or
     expect((await grants.doc(approved.principalUid).get()).data()?.expiresAt.toMillis()).toBe(
       shortenedExpiry
     );
-    await store.revoke(owner.uid, request.pairingId);
+    await store.revoke({ kind: 'owner', uid: owner.uid }, request.pairingId);
     now += CLAIM_INTERVAL_MS;
     await expect(service.claim({ version: 1, secret })).rejects.toMatchObject({
       code: 'PAIRING_UNAVAILABLE',
@@ -397,7 +557,7 @@ test('approval expiry and revocation during signing prevent credential delivery'
       verifyIdToken: (value, revoked) => auth.verifyIdToken(value, revoked),
       createCustomToken: async (uid, claims) => {
         const credential = await auth.createCustomToken(uid, claims);
-        await store.revoke(owner.uid, request.pairingId);
+        await store.revoke({ kind: 'owner', uid: owner.uid }, request.pairingId);
         return credential;
       },
     });

--- a/contracts/office/native-companion.md
+++ b/contracts/office/native-companion.md
@@ -4,7 +4,7 @@ This internal local protocol is separate from the proposed remote work-handoff
 schema. It grants no Office access and does not replace pairing.
 
 The core-owned `OfficeInvocation` has exact operations `probe`, `pair-begin`,
-`pair-poll`, `pair-status` and `inspect`. Its argument vector is
+`pair-poll`, `pair-status`, `inspect` and `sync`. Its argument vector is
 `__tmt-office`, `1`, `<operation>`. Unknown versions, operations,
 extra arguments and non-UTF-8 arguments fail with exit 1, empty stdout and a brief
 stderr diagnostic. There is no arbitrary argv forwarding or shell evaluation.
@@ -43,7 +43,7 @@ separately checks actual Office archives; neither constitutes public publication
 
 ## Pairing operations
 
-Non-probe operations consume one bounded JSON object on stdin (4096 bytes):
+Pairing and inspect operations consume one bounded JSON object on stdin (4096 bytes):
 `world`, `identityId`, `emulator` and `readOnly`, with no unknown or duplicate
 fields. Selectors contain no credentials. The adapter accepts at most 4096 bytes
 per output stream and uses the existing subprocess deadline/cleanup owner.
@@ -59,3 +59,11 @@ adapters stay in the Office feature, not the CLI or core. See
 [native pairing](native-pairing.md) for scope, deadlines and server authority.
 Future operations require a reviewed typed contract before implementation;
 the probe response is never a generic payload or remote authentication.
+
+`sync` consumes exactly `{}`; it requires no active identity or world selector.
+It returns exactly `completed`, `failed`, `pending` (unsigned counts) and
+`failureCode` (a known Office code for failed attempts, otherwise null), or the
+same known `error` result. At most 16 attempts are made within the existing
+25-second operation budget. It uses the same verified child, limits and cleanup
+owner as pairing. An older companion rejects this additive operation; the host
+does not infer successful cleanup from an unsupported response.

--- a/contracts/office/native-pairing.md
+++ b/contracts/office/native-pairing.md
@@ -1,6 +1,6 @@
 # Native pairing v1
 
-Implementation contract for #222 and renewal slice #227. Source builds implement deployment discovery,
+Implementation contract for native pairing, renewal and retirement hooks. Source builds implement deployment discovery,
 pairing and protected credential use; no public Office release is published.
 [Approval and claim](pairing-v1.md) owns remote proof/consent semantics.
 
@@ -74,8 +74,8 @@ return or interpret layout contents. Missing pairing fails `OFFICE_NOT_PAIRED`.
 
 A stable installation UUID is independent of release receipts and binary prefixes:
 one logical installation per ConfigPaths root. Only that public UUID and scope
-locks live in its `office/` directory; there is no disk binding index or second
-identity registry. Missing or corrupt metadata is not automatically regenerated
+locks live in its `office/` directory. SQLite stores opaque lifecycle hook
+references, not another binding/credential registry. Missing or corrupt metadata is not automatically regenerated
 inside an existing installation. One protected record per origin/world/mode/
 installation/identity UUID pins the complete descriptor, immutable approval and
 pending proof/deadline/cadence or paired credential/resource lease, validated
@@ -104,8 +104,8 @@ Office failures use the existing envelope and exit 1:
 `OFFICE_INTERRUPTED`, exit 130. Existing identity/grammar errors retain their
 owners. An unavailable claim cannot distinguish absent from denied approval.
 
-Reassignment, lost-credential recovery and temporary retirement/offline
-revocation remain #209 requirements. Token refresh never extends a grant lease.
+Reassignment and lost-credential recovery remain #209 requirements. Retirement
+delivery is defined below; token refresh never extends a grant lease.
 Actual native/browser/isolated-vault evidence is required by the
 [local-first acceptance contract](../../DEVELOPMENT.md#personal-office-milestone-acceptance).
 
@@ -128,3 +128,57 @@ recovered lease has itself expired, resource use still fails expired; a later
 invocation can renew using the recovered expiry. Each invocation is bounded,
 not an automatic retry loop. Denied, malformed or uncertain renewal never
 authorizes resource use or creates a replacement pairing.
+
+## Identity retirement hooks
+
+Core identity UUID/lifetime remains authoritative. Confirmed temporary pane loss,
+explicit unbind of a temporary identity and explicit removal use the same
+retirement transaction. Saved detachment is not retirement; uncertain pane
+evidence must not authorize it. No command-specific Office cleanup is added to
+these paths.
+
+Before exposing a new approval link, Office saves the protected scope, registers
+its opaque scope key for consumer `tmt-office`, and rechecks the active UUID.
+Accessing an existing scope for pair/inspect also registers it. Registration and
+retirement serialize in SQLite: active subscriptions are `registered`, retired
+ones are `pending`; retirement and enqueue commit or roll back together.
+Repeated registration preserves `delivered` receipts. A replacement with the
+same display name has a new UUID and inherits neither scope nor hooks.
+
+`pair` and `inspect` first attempt pending cleanup at the shared Office boundary.
+`tmt office sync [--prefix <folder>] [--json]` explicitly consumes notifications
+without an active identity, tmux, world selector or new approval. Local `status`
+and ordinary identity commands never perform this remote work. Without an Office
+invocation there is no background delivery guarantee; closing a pane is not
+proof that the remote grant has already been disabled.
+
+Delivery attempts at most 16 records within 25 seconds, least-attempted first.
+Attempts are recorded before external effects so inaccessible scopes cannot
+permanently starve other records. Each consumer uses the existing scope lock,
+loads the protected record, validates its derived scope against the hook, and
+calls the pinned issuer's `/revoke`. Pending scopes use their original proof;
+paired scopes use their bound agent token, refreshing Auth only if needed for
+this authority-reducing operation. No resource renewal or access is permitted
+for a retired UUID.
+
+Only an exact confirmed revocation response permits replacing the protected
+phase with `revoked`, without proof or tokens. Exact vault readback precedes
+SQLite acknowledgment. A crash between remote confirmation, vault publication
+and acknowledgment can replay revocation; the issuer is idempotent, and a
+protected terminal receipt permits acknowledgment without credentials. No SQL
+transaction is held during vault or network work. Missing/locked/corrupt state,
+unknown pending approval, denial and uncertainty remain pending, never silently
+deleted or reported as revoked. Resources and historical identity data remain.
+
+Explicit sync returns `{completed,failed,pending,failureCode}`; `failureCode` is
+null when no attempt failed. Exit 0 requires no failures or pending work; exit 1
+also covers partial batches. An initialization failure uses the normal error
+envelope. Pair/inspect warn on unresolved cleanup, then independently validate
+their requested scope; they cannot use an unrelated cleanup failure as authority.
+Retry sync after resolving the reported obstacle, not in an unbounded loop.
+
+Existing pre-hook vault entries enroll on their next scoped pair/inspect access.
+The OS vault has no portable enumeration contract: unknown scopes retired before
+enrollment cannot be reconstructed or claimed as cleaned. There is no generic
+plugin runtime, daemon, automatic migration of secrets or credential-deletion
+shortcut in this mechanism.

--- a/contracts/office/pairing-v1.md
+++ b/contracts/office/pairing-v1.md
@@ -61,14 +61,14 @@ Application responses are JSON with `Cache-Control: no-store`; errors contain a 
 not raw Firebase errors, secrets or paths. Requests never accept an actor UID as
 authentication. Browser cross-origin access requires an exact operator-approved
 origin; it never authorizes a caller. Non-browser requests may omit `Origin`;
-bearer authentication and live ownership checks still apply. Malformed HTTP/JSON
+the operation's bearer or original-proof authority still applies. Malformed HTTP/JSON
 rejected by the Functions platform before the handler follows platform responses.
 
 | Operation  | Input                                                                                                        | Authority and result                                                                                                            |
 | ---------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | `/approve` | `pairingId`, `worldId`, `installationId`, `identityId`, `installationLabel`, `identityLabel`, `capabilities` | Verified Google bearer ID token, current tester admission and world ownership; returns approved binding and five-minute expiry  |
 | `/claim`   | `secret`                                                                                                     | Original proof; returns the same logical principal, resource grant and a Firebase custom token while the approval remains valid |
-| `/revoke`  | `pairingId`                                                                                                  | Verified admitted owner; atomically disables the approval and any issued grant, retaining resources                             |
+| `/revoke`  | `pairingId`, or `secret` (never both)                                                                        | Verified admitted owner, exact bound agent bearer, or original proof; disables only that approval/grant, retaining resources    |
 
 UUIDs use the grant v1 lowercase hyphenated format; world IDs are 20
 alphanumeric characters. Labels are 1..80 Unicode scalar values, nonblank,
@@ -106,6 +106,8 @@ input before expiry. They never extend the deadline or re-enable a record.
 Revocation is deliberately idempotent for an admitted owner, even after approval
 expiry: the longer-lived resource grant must remain revocable. Unknown/malformed
 records, another owner and lost admission all return permission denied.
+Bound-agent and original-proof retirement cancellation use the reduction-only
+authority defined below; they do not require continuing human admission.
 The first claim transaction creates exactly one [agent grant](agent-grant-v1.md)
 and marks the approval claimed. Later authorized retries reuse that grant and
 its original expiry; missing or disabled grants are never reconstructed.
@@ -160,6 +162,30 @@ principalUid,blockId,capabilities,grantExpiresAt}` with server-authoritative
 expiry and no credentials. Existing authentication, invalid-input, permission,
 unavailable-pairing, conflict and unavailable-service errors retain their
 HTTP mappings. No browser receives agent tokens or direct grant-read authority.
+
+## Retirement cancellation
+
+`POST /revoke` accepts exactly `{version:1,pairingId}` with a verified,
+non-revoked bearer token, or `{version:1,secret}` without an Authorization header.
+Mixed forms reject with `400 INVALID_ARGUMENT`. The owner form retains its
+existing live ownership/admission requirement. An agent token must have the
+agent flag and exactly match the claimed pairing's UID, installation and identity.
+It cannot revoke another assignment. Original proof derives the pairing ID using
+the same canonical decoder as claim; it also permits cleanup of a reserved grant
+whose credential response was lost.
+
+For agent/proof cancellation, expired approvals or leases and lost owner
+admission do not prevent reducing authority. Unknown/malformed pairings or an
+agent scope mismatch return `404 PAIRING_UNAVAILABLE`. An unknown proof never
+creates a tombstone: without an approved record the service has no authenticated
+scope to cancel, and the caller must not mark remote cleanup complete.
+
+The existing revocation transaction is the sole writer for all three authorities.
+It sets only approval and existing grant `enabled` fields to false, does not
+reconstruct a missing grant, and retains block contents and assignment IDs.
+Repeated authorized revocation succeeds, including after expiry. Success is
+exactly `{version:1,pairingId,revoked:true}`. Renewal/claim transactions and live
+Rules cannot turn this response into new authority or revive disabled grants.
 
 ## Deployment and verification boundary
 

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -22,7 +22,9 @@ This is not an invitation, presence or connected-agent implementation.
 Rules also implement the [agent grant boundary](../../contracts/office/agent-grant-v1.md):
 trusted per-agent principals can access only an assigned UUID block with matching
 installation/identity claims, live capability/lease and current owner admission.
-Only the owner can revoke a grant; clients cannot issue or enlarge one. This
+Direct client grant writes are owner-only revocation; clients cannot issue or
+enlarge one. The trusted issuer also accepts scoped agent/proof retirement
+cancellation through its [pairing contract](../../contracts/office/pairing-v1.md#retirement-cancellation). This
 does not provide assignment management. Native credential consumption is owned
 by the optional companion described below. Retained UUID blocks
 use the existing layout validator; no parallel layout/ownership document is introduced.
@@ -93,7 +95,7 @@ The independently versioned native `tmt-office` companion currently implements
 the [typed local protocol](../../contracts/office/native-companion.md), including
 pairing, local status and an authorized assigned-block existence check.
 Its optional adapter feature owns discovery, Auth exchange/refresh, invocation-owned
-resource-lease renewal and protected
+resource-lease renewal, identity retirement hook consumption and protected
 scope records. It has no public distribution. The CLI's explicit `office`
 subtree installs, inspects, updates and deactivates it through existing native
 owners; other CLI operations do not execute or probe it. Shared native protocol
@@ -112,7 +114,8 @@ owns the wire format and recovery policy.
 
 `pairing-contract` owns bounded value decoding; `pairing-store` owns transactional
 approval/grant state, compare-expiry lease renewal and live owner admission.
-`pairing-service` verifies human approval/revocation or bound-agent renewal
+`pairing-service` verifies human approval/revocation, bound-agent renewal or
+reduction-only agent/proof cancellation
 authentication and composes external signing, with a final authority recheck before token
 delivery. `pairing-http` maps transport/error results; `index` alone initializes
 SDKs and exposes the function. Admin bypasses Rules, so server validation is an

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -59,6 +59,20 @@ renews a near-expiry or expired lease through the issuer, preserving the same
 resource and permissions without daily browser approval. Local status does not
 renew. Revoked or missing grants cannot be renewed; expired pending approvals
 and lost credentials still need recovery work. Unpair remains planned.
+Identity retirement queues cleanup locally. Pair/inspect attempt queued Office
+cleanup; to retry explicitly without an active identity or pane, run:
+
+```sh
+tmt office sync --json
+```
+
+Use the same `--prefix` as installation. The result reports `completed`, `failed`,
+`pending` and `failureCode`; exit 0 means no remaining work or failures in that
+batch. Locked credentials or uncertain remote results stay pending. Closing a
+pane or running `ls` does not itself contact the service. There is no background
+delivery guarantee; resolve the obstacle and retry sync before claiming remote
+cleanup. Revocation retains block contents. Saved identities going offline are
+not retired and do not enqueue this cleanup.
 The [native pairing contract](../../contracts/office/native-pairing.md) owns exact
 scope, output, errors and emulator restrictions.
 

--- a/rust/crates/tmt-adapters/src/office_companion.rs
+++ b/rust/crates/tmt-adapters/src/office_companion.rs
@@ -11,7 +11,8 @@ use std::{
     time::{Duration, Instant},
 };
 use tmt_core::office_protocol::{
-    OFFICE_PROTOCOL_OUTPUT_LIMIT, OfficeError, OfficeInvocation, decode_office_probe,
+    OFFICE_HOOK_BATCH_LIMIT, OFFICE_PROTOCOL_OUTPUT_LIMIT, OfficeError, OfficeInvocation,
+    OfficeSyncReport, decode_office_probe,
 };
 
 pub struct PairingCall<'a> {
@@ -36,7 +37,7 @@ pub fn invoke_office_pairing(
     call: &PairingCall<'_>,
     deadline: Instant,
 ) -> io::Result<PairingReply> {
-    if operation == OfficeInvocation::Probe {
+    if matches!(operation, OfficeInvocation::Probe | OfficeInvocation::Sync) {
         return Err(invalid_pairing());
     }
     let input = serde_json::to_vec(
@@ -45,13 +46,31 @@ pub fn invoke_office_pairing(
     if input.len() > 4096 {
         return Err(invalid_pairing());
     }
+    let bytes = invoke_json(executable, operation, &input, deadline)?;
+    decode_pairing_reply(&bytes, call.world)
+}
+
+pub fn invoke_office_sync(
+    executable: &Path,
+    deadline: Instant,
+) -> io::Result<Result<OfficeSyncReport, OfficeError>> {
+    let bytes = invoke_json(executable, OfficeInvocation::Sync, b"{}", deadline)?;
+    decode_sync_reply(&bytes)
+}
+
+fn invoke_json(
+    executable: &Path,
+    operation: OfficeInvocation,
+    input: &[u8],
+    deadline: Instant,
+) -> io::Result<Vec<u8>> {
     let args = operation.arguments().map(OsString::from);
     let running = native_install::with_active_product(Product::Office, executable, |installed| {
         UnixCommandRunner
             .start(CommandRequest {
                 program: installed.active_executable.as_os_str(),
                 args: &args,
-                input: &input,
+                input,
                 deadline,
                 max_output_bytes: 4096,
             })
@@ -61,7 +80,50 @@ pub fn invoke_office_pairing(
     if !output.stderr.is_empty() {
         return Err(invalid_pairing());
     }
-    decode_pairing_reply(&output.stdout, call.world)
+    Ok(output.stdout)
+}
+
+fn decode_sync_reply(bytes: &[u8]) -> io::Result<Result<OfficeSyncReport, OfficeError>> {
+    if bytes.len() > 4096 {
+        return Err(invalid_pairing());
+    }
+    let value: serde_json::Value = serde_json::from_slice(bytes).map_err(|_| invalid_pairing())?;
+    let object = value.as_object().ok_or_else(invalid_pairing)?;
+    if object.len() == 1
+        && let Some(error) = value["error"].as_str().and_then(OfficeError::parse)
+    {
+        return Ok(Err(error));
+    }
+    if object.len() != 4
+        || !["completed", "failed", "pending", "failureCode"]
+            .iter()
+            .all(|key| object.contains_key(*key))
+    {
+        return Err(invalid_pairing());
+    }
+    let completed = value["completed"].as_u64().ok_or_else(invalid_pairing)?;
+    let failed = value["failed"].as_u64().ok_or_else(invalid_pairing)?;
+    let pending = value["pending"].as_u64().ok_or_else(invalid_pairing)?;
+    let failure = match &value["failureCode"] {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(code) => {
+            Some(OfficeError::parse(code).ok_or_else(invalid_pairing)?)
+        }
+        _ => return Err(invalid_pairing()),
+    };
+    if completed
+        .checked_add(failed)
+        .is_none_or(|count| count > OFFICE_HOOK_BATCH_LIMIT as u64)
+        || (failed == 0) != failure.is_none()
+    {
+        return Err(invalid_pairing());
+    }
+    Ok(Ok(OfficeSyncReport {
+        completed,
+        failed,
+        pending,
+        failure,
+    }))
 }
 
 fn decode_pairing_reply(bytes: &[u8], world: &str) -> io::Result<PairingReply> {
@@ -77,7 +139,7 @@ fn decode_pairing_reply(bytes: &[u8], world: &str) -> io::Result<PairingReply> {
         if let Some(error) = value["error"].as_str().and_then(OfficeError::parse) {
             return Ok(PairingReply::Error(error));
         }
-        if let Some(state @ ("unpaired" | "pending" | "credential" | "expired")) =
+        if let Some(state @ ("unpaired" | "pending" | "credential" | "expired" | "revoked")) =
             value["state"].as_str()
         {
             return Ok(PairingReply::State(state.into()));
@@ -154,6 +216,44 @@ fn finish_probe(running: RunningCommand, expected_version: &semver::Version) -> 
 #[cfg(test)]
 mod pairing_tests {
     use super::*;
+
+    #[test]
+    fn sync_reports_are_bounded_and_expose_only_public_delivery_state() {
+        let report = serde_json::json!({"completed":1,"failed":1,"pending":2,"failureCode":"OFFICE_REMOTE_UNCERTAIN"});
+        assert_eq!(
+            decode_sync_reply(report.to_string().as_bytes())
+                .unwrap()
+                .unwrap(),
+            OfficeSyncReport {
+                completed: 1,
+                failed: 1,
+                pending: 2,
+                failure: Some(OfficeError::RemoteUncertain),
+            }
+        );
+        for (key, value) in [
+            ("completed", serde_json::json!(-1)),
+            ("completed", serde_json::json!(16)),
+            ("pending", serde_json::json!("2")),
+            ("failed", serde_json::json!(0)),
+            ("failureCode", serde_json::Value::Null),
+            ("failureCode", serde_json::json!("private diagnostic")),
+            ("refreshToken", serde_json::json!("private")),
+        ] {
+            let mut invalid = report.clone();
+            invalid[key] = value;
+            assert!(
+                decode_sync_reply(invalid.to_string().as_bytes()).is_err(),
+                "{key}"
+            );
+        }
+        assert_eq!(
+            decode_sync_reply(br#"{"error":"OFFICE_CREDENTIALS_UNAVAILABLE"}"#).unwrap(),
+            Err(OfficeError::CredentialsUnavailable)
+        );
+        assert!(decode_sync_reply(br#"{"completed":0}"#).is_err());
+        assert!(decode_sync_reply(&vec![b' '; 4097]).is_err());
+    }
 
     #[test]
     fn pairing_response_accepts_only_public_fields_and_the_selected_world() {

--- a/rust/crates/tmt-adapters/src/office_deployment.rs
+++ b/rust/crates/tmt-adapters/src/office_deployment.rs
@@ -198,6 +198,10 @@ impl OfficeDeployment {
     pub fn renewal_url(&self) -> String {
         format!("{}/renew", self.pairing_url)
     }
+
+    pub fn revocation_url(&self) -> String {
+        format!("{}/revoke", self.pairing_url)
+    }
 }
 
 fn canonical_url(value: &str) -> Result<Url, InvalidDeployment> {

--- a/rust/crates/tmt-adapters/src/office_pairing.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing.rs
@@ -1,5 +1,6 @@
 //! Native approval/proof codec. Secret-bearing values deliberately have no Debug.
 
+mod hooks;
 mod invocation;
 mod local;
 mod record;

--- a/rust/crates/tmt-adapters/src/office_pairing/hooks.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/hooks.rs
@@ -1,0 +1,103 @@
+//! Office consumes committed lifecycle notifications; it never owns retirement.
+
+use super::{OfficeError, OfficeInstallation, PairingRecord, ProtectedEntry};
+use crate::{config::ConfigPaths, storage::Storage};
+use std::{io, time::Instant};
+use tmt_core::{
+    identity_hooks::IdentityHook,
+    office_protocol::{OFFICE_HOOK_BATCH_LIMIT, OfficeSyncReport},
+};
+
+const CONSUMER: &str = "tmt-office";
+
+pub(super) fn register(paths: &ConfigPaths, identity: &str, key: &str) -> Result<(), OfficeError> {
+    let hook =
+        IdentityHook::new(CONSUMER, identity, key).map_err(|_| OfficeError::CredentialsInvalid)?;
+    let mut storage = Storage::open(&paths.database).map_err(unavailable)?;
+    storage.register_identity_hook(&hook).map_err(unavailable)?;
+    storage.close().map_err(unavailable)
+}
+
+pub(super) fn sync(
+    paths: &ConfigPaths,
+    deadline: Instant,
+) -> Result<OfficeSyncReport, OfficeError> {
+    // No prior local identity database means there can be no registered hooks.
+    match std::fs::symlink_metadata(&paths.database) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(OfficeSyncReport::default());
+        }
+        Err(_) => return Err(OfficeError::CredentialsUnavailable),
+        Ok(_) => {}
+    }
+    let mut storage = Storage::open(&paths.database).map_err(unavailable)?;
+    let pending = storage
+        .pending_identity_hooks(CONSUMER, OFFICE_HOOK_BATCH_LIMIT)
+        .map_err(unavailable)?;
+    let mut report = OfficeSyncReport::default();
+    if !pending.is_empty() {
+        let installation =
+            OfficeInstallation::open(paths, false)?.ok_or(OfficeError::CredentialsUnavailable)?;
+        for delivery in pending {
+            if Instant::now() >= deadline {
+                break;
+            }
+            let hook = delivery.hook;
+            // Record the attempt before external effects. Contended/failed work
+            // rotates behind less-attempted items instead of starving the queue.
+            if !storage
+                .record_identity_hook_attempt(&hook)
+                .map_err(unavailable)?
+            {
+                continue;
+            }
+            let result = installation.with_key(hook.reference(), || {
+                deliver(&installation, &hook, deadline)?;
+                storage
+                    .acknowledge_identity_hook(&hook)
+                    .map_err(unavailable)
+            });
+            match result {
+                Ok(true) => report.completed += 1,
+                Ok(false) => {}
+                Err(error) => {
+                    report.failed += 1;
+                    report.failure.get_or_insert(error);
+                }
+            }
+        }
+    }
+    report.pending = storage
+        .count_pending_identity_hooks(CONSUMER)
+        .map_err(unavailable)?;
+    storage.close().map_err(unavailable)?;
+    Ok(report)
+}
+
+fn deliver(
+    installation: &OfficeInstallation,
+    hook: &IdentityHook,
+    deadline: Instant,
+) -> Result<(), OfficeError> {
+    let entry = ProtectedEntry::open(hook.reference())?;
+    let bytes = entry.read()?.ok_or(OfficeError::CredentialsUnavailable)?;
+    let target = PairingRecord::hook_target(&bytes)?;
+    if installation.scope_key(&target, hook.identity_id())? != hook.reference() {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    let mut record = PairingRecord::decode(&bytes, &target, installation.id(), hook.identity_id())?;
+    if record.has_credentials()
+        && record.refresh_if_needed(&target, super::invocation::now_ms()?, deadline)?
+    {
+        // A retired identity can refresh only here for authority reduction. The
+        // normal resource path still requires an active UUID before each effect.
+        entry.write(&record.encode()?)?;
+    }
+    record.revoke(&target, deadline)?;
+    entry.write(&record.encode()?)?;
+    Ok(())
+}
+
+fn unavailable(_: impl std::error::Error) -> OfficeError {
+    OfficeError::CredentialsUnavailable
+}

--- a/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
@@ -33,6 +33,18 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
     if bytes.len() > 4096 || operation == OfficeInvocation::Probe {
         return Err(OfficeError::CredentialsInvalid);
     }
+    if operation == OfficeInvocation::Sync {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct SyncRequest {}
+        let _: SyncRequest =
+            serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+        let paths = ConfigPaths::discover().map_err(|_| OfficeError::CredentialsUnavailable)?;
+        let report = super::hooks::sync(&paths, Instant::now() + Duration::from_secs(25))?;
+        return Ok(
+            json!({"completed":report.completed,"failed":report.failed,"pending":report.pending,"failureCode":report.failure.map(|error| error.code())}),
+        );
+    }
     let request: Request =
         serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
     let mode = if request.emulator {
@@ -59,6 +71,10 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
             .read()?
             .map(|bytes| PairingRecord::decode(&bytes, &target, installation.id(), &identity.id))
             .transpose()?;
+        if existing.is_some() && operation != OfficeInvocation::PairStatus {
+            super::hooks::register(&paths, &identity.id, key)?;
+            active_identity(&paths, &identity.id)?;
+        }
         match operation {
             OfficeInvocation::Inspect => {
                 let mut record = existing.ok_or(OfficeError::NotPaired)?;
@@ -111,6 +127,8 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
                             PairingRecord::pending(&deployment, approval, proof, now_ms()?)?;
                         active_identity(&paths, &identity.id)?;
                         entry.write(&record.encode()?)?;
+                        super::hooks::register(&paths, &identity.id, key)?;
+                        active_identity(&paths, &identity.id)?;
                         record
                     }
                 };
@@ -146,7 +164,9 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
                 active_identity(&paths, &identity.id)?;
                 Ok(json!({"state":"credential"}))
             }
-            OfficeInvocation::Probe => Err(OfficeError::CredentialsInvalid),
+            OfficeInvocation::Probe | OfficeInvocation::Sync => {
+                Err(OfficeError::CredentialsInvalid)
+            }
         }
     };
     if operation == OfficeInvocation::PairStatus {
@@ -165,7 +185,7 @@ fn active_identity(paths: &ConfigPaths, id: &str) -> Result<Identity, OfficeErro
         .ok_or(OfficeError::NotPaired)
 }
 
-fn now_ms() -> Result<u64, OfficeError> {
+pub(super) fn now_ms() -> Result<u64, OfficeError> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|_| OfficeError::CredentialsUnavailable)?

--- a/rust/crates/tmt-adapters/src/office_pairing/local.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/local.rs
@@ -89,9 +89,20 @@ impl OfficeInstallation {
         operation: impl FnOnce(&str) -> Result<T, OfficeError>,
     ) -> Result<T, OfficeError> {
         let key = self.scope_key(target, identity_id)?;
+        self.with_key(&key, || operation(&key))
+    }
+
+    pub(super) fn with_key<T>(
+        &self,
+        key: &str,
+        operation: impl FnOnce() -> Result<T, OfficeError>,
+    ) -> Result<T, OfficeError> {
+        if !crate::content_digest::is_sha256(key) {
+            return Err(OfficeError::CredentialsInvalid);
+        }
         let _lock = file_lock::exclusive(&self.directory.join(format!("{key}.lock")))
             .map_err(unavailable)?;
-        operation(&key)
+        operation()
     }
 
     pub fn scope_key(

--- a/rust/crates/tmt-adapters/src/office_pairing/record.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/record.rs
@@ -1,4 +1,4 @@
-//! One protected binding record. No second disk index or secret-file fallback.
+//! One protected binding record; lifecycle hooks hold only its opaque scope key.
 
 use super::{
     AgentCredential, Approval, Claim, OfficeError, Proof, vault::RECORD_LIMIT, wire::valid_uuid,
@@ -31,6 +31,7 @@ pub struct PairingRecord {
     deny_unknown_fields
 )]
 enum Phase {
+    Revoked {},
     Pending {
         secret: String,
         next_claim_at: u64,
@@ -44,6 +45,48 @@ enum Phase {
 }
 
 impl PairingRecord {
+    pub(super) fn has_credentials(&self) -> bool {
+        matches!(self.phase, Phase::Paired { .. })
+    }
+    /// A hook can locate a retired identity's record without resolving its old
+    /// display name. The consumer verifies the derived scope key before use.
+    pub(super) fn hook_target(bytes: &[u8]) -> Result<WorldTarget, OfficeError> {
+        if bytes.len() > RECORD_LIMIT {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let value: Self =
+            serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+        WorldTarget::parse(
+            &format!("{}/worlds/{}", value.origin, value.approval.world_id()),
+            value.mode,
+        )
+        .map_err(|_| OfficeError::CredentialsInvalid)
+    }
+
+    pub(super) fn revoke(
+        &mut self,
+        target: &WorldTarget,
+        deadline: std::time::Instant,
+    ) -> Result<(), OfficeError> {
+        let deployment = self.deployment(target)?;
+        match &self.phase {
+            Phase::Pending { secret, .. } => super::remote::cancel_pairing(
+                &deployment,
+                &Proof::decode(secret)?,
+                &self.approval,
+                deadline,
+            )?,
+            Phase::Paired { credential, .. } => {
+                credential.revoke(&deployment, &self.approval, deadline)?;
+            }
+            Phase::Revoked {} => return Ok(()),
+        }
+        // Confirmed cancellation removes live secrets, but preserves a durable
+        // receipt for retry if the SQLite acknowledgment fails afterwards.
+        self.phase = Phase::Revoked {};
+        Ok(())
+    }
+
     pub fn refresh_if_needed(
         &mut self,
         target: &WorldTarget,
@@ -69,7 +112,7 @@ impl PairingRecord {
                 )?;
                 Ok(true)
             }
-            Phase::Pending { .. } => Err(OfficeError::NotPaired),
+            Phase::Pending { .. } | Phase::Revoked {} => Err(OfficeError::NotPaired),
         }
     }
 
@@ -107,7 +150,7 @@ impl PairingRecord {
                 *grant_expires_at = expiry;
                 Ok(changed)
             }
-            Phase::Pending { .. } => Err(OfficeError::NotPaired),
+            Phase::Pending { .. } | Phase::Revoked {} => Err(OfficeError::NotPaired),
         }
     }
 
@@ -129,7 +172,7 @@ impl PairingRecord {
                 }
                 credential.inspect_block(&self.deployment(target)?, block_id, deadline)
             }
-            Phase::Pending { .. } => Err(OfficeError::NotPaired),
+            Phase::Pending { .. } | Phase::Revoked {} => Err(OfficeError::NotPaired),
         }
     }
 
@@ -186,6 +229,7 @@ impl PairingRecord {
         value.approval.approval_url(target)?;
         let deployment = value.deployment(target)?;
         match &value.phase {
+            Phase::Revoked {} => {}
             Phase::Pending {
                 secret,
                 next_claim_at,
@@ -254,7 +298,7 @@ impl PairingRecord {
                     .ok_or(OfficeError::CredentialsInvalid)?;
                 Proof::decode(secret)
             }
-            Phase::Paired { .. } => Err(OfficeError::CredentialsInvalid),
+            Phase::Paired { .. } | Phase::Revoked {} => Err(OfficeError::CredentialsInvalid),
         }
     }
 
@@ -285,6 +329,7 @@ impl PairingRecord {
 
     pub fn local_state(&self, now_ms: u64) -> &'static str {
         match &self.phase {
+            Phase::Revoked {} => "revoked",
             Phase::Pending { .. } if now_ms < self.expires_at => "pending",
             Phase::Paired {
                 grant_expires_at, ..

--- a/rust/crates/tmt-adapters/src/office_pairing/record_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/record_tests.rs
@@ -18,6 +18,39 @@ fn fixture() -> (WorldTarget, PairingRecord) {
 }
 
 #[test]
+fn revoked_receipt_has_no_secret_and_can_resume_without_remote_authority() {
+    let (target, mut record) = fixture();
+    let secret = record.reserve_claim(1000).unwrap().secret();
+    // Remote confirmation is exercised by the emulator test; this assertion
+    // isolates the durable terminal representation and its retry behavior.
+    record.phase = Phase::Revoked {};
+    let bytes = record.encode().unwrap();
+    assert!(!String::from_utf8_lossy(&bytes).contains(&secret));
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()["phase"],
+        json!({"state":"revoked"})
+    );
+    let mut resumed = PairingRecord::decode(&bytes, &target, INSTALLATION, IDENTITY).unwrap();
+    assert_eq!(resumed.local_state(u64::MAX), "revoked");
+    assert!(!resumed.has_credentials());
+    // An elapsed deadline proves a terminal retry needs no network exchange.
+    resumed.revoke(&target, std::time::Instant::now()).unwrap();
+    assert_eq!(resumed.encode().unwrap(), bytes);
+    assert_eq!(PairingRecord::hook_target(&bytes).unwrap(), target);
+    let mut invalid: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    invalid["phase"]["secret"] = json!(secret);
+    assert!(
+        PairingRecord::decode(
+            &serde_json::to_vec(&invalid).unwrap(),
+            &target,
+            INSTALLATION,
+            IDENTITY
+        )
+        .is_err()
+    );
+}
+
+#[test]
 fn protected_record_round_trip_preserves_proof_deadline_and_full_deployment() {
     let (target, mut original) = fixture();
     let proof = original.reserve_claim(1000).unwrap();

--- a/rust/crates/tmt-adapters/src/office_pairing/remote.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/remote.rs
@@ -33,6 +33,42 @@ pub fn claim_pairing(
     Claim::decode(&bytes, approval, now_ms)
 }
 
+pub(super) fn cancel_pairing(
+    deployment: &OfficeDeployment,
+    proof: &Proof,
+    approval: &Approval,
+    deadline: Instant,
+) -> Result<(), OfficeError> {
+    if proof.challenge() != approval.pairing_id() {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    let bytes = post(
+        deployment,
+        &deployment.revocation_url(),
+        &serde_json::json!({"version":1,"secret":proof.secret()}).to_string(),
+        "application/json",
+        deadline,
+        PostPurpose::Revocation(None),
+    )?;
+    decode_revocation(&bytes, approval)
+}
+
+fn decode_revocation(bytes: &[u8], approval: &Approval) -> Result<(), OfficeError> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct Revoked {
+        version: u8,
+        pairing_id: String,
+        revoked: bool,
+    }
+    let value: Revoked =
+        serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+    if value.version != 1 || value.pairing_id != approval.pairing_id() || !value.revoked {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    Ok(())
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AgentCredential {
@@ -72,6 +108,26 @@ struct TokenBinding {
 }
 
 impl AgentCredential {
+    pub(super) fn revoke(
+        &self,
+        deployment: &OfficeDeployment,
+        approval: &Approval,
+        deadline: Instant,
+    ) -> Result<(), OfficeError> {
+        if !valid_token(&self.id_token) {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let bytes = post(
+            deployment,
+            &deployment.revocation_url(),
+            &serde_json::json!({"version":1,"pairingId":approval.pairing_id()}).to_string(),
+            "application/json",
+            deadline,
+            PostPurpose::Revocation(Some(&self.id_token)),
+        )?;
+        decode_revocation(&bytes, approval)
+    }
+
     pub fn renew_grant(
         &self,
         deployment: &OfficeDeployment,
@@ -284,6 +340,7 @@ enum PostPurpose<'a> {
     Auth,
     Claim,
     Renewal(&'a str),
+    Revocation(Option<&'a str>),
 }
 
 fn post(
@@ -301,7 +358,7 @@ fn post(
         .header("Content-Type", content_type)
         .header("Accept", "application/json")
         .header("Cache-Control", "no-store");
-    if let PostPurpose::Renewal(token) = purpose {
+    if let PostPurpose::Renewal(token) | PostPurpose::Revocation(Some(token)) = purpose {
         request = request.header("Authorization", &format!("Bearer {token}"));
     }
     let mut response = request

--- a/rust/crates/tmt-adapters/src/office_pairing/remote_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/remote_tests.rs
@@ -25,6 +25,33 @@ fn scope() -> (OfficeDeployment, Approval) {
 
 const PRINCIPAL: &str = "office-agent:00000000-0000-4000-8000-000000000003";
 
+#[test]
+fn revocation_requires_an_exact_confirmed_receipt() {
+    let (_, approval) = scope();
+    let receipt = json!({"version":1,"pairingId":approval.pairing_id(),"revoked":true});
+    assert_eq!(
+        decode_revocation(receipt.to_string().as_bytes(), &approval),
+        Ok(())
+    );
+    for (key, value) in [
+        ("version", json!(2)),
+        ("pairingId", json!("0".repeat(64))),
+        ("revoked", json!(false)),
+        ("revoked", json!("true")),
+        ("token", json!("unexpected")),
+    ] {
+        let mut invalid = receipt.clone();
+        invalid[key] = value;
+        assert_eq!(
+            decode_revocation(invalid.to_string().as_bytes(), &approval),
+            Err(OfficeError::CredentialsInvalid)
+        );
+    }
+    let duplicate = receipt.to_string().replacen('{', "{\"revoked\":true,", 1);
+    assert!(decode_revocation(duplicate.as_bytes(), &approval).is_err());
+    assert!(decode_revocation(b"{}", &approval).is_err());
+}
+
 fn claims() -> Value {
     json!({"aud":"example-office","iss":"https://securetoken.google.com/example-office","sub":PRINCIPAL,
         "tmtOfficeAgent":true,"tmtInstallationId":"00000000-0000-4000-8000-000000000001",

--- a/rust/crates/tmt-adapters/src/office_pairing/wire.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/wire.rs
@@ -103,6 +103,10 @@ impl Approval {
         &self.identity_id
     }
 
+    pub fn world_id(&self) -> &str {
+        &self.world_id
+    }
+
     pub fn read_only(&self) -> bool {
         self.capabilities.len() == 1
     }

--- a/rust/crates/tmt-adapters/src/storage/bindings.rs
+++ b/rust/crates/tmt-adapters/src/storage/bindings.rs
@@ -199,7 +199,8 @@ impl BindingRecords for BindingRows<'_> {
                 )
                 .map_err(|error| classify(error, "Remove identity preamble"))?;
         }
-        self.0
+        let changed = self
+            .0
             .execute(
                 "UPDATE identities
                  SET retired_at_ms = CAST(strftime('%s','now') AS INTEGER) * 1000
@@ -208,6 +209,9 @@ impl BindingRecords for BindingRows<'_> {
                 [&identity.id],
             )
             .map_err(|error| classify(error, "Retire identity"))?;
+        if changed == 1 {
+            super::identity_hooks::enqueue_retirement(self.0, &identity.id)?;
+        }
         Ok(())
     }
 }

--- a/rust/crates/tmt-adapters/src/storage/identity_hooks.rs
+++ b/rust/crates/tmt-adapters/src/storage/identity_hooks.rs
@@ -1,0 +1,158 @@
+//! Subscription registration and retirement share the identity transaction owner.
+
+use rusqlite::{Connection, OptionalExtension, params};
+use tmt_core::identity_hooks::{
+    IdentityHook, IdentityHookState, MAX_PENDING_IDENTITY_HOOKS, PendingIdentityHook,
+    valid_hook_consumer,
+};
+
+use super::{
+    Storage, StorageError, StorageErrorCode, errors::classify,
+    identities::with_immediate_transaction,
+};
+
+fn invalid() -> StorageError {
+    StorageError::new(
+        StorageErrorCode::Unknown,
+        "Invalid identity hook input or state",
+    )
+}
+
+fn state(value: &str) -> Result<IdentityHookState, StorageError> {
+    match value {
+        "registered" => Ok(IdentityHookState::Registered),
+        "pending" => Ok(IdentityHookState::Pending),
+        "delivered" => Ok(IdentityHookState::Delivered),
+        _ => Err(invalid()),
+    }
+}
+
+fn read_state(
+    connection: &Connection,
+    hook: &IdentityHook,
+) -> Result<IdentityHookState, StorageError> {
+    let value: String = connection.query_row(
+        "SELECT state FROM identity_hooks WHERE consumer = ? AND identity_id = ? AND reference = ?",
+        params![hook.consumer(), hook.identity_id(), hook.reference()], |row| row.get(0),
+    ).map_err(|error| classify(error, "Read identity hook state"))?;
+    state(&value)
+}
+
+pub(super) fn enqueue_retirement(
+    connection: &Connection,
+    identity_id: &str,
+) -> Result<(), StorageError> {
+    connection.execute("UPDATE identity_hooks SET state = 'pending' WHERE identity_id = ? AND state = 'registered'", [identity_id])
+        .map_err(|error| classify(error, "Queue identity retirement hooks"))?;
+    Ok(())
+}
+
+impl Storage {
+    pub fn register_identity_hook(
+        &mut self,
+        hook: &IdentityHook,
+    ) -> Result<IdentityHookState, StorageError> {
+        with_immediate_transaction(self, "identity hook registration", |transaction| {
+            let retired: bool = transaction
+                .query_row(
+                    "SELECT retired_at_ms IS NOT NULL FROM identities WHERE id = ?",
+                    [hook.identity_id()],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|error| classify(error, "Read hook identity"))?
+                .ok_or_else(invalid)?;
+            transaction.execute("INSERT INTO identity_hooks (consumer, identity_id, reference, state) VALUES (?, ?, ?, ?) ON CONFLICT (consumer, identity_id, reference) DO NOTHING",
+                params![hook.consumer(), hook.identity_id(), hook.reference(), if retired { "pending" } else { "registered" }])
+                .map_err(|error| classify(error, "Register identity hook"))?;
+            read_state(transaction, hook)
+        })
+    }
+
+    pub fn pending_identity_hooks(
+        &self,
+        consumer: &str,
+        limit: usize,
+    ) -> Result<Vec<PendingIdentityHook>, StorageError> {
+        if !valid_hook_consumer(consumer) || !(1..=MAX_PENDING_IDENTITY_HOOKS).contains(&limit) {
+            return Err(invalid());
+        }
+        let mut statement = self.connection()?.prepare("SELECT consumer, identity_id, reference, attempt_count FROM identity_hooks WHERE consumer = ? AND state = 'pending' ORDER BY attempt_count, identity_id, reference LIMIT ?")
+            .map_err(|error| classify(error, "Prepare pending identity hooks"))?;
+        statement
+            .query_map(params![consumer, limit as i64], |row| {
+                let hook = IdentityHook::new(
+                    &row.get::<_, String>(0)?,
+                    &row.get::<_, String>(1)?,
+                    &row.get::<_, String>(2)?,
+                )
+                .map_err(|_| rusqlite::Error::InvalidQuery)?;
+                let attempt_count = u64::try_from(row.get::<_, i64>(3)?)
+                    .map_err(|_| rusqlite::Error::InvalidQuery)?;
+                Ok(PendingIdentityHook {
+                    hook,
+                    attempt_count,
+                })
+            })
+            .and_then(|rows| rows.collect())
+            .map_err(|error| classify(error, "Read pending identity hooks"))
+    }
+
+    pub fn count_pending_identity_hooks(&self, consumer: &str) -> Result<u64, StorageError> {
+        if !valid_hook_consumer(consumer) {
+            return Err(invalid());
+        }
+        self.connection()?
+            .query_row(
+                "SELECT COUNT(*) FROM identity_hooks WHERE consumer = ? AND state = 'pending'",
+                [consumer],
+                |row| {
+                    u64::try_from(row.get::<_, i64>(0)?).map_err(|_| rusqlite::Error::InvalidQuery)
+                },
+            )
+            .map_err(|error| classify(error, "Count pending identity hooks"))
+    }
+
+    pub fn acknowledge_identity_hook(&mut self, hook: &IdentityHook) -> Result<bool, StorageError> {
+        update_pending(
+            self,
+            hook,
+            "UPDATE identity_hooks SET state = 'delivered' WHERE consumer = ? AND identity_id = ? AND reference = ? AND state = 'pending'",
+        )
+    }
+
+    pub fn record_identity_hook_attempt(
+        &mut self,
+        hook: &IdentityHook,
+    ) -> Result<bool, StorageError> {
+        update_pending(
+            self,
+            hook,
+            "UPDATE identity_hooks SET attempt_count = attempt_count + 1 WHERE consumer = ? AND identity_id = ? AND reference = ? AND state = 'pending'",
+        )
+    }
+}
+
+fn update_pending(
+    storage: &mut Storage,
+    hook: &IdentityHook,
+    sql: &str,
+) -> Result<bool, StorageError> {
+    with_immediate_transaction(storage, "identity hook delivery", |transaction| {
+        match read_state(transaction, hook)? {
+            IdentityHookState::Delivered => return Ok(false),
+            IdentityHookState::Registered => return Err(invalid()),
+            IdentityHookState::Pending => {}
+        }
+        transaction
+            .execute(
+                sql,
+                params![hook.consumer(), hook.identity_id(), hook.reference()],
+            )
+            .map_err(|error| classify(error, "Update pending identity hook"))?;
+        Ok(true)
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/crates/tmt-adapters/src/storage/identity_hooks/tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/identity_hooks/tests.rs
@@ -1,0 +1,251 @@
+use super::*;
+use crate::test_support::TestDirectory;
+use tmt_core::{
+    binding::BindingRepository,
+    identity::{Identity, Lifetime, create_or_resolve},
+};
+
+fn identity(storage: &mut Storage) -> Identity {
+    create_or_resolve(storage, "agent", Lifetime::Temporary)
+        .unwrap()
+        .identity
+}
+
+fn retire(storage: &mut Storage, identity: &Identity) {
+    storage
+        .with_binding_transaction(|rows| rows.retire_identity(identity, false))
+        .unwrap();
+}
+
+#[test]
+fn registration_retirement_reopen_and_delivery_preserve_terminal_state() {
+    let directory = TestDirectory::new();
+    let path = directory.path.join("hooks.db");
+    let mut storage = Storage::open(&path).unwrap();
+    let original = identity(&mut storage);
+    let hook = IdentityHook::new("office", &original.id, "scope").unwrap();
+    for _ in 0..2 {
+        assert_eq!(
+            storage.register_identity_hook(&hook).unwrap(),
+            IdentityHookState::Registered
+        );
+    }
+    assert!(storage.acknowledge_identity_hook(&hook).is_err());
+    assert!(storage.record_identity_hook_attempt(&hook).is_err());
+    retire(&mut storage, &original);
+    storage.close().unwrap();
+    let mut storage = Storage::open(&path).unwrap();
+    assert_eq!(storage.health().unwrap().schema_version, 10);
+    assert_eq!(
+        storage.pending_identity_hooks("office", 100).unwrap()[0].hook,
+        hook
+    );
+    assert!(storage.record_identity_hook_attempt(&hook).unwrap());
+    assert_eq!(
+        storage.pending_identity_hooks("office", 1).unwrap()[0].attempt_count,
+        1
+    );
+    assert!(storage.acknowledge_identity_hook(&hook).unwrap());
+    assert!(!storage.acknowledge_identity_hook(&hook).unwrap());
+    assert!(!storage.record_identity_hook_attempt(&hook).unwrap());
+    retire(&mut storage, &original);
+    assert_eq!(
+        storage.register_identity_hook(&hook).unwrap(),
+        IdentityHookState::Delivered
+    );
+    assert_eq!(storage.count_pending_identity_hooks("office").unwrap(), 0);
+    let replacement = identity(&mut storage);
+    assert_ne!(replacement.id, original.id);
+    let replacement_hook = IdentityHook::new("office", &replacement.id, "scope").unwrap();
+    assert_eq!(
+        storage.register_identity_hook(&replacement_hook).unwrap(),
+        IdentityHookState::Registered
+    );
+    let late = IdentityHook::new("office", &original.id, "late").unwrap();
+    assert_eq!(
+        storage.register_identity_hook(&late).unwrap(),
+        IdentityHookState::Pending
+    );
+}
+
+#[test]
+fn returned_error_and_queue_failure_roll_back_retirement() {
+    let directory = TestDirectory::new();
+    let mut storage = Storage::open(directory.path.join("hooks.db")).unwrap();
+    let original = identity(&mut storage);
+    let hook = IdentityHook::new("office", &original.id, "scope").unwrap();
+    storage.register_identity_hook(&hook).unwrap();
+    let result: Result<(), StorageError> = storage.with_binding_transaction(|rows| {
+        rows.retire_identity(&original, false)?;
+        Err(invalid())
+    });
+    assert!(result.is_err());
+    assert!(
+        storage
+            .find_active_identity_by_id(&original.id)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(storage.count_pending_identity_hooks("office").unwrap(), 0);
+    storage.connection().unwrap().execute_batch("CREATE TRIGGER reject_hook BEFORE UPDATE ON identity_hooks BEGIN SELECT RAISE(ABORT, 'fixture failure'); END;").unwrap();
+    assert!(
+        storage
+            .with_binding_transaction(|rows| rows.retire_identity(&original, false))
+            .is_err()
+    );
+    assert!(
+        storage
+            .find_active_identity_by_id(&original.id)
+            .unwrap()
+            .is_some()
+    );
+    storage
+        .connection()
+        .unwrap()
+        .execute_batch("DROP TRIGGER reject_hook")
+        .unwrap();
+    retire(&mut storage, &original);
+    assert_eq!(storage.count_pending_identity_hooks("office").unwrap(), 1);
+}
+
+#[test]
+fn attempts_make_progress_and_invalid_inputs_or_rows_fail() {
+    let directory = TestDirectory::new();
+    let mut storage = Storage::open(directory.path.join("hooks.db")).unwrap();
+    let original = identity(&mut storage);
+    retire(&mut storage, &original);
+    let first = IdentityHook::new("office", &original.id, "a").unwrap();
+    let second = IdentityHook::new("office", &original.id, "b").unwrap();
+    storage.register_identity_hook(&first).unwrap();
+    storage.register_identity_hook(&second).unwrap();
+    assert_eq!(
+        storage.pending_identity_hooks("office", 1).unwrap()[0].hook,
+        first
+    );
+    storage.record_identity_hook_attempt(&first).unwrap();
+    assert_eq!(
+        storage.pending_identity_hooks("office", 1).unwrap()[0].hook,
+        second
+    );
+    for limit in [0, 101, usize::MAX] {
+        assert!(storage.pending_identity_hooks("office", limit).is_err());
+    }
+    assert!(storage.count_pending_identity_hooks("").is_err());
+    let missing =
+        IdentityHook::new("office", &uuid::Uuid::new_v4().to_string(), "missing").unwrap();
+    assert!(storage.register_identity_hook(&missing).is_err());
+    assert!(storage.acknowledge_identity_hook(&missing).is_err());
+    storage
+        .connection()
+        .unwrap()
+        .execute(
+            "UPDATE identity_hooks SET reference = char(10) WHERE reference = 'a'",
+            [],
+        )
+        .unwrap();
+    assert!(storage.pending_identity_hooks("office", 100).is_err());
+}
+
+#[test]
+fn saved_detach_does_not_enqueue_and_registration_serializes_with_retirement() {
+    let directory = TestDirectory::new();
+    let path = directory.path.join("hooks.db");
+    let mut storage = Storage::open(&path).unwrap();
+    let original = create_or_resolve(&mut storage, "agent", Lifetime::Saved)
+        .unwrap()
+        .identity;
+    let hook = IdentityHook::new("office", &original.id, "scope").unwrap();
+    storage.register_identity_hook(&hook).unwrap();
+    let binding = storage
+        .with_binding_transaction(|rows| {
+            rows.insert_binding(
+                &original,
+                &tmt_core::endpoint::ServerEvidence {
+                    server_id: uuid::Uuid::new_v4().to_string(),
+                    socket_path: "/fixture/socket".into(),
+                    server_pid: 100,
+                    server_start_time: "fixture".into(),
+                },
+                &tmt_core::endpoint::PaneObservation {
+                    id: "%1".into(),
+                    target: None,
+                    cwd: None,
+                    command: "fixture".into(),
+                    pane_pid: 101,
+                    suggested_name: None,
+                    marker: None,
+                },
+            )
+        })
+        .unwrap();
+    storage
+        .with_binding_transaction(|rows| rows.detach_binding(&binding.id))
+        .unwrap();
+    assert!(
+        storage
+            .find_active_identity_by_id(&original.id)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(storage.count_pending_identity_hooks("office").unwrap(), 0);
+    let mut concurrent = Storage::open(&path).unwrap();
+    let barrier = std::sync::Barrier::new(2);
+    let late = IdentityHook::new("office", &original.id, "late").unwrap();
+    let peer_hook = late.clone();
+    std::thread::scope(|scope| {
+        let peer = scope.spawn(|| {
+            barrier.wait();
+            concurrent.register_identity_hook(&peer_hook).unwrap();
+        });
+        barrier.wait();
+        retire(&mut storage, &original);
+        peer.join().unwrap();
+    });
+    assert_eq!(
+        storage.register_identity_hook(&late).unwrap(),
+        IdentityHookState::Pending
+    );
+    assert_eq!(storage.count_pending_identity_hooks("office").unwrap(), 2);
+}
+
+#[test]
+fn schema_nine_upgrade_is_atomic_and_preserves_identity() {
+    let directory = TestDirectory::new();
+    let path = directory.path.join("hooks.db");
+    let mut storage = Storage::open(&path).unwrap();
+    let original = identity(&mut storage);
+    // Restore the exact predecessor table inventory; no hook existed in v9.
+    storage.connection().unwrap().execute_batch("DROP TABLE identity_hooks; DELETE FROM _migrations WHERE version = 10;
+        CREATE TRIGGER reject_tenth BEFORE INSERT ON _migrations WHEN NEW.version = 10 BEGIN SELECT RAISE(ABORT, 'fixture failure'); END;").unwrap();
+    storage.close().unwrap();
+    let error = match Storage::open(&path) {
+        Ok(_) => panic!("migration should fail"),
+        Err(error) => error,
+    };
+    assert_eq!(error.migration_version, Some(10));
+    let observer = Connection::open(&path).unwrap();
+    let table_count: i64 = observer
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'identity_hooks'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(table_count, 0);
+    observer.execute_batch("DROP TRIGGER reject_tenth").unwrap();
+    observer.close().unwrap();
+    let mut storage = Storage::open(&path).unwrap();
+    assert_eq!(storage.health().unwrap().schema_version, 10);
+    assert_eq!(
+        storage
+            .find_active_identity_by_id(&original.id)
+            .unwrap()
+            .unwrap(),
+        original
+    );
+    let hook = IdentityHook::new("office", &original.id, "scope").unwrap();
+    assert_eq!(
+        storage.register_identity_hook(&hook).unwrap(),
+        IdentityHookState::Registered
+    );
+}

--- a/rust/crates/tmt-adapters/src/storage/migrations.rs
+++ b/rust/crates/tmt-adapters/src/storage/migrations.rs
@@ -53,6 +53,10 @@ const MIGRATIONS: &[Migration] = &[
         name: "add identity lifetimes and reusable retired names",
         sql: include_str!("schema/009.sql"),
     },
+    Migration {
+        name: "add durable identity retirement hooks",
+        sql: include_str!("schema/010.sql"),
+    },
 ];
 
 pub(super) fn apply(connection: &mut Connection) -> Result<(), StorageError> {

--- a/rust/crates/tmt-adapters/src/storage/migrations/receipt_tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/migrations/receipt_tests.rs
@@ -39,7 +39,7 @@ fn v1_executes_after_migration_for_every_eligible_inflight_state() {
         .unwrap();
         old.close().unwrap();
         let mut native = Storage::open(&path).unwrap();
-        assert_eq!(native.health().unwrap().schema_version, 9);
+        assert_eq!(native.health().unwrap().schema_version, 10);
         let final_response = RequestService::new(&mut native, || (NOW + 2 * DAY) as u64)
             .submit_response(submission("\u{feff}late\0\r\n"))
             .unwrap();

--- a/rust/crates/tmt-adapters/src/storage/mod.rs
+++ b/rust/crates/tmt-adapters/src/storage/mod.rs
@@ -1,6 +1,7 @@
 mod bindings;
 mod errors;
 mod identities;
+mod identity_hooks;
 mod migrations;
 mod profiles;
 mod requests;

--- a/rust/crates/tmt-adapters/src/storage/schema/010.sql
+++ b/rust/crates/tmt-adapters/src/storage/schema/010.sql
@@ -1,0 +1,10 @@
+CREATE TABLE identity_hooks (
+    consumer TEXT NOT NULL CHECK (length(consumer) BETWEEN 1 AND 64),
+    identity_id TEXT NOT NULL REFERENCES identities(id),
+    reference TEXT NOT NULL CHECK (length(reference) BETWEEN 1 AND 256),
+    state TEXT NOT NULL CHECK (state IN ('registered', 'pending', 'delivered')),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (typeof(attempt_count) = 'integer' AND attempt_count >= 0),
+    PRIMARY KEY (consumer, identity_id, reference)
+);
+CREATE INDEX identity_hooks_pending ON identity_hooks (consumer, state, attempt_count, identity_id, reference);
+CREATE INDEX identity_hooks_retirement ON identity_hooks (identity_id, state);

--- a/rust/crates/tmt-adapters/src/storage/tests.rs
+++ b/rust/crates/tmt-adapters/src/storage/tests.rs
@@ -27,7 +27,7 @@ fn open_enforces_connection_features_and_private_files() {
         storage.health().unwrap(),
         StorageHealth {
             path: fixture.database.clone(),
-            schema_version: 9,
+            schema_version: 10,
             journal_mode: "wal",
             foreign_keys: true,
             busy_timeout_ms: 5000,
@@ -153,7 +153,7 @@ fn concurrent_openers_commit_each_migration_only_once() {
     initial.pragma_update(None, "journal_mode", "WAL").unwrap();
     initial.close().unwrap();
     for result in concurrent_opens(&fixture) {
-        assert_eq!(result.unwrap(), 9);
+        assert_eq!(result.unwrap(), 10);
     }
     assert_complete_history(&fixture);
 }
@@ -165,7 +165,7 @@ fn cold_open_race_only_returns_success_or_retryable_contention() {
     for result in concurrent_opens(&fixture) {
         match result {
             Ok(version) => {
-                assert_eq!(version, 9);
+                assert_eq!(version, 10);
                 successful += 1;
             }
             Err(error) => {
@@ -179,7 +179,7 @@ fn cold_open_race_only_returns_success_or_retryable_contention() {
     }
     assert!(successful > 0);
     let mut recovered = Storage::open(&fixture.database).unwrap();
-    assert_eq!(recovered.health().unwrap().schema_version, 9);
+    assert_eq!(recovered.health().unwrap().schema_version, 10);
     recovered.close().unwrap();
     assert_complete_history(&fixture);
 }
@@ -212,7 +212,7 @@ fn assert_complete_history(fixture: &Fixture) {
     let count: i64 = verification
         .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(count, 9);
+    assert_eq!(count, 10);
     let check: String = verification
         .query_row("PRAGMA integrity_check", [], |row| row.get(0))
         .unwrap();

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -270,6 +270,10 @@ fn office(name: &'static str, about: &'static str) -> Command {
 
 fn office_commands() -> Command {
     office("office", "Manage the optional Office companion")
+        .subcommand(office(
+            "sync",
+            "Deliver pending identity retirement hooks to Office",
+        ))
         .subcommand(office_scope(
             office(
                 "inspect",

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -79,6 +79,7 @@ pub enum Invocation {
 pub enum OfficeOperation {
     Open,
     Status,
+    Sync,
     Inspect {
         world: String,
         identity: Option<String>,

--- a/rust/crates/tmt-cli/src/office_command.rs
+++ b/rust/crates/tmt-cli/src/office_command.rs
@@ -212,7 +212,8 @@ fn run(
     match operation {
         OfficeOperation::Pair { .. }
         | OfficeOperation::PairStatus { .. }
-        | OfficeOperation::Inspect { .. } => {
+        | OfficeOperation::Inspect { .. }
+        | OfficeOperation::Sync => {
             if !installed(&executable)? {
                 return Err(Failure::new("OFFICE_NOT_INSTALLED", INSTALL_HINT, 1));
             }

--- a/rust/crates/tmt-cli/src/office_pairing_command.rs
+++ b/rust/crates/tmt-cli/src/office_pairing_command.rs
@@ -13,12 +13,30 @@ use std::{
 use tmt_adapters::{
     config::ConfigPaths,
     interrupt::Interrupt,
-    office_companion::{PairingCall, PairingReply, invoke_office_pairing},
+    office_companion::{PairingCall, PairingReply, invoke_office_pairing, invoke_office_sync},
     storage::Storage,
 };
 use tmt_core::office_protocol::{OfficeError, OfficeInvocation};
 
 pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> Result<u8, Failure> {
+    if matches!(operation, OfficeOperation::Sync) {
+        return sync(executable, mode);
+    }
+    let interrupt = Interrupt::install().map_err(unavailable)?;
+    // The Office boundary alone consumes its hooks. Ordinary identity commands
+    // commit notifications without loading a companion or waiting for a network.
+    if matches!(
+        operation,
+        OfficeOperation::Pair { .. } | OfficeOperation::Inspect { .. }
+    ) {
+        match invoke_office_sync(executable, Instant::now() + Duration::from_secs(30)) {
+            Ok(Ok(report)) if report.pending == 0 => {},
+            _ => writeln!(io::stderr().lock(), "Office retirement cleanup remains unconfirmed. Run tmt office sync to retry; the requested operation is checked separately.").map_err(unavailable)?,
+        }
+        if interrupt.is_interrupted() {
+            return Err(interrupted());
+        }
+    }
     let inspect = matches!(&operation, OfficeOperation::Inspect { .. });
     let (world, identity, emulator, read_only, timeout, pair) = match operation {
         OfficeOperation::Pair {
@@ -57,7 +75,6 @@ pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> R
         emulator,
         read_only,
     };
-    let interrupt = Interrupt::install().map_err(unavailable)?;
     let deadline = Instant::now() + Duration::from_secs(timeout);
     let mut operation = if pair {
         OfficeInvocation::PairBegin
@@ -132,6 +149,37 @@ pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> R
             .wait_until(deadline.min(Instant::now() + Duration::from_secs(5)))
             .map_err(unavailable)?;
     }
+}
+
+fn sync(executable: &Path, mode: OutputMode) -> Result<u8, Failure> {
+    let interrupt = Interrupt::install().map_err(unavailable)?;
+    let result = invoke_office_sync(executable, Instant::now() + Duration::from_secs(30));
+    if interrupt.is_interrupted() {
+        return Err(interrupted());
+    }
+    let report = result.map_err(unavailable)?.map_err(pairing_error)?;
+    let value = serde_json::json!({"completed":report.completed,"failed":report.failed,"pending":report.pending,"failureCode":report.failure.map(|error| error.code())});
+    writeln!(
+        io::stdout().lock(),
+        "{}",
+        if mode.json {
+            value.to_string()
+        } else {
+            format!(
+                "Office retirement hooks: {} completed, {} failed, {} pending.{}",
+                report.completed,
+                report.failed,
+                report.pending,
+                if report.pending > 0 {
+                    " Run tmt office sync to retry; remote cleanup is not yet complete."
+                } else {
+                    ""
+                }
+            )
+        }
+    )
+    .map_err(unavailable)?;
+    Ok(u8::from(report.pending > 0 || report.failed > 0))
 }
 
 fn pairing_error(error: OfficeError) -> Failure {

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -151,11 +151,13 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
         | ["office", "status"]
         | ["office", "pair"]
         | ["office", "inspect"]
+        | ["office", "sync"]
         | ["office", "install"]
         | ["office", "upgrade"]
         | ["office", "uninstall"] => Invocation::Office {
             prefix: text(m, "prefix"),
             operation: match path.last().copied() {
+                Some("sync") => OfficeOperation::Sync,
                 Some("inspect") => OfficeOperation::Inspect {
                     world: required(m, "world"),
                     identity: text(m, "identity"),

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -127,6 +127,30 @@ fn office_prefix_is_scoped_to_its_subtree_and_file_inputs_are_paired() {
 }
 
 #[test]
+fn office_sync_is_install_scoped_not_active_identity_scoped() {
+    use crate::invocation::OfficeOperation;
+    assert_eq!(
+        parsed(&["office", "sync", "--prefix", "/office", "--json"]).invocation,
+        Invocation::Office {
+            prefix: Some("/office".into()),
+            operation: OfficeOperation::Sync
+        }
+    );
+    for input in [
+        vec!["office", "sync", "--identity", "Alice"],
+        vec![
+            "office",
+            "sync",
+            "--world",
+            "https://office.example/worlds/abcdefghijklmnopqrst",
+        ],
+        vec!["office", "sync", "--emulator"],
+    ] {
+        assert_eq!(parse_error(&input).code, "USAGE_ERROR");
+    }
+}
+
+#[test]
 fn native_upgrade_alias_and_selection_share_one_typed_contract() {
     for command in ["upgrade", "update"] {
         let invocation = parsed(&[

--- a/rust/crates/tmt-core/src/identity_hooks.rs
+++ b/rust/crates/tmt-core/src/identity_hooks.rs
@@ -1,0 +1,122 @@
+//! Opaque subscriptions to the terminal retirement of an identity UUID.
+
+use std::{error::Error, fmt};
+
+pub const MAX_PENDING_IDENTITY_HOOKS: usize = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookError {
+    Consumer,
+    Identity,
+    Reference,
+}
+
+impl fmt::Display for HookError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Consumer => "Invalid identity hook consumer",
+            Self::Identity => "Invalid identity hook UUID",
+            Self::Reference => "Invalid identity hook reference",
+        })
+    }
+}
+
+impl Error for HookError {}
+
+pub fn valid_hook_consumer(value: &str) -> bool {
+    (1..=64).contains(&value.len())
+        && value.as_bytes()[0].is_ascii_lowercase()
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-')
+        })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentityHook {
+    consumer: String,
+    identity_id: String,
+    reference: String,
+}
+
+impl IdentityHook {
+    pub fn new(consumer: &str, identity_id: &str, reference: &str) -> Result<Self, HookError> {
+        if !valid_hook_consumer(consumer) {
+            return Err(HookError::Consumer);
+        }
+        if !uuid::Uuid::parse_str(identity_id).is_ok_and(|id| {
+            id.get_version_num() == 4
+                && id.get_variant() == uuid::Variant::RFC4122
+                && id.to_string() == identity_id
+        }) {
+            return Err(HookError::Identity);
+        }
+        if !(1..=256).contains(&reference.len())
+            || !reference.bytes().all(|byte| byte.is_ascii_graphic())
+        {
+            return Err(HookError::Reference);
+        }
+        Ok(Self {
+            consumer: consumer.into(),
+            identity_id: identity_id.into(),
+            reference: reference.into(),
+        })
+    }
+
+    pub fn consumer(&self) -> &str {
+        &self.consumer
+    }
+    pub fn identity_id(&self) -> &str {
+        &self.identity_id
+    }
+    pub fn reference(&self) -> &str {
+        &self.reference
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityHookState {
+    Registered,
+    Pending,
+    Delivered,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingIdentityHook {
+    pub hook: IdentityHook,
+    pub attempt_count: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ID: &str = "11111111-1111-4111-8111-111111111111";
+
+    #[test]
+    fn hook_bounds_and_uuid_are_validated_without_normalization() {
+        assert!(IdentityHook::new("office", ID, "opaque-reference").is_ok());
+        for consumer in ["", "Office", "office.name", "1office", &"a".repeat(65)] {
+            assert_eq!(
+                IdentityHook::new(consumer, ID, "ref"),
+                Err(HookError::Consumer)
+            );
+        }
+        for id in [
+            "name",
+            "11111111-1111-1111-8111-111111111111",
+            "AAAAAAAA-1111-4111-8111-111111111111",
+        ] {
+            assert_eq!(
+                IdentityHook::new("office", id, "ref"),
+                Err(HookError::Identity)
+            );
+        }
+        for reference in ["", "two words", "\n", "é", &"x".repeat(257)] {
+            assert_eq!(
+                IdentityHook::new("office", ID, reference),
+                Err(HookError::Reference)
+            );
+        }
+        assert!(IdentityHook::new(&"a".repeat(64), ID, &"x".repeat(256)).is_ok());
+    }
+}

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod binding;
 pub mod endpoint;
 pub mod exact_text;
 pub mod identity;
+pub mod identity_hooks;
 pub mod limits;
 pub mod names;
 pub mod native_install;

--- a/rust/crates/tmt-core/src/office_protocol.rs
+++ b/rust/crates/tmt-core/src/office_protocol.rs
@@ -4,6 +4,15 @@ use semver::Version;
 
 pub const OFFICE_PROTOCOL_VERSION: &str = "1";
 pub const OFFICE_PROTOCOL_OUTPUT_LIMIT: usize = 1024;
+pub const OFFICE_HOOK_BATCH_LIMIT: usize = 16;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OfficeSyncReport {
+    pub completed: u64,
+    pub failed: u64,
+    pub pending: u64,
+    pub failure: Option<OfficeError>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OfficeError {
@@ -61,6 +70,7 @@ pub enum OfficeInvocation {
     PairPoll,
     PairStatus,
     Inspect,
+    Sync,
 }
 
 impl OfficeInvocation {
@@ -71,6 +81,7 @@ impl OfficeInvocation {
             Self::PairPoll => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "pair-poll"],
             Self::PairStatus => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "pair-status"],
             Self::Inspect => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "inspect"],
+            Self::Sync => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "sync"],
         }
     }
 
@@ -81,6 +92,7 @@ impl OfficeInvocation {
             Self::PairPoll,
             Self::PairStatus,
             Self::Inspect,
+            Self::Sync,
         ]
         .into_iter()
         .find(|operation| arguments == operation.arguments())
@@ -139,6 +151,7 @@ mod tests {
             ("pair-poll", OfficeInvocation::PairPoll),
             ("pair-status", OfficeInvocation::PairStatus),
             ("inspect", OfficeInvocation::Inspect),
+            ("sync", OfficeInvocation::Sync),
         ] {
             assert_eq!(operation.arguments(), ["__tmt-office", "1", name]);
             assert_eq!(

--- a/services/office/Dockerfile
+++ b/services/office/Dockerfile
@@ -26,7 +26,7 @@ CMD ["firebase", "emulators:start", "--only", "auth,firestore", "--project", "de
 # Opt-in browser proof reuses the emulator owner; no host credentials or volumes.
 FROM emulator-tools AS browser-tests
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends dbus gnome-keyring libglib2.0-bin libsecret-tools && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends dbus gnome-keyring libglib2.0-bin libsecret-tools sqlite3 tmux && rm -rf /var/lib/apt/lists/*
 RUN npm install --global pnpm@10.33.0 && mkdir -p /workspace/apps/office && chown -R node:node /workspace
 WORKDIR /workspace
 COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -36,7 +36,7 @@ USER node
 RUN pnpm office:install && test ! -e node_modules/better-sqlite3 && test ! -e /node_modules
 RUN cd services/office/functions && pnpm install --ignore-workspace --lockfile-dir "$PWD/../../.." --frozen-lockfile
 # Combined native/browser acceptance uses root-owned process/archive helpers.
-# The independent SQLite oracle is not built or executed by this browser image.
+# sqlite3 supplies the independent hook oracle; no native Node addon is built.
 RUN pnpm --filter tmux-team install --frozen-lockfile --ignore-scripts
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 USER root
@@ -45,6 +45,7 @@ USER node
 COPY --from=emulators --chown=node:node /home/node/office/ /home/node/office/
 COPY --chown=node:node apps/office apps/office
 COPY --chown=node:node contracts/office contracts/office
+COPY --chown=node:node test/e2e test/e2e
 COPY --chown=node:node test/support test/support
 COPY --from=native-office --chown=node:node /workspace/rust/target/release/tmt /workspace/rust/target/debug/tmt
 COPY --from=native-office --chown=node:node /workspace/rust/target/release/tmt-office /workspace/rust/target/debug/tmt-office

--- a/services/office/functions/src/pairing-contract.ts
+++ b/services/office/functions/src/pairing-contract.ts
@@ -141,10 +141,15 @@ export function parseRenewal(input: unknown): Renewal {
   };
 }
 
-export function parseRevocation(input: unknown): string {
+export type Revocation =
+  | { kind: 'pairing'; pairingId: string }
+  | { kind: 'proof'; pairingId: string };
+
+export function parseRevocation(input: unknown): Revocation {
   const value = object(input);
+  if (Object.hasOwn(value, 'secret')) return { kind: 'proof', pairingId: parseClaim(value) };
   exact(value, ['version', 'pairingId']);
   if (value.version !== 1 || !matches(value.pairingId, PAIRING_ID))
     throw new PairingError('INVALID_ARGUMENT');
-  return value.pairingId;
+  return { kind: 'pairing', pairingId: value.pairingId };
 }

--- a/services/office/functions/src/pairing-service.ts
+++ b/services/office/functions/src/pairing-service.ts
@@ -25,15 +25,13 @@ export function createPairingService(store: PairingStore, auth: PairingAuthentic
     }
   }
 
-  async function human(authorization: string | undefined): Promise<string> {
-    const token = await verified(authorization);
-    if (token.firebase.sign_in_provider !== 'google.com' || token.email_verified !== true)
+  function human(token: DecodedIdToken): string {
+    if (token.firebase?.sign_in_provider !== 'google.com' || token.email_verified !== true)
       throw new PairingError('PERMISSION_DENIED');
     return token.uid;
   }
 
-  async function agent(authorization: string | undefined): Promise<AgentIdentity> {
-    const token = await verified(authorization);
+  function agent(token: DecodedIdToken): AgentIdentity {
     if (
       token.tmtOfficeAgent !== true ||
       typeof token.tmtInstallationId !== 'string' ||
@@ -52,7 +50,7 @@ export function createPairingService(store: PairingStore, auth: PairingAuthentic
   return {
     async approve(input: unknown, authorization?: string) {
       const request = parseApproval(input);
-      return store.approve(await human(authorization), request);
+      return store.approve(human(await verified(authorization)), request);
     },
     async claim(input: unknown) {
       const id = parseClaim(input);
@@ -73,16 +71,27 @@ export function createPairingService(store: PairingStore, auth: PairingAuthentic
     async renew(input: unknown, authorization?: string) {
       const renewal = parseRenewal(input);
       const binding = await store.renew(
-        await agent(authorization),
+        agent(await verified(authorization)),
         renewal.pairingId,
         renewal.grantExpiresAt
       );
       return binding;
     },
     async revoke(input: unknown, authorization?: string) {
-      const id = parseRevocation(input);
-      await store.revoke(await human(authorization), id);
-      return { version: 1, pairingId: id, revoked: true };
+      const request = parseRevocation(input);
+      if (request.kind === 'proof') {
+        if (authorization !== undefined) throw new PairingError('INVALID_ARGUMENT');
+        await store.revoke({ kind: 'proof' }, request.pairingId);
+      } else {
+        const token = await verified(authorization);
+        await store.revoke(
+          token.tmtOfficeAgent === true
+            ? { kind: 'agent', agent: agent(token) }
+            : { kind: 'owner', uid: human(token) },
+          request.pairingId
+        );
+      }
+      return { version: 1, pairingId: request.pairingId, revoked: true };
     },
   };
 }

--- a/services/office/functions/src/pairing-store.ts
+++ b/services/office/functions/src/pairing-store.ts
@@ -44,6 +44,19 @@ export interface AgentIdentity {
   identityId: string;
 }
 
+export type RevocationActor =
+  | { kind: 'owner'; uid: string }
+  | { kind: 'agent'; agent: AgentIdentity }
+  | { kind: 'proof' };
+
+function matchesAgent(pairing: Pairing, agent: AgentIdentity): boolean {
+  return (
+    pairing.principalUid === agent.uid &&
+    pairing.request.installationId === agent.installationId &&
+    pairing.request.identityId === agent.identityId
+  );
+}
+
 export interface RenewedBinding {
   version: 1;
   pairingId: string;
@@ -312,12 +325,7 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
         validApproval(pairing, now, 'renewal');
         if (!pairing.claimed || !(await ownsWorld(tx, pairing.ownerUid, pairing.request.worldId)))
           unavailable();
-        if (
-          pairing.principalUid !== agent.uid ||
-          pairing.request.installationId !== agent.installationId ||
-          pairing.request.identityId !== agent.identityId
-        )
-          unavailable();
+        if (!matchesAgent(pairing, agent)) unavailable();
 
         const grant = await tx.get(grantRef(pairing));
         const currentGrantExpiresAt = validGrant(grant.data(), pairing, now, 'renewal');
@@ -338,17 +346,29 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
       });
     },
 
-    async revoke(uid: string, id: string): Promise<void> {
+    async revoke(actor: RevocationActor, id: string): Promise<void> {
       await db.runTransaction(async (tx) => {
         const snapshot = await tx.get(pairingRef(id));
         let pairing: Pairing;
         try {
           pairing = decode(snapshot.data(), id);
         } catch {
-          throw new PairingError('PERMISSION_DENIED');
+          throw new PairingError(
+            actor.kind === 'owner' ? 'PERMISSION_DENIED' : 'PAIRING_UNAVAILABLE'
+          );
         }
-        if (pairing.ownerUid !== uid || !(await ownsWorld(tx, uid, pairing.request.worldId)))
-          throw new PairingError('PERMISSION_DENIED');
+        if (actor.kind === 'owner') {
+          if (
+            pairing.ownerUid !== actor.uid ||
+            !(await ownsWorld(tx, actor.uid, pairing.request.worldId))
+          )
+            throw new PairingError('PERMISSION_DENIED');
+        } else if (
+          actor.kind === 'agent' &&
+          (!pairing.claimed || !matchesAgent(pairing, actor.agent))
+        ) {
+          unavailable();
+        }
         const grant = await tx.get(grantRef(pairing));
         tx.update(pairingRef(id), { enabled: false });
         if (grant.exists) tx.update(grantRef(pairing), { enabled: false });

--- a/services/office/functions/test/pairing-contract.test.ts
+++ b/services/office/functions/test/pairing-contract.test.ts
@@ -25,7 +25,10 @@ describe('pairing input contract', () => {
     expect(parseApproval({ ...approval, capabilities: ['layout.read'] }).capabilities).toEqual([
       'layout.read',
     ]);
-    expect(parseRevocation({ version: 1, pairingId: approval.pairingId })).toBe(approval.pairingId);
+    expect(parseRevocation({ version: 1, pairingId: approval.pairingId })).toEqual({
+      kind: 'pairing',
+      pairingId: approval.pairingId,
+    });
     expect(parseRenewal({ version: 1, pairingId: approval.pairingId, grantExpiresAt: 1 })).toEqual({
       version: 1,
       pairingId: approval.pairingId,

--- a/services/office/functions/test/pairing-renewal.test.ts
+++ b/services/office/functions/test/pairing-renewal.test.ts
@@ -1,6 +1,5 @@
 import { Timestamp } from 'firebase-admin/firestore';
 import type { DecodedIdToken } from 'firebase-admin/auth';
-import type { Firestore } from 'firebase-admin/firestore';
 import { describe, expect, it } from 'vitest';
 import { APPROVAL_MS, GRANT_MS, RENEWAL_WINDOW_MS } from '../src/pairing-contract.js';
 import { createPairingStore } from '../src/pairing-store.js';
@@ -8,112 +7,18 @@ import type { PairingAuthentication } from '../src/pairing-service.js';
 import { createPairingService } from '../src/pairing-service.js';
 import type { PairingStore } from '../src/pairing-store.js';
 
-const OWNER = 'owner-uid';
-const WORLD = 'abcdefghijklmnopqrst';
-const PAIRING = 'a'.repeat(64);
-const PRINCIPAL = 'office-agent:00000000-0000-4000-8000-000000000001';
-const INSTALLATION = '00000000-0000-4000-8000-000000000002';
-const IDENTITY = '00000000-0000-4000-8000-000000000003';
-const BLOCK = '00000000-0000-4000-8000-000000000004';
-const NOW = 1_700_000_000_000;
-
-type Ref = { path: string; id: string; collection(name: string): Ref; doc(id: string): Ref };
-
-function reference(path: string): Ref {
-  const parts = path.split('/');
-  const ref = {
-    path,
-    id: parts.at(-1)!,
-    collection(name: string) {
-      return reference(`${path}/${name}`);
-    },
-    doc(id: string) {
-      return reference(`${path}/${id}`);
-    },
-  };
-  return ref;
-}
-
-function fakeFirestore(initial: Record<string, unknown>) {
-  const values = new Map(Object.entries(initial));
-  const updates: Array<{ path: string; value: Record<string, unknown> }> = [];
-  const snapshot = (ref: Ref) => ({
-    ref,
-    exists: values.has(ref.path),
-    data: () => values.get(ref.path),
-  });
-  const db = {
-    collection: (name: string) => reference(name),
-    runTransaction: async (operation: (transaction: unknown) => Promise<unknown>) =>
-      operation({
-        get: async (ref: Ref) => snapshot(ref),
-        getAll: async (...refs: Ref[]) => refs.map((ref) => snapshot(ref)),
-        update: (ref: Ref, value: Record<string, unknown>) => {
-          const current = values.get(ref.path);
-          values.set(ref.path, { ...(current as Record<string, unknown>), ...value });
-          updates.push({ path: ref.path, value });
-        },
-      }),
-  };
-  return { db: db as unknown as Firestore, values, updates };
-}
-
-function seed(
-  grantExpiresAt: number,
-  options: {
-    pairingEnabled?: boolean;
-    claimed?: boolean;
-    ownerAdmitted?: boolean;
-    requestPatch?: Record<string, unknown>;
-    pairingPatch?: Record<string, unknown>;
-    grant?: Record<string, unknown>;
-    missingGrant?: boolean;
-  } = {}
-) {
-  const pairing = {
-    request: {
-      version: 1 as const,
-      pairingId: PAIRING,
-      worldId: WORLD,
-      installationId: INSTALLATION,
-      identityId: IDENTITY,
-      installationLabel: 'Installation',
-      identityLabel: 'Alice',
-      capabilities: ['layout.read', 'layout.write'] as ['layout.read', 'layout.write'],
-      ...options.requestPatch,
-    },
-    ownerUid: OWNER,
-    principalUid: PRINCIPAL,
-    blockId: BLOCK,
-    createdAt: Timestamp.fromMillis(NOW - APPROVAL_MS),
-    expiresAt: Timestamp.fromMillis(NOW),
-    enabled: options.pairingEnabled ?? true,
-    claimed: options.claimed ?? true,
-    nextClaimAt: Timestamp.fromMillis(NOW),
-    ...options.pairingPatch,
-  };
-  const grant = {
-    version: 1,
-    ownerUid: OWNER,
-    installationId: INSTALLATION,
-    identityId: IDENTITY,
-    blockId: BLOCK,
-    capabilities: ['layout.read', 'layout.write'],
-    enabled: true,
-    createdAt: Timestamp.fromMillis(grantExpiresAt - GRANT_MS),
-    expiresAt: Timestamp.fromMillis(grantExpiresAt),
-    ...options.grant,
-  };
-  const initial: Record<string, unknown> = {
-    [`officePairings/${PAIRING}`]: pairing,
-    [`worlds/${WORLD}`]: { ownerUid: OWNER },
-  };
-  if (options.ownerAdmitted !== false) initial[`testers/${OWNER}`] = { enabled: true };
-  if (!options.missingGrant) initial[`worlds/${WORLD}/agentGrants/${PRINCIPAL}`] = grant;
-  return fakeFirestore(initial);
-}
-
-const agent = { uid: PRINCIPAL, installationId: INSTALLATION, identityId: IDENTITY };
+import {
+  OWNER,
+  WORLD,
+  PAIRING,
+  PRINCIPAL,
+  INSTALLATION,
+  IDENTITY,
+  BLOCK,
+  NOW,
+  agent,
+  seed,
+} from './pairing-store-fixture.js';
 
 describe('renewal authentication', () => {
   it('requires a checked agent token and returns only the exact public lease view', async () => {

--- a/services/office/functions/test/pairing-revocation.test.ts
+++ b/services/office/functions/test/pairing-revocation.test.ts
@@ -1,0 +1,223 @@
+import { createHash } from 'node:crypto';
+import type { DecodedIdToken } from 'firebase-admin/auth';
+import { describe, expect, it, vi } from 'vitest';
+import { createPairingStore } from '../src/pairing-store.js';
+import type { RevocationActor } from '../src/pairing-store.js';
+import { createPairingService } from '../src/pairing-service.js';
+import {
+  OWNER,
+  WORLD,
+  PAIRING,
+  PRINCIPAL,
+  INSTALLATION,
+  IDENTITY,
+  BLOCK,
+  NOW,
+  agent,
+  seed,
+} from './pairing-store-fixture.js';
+
+const pairingPath = `officePairings/${PAIRING}`;
+const grantPath = `worlds/${WORLD}/agentGrants/${PRINCIPAL}`;
+const actors: RevocationActor[] = [
+  { kind: 'owner', uid: OWNER },
+  { kind: 'agent', agent },
+  { kind: 'proof' },
+];
+
+describe('revocation transaction', () => {
+  it.each(actors)(
+    'only disables authority and retains resources across expiry and retries: $kind',
+    async (actor) => {
+      const fixture = seed(NOW - 1);
+      const blockPath = `worlds/${WORLD}/blocks/${BLOCK}`;
+      fixture.values.set(blockPath, { content: 'retained' });
+      const before = new Map(fixture.values);
+      const store = createPairingStore(fixture.db, () => NOW);
+      await store.revoke(actor, PAIRING);
+      await store.revoke(actor, PAIRING);
+      for (const [path, value] of before) {
+        expect(fixture.values.get(path)).toEqual(
+          path === pairingPath || path === grantPath
+            ? { ...(value as Record<string, unknown>), enabled: false }
+            : value
+        );
+      }
+      expect(fixture.values.size).toBe(before.size);
+    }
+  );
+
+  it.each(actors)('never reconstructs a missing grant: $kind', async (actor) => {
+    const fixture = seed(NOW - 1, { missingGrant: true });
+    await createPairingStore(fixture.db).revoke(actor, PAIRING);
+    expect(fixture.values.has(grantPath)).toBe(false);
+    expect(fixture.updates).toEqual([{ path: pairingPath, value: { enabled: false } }]);
+  });
+
+  it.each(actors.filter((actor) => actor.kind !== 'owner'))(
+    'permits reduction after owner admission loss: $kind',
+    async (actor) => {
+      const fixture = seed(NOW - 1, { ownerAdmitted: false, pairingEnabled: false });
+      await createPairingStore(fixture.db).revoke(actor, PAIRING);
+      expect(fixture.values.get(grantPath)).toMatchObject({ enabled: false });
+    }
+  );
+
+  it('cancels an unclaimed approval without creating a grant', async () => {
+    const fixture = seed(NOW - 1, { claimed: false, missingGrant: true, ownerAdmitted: false });
+    await createPairingStore(fixture.db).revoke({ kind: 'proof' }, PAIRING);
+    expect(fixture.values.get(pairingPath)).toMatchObject({ enabled: false, claimed: false });
+    expect(fixture.values.has(grantPath)).toBe(false);
+  });
+
+  it.each([
+    { ...agent, uid: OWNER },
+    { ...agent, installationId: IDENTITY },
+    { ...agent, identityId: INSTALLATION },
+  ])('denies mismatched claimed agent without any mutation: %j', async (mismatch) => {
+    const fixture = seed(NOW - 1);
+    const before = new Map(fixture.values);
+    await expect(
+      createPairingStore(fixture.db).revoke({ kind: 'agent', agent: mismatch }, PAIRING)
+    ).rejects.toMatchObject({ code: 'PAIRING_UNAVAILABLE' });
+    expect(fixture.values).toEqual(before);
+    expect(fixture.updates).toEqual([]);
+  });
+
+  it('denies an unclaimed agent and an owner with lost admission', async () => {
+    for (const actor of actors.slice(0, 2)) {
+      const fixture = seed(NOW - 1, { claimed: false, ownerAdmitted: false });
+      const before = new Map(fixture.values);
+      await expect(createPairingStore(fixture.db).revoke(actor, PAIRING)).rejects.toMatchObject({
+        code: actor.kind === 'owner' ? 'PERMISSION_DENIED' : 'PAIRING_UNAVAILABLE',
+      });
+      expect(fixture.values).toEqual(before);
+      expect(fixture.updates).toEqual([]);
+    }
+  });
+
+  it.each(actors)(
+    'denies missing and malformed records without tombstones: $kind',
+    async (actor) => {
+      for (const malformed of [false, true]) {
+        const fixture = seed(NOW - 1);
+        if (malformed) fixture.values.set(pairingPath, { invalid: true });
+        else fixture.values.delete(pairingPath);
+        const before = new Map(fixture.values);
+        await expect(createPairingStore(fixture.db).revoke(actor, PAIRING)).rejects.toMatchObject({
+          code: actor.kind === 'owner' ? 'PERMISSION_DENIED' : 'PAIRING_UNAVAILABLE',
+        });
+        expect(fixture.values).toEqual(before);
+        expect(fixture.updates).toEqual([]);
+      }
+    }
+  );
+});
+
+describe('revocation authentication and proof', () => {
+  function setup(token: Record<string, unknown> = {}) {
+    const fixture = seed(NOW - 1);
+    const verifyIdToken = vi.fn(async () => token as unknown as DecodedIdToken);
+    const createCustomToken = vi.fn(async () => 'unused');
+    const service = createPairingService(createPairingStore(fixture.db), {
+      verifyIdToken,
+      createCustomToken,
+    });
+    return { ...fixture, service, verifyIdToken, createCustomToken };
+  }
+  const agentToken = {
+    uid: PRINCIPAL,
+    tmtOfficeAgent: true,
+    tmtInstallationId: INSTALLATION,
+    tmtIdentityId: IDENTITY,
+  };
+
+  it.each([
+    agentToken,
+    { uid: OWNER, email_verified: true, firebase: { sign_in_provider: 'google.com' } },
+  ])('uses checked authentication for owner or agent without minting: %j', async (token) => {
+    const fixture = setup(token);
+    await expect(
+      fixture.service.revoke({ version: 1, pairingId: PAIRING }, 'Bearer checked-token')
+    ).resolves.toEqual({ version: 1, pairingId: PAIRING, revoked: true });
+    expect(fixture.verifyIdToken).toHaveBeenCalledExactlyOnceWith('checked-token', true);
+    expect(fixture.createCustomToken).not.toHaveBeenCalled();
+    expect(fixture.values.get(grantPath)).toMatchObject({ enabled: false });
+  });
+
+  it.each([
+    { ...agentToken, tmtInstallationId: 'invalid' },
+    { ...agentToken, tmtIdentityId: 'invalid' },
+    { ...agentToken, tmtOfficeAgent: false },
+    { uid: OWNER, email_verified: false, firebase: { sign_in_provider: 'google.com' } },
+  ])('denies malformed or non-authoritative tokens before writes: %j', async (token) => {
+    const fixture = setup(token);
+    await expect(
+      fixture.service.revoke({ version: 1, pairingId: PAIRING }, 'Bearer token')
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(fixture.updates).toEqual([]);
+  });
+
+  it('denies revoked tokens and absent authentication without writes', async () => {
+    const fixture = setup(agentToken);
+    fixture.verifyIdToken.mockRejectedValue(new Error('revoked'));
+    for (const header of [undefined, 'Bearer revoked']) {
+      await expect(
+        fixture.service.revoke({ version: 1, pairingId: PAIRING }, header)
+      ).rejects.toMatchObject({ code: 'UNAUTHENTICATED' });
+    }
+    expect(fixture.updates).toEqual([]);
+  });
+
+  const bytes = Buffer.alloc(32, 1);
+  const secret = bytes.toString('base64url');
+  const digest = createHash('sha256').update(bytes).digest('hex');
+
+  it('uses the original byte digest for known-proof cancellation and never authenticates or mints', async () => {
+    const fixture = setup();
+    const pairing = fixture.values.get(pairingPath) as { request: Record<string, unknown> };
+    fixture.values.delete(pairingPath);
+    fixture.values.set(`officePairings/${digest}`, {
+      ...pairing,
+      request: { ...pairing.request, pairingId: digest },
+    });
+    await expect(fixture.service.revoke({ version: 1, secret })).resolves.toEqual({
+      version: 1,
+      pairingId: digest,
+      revoked: true,
+    });
+    expect(fixture.values.get(grantPath)).toMatchObject({ enabled: false });
+    expect(fixture.verifyIdToken).not.toHaveBeenCalled();
+    expect(fixture.createCustomToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps unknown proof unavailable without creating a tombstone', async () => {
+    const fixture = setup();
+    await expect(fixture.service.revoke({ version: 1, secret })).rejects.toMatchObject({
+      code: 'PAIRING_UNAVAILABLE',
+    });
+    expect(fixture.values.has(`officePairings/${digest}`)).toBe(false);
+    expect(fixture.updates).toEqual([]);
+  });
+
+  it.each([
+    [{ version: 1, secret: secret + '=' }, undefined],
+    [{ version: 1, secret: secret.slice(1) }, undefined],
+    [{ version: 1, secret: secret.slice(0, -1) + 'R' }, undefined],
+    [{ version: 2, secret }, undefined],
+    [{ version: 1, secret, pairingId: PAIRING }, undefined],
+    [{ version: 1, secret, extra: true }, undefined],
+    [{ version: 1, secret }, 'Bearer token'],
+    [{ version: 1, secret }, ''],
+  ])(
+    'rejects malformed or ambiguous proof requests before effects: %j',
+    async (input, authorization) => {
+      const fixture = setup();
+      await expect(fixture.service.revoke(input, authorization)).rejects.toMatchObject({
+        code: 'INVALID_ARGUMENT',
+      });
+      expect(fixture.updates).toEqual([]);
+      expect(fixture.verifyIdToken).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/services/office/functions/test/pairing-store-fixture.ts
+++ b/services/office/functions/test/pairing-store-fixture.ts
@@ -1,0 +1,110 @@
+import { Timestamp } from 'firebase-admin/firestore';
+import type { Firestore } from 'firebase-admin/firestore';
+import { APPROVAL_MS, GRANT_MS } from '../src/pairing-contract.js';
+
+export const OWNER = 'owner-uid';
+export const WORLD = 'abcdefghijklmnopqrst';
+export const PAIRING = 'a'.repeat(64);
+export const PRINCIPAL = 'office-agent:00000000-0000-4000-8000-000000000001';
+export const INSTALLATION = '00000000-0000-4000-8000-000000000002';
+export const IDENTITY = '00000000-0000-4000-8000-000000000003';
+export const BLOCK = '00000000-0000-4000-8000-000000000004';
+export const NOW = 1_700_000_000_000;
+
+type Ref = { path: string; id: string; collection(name: string): Ref; doc(id: string): Ref };
+
+function reference(path: string): Ref {
+  const parts = path.split('/');
+  const ref = {
+    path,
+    id: parts.at(-1)!,
+    collection(name: string) {
+      return reference(`${path}/${name}`);
+    },
+    doc(id: string) {
+      return reference(`${path}/${id}`);
+    },
+  };
+  return ref;
+}
+
+function fakeFirestore(initial: Record<string, unknown>) {
+  const values = new Map(Object.entries(initial));
+  const updates: Array<{ path: string; value: Record<string, unknown> }> = [];
+  const snapshot = (ref: Ref) => ({
+    ref,
+    exists: values.has(ref.path),
+    data: () => values.get(ref.path),
+  });
+  const db = {
+    collection: (name: string) => reference(name),
+    runTransaction: async (operation: (transaction: unknown) => Promise<unknown>) =>
+      operation({
+        get: async (ref: Ref) => snapshot(ref),
+        getAll: async (...refs: Ref[]) => refs.map((ref) => snapshot(ref)),
+        update: (ref: Ref, value: Record<string, unknown>) => {
+          const current = values.get(ref.path);
+          values.set(ref.path, { ...(current as Record<string, unknown>), ...value });
+          updates.push({ path: ref.path, value });
+        },
+      }),
+  };
+  return { db: db as unknown as Firestore, values, updates };
+}
+
+export function seed(
+  grantExpiresAt: number,
+  options: {
+    pairingEnabled?: boolean;
+    claimed?: boolean;
+    ownerAdmitted?: boolean;
+    requestPatch?: Record<string, unknown>;
+    pairingPatch?: Record<string, unknown>;
+    grant?: Record<string, unknown>;
+    missingGrant?: boolean;
+  } = {}
+) {
+  const pairing = {
+    request: {
+      version: 1 as const,
+      pairingId: PAIRING,
+      worldId: WORLD,
+      installationId: INSTALLATION,
+      identityId: IDENTITY,
+      installationLabel: 'Installation',
+      identityLabel: 'Alice',
+      capabilities: ['layout.read', 'layout.write'] as ['layout.read', 'layout.write'],
+      ...options.requestPatch,
+    },
+    ownerUid: OWNER,
+    principalUid: PRINCIPAL,
+    blockId: BLOCK,
+    createdAt: Timestamp.fromMillis(NOW - APPROVAL_MS),
+    expiresAt: Timestamp.fromMillis(NOW),
+    enabled: options.pairingEnabled ?? true,
+    claimed: options.claimed ?? true,
+    nextClaimAt: Timestamp.fromMillis(NOW),
+    ...options.pairingPatch,
+  };
+  const grant = {
+    version: 1,
+    ownerUid: OWNER,
+    installationId: INSTALLATION,
+    identityId: IDENTITY,
+    blockId: BLOCK,
+    capabilities: ['layout.read', 'layout.write'],
+    enabled: true,
+    createdAt: Timestamp.fromMillis(grantExpiresAt - GRANT_MS),
+    expiresAt: Timestamp.fromMillis(grantExpiresAt),
+    ...options.grant,
+  };
+  const initial: Record<string, unknown> = {
+    [`officePairings/${PAIRING}`]: pairing,
+    [`worlds/${WORLD}`]: { ownerUid: OWNER },
+  };
+  if (options.ownerAdmitted !== false) initial[`testers/${OWNER}`] = { enabled: true };
+  if (!options.missingGrant) initial[`worlds/${WORLD}/agentGrants/${PRINCIPAL}`] = grant;
+  return fakeFirestore(initial);
+}
+
+export const agent = { uid: PRINCIPAL, installationId: INSTALLATION, identityId: IDENTITY };

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,7 +9,7 @@ or separate slash-command package is required. All providers use the same bundle
 The native runtime needs no Node.js, Rust toolchain or source checkout; tmux is
 still required for pane operations. Native bindings are temporary by default:
 use `-s`/`--save` to keep one, and `tmt rm <name>` to retire a temporary identity
-(`--force` is required for a saved identity). Native schema 9 is forward-only;
+(`--force` is required for a saved identity). Native schema migrations are forward-only;
 do not use the legacy TypeScript runtime on a native database.
 
 ## Install

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -15,7 +15,7 @@ directory. Active presence also requires matching live tmux binding metadata.
 These instructions target the standalone Rust native alpha. Older npm/pnpm
 installations use TypeScript and do not implement native identity lifetimes,
 removal or self-update. Check `tmt --help` when the installation is uncertain;
-do not fall back to TypeScript on native state. Native schema 9 is forward-only
+do not fall back to TypeScript on native state. Native schema 10 is forward-only
 and TypeScript cannot reopen it. Switching installations does not migrate or
 delete old data. Stop old writers before switching.
 
@@ -25,7 +25,7 @@ tmux; there is no non-tmux recipient transport yet.
 
 Native talk supplies a compact `v2_` receipt; use it unchanged. Native reply
 also accepts retained legacy receipts, but TypeScript cannot consume native
-receipts or schema 9. Do not mix runtimes for an active exchange.
+receipts or current native schemas. Do not mix runtimes for an active exchange.
 
 `name`, retained alias `this`, and
 `add <pane-target> <name>` default to temporary identities; `-s`/`--save` saves
@@ -478,6 +478,16 @@ on failures. Disabled/missing grants, expired pending approvals and lost
 credentials cannot be repaired by silently creating another grant. Report those
 errors; never delete state to bypass revocation. Uninstall does not revoke
 remote grants. Do not use proposed connector or resource-edit commands.
+
+Retiring a paired identity queues Office cleanup by UUID. Pair/inspect attempt
+pending cleanup; ordinary `ls`, `rm` and `unbind` do not contact Office. Use
+`tmt office sync --json` (with the same installation `--prefix`, if customized)
+to retry without an active identity or tmux pane. Inspect `completed`, `failed`,
+`pending`, `failureCode` and exit status: local retirement is not proof of remote
+revocation. Locked credentials or uncertain results stay pending. Resolve the
+reported obstacle before retrying; do not loop or delete protected state.
+No invocation means no background delivery guarantee. Confirmed revocation
+retains block contents; a saved identity merely going offline is not retirement.
 
 ## Configuration safety
 

--- a/test/native/identity.test.ts
+++ b/test/native/identity.test.ts
@@ -536,7 +536,7 @@ describe('native durable identity process boundary', () => {
       withDatabase(sandbox.database, (database) => {
         database
           .prepare('INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, ?)')
-          .run(10, 'unsupported future migration', '2026-01-07T00:00:00.000Z');
+          .run(11, 'unsupported future migration', '2026-01-07T00:00:00.000Z');
       });
       const result = await runCli(sandbox, ['identity', 'show', created.canonicalName, '--json']);
       expect(result.status).toBe(1);
@@ -552,7 +552,7 @@ describe('native durable identity process boundary', () => {
         history: [
           ...before.history,
           {
-            version: 10,
+            version: 11,
             name: 'unsupported future migration',
             applied_at: '2026-01-07T00:00:00.000Z',
           },

--- a/test/native/native-installation.test.ts
+++ b/test/native/native-installation.test.ts
@@ -111,6 +111,7 @@ describe('native installation process contract', () => {
             deadlineMs: INSTALL_PROCESS_BUDGET_MS,
           });
         expectError(await office(['status']), 'OFFICE_NOT_INSTALLED');
+        expectError(await office(['sync']), 'OFFICE_NOT_INSTALLED');
         expectError(await office([]), 'OFFICE_NOT_INSTALLED');
         expectError(await office(['install']), 'OFFICE_CONSENT_REQUIRED');
         expectError(await office(['uninstall']), 'OFFICE_CONSENT_REQUIRED');
@@ -144,6 +145,17 @@ describe('native installation process contract', () => {
           version: '0.1.0-alpha.1',
         });
         expectError(await office([]), 'OFFICE_NOT_PAIRED');
+        const emptySync = await office(['sync']);
+        expect(emptySync.status, emptySync.stdout).toBe(0);
+        expect(emptySync.stderr).toBe('');
+        expect(parseWholeStdout(emptySync)).toEqual({
+          completed: 0,
+          failed: 0,
+          pending: 0,
+          failureCode: null,
+        });
+        expect(existsSync(sandbox.database)).toBe(false);
+        expect(existsSync(path.join(sandbox.globalDir, 'office'))).toBe(false);
         expect(parseWholeStdout(await office(args))).toMatchObject({ changed: false });
         const payload = readFileSync(path.join(prefix, 'bin/tmt-office'));
         const releases = path.join(prefix, 'lib/tmt-office/releases');

--- a/test/native/profile.test.ts
+++ b/test/native/profile.test.ts
@@ -126,7 +126,7 @@ describe('native role and preamble process contracts', () => {
       let identities: unknown[];
       try {
         writer.exec(
-          "INSERT INTO _migrations VALUES (10, 'future migration', '2026-01-01T00:00:00.000Z')"
+          "INSERT INTO _migrations VALUES (11, 'future migration', '2026-01-01T00:00:00.000Z')"
         );
         history = writer.prepare('SELECT * FROM _migrations ORDER BY version').all();
         identities = writer.prepare('SELECT * FROM identities ORDER BY id').all();

--- a/test/native/response.test.ts
+++ b/test/native/response.test.ts
@@ -442,7 +442,7 @@ describe('native reply/result process contract', () => {
         body,
         submission.submittedAtMs
       );
-      expect(schemaVersion(sandbox.database)).toBe(9);
+      expect(schemaVersion(sandbox.database)).toBe(10);
     }));
 
   it(

--- a/test/native/storage.test.ts
+++ b/test/native/storage.test.ts
@@ -49,17 +49,55 @@ function table(snapshot: ReturnType<typeof storageSnapshot>, name: string) {
   return found!;
 }
 
-function expectNativeSchema9(
+function expectNativeSchema10(
   reference: ReturnType<typeof storageSnapshot>,
   migrated: ReturnType<typeof storageSnapshot>
 ): void {
   expect(migrated.migrations.slice(0, 8)).toEqual(reference.migrations);
-  expect(migrated.migrations).toHaveLength(9);
+  expect(migrated.migrations).toHaveLength(10);
   expect(migrated.migrations[8]).toEqual({
     version: 9,
     name: 'add identity lifetimes and reusable retired names',
   });
-  expect(migrated.tables.map(({ name }) => name)).toEqual(reference.tables.map(({ name }) => name));
+  expect(migrated.migrations[9]).toEqual({
+    version: 10,
+    name: 'add durable identity retirement hooks',
+  });
+  expect(migrated.tables.map(({ name }) => name)).toEqual(
+    [...reference.tables.map(({ name }) => name), 'identity_hooks'].sort()
+  );
+  const hooks = table(migrated, 'identity_hooks');
+  expect(hooks.rows).toEqual([]);
+  expect(hooks.columns).toEqual([
+    { cid: 0, name: 'consumer', type: 'TEXT', notnull: 1, dflt_value: null, pk: 1 },
+    { cid: 1, name: 'identity_id', type: 'TEXT', notnull: 1, dflt_value: null, pk: 2 },
+    { cid: 2, name: 'reference', type: 'TEXT', notnull: 1, dflt_value: null, pk: 3 },
+    { cid: 3, name: 'state', type: 'TEXT', notnull: 1, dflt_value: null, pk: 0 },
+    { cid: 4, name: 'attempt_count', type: 'INTEGER', notnull: 1, dflt_value: '0', pk: 0 },
+  ]);
+  expect(hooks.foreignKeys).toEqual([
+    {
+      id: 0,
+      seq: 0,
+      table: 'identities',
+      from: 'identity_id',
+      to: 'id',
+      on_update: 'NO ACTION',
+      on_delete: 'NO ACTION',
+      match: 'NONE',
+    },
+  ]);
+  expect(hooks.indexes).toHaveLength(3);
+  const queueIndex = hooks.indexes.find((index) => index.name === 'identity_hooks_pending');
+  expect(queueIndex).toMatchObject({ unique: 0, partial: 0, origin: 'c' });
+  expect(
+    queueIndex?.columns.filter((column) => column.key === 1).map((column) => column.name)
+  ).toEqual(['consumer', 'state', 'attempt_count', 'identity_id', 'reference']);
+  const retirementIndex = hooks.indexes.find((index) => index.name === 'identity_hooks_retirement');
+  expect(retirementIndex).toMatchObject({ unique: 0, partial: 0, origin: 'c' });
+  expect(
+    retirementIndex?.columns.filter((column) => column.key === 1).map((column) => column.name)
+  ).toEqual(['identity_id', 'state']);
 
   const unchangedTables = reference.tables
     .filter(({ name }) => name !== '_migrations' && name !== 'identities')
@@ -77,6 +115,7 @@ function expectNativeSchema9(
   expect(newHistory.rows).toEqual([
     ...oldHistory.rows,
     { version: 9, name: migrated.migrations[8]!.name },
+    { version: 10, name: migrated.migrations[9]!.name },
   ]);
 
   const oldIdentities = table(reference, 'identities');
@@ -113,7 +152,7 @@ function expectNativeSchema9(
 
 describe('native SQLite lifecycle compatibility', () => {
   it.each(Array.from({ length: 9 }, (_, version) => version))(
-    'upgrades closed TypeScript schema %i to schema 9 without changing durable data',
+    'upgrades closed TypeScript schema %i to schema 10 without changing durable data',
     async (version) => {
       await withSandbox(async (sandbox) => {
         const reference = path.join(sandbox.root, 'reference', 'state.db');
@@ -126,7 +165,7 @@ describe('native SQLite lifecycle compatibility', () => {
         expect(parseWholeStdout(result)).toEqual({
           path: sandbox.database,
           open: true,
-          schemaVersion: 9,
+          schemaVersion: 10,
           journalMode: 'wal',
           foreignKeys: true,
           busyTimeoutMs: 5000,
@@ -134,7 +173,7 @@ describe('native SQLite lifecycle compatibility', () => {
           fts5: true,
         });
         const migrated = storageSnapshot(sandbox.database);
-        expectNativeSchema9(storageSnapshot(reference), migrated);
+        expectNativeSchema10(storageSnapshot(reference), migrated);
         if (version >= 5) {
           const responses = migrated.tables.find(
             (table) => table.name === 'request_responses'
@@ -165,7 +204,7 @@ describe('native SQLite lifecycle compatibility', () => {
           );
         }
         const timestamps = migrationTimestamps(sandbox.database);
-        expect(timestamps).toHaveLength(9);
+        expect(timestamps).toHaveLength(10);
         expect(timestamps.slice(0, version)).toEqual(originalTimestamps);
         for (const timestamp of timestamps) {
           expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
@@ -191,10 +230,66 @@ describe('native SQLite lifecycle compatibility', () => {
         expect(result.status).toBe('fulfilled');
         if (result.status === 'fulfilled') {
           expect(result.value.status, result.value.stdout).toBe(0);
-          expect(parseWholeStdout(result.value).schemaVersion).toBe(9);
+          expect(parseWholeStdout(result.value).schemaVersion).toBe(10);
         }
       }
-      expectNativeSchema9(storageSnapshot(reference), storageSnapshot(sandbox.database));
+      expectNativeSchema10(storageSnapshot(reference), storageSnapshot(sandbox.database));
+    });
+  });
+
+  it('enforces retirement subscription uniqueness, foreign keys and delivery state bounds', async () => {
+    await withSandbox(async (sandbox) => {
+      expect((await runStorage(sandbox)).status).toBe(0);
+      const database = new Database(sandbox.database);
+      try {
+        database.pragma('foreign_keys = ON');
+        database.exec(
+          "INSERT INTO identities (id, name, canonical_name, created_at, updated_at) VALUES ('hook-id', 'Agent', 'agent', 'created', 'updated')"
+        );
+        const insert = database.prepare(
+          'INSERT INTO identity_hooks (consumer, identity_id, reference, state, attempt_count) VALUES (?, ?, ?, ?, ?)'
+        );
+        insert.run('office', 'hook-id', 'scope', 'registered', 0);
+        expect(() => insert.run('office', 'hook-id', 'scope', 'pending', 0)).toThrow(/UNIQUE/);
+        expect(() => insert.run('office', 'missing', 'scope', 'registered', 0)).toThrow(
+          /FOREIGN KEY/
+        );
+        for (const state of ['unknown', '']) {
+          expect(() => insert.run('office', 'hook-id', 'other', state, 0)).toThrow(/CHECK/);
+        }
+        for (const attempt of [-1, 0.5]) {
+          expect(() => insert.run('office', 'hook-id', 'other', 'pending', attempt)).toThrow(
+            /CHECK/
+          );
+        }
+        expect(() => insert.run('', 'hook-id', 'other', 'registered', 0)).toThrow(/CHECK/);
+        expect(() => insert.run('a'.repeat(65), 'hook-id', 'other', 'registered', 0)).toThrow(
+          /CHECK/
+        );
+        expect(() => insert.run('office', 'hook-id', '', 'registered', 0)).toThrow(/CHECK/);
+        expect(() => insert.run('office', 'hook-id', 'a'.repeat(257), 'registered', 0)).toThrow(
+          /CHECK/
+        );
+        // Different consumers and references remain separate subscriptions.
+        insert.run('another', 'hook-id', 'scope', 'pending', 1);
+        insert.run('office', 'hook-id', 'other', 'delivered', 2);
+        expect(
+          database
+            .prepare(
+              'SELECT consumer, reference, state, attempt_count FROM identity_hooks ORDER BY consumer, reference'
+            )
+            .all()
+        ).toEqual([
+          { consumer: 'another', reference: 'scope', state: 'pending', attempt_count: 1 },
+          { consumer: 'office', reference: 'other', state: 'delivered', attempt_count: 2 },
+          { consumer: 'office', reference: 'scope', state: 'registered', attempt_count: 0 },
+        ]);
+        expect(() => database.exec("DELETE FROM identities WHERE id = 'hook-id'")).toThrow(
+          /FOREIGN KEY/
+        );
+      } finally {
+        database.close();
+      }
     });
   });
 
@@ -342,7 +437,7 @@ describe('native SQLite lifecycle compatibility', () => {
         repair.close();
       }
       expect((await runStorage(sandbox)).status).toBe(0);
-      expect(parseWholeStdout(await runStorage(sandbox))).toMatchObject({ schemaVersion: 9 });
+      expect(parseWholeStdout(await runStorage(sandbox))).toMatchObject({ schemaVersion: 10 });
     });
   });
 
@@ -566,14 +661,14 @@ describe('native SQLite lifecycle compatibility', () => {
         if (kind === 'future') {
           const upgraded = await runStorage(sandbox);
           expect(upgraded.status).toBe(0);
-          expect(parseWholeStdout(upgraded)).toMatchObject({ schemaVersion: 9 });
+          expect(parseWholeStdout(upgraded)).toMatchObject({ schemaVersion: 10 });
         }
         const writer = new Database(sandbox.database);
         try {
           if (kind === 'renamed')
             writer.exec("UPDATE _migrations SET name = 'unknown' WHERE version = 2");
           else if (kind === 'gap') writer.exec('DELETE FROM _migrations WHERE version = 2');
-          else writer.exec("INSERT INTO _migrations VALUES (10, 'future', 'timestamp')");
+          else writer.exec("INSERT INTO _migrations VALUES (11, 'future', 'timestamp')");
         } finally {
           writer.close();
         }
@@ -631,7 +726,7 @@ describe('native SQLite lifecycle compatibility', () => {
       }
       expect(storageSnapshot(sandbox.database)).toEqual(before);
       expect((await runStorage(sandbox)).status).toBe(0);
-      expectNativeSchema9(storageSnapshot(reference), storageSnapshot(sandbox.database));
+      expectNativeSchema10(storageSnapshot(reference), storageSnapshot(sandbox.database));
     });
   }, 15_000);
 });


### PR DESCRIPTION
## Scope

Closes #229. Delivers the complete identity retirement → durable hook → Office revocation → acknowledgment path for parent #209 and M1 #173. Those broader issues remain open.

- Identity retirement registers and queues extension work through the existing core/SQLite owner, not command-specific cleanup in `rm`, `unbind`, or `ls`.
- Office registers protected scopes automatically, drains pending work before pair/inspect, and exposes `tmt office sync [--prefix <path>] [--json]` without requiring an active identity or pane.
- The existing issuer revocation transaction accepts the exact bound agent or original proof, in addition to the existing owner policy. It only disables authority; assigned blocks remain intact.

## Architecture and review

Core owns typed hook values; schema 10 stores only consumer ID, identity UUID, opaque reference and delivery state. Retirement and enqueue commit atomically. Registration racing retirement queues immediately; duplicate registration cannot resurrect a delivered hook. Consumer and identity indexes keep bounded draining and per-identity retirement independent of global history size.

Office reuses verified companion dispatch, ConfigPaths, per-scope locks, protected-store readback and bounded HTTP. Delivery is remote confirmation → secret-free protected receipt → SQLite acknowledgment, with no SQL transaction across external work. Failed, missing, corrupt or uncertain evidence remains pending. Retried authority reduction is idempotent; same-name identities cannot inherit the old UUID's scope. No second credential/grant index, arbitrary hook executable, daemon or plugin runtime is introduced.

`sync` returns `{completed,failed,pending,failureCode}` and exits nonzero for unresolved work. Ordinary identity commands and local Office status never synchronize remotely. Without an Office invocation there is no background delivery guarantee. Pre-hook vault scopes enroll on their next pair/inspect access; unknown historical scopes cannot be reconstructed portably.

Primary reviewer: Codex. Reviewed commit: `a8fb19c209350d0551cab6092037807a0b633cdf`.

Primary review covered every changed file and the existing binding transaction, process, vault, installation, issuer, parser and test callers. Independent Luna scanning found no additional actionable architecture defects. Findings resolved before acceptance:

- A negative test exposed Serde unit-variant acceptance of extra fields; the revoked receipt now uses a strict empty struct variant.
- Replaced a duplicated/unbounded test process wrapper with the existing sandbox and tmux lifecycle owners; shared native installation/vault fixture code has one owner.
- Added an identity-leading index so ordinary retirement does not scan all extension hook history.
- Updated current schema oracles without rewriting frozen historical schemas or migration-9 failure fixtures.

## Verification

- [x] Primary reviewed changed files and relevant callers/tests.
- [x] Local commands and results are recorded below.
- [x] All 17 CI checks passed on reviewed head `a8fb19c209350d0551cab6092037807a0b633cdf`, without reruns, before merge.

Local verification:

Rust commands run in the pinned Linux toolchain image from `rust/`:

```sh
cargo +1.97.0 fmt --all --check
cargo +1.97.0 clippy --locked --workspace --all-targets --all-features -- -D warnings
cargo +1.97.0 test --locked --workspace --all-features
cargo +1.88.0 build --locked --workspace --all-features
cargo +1.88.0 test --locked -p tmt-cli --test architecture
CARGO_PROFILE_DEV_DEBUG=0 cargo build --locked -p tmt-office
CARGO_PROFILE_DEV_DEBUG=0 cargo build --locked -p tmt-cli
CARGO_PROFILE_DEV_DEBUG=0 cargo build --locked --example storage-probe
```

- Rust 1.97 formatting, strict all-target/all-feature Clippy and workspace tests: 474 passed, one pre-existing ignored test.
- Rust 1.88 locked workspace build and architecture guard: passed, 21 architecture tests.
- Separate debug-0 Office/CLI/storage-probe builds and `pnpm test:native` in Linux: 155 passed.
- `pnpm check`: passed. Host Node 26 produced non-fatal engine notices; isolated Office checks use pinned Node 22.
- `pnpm test:run` in isolated Node 22/Linux: 156 passed. Host execution of Linux artifacts was rejected with ENOEXEC; no test was weakened to hide that environment mismatch.
- Service check/test/build: passed, 97 tests.
- `pnpm test:e2e`, twice: each passed 321 adapter tests and 170 tmux scenarios. Only the existing ignored adapter test and opt-in performance benchmark were excluded.
- `docker build --target browser-tests -f services/office/Dockerfile` and two complete disposable browser runs: 43 passed each. This covers both native hook scenarios, real tmux, SQLite, protected credentials, browser consent, Auth/Firestore and cached-token denial. The final subsequent delta is only the retirement lookup index and its independent schema oracle.
- Final committed head recheck: Rust 1.97 `cargo fmt --all --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --locked` passed; separate debug-0 products built; native tests passed 155/155; two additional tmux E2E runs each passed 170 tests across 36 files (one opt-in test skipped).
- Canonical skill validation and diff whitespace checks: passed.

Behavioral assertions include atomic rollback/reopen, registration races, fair retries, saved detachment, same-name replacement, unavailable and missing vaults, retired-token refresh for reduction, unknown proof followed by later approval, remote success with failed local acknowledgment, exact tombstone retry, retained blocks, wrong-agent denial and renewal/revocation races. No paid model, host tmux/credentials or production Firebase was used.

## Project lifecycle

Architecture, pairing/protocol definitions, command guidance and the canonical installed skill are updated in the same PR. The issue remains In Progress until merge. Work uses one dedicated branch in the main checkout; no additional worktree was created. No release or deployment is included. Reassignment and lost-credential recovery remain outside this slice.
