### PR TITLE
feat: expose retained agent spaces in the owner editor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,11 +37,13 @@ delivery. Future connector dispatch reuses native request/storage ownership,
 not CLI-output scraping or a competing exchange engine. Ordinary CLI operations
 remain independent of Office.
 
-Office has four app-owned boundaries: `auth` initializes Firebase/session,
+Office has app-owned boundaries: `auth` initializes Firebase/session,
 `worlds` owns admission and world access, and `blocks` owns the layout contract,
 codec, adapter and editor lifecycle. `pairing` owns public-link decoding, explicit
 owner approval/revocation and sanitized action state, reusing the selected-world
-lifecycle and authenticated runtime composition. Rules and the trusted issuer
+lifecycle and authenticated runtime composition. `spaces` projects bounded
+owner-only grant pages and selects the existing block editor; it has no
+assignment registry or permission mutation. Rules and the trusted issuer
 enforce authority; views never grant it. Remote snapshots have one owner, separate
 from unsaved drafts and ephemeral
 presentation state. No stored markup executes and no parallel layout is stored.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -242,6 +242,13 @@ and token expiry must not stand in for that value.
 
 ## Personal-office milestone acceptance
 
+`retained-spaces.spec.ts` proves owner discovery of a revoked grant, opening and
+editing its retained UUID block through the shared editor, independent stored
+state, unchanged home layout, reopening and admission loss. The grant Rules
+suite independently checks bounded owner pagination and denies unbounded,
+oversized, foreign-owner, agent and revoked-admission queries. Owner editing
+does not prove native block mutation, reassignment or credential recovery.
+
 The M1 acceptance target is a causal local flow: actual native CLI and Office
 companion -> browser owner approval -> scoped credential use -> durable resource
 change -> visible browser result. Use deterministic mock agents, isolated real

--- a/apps/office/e2e/agent-grant-rules.spec.ts
+++ b/apps/office/e2e/agent-grant-rules.spec.ts
@@ -8,8 +8,14 @@ import {
   serverTimestamp,
   setDoc,
   updateDoc,
+  query,
+  limit,
+  orderBy,
+  documentId,
+  startAfter,
 } from 'firebase/firestore';
 import { createWorldPort } from '../src/worlds/firebase-worlds.js';
+import { createSpacePort } from '../src/spaces/firebase-spaces.js';
 import { createFirestoreFixture, setTester, writeAgentGrantFields } from './firestore-fixture.js';
 
 async function withAssignment(
@@ -76,6 +82,87 @@ const layout = (revision: number, objects: string[] = ['d000']) => ({
 });
 const denied = (operation: Promise<unknown>) =>
   expect(operation).rejects.toMatchObject({ code: 'permission-denied' });
+
+test('the owner inventory adapter pages real grants and opens an absent UUID block without touching home', async () => {
+  const fixture = await createFirestoreFixture();
+  try {
+    const owner = await fixture.client(true);
+    const worlds = createWorldPort(owner.db);
+    const world = worlds.draft('Inventory adapter');
+    await worlds.create(world, owner.uid);
+    const blockId = crypto.randomUUID();
+    for (let i = 0; i < 21; i++)
+      await writeAgentGrantFields(
+        world.id,
+        `office-agent:00000000-0000-4000-8000-${i.toString().padStart(12, '0')}`,
+        {
+          version: { integerValue: '1' },
+          ownerUid: { stringValue: owner.uid },
+          installationId: { stringValue: crypto.randomUUID() },
+          identityId: { stringValue: crypto.randomUUID() },
+          blockId: { stringValue: blockId },
+          capabilities: { arrayValue: { values: [{ stringValue: 'layout.read' }] } },
+          enabled: { booleanValue: false },
+          createdAt: { timestampValue: new Date(1000).toISOString() },
+          expiresAt: { timestampValue: new Date(2000).toISOString() },
+        }
+      );
+    const port = createSpacePort(owner.db);
+    const first = await port.list(world.id, owner.uid);
+    expect(first.entries).toHaveLength(20);
+    expect(first.next).toBe('office-agent:00000000-0000-4000-8000-000000000019');
+    const second = await port.list(world.id, owner.uid, first.next!);
+    expect(second.entries).toHaveLength(1);
+    expect(second.entries[0].principalUid).toBe(
+      'office-agent:00000000-0000-4000-8000-000000000020'
+    );
+    expect(second.next).toBeNull();
+    const target = port.block(blockId);
+    const result = await target.apply(world.id, 0, [{ asset: 'desk', x: 0, y: 0, rotation: 0 }]);
+    expect(result.revision).toBe(1);
+    expect(
+      (await getDocFromServer(doc(owner.db, 'worlds', world.id, 'blocks', blockId))).data()?.objects
+    ).toEqual(['d000']);
+    expect(
+      (await getDocFromServer(doc(owner.db, 'worlds', world.id, 'blocks', 'home'))).exists()
+    ).toBe(false);
+    expect(() => port.block('../home')).toThrow();
+    await expect(port.list(world.id, owner.uid, '../grant')).rejects.toThrow();
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('only the admitted owner can enumerate bounded grant pages, including revoked history', async () => {
+  await withAssignment(async ({ fixture, owner, agent, world, fields }) => {
+    for (let i = 0; i < 21; i++)
+      await writeAgentGrantFields(
+        world.id,
+        `office-agent:00000000-0000-4000-8000-${i.toString().padStart(12, '0')}`,
+        { ...fields, enabled: { booleanValue: false } }
+      );
+    const grants = collection(owner.db, 'worlds', world.id, 'agentGrants');
+    const first = await getDocsFromServer(query(grants, orderBy(documentId()), limit(20)));
+    const second = await getDocsFromServer(
+      query(grants, orderBy(documentId()), startAfter(first.docs.at(-1)!.id), limit(20))
+    );
+    expect(first.size).toBe(20);
+    expect(second.size).toBe(2);
+    expect(new Set([...first.docs, ...second.docs].map((row) => row.id)).size).toBe(22);
+    expect(
+      [...first.docs, ...second.docs].filter((row) => row.data().enabled === false)
+    ).toHaveLength(21);
+    await denied(getDocsFromServer(grants));
+    await denied(getDocsFromServer(query(grants, limit(21))));
+    const foreign = await fixture.client(true);
+    for (const actor of [agent, foreign])
+      await denied(
+        getDocsFromServer(query(collection(actor.db, 'worlds', world.id, 'agentGrants'), limit(20)))
+      );
+    await setTester(owner.uid, false);
+    await denied(getDocsFromServer(query(grants, limit(20))));
+  });
+});
 
 test('an assigned principal edits only its block with the existing bounded revision contract', async () => {
   await withAssignment(

--- a/apps/office/e2e/firestore-fixture.ts
+++ b/apps/office/e2e/firestore-fixture.ts
@@ -13,9 +13,10 @@ import { connectFirestoreEmulator, initializeFirestore, terminate } from 'fireba
 const projectId = 'demo-tmt-office';
 const documents = `http://127.0.0.1:8080/v1/projects/${projectId}/databases/(default)/documents`;
 
-export async function readBlockDocument(worldId: string): Promise<unknown> {
+export async function readBlockDocument(worldId: string, blockId = 'home'): Promise<unknown> {
   expect(worldId).toMatch(/^[a-zA-Z0-9]{20}$/);
-  const response = await fetch(`${documents}/worlds/${worldId}/blocks/home`, {
+  expect(blockId).toMatch(/^(home|[0-9a-f-]{36})$/);
+  const response = await fetch(`${documents}/worlds/${worldId}/blocks/${blockId}`, {
     headers: { authorization: 'Bearer owner' },
     signal: AbortSignal.timeout(10_000),
   });
@@ -81,6 +82,16 @@ export async function writeAgentGrantFields(
     `worlds/${worldId}/agentGrants/${encodeURIComponent(principalUid)}`,
     fields
   );
+}
+
+export async function writeBlockFields(
+  worldId: string,
+  blockId: string,
+  fields: Record<string, unknown>
+): Promise<void> {
+  expect(worldId).toMatch(/^[a-zA-Z0-9]{20}$/);
+  expect(blockId).toMatch(/^[0-9a-f-]{36}$/);
+  await writeOperatorDocument(`worlds/${worldId}/blocks/${blockId}`, fields);
 }
 
 async function writeOperatorDocument(path: string, fields: Record<string, unknown>): Promise<void> {

--- a/apps/office/e2e/native-hooks.spec.ts
+++ b/apps/office/e2e/native-hooks.spec.ts
@@ -315,6 +315,15 @@ test('retirement delivers Office hooks and recovers after vault and acknowledgme
             expect(await hook()).toEqual([{ state: 'delivered', attempt_count: 4 }]);
             expect((await grant.get()).data()).toEqual({ ...savedGrant, enabled: false });
             expect((await block.get()).data()).toEqual(savedBlock);
+            await page.getByRole('link', { name: 'Office', exact: true }).click();
+            await page.getByLabel('World ID', { exact: true }).fill(worldId);
+            await page.getByRole('button', { name: 'Open world', exact: true }).click();
+            await expect(page.getByText(/^Revoked · Lease expires/)).toBeVisible();
+            await page
+              .getByRole('button', { name: `Open block ${remote.blockId}`, exact: true })
+              .click();
+            await expect(page.getByRole('button', { name: 'Desk 1', exact: true })).toBeVisible();
+            expect((await block.get()).data()).toEqual(savedBlock);
           } finally {
             expect((await vault('clear')).status).toBe(0);
             expect((await vault('lookup')).status).toBe(1);

--- a/apps/office/e2e/retained-spaces.spec.ts
+++ b/apps/office/e2e/retained-spaces.spec.ts
@@ -1,0 +1,78 @@
+import { expect } from '@playwright/test';
+import { test, signIn } from './browser-session.js';
+import {
+  setTester,
+  writeAgentGrantFields,
+  writeBlockFields,
+  readBlockDocument,
+} from './firestore-fixture.js';
+
+test('owner discovers a revoked grant, edits its retained block and keeps home independent', async ({
+  openSession,
+}) => {
+  const { page } = await openSession();
+  await signIn(page, 'Space owner');
+  const uid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+  await setTester(uid, true);
+  await page.getByLabel('World name').fill('Retained studio');
+  await page.getByRole('button', { name: 'Create world', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Retained studio' })).toBeVisible();
+  const worldId = new URL(page.url()).pathname.split('/').at(-1)!;
+  await page.getByRole('button', { name: 'Add plant', exact: true }).click();
+  await page.getByRole('button', { name: 'Save layout', exact: true }).click();
+  await expect(page.getByText('Saved · revision 1', { exact: true })).toBeVisible();
+  const home = await readBlockDocument(worldId);
+  const blockId = crypto.randomUUID();
+  const identityId = crypto.randomUUID();
+  const principalUid = `office-agent:${crypto.randomUUID()}`;
+  await writeAgentGrantFields(worldId, principalUid, {
+    version: { integerValue: '1' },
+    ownerUid: { stringValue: uid },
+    installationId: { stringValue: crypto.randomUUID() },
+    identityId: { stringValue: identityId },
+    blockId: { stringValue: blockId },
+    capabilities: { arrayValue: { values: [{ stringValue: 'layout.read' }] } },
+    enabled: { booleanValue: false },
+    createdAt: { timestampValue: new Date(Date.now() - 120_000).toISOString() },
+    expiresAt: { timestampValue: new Date(Date.now() - 60_000).toISOString() },
+  });
+  await writeBlockFields(worldId, blockId, {
+    version: { integerValue: '1' },
+    revision: { integerValue: '1' },
+    objects: { arrayValue: { values: [{ stringValue: 'd000' }] } },
+    updatedAt: { timestampValue: new Date().toISOString() },
+  });
+  await page.getByRole('button', { name: 'Refresh spaces', exact: true }).click();
+  await expect(page.getByText(identityId, { exact: true })).toBeVisible();
+  await expect(page.getByText(/^Revoked · Lease expires/)).toBeVisible();
+  await page.getByRole('button', { name: `Open block ${blockId}`, exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Desk 1', exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Add chair', exact: true }).click();
+  await page.getByRole('button', { name: 'Save layout', exact: true }).click();
+  await expect(page.getByText('Saved · revision 2', { exact: true })).toBeVisible();
+  expect(await readBlockDocument(worldId, blockId)).toMatchObject({
+    fields: {
+      revision: { integerValue: '2' },
+      objects: { arrayValue: { values: [{ stringValue: 'd000' }, { stringValue: 'c0ee' }] } },
+    },
+  });
+  expect(await readBlockDocument(worldId)).toEqual(home);
+  await page.getByRole('button', { name: 'Open home block', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Plant 1', exact: true })).toBeVisible();
+  await page.getByRole('button', { name: `Open block ${blockId}`, exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Chair 2', exact: true })).toBeVisible();
+  await page
+    .getByRole('region', { name: 'Agent spaces' })
+    .screenshot({ path: test.info().outputPath('retained-spaces-desktop.png') });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page
+    .getByRole('region', { name: 'Agent spaces' })
+    .screenshot({ path: test.info().outputPath('retained-spaces-mobile.png') });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
+    true
+  );
+  await setTester(uid, false);
+  await expect(page.getByRole('heading', { name: 'Waiting for access' })).toBeVisible();
+  await expect(page.getByRole('region', { name: 'Agent spaces' })).toHaveCount(0);
+  await expect(page.getByRole('region', { name: 'Office block editor' })).toHaveCount(0);
+});

--- a/apps/office/src/auth/firebase-session.ts
+++ b/apps/office/src/auth/firebase-session.ts
@@ -21,6 +21,7 @@ import { createWorldPort } from '../worlds/firebase-worlds.js';
 import { createWorldState } from '../worlds/world-state.js';
 import { createBlockPort } from '../blocks/firebase-blocks.js';
 import { createPairingPort } from '../pairing/pairing-transport.js';
+import { createSpacePort } from '../spaces/firebase-spaces.js';
 
 /** One composition root for both explicit environments, outside React rendering. */
 export function startOfficeRuntime(
@@ -60,6 +61,7 @@ export function startOfficeRuntime(
     session,
     worlds,
     blocks: createBlockPort(db),
+    spaces: createSpacePort(db),
     pairing: pairingUrl ? createPairingPort(auth, pairingUrl) : undefined,
     mode,
     dispose: async () => {

--- a/apps/office/src/blocks/block-view.tsx
+++ b/apps/office/src/blocks/block-view.tsx
@@ -7,8 +7,17 @@ import { BlockScene } from './block-scene.js';
 import './block.css';
 
 export const BlockContext = createContext<BlockPort | undefined>(undefined);
-export function BlockPanel({ worldId }: { worldId: string }) {
-  const port = useContext(BlockContext);
+export function BlockPanel({
+  worldId,
+  blockPort,
+  label,
+}: {
+  worldId: string;
+  blockPort?: BlockPort;
+  label?: string;
+}) {
+  const defaultPort = useContext(BlockContext);
+  const port = blockPort ?? defaultPort;
   const [state, setState] = useState<BlockState>();
   useEffect(() => {
     if (!port) return;
@@ -16,9 +25,15 @@ export function BlockPanel({ worldId }: { worldId: string }) {
     setState(next);
     return () => next.dispose();
   }, [port, worldId]);
-  return state ? <BlockEditor state={state} /> : null;
+  return state ? <BlockEditor state={state} label={label} /> : null;
 }
-export function BlockEditor({ state }: { state: BlockState }) {
+export function BlockEditor({
+  state,
+  label = 'YOUR SPACE / HOME BLOCK',
+}: {
+  state: BlockState;
+  label?: string;
+}) {
   const { remote, draft, ready, busy, error } = useSyncExternalStore(
     state.subscribe,
     state.getSnapshot
@@ -40,7 +55,7 @@ export function BlockEditor({ state }: { state: BlockState }) {
     <section className="block-editor" aria-label="Office block editor">
       <div className="block-heading">
         <div>
-          <p className="eyebrow">YOUR SPACE / HOME BLOCK</p>
+          <p className="eyebrow">{label}</p>
           <h2>Make room for your team.</h2>
         </div>
         <span role="status">

--- a/apps/office/src/blocks/firebase-blocks.ts
+++ b/apps/office/src/blocks/firebase-blocks.ts
@@ -27,10 +27,12 @@ function readBlock(value: Record<string, unknown>): Block {
     updatedAtMs: value.updatedAt.toMillis(),
   };
 }
-export function createBlockPort(db: Firestore): BlockPort {
+export function createBlockPort(db: Firestore, blockId = 'home'): BlockPort {
+  if (!/^(home|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/.test(blockId))
+    throw new Error('Invalid block ID.');
   function reference(worldId: string) {
     if (!validWorldId(worldId)) throw new Error('Invalid world ID.');
-    return doc(db, 'worlds', worldId, 'blocks', 'home');
+    return doc(db, 'worlds', worldId, 'blocks', blockId);
   }
   return {
     watch(worldId, changed, failed) {

--- a/apps/office/src/main.tsx
+++ b/apps/office/src/main.tsx
@@ -43,6 +43,7 @@ async function mount(): Promise<void> {
         worlds={runtime?.worlds}
         blocks={runtime?.blocks}
         pairing={runtime?.pairing}
+        spaces={runtime?.spaces}
         mode={runtime?.mode}
       />
     </StrictMode>

--- a/apps/office/src/office-app.tsx
+++ b/apps/office/src/office-app.tsx
@@ -11,6 +11,8 @@ import { BlockContext } from './blocks/block-view.js';
 import type { BlockPort } from './blocks/block-contract.js';
 import { PairingContext } from './pairing/pairing-view.js';
 import type { PairingPort } from './pairing/pairing-contract.js';
+import { SpaceContext } from './spaces/space-view.js';
+import type { SpacePort } from './spaces/space-contract.js';
 
 export function OfficeApp({
   router,
@@ -18,6 +20,7 @@ export function OfficeApp({
   worlds,
   blocks,
   pairing,
+  spaces,
   mode = 'emulator',
 }: {
   router: ReturnType<typeof createOfficeRouter>;
@@ -25,6 +28,7 @@ export function OfficeApp({
   worlds?: WorldState;
   blocks?: BlockPort;
   pairing?: PairingPort;
+  spaces?: SpacePort;
   mode?: string;
 }): ReactElement {
   // A mounted app owns its UI state; tests and future embedded views cannot leak it.
@@ -36,7 +40,9 @@ export function OfficeApp({
           <WorldContext value={worlds}>
             <BlockContext value={blocks}>
               <PairingContext value={pairing}>
-                <RouterProvider router={router} />
+                <SpaceContext value={spaces}>
+                  <RouterProvider router={router} />
+                </SpaceContext>
               </PairingContext>
             </BlockContext>
           </WorldContext>

--- a/apps/office/src/spaces/firebase-spaces.test.ts
+++ b/apps/office/src/spaces/firebase-spaces.test.ts
@@ -1,0 +1,52 @@
+import { Timestamp } from 'firebase/firestore';
+import { expect, it } from 'vitest';
+import { readAgentSpace } from './firebase-spaces.js';
+
+const id = '00000000-0000-4000-8000-000000000001';
+const principal = `office-agent:${id}`;
+const value = {
+  version: 1,
+  ownerUid: 'owner',
+  installationId: id,
+  identityId: id,
+  blockId: id,
+  capabilities: ['layout.read'],
+  enabled: false,
+  createdAt: Timestamp.fromMillis(1000),
+  expiresAt: Timestamp.fromMillis(2000),
+};
+it('keeps revoked and expired records visible without inferring presence or authority', () => {
+  expect(readAgentSpace(principal, value, 'owner')).toEqual({
+    principalUid: principal,
+    installationId: id,
+    identityId: id,
+    blockId: id,
+    capabilities: ['layout.read'],
+    enabled: false,
+    expiresAtMs: 2000,
+  });
+  expect(readAgentSpace(principal, { ...value, enabled: true }, 'owner').enabled).toBe(true);
+});
+it('rejects incomplete, expanded, wrong-owner and malformed authority projections', () => {
+  for (const key of Object.keys(value)) {
+    const incomplete: Record<string, unknown> = { ...value };
+    delete incomplete[key];
+    expect(() => readAgentSpace(principal, incomplete, 'owner')).toThrow();
+  }
+  for (const patch of [
+    { extra: true },
+    { ownerUid: 'other' },
+    { version: 2 },
+    { enabled: 'true' },
+    { blockId: 'home' },
+    { identityId: '../identity' },
+    { installationId: '' },
+    { capabilities: ['layout.write'] },
+    { capabilities: ['layout.read', 'board.write'] },
+    { createdAt: 1000 },
+    { expiresAt: Timestamp.fromMillis(1000) },
+    { expiresAt: Timestamp.fromMillis(86_401_001) },
+  ])
+    expect(() => readAgentSpace(principal, { ...value, ...patch }, 'owner')).toThrow();
+  expect(() => readAgentSpace('alice', value, 'owner')).toThrow();
+});

--- a/apps/office/src/spaces/firebase-spaces.ts
+++ b/apps/office/src/spaces/firebase-spaces.ts
@@ -1,0 +1,83 @@
+import {
+  collection,
+  documentId,
+  getDocsFromServer,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+  Timestamp,
+} from 'firebase/firestore';
+import type { Firestore } from 'firebase/firestore';
+import { validWorldId } from '../worlds/world-contract.js';
+import { createBlockPort } from '../blocks/firebase-blocks.js';
+import { SPACE_PAGE_SIZE } from './space-contract.js';
+import type { AgentSpace, SpacePort } from './space-contract.js';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+function validPrincipal(value: string): boolean {
+  return value.startsWith('office-agent:') && UUID.test(value.slice('office-agent:'.length));
+}
+
+/** A read projection, not a second authority model. Rules decide who may read. */
+export function readAgentSpace(
+  principalUid: string,
+  value: Record<string, unknown>,
+  ownerUid: string
+): AgentSpace {
+  const capabilities = value.capabilities;
+  if (
+    !validPrincipal(principalUid) ||
+    Object.keys(value).length !== 9 ||
+    value.version !== 1 ||
+    value.ownerUid !== ownerUid ||
+    !['installationId', 'identityId', 'blockId'].every(
+      (key) => typeof value[key] === 'string' && UUID.test(value[key])
+    ) ||
+    typeof value.enabled !== 'boolean' ||
+    !(value.createdAt instanceof Timestamp) ||
+    !(value.expiresAt instanceof Timestamp) ||
+    value.createdAt.toMillis() <= 0 ||
+    value.expiresAt.toMillis() <= value.createdAt.toMillis() ||
+    value.expiresAt.toMillis() - value.createdAt.toMillis() > 86_400_000 ||
+    !Array.isArray(capabilities) ||
+    capabilities[0] !== 'layout.read' ||
+    !(
+      capabilities.length === 1 ||
+      (capabilities.length === 2 && capabilities[1] === 'layout.write')
+    )
+  )
+    throw new Error('Unsupported agent grant.');
+  return {
+    principalUid,
+    installationId: value.installationId as string,
+    identityId: value.identityId as string,
+    blockId: value.blockId as string,
+    capabilities: capabilities.length === 1 ? ['layout.read'] : ['layout.read', 'layout.write'],
+    enabled: value.enabled,
+    expiresAtMs: value.expiresAt.toMillis(),
+  };
+}
+
+export function createSpacePort(db: Firestore): SpacePort {
+  return {
+    async list(worldId, ownerUid, after) {
+      if (!validWorldId(worldId) || !ownerUid || (after !== undefined && !validPrincipal(after)))
+        throw new Error('Invalid space query.');
+      const snapshot = await getDocsFromServer(
+        query(
+          collection(db, 'worlds', worldId, 'agentGrants'),
+          orderBy(documentId()),
+          ...(after === undefined ? [] : [startAfter(after)]),
+          limit(SPACE_PAGE_SIZE)
+        )
+      );
+      const entries = snapshot.docs.map((row) => readAgentSpace(row.id, row.data(), ownerUid));
+      return {
+        entries,
+        next: entries.length === SPACE_PAGE_SIZE ? entries.at(-1)!.principalUid : null,
+      };
+    },
+    block: (blockId) => createBlockPort(db, blockId),
+  };
+}

--- a/apps/office/src/spaces/space-contract.ts
+++ b/apps/office/src/spaces/space-contract.ts
@@ -1,0 +1,21 @@
+import type { BlockPort } from '../blocks/block-contract.js';
+import type { PairingCapabilities } from '../pairing/pairing-contract.js';
+
+export const SPACE_PAGE_SIZE = 20;
+export interface AgentSpace {
+  principalUid: string;
+  installationId: string;
+  identityId: string;
+  blockId: string;
+  capabilities: PairingCapabilities;
+  enabled: boolean;
+  expiresAtMs: number;
+}
+export interface SpacePage {
+  entries: AgentSpace[];
+  next: string | null;
+}
+export interface SpacePort {
+  list(worldId: string, ownerUid: string, after?: string): Promise<SpacePage>;
+  block(blockId: string): BlockPort;
+}

--- a/apps/office/src/spaces/space-state.test.ts
+++ b/apps/office/src/spaces/space-state.test.ts
@@ -1,0 +1,67 @@
+import { expect, it, vi } from 'vitest';
+import { createSpaceState } from './space-state.js';
+import type { SpacePage, SpacePort } from './space-contract.js';
+
+function fixture() {
+  const port: SpacePort = {
+    list: vi.fn(async () => ({ entries: [], next: 'cursor' })),
+    block: () => {
+      throw new Error('No block access in inventory state.');
+    },
+  };
+  return { port, state: createSpaceState(port, 'world', 'owner') };
+}
+it('loads one bounded page at a time and refresh restarts rather than merging a second cache', async () => {
+  const { port, state } = fixture();
+  await state.next();
+  expect(port.list).not.toHaveBeenCalled();
+  await state.refresh();
+  await state.next();
+  expect(port.list).toHaveBeenNthCalledWith(2, 'world', 'owner', 'cursor');
+  await state.refresh();
+  expect(port.list).toHaveBeenNthCalledWith(3, 'world', 'owner', undefined);
+  expect(state.getSnapshot().ready).toBe(true);
+  state.dispose();
+});
+it.each(['success', 'failure'])(
+  'suppresses concurrent loads and fences late %s after disposal',
+  async (outcome) => {
+    const { port, state } = fixture();
+    let resolve!: (page: SpacePage) => void;
+    let reject!: (error: Error) => void;
+    vi.mocked(port.list).mockImplementation(
+      () =>
+        new Promise((yes, no) => {
+          resolve = yes;
+          reject = no;
+        })
+    );
+    const pending = state.refresh();
+    await state.refresh();
+    expect(port.list).toHaveBeenCalledOnce();
+    state.dispose();
+    if (outcome === 'success') resolve({ entries: [], next: 'late' });
+    else reject(new Error('late'));
+    await pending;
+    await state.refresh();
+    expect(state.getSnapshot()).toMatchObject({
+      entries: [],
+      next: null,
+      ready: false,
+      busy: false,
+      error: null,
+    });
+    expect(port.list).toHaveBeenCalledOnce();
+  }
+);
+it('a failed refresh clears the prior page and allows an explicit retry', async () => {
+  const { port, state } = fixture();
+  await state.refresh();
+  vi.mocked(port.list).mockRejectedValueOnce(new Error('permission-denied'));
+  await state.refresh();
+  expect(state.getSnapshot()).toMatchObject({ entries: [], next: null, ready: false, busy: false });
+  expect(state.getSnapshot().error).toContain('unavailable');
+  await state.refresh();
+  expect(state.getSnapshot()).toMatchObject({ ready: true, error: null });
+  state.dispose();
+});

--- a/apps/office/src/spaces/space-state.ts
+++ b/apps/office/src/spaces/space-state.ts
@@ -1,0 +1,63 @@
+import type { SpacePage, SpacePort } from './space-contract.js';
+
+interface Snapshot extends SpacePage {
+  busy: boolean;
+  ready: boolean;
+  error: string | null;
+  observedAtMs: number;
+}
+/** One bounded page per mounted world. No polling or grant snapshot mirror. */
+export function createSpaceState(port: SpacePort, worldId: string, ownerUid: string) {
+  let snapshot: Snapshot = {
+    entries: [],
+    next: null,
+    busy: false,
+    ready: false,
+    error: null,
+    observedAtMs: 0,
+  };
+  let disposed = false;
+  const listeners = new Set<() => void>();
+  function publish(next: Partial<Snapshot>) {
+    if (disposed) return;
+    snapshot = { ...snapshot, ...next };
+    for (const listener of listeners) listener();
+  }
+  async function load(after?: string) {
+    if (disposed || snapshot.busy) return;
+    publish({ busy: true, ready: false, entries: [], next: null, error: null });
+    try {
+      const page = await port.list(worldId, ownerUid, after);
+      publish({ ...page, ready: true, observedAtMs: Date.now() });
+    } catch {
+      publish({ error: 'Agent spaces unavailable. Refresh to retry.' });
+    } finally {
+      publish({ busy: false });
+    }
+  }
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener: () => void) {
+      if (disposed) return () => {};
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    refresh: () => load(),
+    next: () => (snapshot.next ? load(snapshot.next) : Promise.resolve()),
+    dispose() {
+      disposed = true;
+      listeners.clear();
+      snapshot = {
+        entries: [],
+        next: null,
+        busy: false,
+        ready: false,
+        error: null,
+        observedAtMs: 0,
+      };
+    },
+  };
+}
+export type SpaceState = ReturnType<typeof createSpaceState>;

--- a/apps/office/src/spaces/space-view.test.tsx
+++ b/apps/office/src/spaces/space-view.test.tsx
@@ -1,0 +1,80 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, it, vi } from 'vitest';
+import { BlockContext } from '../blocks/block-view.js';
+import type { Block, BlockPort } from '../blocks/block-contract.js';
+import { OfficeSpaces, SpaceContext } from './space-view.js';
+import type { SpacePort } from './space-contract.js';
+
+it('switching targets disposes the old editor and late saves cannot replace home', async () => {
+  const blockId = '00000000-0000-4000-8000-000000000001';
+  const homeStop = vi.fn();
+  const retainedStop = vi.fn();
+  let finish!: (block: Block) => void;
+  const home: BlockPort = {
+    watch: (_world, next) => {
+      next({ revision: 3, objects: [{ asset: 'plant', x: 1, y: 1, rotation: 0 }], updatedAtMs: 1 });
+      return homeStop;
+    },
+    apply: vi.fn(async () => {
+      throw new Error('Home must not be written.');
+    }),
+  };
+  const retained: BlockPort = {
+    watch: (_world, next) => {
+      next(null);
+      return retainedStop;
+    },
+    apply: vi.fn(
+      () =>
+        new Promise<Block>((resolve) => {
+          finish = resolve;
+        })
+    ),
+  };
+  const port: SpacePort = {
+    list: async () => ({
+      entries: [
+        {
+          principalUid: 'principal',
+          identityId: 'identity',
+          installationId: 'installation',
+          blockId,
+          capabilities: ['layout.read'],
+          enabled: false,
+          expiresAtMs: 1000,
+        },
+      ],
+      next: null,
+    }),
+    block: vi.fn(() => retained),
+  };
+  const world = { id: 'a'.repeat(20), ownerUid: 'owner', name: 'Studio', createdAtMs: 1 };
+  const view = render(
+    <SpaceContext value={port}>
+      <BlockContext value={home}>
+        <OfficeSpaces world={world} />
+      </BlockContext>
+    </SpaceContext>
+  );
+  try {
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: `Open block ${blockId}` }));
+    expect(port.block).toHaveBeenCalledExactlyOnceWith(blockId);
+    expect(homeStop).toHaveBeenCalledOnce();
+    expect(screen.getByText('No saved layout yet')).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: 'Add desk' }));
+    await user.click(screen.getByRole('button', { name: 'Save layout' }));
+    expect(retained.apply).toHaveBeenCalledExactlyOnceWith(world.id, 0, [
+      { asset: 'desk', x: 14, y: 14, rotation: 0 },
+    ]);
+    await user.click(screen.getByRole('button', { name: 'Open home block' }));
+    expect(retainedStop).toHaveBeenCalledOnce();
+    await act(async () => finish({ revision: 1, objects: [], updatedAtMs: 1 }));
+    expect(screen.getByText('Saved · revision 3')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Plant 1' })).toBeTruthy();
+    expect(home.apply).not.toHaveBeenCalled();
+  } finally {
+    view.unmount();
+  }
+});

--- a/apps/office/src/spaces/space-view.tsx
+++ b/apps/office/src/spaces/space-view.tsx
@@ -1,0 +1,97 @@
+import { createContext, useContext, useEffect, useState, useSyncExternalStore } from 'react';
+import { BlockPanel } from '../blocks/block-view.js';
+import type { BlockPort } from '../blocks/block-contract.js';
+import type { World } from '../worlds/world-contract.js';
+import type { SpacePort } from './space-contract.js';
+import { createSpaceState } from './space-state.js';
+import type { SpaceState } from './space-state.js';
+import './spaces.css';
+
+export const SpaceContext = createContext<SpacePort | undefined>(undefined);
+export function OfficeSpaces({ world }: { world: World }) {
+  const port = useContext(SpaceContext);
+  return port ? (
+    <ConnectedSpaces key={world.id} world={world} port={port} />
+  ) : (
+    <BlockPanel worldId={world.id} />
+  );
+}
+function ConnectedSpaces({ world, port }: { world: World; port: SpacePort }) {
+  const [state, setState] = useState<SpaceState>();
+  const [selected, setSelected] = useState<{ id: string; port: BlockPort }>();
+  useEffect(() => {
+    const next = createSpaceState(port, world.id, world.ownerUid);
+    setState(next);
+    void next.refresh();
+    return () => next.dispose();
+  }, [port, world.id, world.ownerUid]);
+  return (
+    <>
+      {state && (
+        <SpaceList state={state} open={(id) => setSelected({ id, port: port.block(id) })} />
+      )}
+      {selected && (
+        <p className="space-selection">
+          Viewing retained block <code>{selected.id}</code>. Switching spaces discards unsaved
+          edits.
+          <button onClick={() => setSelected(undefined)}>Open home block</button>
+        </p>
+      )}
+      <BlockPanel
+        key={selected?.id ?? 'home'}
+        worldId={world.id}
+        blockPort={selected?.port}
+        label={selected ? `AGENT SPACE / ${selected.id}` : undefined}
+      />
+    </>
+  );
+}
+export function SpaceList({ state, open }: { state: SpaceState; open: (id: string) => void }) {
+  const { entries, ready, busy, next, error, observedAtMs } = useSyncExternalStore(
+    state.subscribe,
+    state.getSnapshot
+  );
+  return (
+    <section className="agent-spaces" aria-label="Agent spaces">
+      <h2>Agent spaces</h2>
+      <p>
+        Grant records, not online presence. Expired leases may renew; revoked access does not delete
+        a block. Refresh for current records. Switching spaces discards unsaved edits.
+      </p>
+      <button disabled={busy} onClick={() => void state.refresh()}>
+        Refresh spaces
+      </button>
+      <button disabled={busy || !next} onClick={() => void state.next()}>
+        Next spaces
+      </button>
+      {busy && <p role="status">Loading agent spaces…</p>}
+      {error && <p role="alert">{error}</p>}
+      {ready && entries.length === 0 && <p>No grant records on this page.</p>}
+      <ul>
+        {entries.map((entry) => (
+          <li key={entry.principalUid}>
+            <p>
+              Identity: <code>{entry.identityId}</code>
+            </p>
+            <p>
+              Installation: <code>{entry.installationId}</code>
+            </p>
+            <p>
+              Principal: <code>{entry.principalUid}</code>
+            </p>
+            <p>
+              {!entry.enabled
+                ? 'Revoked'
+                : entry.expiresAtMs <= observedAtMs
+                  ? 'Enabled · lease expired at last refresh'
+                  : 'Enabled at last refresh'}{' '}
+              · Lease expires {new Date(entry.expiresAtMs).toISOString()} ·{' '}
+              {entry.capabilities.join(', ')}
+            </p>
+            <button onClick={() => open(entry.blockId)}>Open block {entry.blockId}</button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/office/src/spaces/spaces.css
+++ b/apps/office/src/spaces/spaces.css
@@ -1,0 +1,29 @@
+.agent-spaces {
+  margin: 24px 0;
+  padding: 20px;
+  border: 1px solid #d4dccf;
+  border-radius: 12px;
+  background: #fff;
+}
+.agent-spaces,
+.space-selection {
+  overflow-wrap: anywhere;
+}
+.agent-spaces ul {
+  list-style: none;
+  padding: 0;
+}
+.agent-spaces li {
+  padding: 12px 0;
+  border-top: 1px solid #d4dccf;
+}
+.agent-spaces li p {
+  margin: 4px 0;
+}
+.agent-spaces button,
+.space-selection button {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  margin: 4px 8px 4px 0;
+  padding: 8px 12px;
+}

--- a/apps/office/src/worlds/world-view.tsx
+++ b/apps/office/src/worlds/world-view.tsx
@@ -4,7 +4,7 @@ import type { ReactElement, ReactNode } from 'react';
 import type { WorldState } from './world-state.js';
 import { WORLD_ID_PATTERN } from './world-contract.js';
 import type { World } from './world-contract.js';
-import { BlockPanel } from '../blocks/block-view.js';
+import { OfficeSpaces } from '../spaces/space-view.js';
 
 export const WorldContext = createContext<WorldState | undefined>(undefined);
 
@@ -120,7 +120,7 @@ export function SelectedWorld({
       <p>
         World ID: <code>{world.id}</code>
       </p>
-      {children ? children(world) : <BlockPanel key={world.id} worldId={world.id} />}
+      {children ? children(world) : <OfficeSpaces key={world.id} world={world} />}
     </section>
   );
 }

--- a/contracts/office/agent-grant-v1.md
+++ b/contracts/office/agent-grant-v1.md
@@ -33,8 +33,9 @@ An ID token or locally cached approval alone never grants access. Unknown fields
 versions, capabilities, malformed identifiers and timestamps fail closed.
 
 Grants are issued only by the [trusted pairing service](pairing-v1.md), currently
-verified locally with emulators rather than deployed. All client creates,
-deletes and lists are denied. Only the admitted world owner can read a known
+verified locally with emulators rather than deployed. All client creates and
+deletes are denied. Owner-only lists require an explicit limit from 1 to 20;
+agents and foreign owners cannot enumerate. Only the admitted world owner can read a known
 grant or change `enabled: true` to `false`, without changing any other field.
 Owners cannot enlarge, renew or reactivate it through Firestore client writes.
 They may also disable a malformed record as fail-closed recovery. Agents cannot
@@ -52,8 +53,23 @@ Neither owner nor agent can delete a block; clearing uses an empty layout.
 
 Layout authority confers no world-root, notebook, profile, board, message, work
 dispatch or general Firestore access. Those capabilities need separately reviewed
-contracts. Presentation cannot grant permission. The browser still edits only
-`home`; this boundary does not claim an agent-block UI already exists.
+contracts. Presentation cannot grant permission. The browser owner can select
+a grant's UUID block through the same editor as `home`. A revoked grant is not
+proof that a block is unassigned; retained content remains owner-managed.
+
+## Owner inventory
+
+The browser reads one server-confirmed page of 20 grant documents ordered by
+document ID, with an exclusive last-ID cursor. Refresh restarts at the first
+page; it does not accumulate an unbounded cache. A full page may have an empty
+next page. Concurrent insertions before a cursor appear only after refresh;
+pages are not a point-in-time snapshot of the collection. No grant polling or
+per-entry subscriptions are installed. Invalid records make the page unavailable.
+
+Labels reflect the last fetch and the browser clock, not online presence or
+fresh server authorization. Expired enabled leases may renew; revoked records
+remain visible. The inventory does not change grants, recover credentials,
+reassign resources or enumerate blocks without surviving grant references.
 
 Revocation denies subsequent server operations even with the same cached token.
 It neither erases retained blocks nor recalls already disclosed content. Expiry

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -29,7 +29,7 @@ does not provide assignment management. Native credential consumption is owned
 by the optional companion described below. Retained UUID blocks
 use the existing layout validator; no parallel layout/ownership document is introduced.
 
-The current browser edits one owner-only `home` block per admitted world.
+The browser owner edits `home` or a UUID block selected from its grant inventory.
 `src/blocks/block-contract.ts` owns client values, catalog and footprint policy;
 `firebase-blocks.ts` implements its port using the existing initialized SDK.
 `block-state.ts` owns the server-confirmed projection and separate unsaved draft.
@@ -43,7 +43,8 @@ route/admission loss. Late observations and saves cannot restore disposed data.
 selection and controls. No canvas engine, generic scene framework, new global
 store or remote-state copy is introduced. Pointer selection/tile placement and
 equivalent numeric/keyboard controls edit locally; explicit Save uses the
-revision-checked Firestore transaction. Agent assignment and commands are not implemented. The contract and shared validation vectors live in `contracts/office`.
+revision-checked Firestore transaction. Agent reassignment and native block mutation
+commands are not implemented. The contract and shared validation vectors live in `contracts/office`.
 Save confirmation and conflict inspection use one-shot transaction reads in the
 same adapter, independent of watch-channel recovery. Watch snapshots remain
 the ongoing projection, not an acknowledgment channel for explicit saves.
@@ -103,6 +104,23 @@ values remain in the existing core.
 Create each only with its first concrete consumer and reviewed contract.
 Do not relocate established Rust, test, script or canonical skill paths simply
 to make the tree symmetric.
+
+### Owner retained spaces
+
+`src/spaces` owns a bounded one-page projection of existing `agentGrants`, not
+a new assignment store. Its Firebase adapter performs server-only, document-ID
+ordered queries; Rules allow at most 20 documents to the admitted world owner.
+The mounted world owns its disposable page state. Refresh clears stale data,
+late results are fenced after disposal, and no per-grant listener is created.
+Read failures do not imply an empty collection or revoked authority.
+
+The space view selects a target-bound `BlockPort` from the existing blocks adapter.
+The same editor/state/codec handles home and UUID blocks; switching targets remounts
+the editor and discards unsaved drafts. Submitted writes may still complete against
+their original target, but cannot repopulate another editor. Layout mutations do
+not edit grants, profiles or notebooks. Expiry labels are observations, never
+presence or permission decisions. See the [grant contract](../../contracts/office/agent-grant-v1.md#owner-inventory)
+for paging consistency and limitations.
 
 ### Trusted pairing issuer
 

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -31,6 +31,19 @@ requires explicit consent and removes verified activation links only. Release
 files and unrelated data remain. A partial removal reports an invalid
 installation; repeat explicit uninstall to finish before reinstalling.
 
+## Owner space review (web)
+
+In an admitted private world, **Agent spaces** lists existing resource grants.
+Use **Refresh spaces** for the first page and **Next spaces** to advance. These
+records are not online status; lease labels reflect the last fetch. Revocation
+retains content, and an expired enabled lease may later renew.
+
+Choose **Open block** to inspect or edit the referenced space using the existing
+layout editor. **Open home block** returns to your own layout. Switching spaces
+discards unsaved edits; already submitted writes may still complete on their
+original target. An absent layout is shown as **No saved layout yet**, not as
+deleted content. Reassignment and credential recovery are not available here.
+
 ## Native pairing (source builds)
 
 Pairing requires an installed compatible companion and an unlocked OS credential

--- a/services/office/firestore.rules
+++ b/services/office/firestore.rules
@@ -110,12 +110,14 @@ service cloud.firestore {
 
       match /agentGrants/{principalUid} {
         allow get: if ownsWorld();
+        allow list: if ownsWorld() && request.query.limit != null
+          && request.query.limit > 0 && request.query.limit <= 20;
         // Issuance/renewal is a trusted service operation, not a client write.
         // An owner may only revoke; no edits can reactivate or enlarge a grant.
         allow update: if ownsWorld() && resource.data.enabled == true
           && request.resource.data.enabled == false
           && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['enabled']);
-        allow create, list, delete: if false;
+        allow create, delete: if false;
       }
 
       match /blocks/{blockId} {


### PR DESCRIPTION
## Outcome

Closes #231, a bounded child of #209 in personal-office M1 (#173). The admitted owner can inspect bounded grant pages and open a retained UUID block in the existing revision-safe editor. This does not complete #209, implement reassignment, recover credentials, add native block mutations, or deploy/publish Office.

## Architecture

- Existing Firestore agentGrants remain the only authority records. The new spaces boundary owns a server-read page projection and target selection, not an assignment registry, cache mirror or background monitor.
- Rules permit only admitted world owners to list 1–20 grant documents. Agents, foreign owners, revoked admission and unbounded/oversized queries remain denied.
- The existing BlockPort factory binds an explicit home/UUID target. Both views use the same codec, transaction, state and editor. Target switches dispose drafts and fence late results; already submitted writes retain their original target.
- Grant labels are observations, not presence or authorization. Revoked records preserve block access for the owner; a missing layout is not a deletion claim. Paging consistency and recovery limits are explicit in the contract and guide.

Primary reviewer: Codex. Reviewed commit: `1ab58873f6989cf3bf6e5fb1e0415f57e3de3d07`.

Primary review covers all changed source/tests/docs, runtime/world composition, admission teardown, existing block adapter and editor state, Rules, and native retirement/browser fixture integration. No new runtime dependency, schema or duplicate editor/authority store. The optional independent reviewer remained pending initialization and was canceled; no independent code-review evidence is claimed. Luna executed ticket maintenance and verification; primary retained source and visual acceptance.

## Verification

- Office unit suite: 147 tests passed across 18 files.
- Office quality and E2E type check: passed after correcting three test-only TypeScript errors (no assertions weakened).
- Root tooling quality: passed; shared Office contract suite: 25 passed.
- Full browser/emulator runs: 46 passed twice, no test retries. Primary inspected desktop and narrow screenshots; content wraps without horizontal overflow.
- Required exact-head CI: all 17 checks passed on `1ab58873f6989cf3bf6e5fb1e0415f57e3de3d07`, without reruns. The normal repository Docker browser build also passed in CI.

Tests exercise real bounded grant pagination and denial controls, current SpacePort reads and UUID writes, unchanged home, missing layouts, browser revoke/history/open/edit/reopen, admission loss, source revision and late-result fencing. The existing native hook scenario also opens the exact retained block after real CLI retirement and revocation.

The normal Docker build hit Docker Hub metadata timeouts twice before tests. Local fallback uses the previously verified browser dependency image `sha256:bce0785bceaecc93ba18efd344cae976cd151282634a64a9483158528b0e1b33`, copies current sources/Rules and the verified main native products, and reruns the same network-disabled build/quality gates and browser command. Dependencies, native source and repository Dockerfile are unchanged. This is local verification evidence, not a production deployment or replacement CI policy. No paid model APIs or host credentials are used.

## Lifecycle

Issue #231 remains In Progress until merge. Parent #209 and M1 #173 stay open. Board #211 and skill #213 were refined separately to the agreed repo/general discussion board and two-product-skill model; neither is implemented by this PR. One dedicated branch in the main checkout; no additional worktree.
