### PR TITLE
feat(office): reassign retained blocks through owner approval

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,6 +47,10 @@ assignment registry or permission mutation. Rules and the trusted issuer
 enforce authority; views never grant it. Remote snapshots have one owner, separate
 from unsaved drafts and ephemeral
 presentation state. No stored markup executes and no parallel layout is stored.
+Owner approval may select a revoked grant's retained block through the same
+bounded space projection. The pairing transaction reserves that source grant
+with a transfer receipt and records immutable approval intent; no second
+assignment registry or resource copy is introduced.
 The detailed lifecycle and verification map lives only in
 [Office architecture](docs/office/architecture.md); exact persisted data belongs
 in [Office contracts](contracts/office/README.md).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -247,7 +247,16 @@ editing its retained UUID block through the shared editor, independent stored
 state, unchanged home layout, reopening and admission loss. The grant Rules
 suite independently checks bounded owner pagination and denies unbounded,
 oversized, foreign-owner, agent and revoked-admission queries. Owner editing
-does not prove native block mutation, reassignment or credential recovery.
+does not by itself prove native block mutation, reassignment or credential recovery.
+
+Retained-block reassignment adds actual competing approval transactions in
+`pairing-reassignment.spec.ts`: one source reservation, exact retries, abandoned
+unclaimed recovery and denial of claimed ancestors. Browser approval selects
+the source explicitly and preserves assignment across uncertain responses.
+The native acceptance must resume the original protected proof, inspect the
+same retained block and corroborate it in the browser and independent database;
+seeded grants or a browser-only claim do not substitute for that chain. Keep
+the former cached credential's denial and unchanged layout as separate assertions.
 
 The M1 acceptance target is a causal local flow: actual native CLI and Office
 companion -> browser owner approval -> scoped credential use -> durable resource

--- a/apps/office/e2e/agent-grant-rules.spec.ts
+++ b/apps/office/e2e/agent-grant-rules.spec.ts
@@ -340,10 +340,13 @@ test('owner revocation is one-way, denies cached credentials and retains the exa
         { capabilities: ['layout.read'] },
         { expiresAt: serverTimestamp() },
         { enabled: false, blockId: crypto.randomUUID() },
+        { replacedByPairingId: '0'.repeat(64) },
+        { replacedByPairingId: 'not-a-pairing-id' },
       ])
         await denied(updateDoc(ownerGrant, changes));
       expect((await getDocFromServer(ownerGrant)).data()).toEqual(grant);
       await updateDoc(ownerGrant, { enabled: false });
+      await denied(updateDoc(ownerGrant, { replacedByPairingId: '0'.repeat(64) }));
       await denied(getDocFromServer(agentBlock));
       await denied(setDoc(agentBlock, layout(2)));
       await denied(updateDoc(ownerGrant, { enabled: true }));

--- a/apps/office/e2e/native-pairing.spec.ts
+++ b/apps/office/e2e/native-pairing.spec.ts
@@ -3,10 +3,199 @@ import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { expect } from '@playwright/test';
 import { test, signIn } from './browser-session.js';
-import { setTester } from './firestore-fixture.js';
+import { setTester, writeAgentGrantFields, writeBlockFields } from './firestore-fixture.js';
 import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
 import { runCli, withSandbox } from '../../../test/support/cli-process.js';
 import { installNativeOffice, protectedOfficeRecord } from './native-office-fixture.js';
+
+test('native pairing selects a retained block, resumes it, and exposes the same layout in Office', async ({
+  openSession,
+}) => {
+  test.setTimeout(90_000);
+  const admin = createPairingEmulatorFixture();
+  try {
+    await withSandbox(async (sandbox) => {
+      const clearProtectedScopes = async () => {
+        let names: string[];
+        try {
+          names = readdirSync(path.join(sandbox.globalDir, 'office'));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+          throw error;
+        }
+        for (const name of names) {
+          if (!/^[0-9a-f]{64}\.lock$/.test(name)) continue;
+          const key = name.slice(0, -'.lock'.length);
+          expect((await protectedOfficeRecord(sandbox, key, 'clear')).status).toBe(0);
+          expect((await protectedOfficeRecord(sandbox, key, 'lookup')).status).toBe(1);
+        }
+      };
+      try {
+        const prefix = await installNativeOffice(sandbox);
+        expect(
+          (await runCli(sandbox, ['identity', 'create', 'RetainedNative', '--json'])).status
+        ).toBe(0);
+        const worldId = admin.db.collection('worlds').doc().id;
+        const world = `http://127.0.0.1:4173/worlds/${worldId}`;
+        const office = (operation: string, extra: string[] = []) =>
+          runCli(
+            sandbox,
+            [
+              'office',
+              operation,
+              '--prefix',
+              prefix,
+              '--world',
+              world,
+              '--identity',
+              'RetainedNative',
+              '--emulator',
+              '--json',
+              ...extra,
+            ],
+            { deadlineMs: 35_000 }
+          );
+        const pending = await office('pair', ['--timeout', '5']);
+        expect(pending.status).toBe(1);
+        expect(JSON.parse(pending.stdout).error.code).toBe('OFFICE_PAIRING_PENDING');
+        const link = pending.stderr.trim();
+        const request = JSON.parse(
+          Buffer.from(link.split('#tmt-pair=')[1]!, 'base64url').toString('utf8')
+        ) as {
+          version: 1;
+          pairingId: string;
+          worldId: string;
+          installationId: string;
+          identityId: string;
+          installationLabel: string;
+          identityLabel: string;
+          capabilities: ['layout.read', 'layout.write'];
+        };
+        const sourcePrincipal = 'office-agent:00000000-0000-4233-8233-000000000233';
+        const sourceBlock = crypto.randomUUID();
+        const sourceIdentity = crypto.randomUUID();
+        const sourceInstallation = crypto.randomUUID();
+        await writeAgentGrantFields(worldId, sourcePrincipal, {
+          version: { integerValue: '1' },
+          ownerUid: { stringValue: 'pending-owner' },
+          installationId: { stringValue: sourceInstallation },
+          identityId: { stringValue: sourceIdentity },
+          blockId: { stringValue: sourceBlock },
+          capabilities: {
+            arrayValue: {
+              values: [{ stringValue: 'layout.read' }, { stringValue: 'layout.write' }],
+            },
+          },
+          enabled: { booleanValue: false },
+          createdAt: { timestampValue: new Date(Date.now() - 120_000).toISOString() },
+          expiresAt: { timestampValue: new Date(Date.now() - 60_000).toISOString() },
+        });
+        await writeBlockFields(worldId, sourceBlock, {
+          version: { integerValue: '1' },
+          revision: { integerValue: '1' },
+          objects: { arrayValue: { values: [{ stringValue: 'd000' }] } },
+          updatedAt: { timestampValue: new Date().toISOString() },
+        });
+        const blockRef = admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .collection('blocks')
+          .doc(sourceBlock);
+        const blockBefore = (await blockRef.get()).data()!;
+
+        const { page } = await openSession(link);
+        await signIn(page, 'Native retained owner');
+        const ownerUid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+        await admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .set({ version: 1, name: 'Native retained office', ownerUid, createdAt: new Date() });
+        await admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .collection('agentGrants')
+          .doc(sourcePrincipal)
+          .update({ ownerUid });
+        await setTester(ownerUid, true);
+        await expect(page.getByRole('region', { name: 'Agent pairing request' })).toBeVisible();
+        await page.getByRole('button', { name: 'Refresh retained spaces', exact: true }).click();
+        const retained = page.getByRole('radio', {
+          name: new RegExp(`Retained block ${sourceBlock} · Previous identity ${sourceIdentity}`),
+        });
+        await expect(retained).toBeVisible();
+        await retained.check();
+        await page
+          .getByRole('checkbox', { name: 'I recognize this agent and installation.' })
+          .check();
+        const approvalRequest = page.waitForRequest(
+          (outgoing) => outgoing.url().endsWith('/approve') && outgoing.method() === 'POST'
+        );
+        await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+        expect((await approvalRequest).postDataJSON()).toEqual({
+          ...request,
+          replacesPrincipalUid: sourcePrincipal,
+        });
+        await expect(
+          page.getByRole('status').filter({ hasText: 'Approved. Return' })
+        ).toBeVisible();
+
+        const resumed = await office('pair', ['--timeout', '25']);
+        expect(resumed.status, resumed.stdout).toBe(0);
+        expect(JSON.parse(resumed.stdout).state).toBe('credential');
+        const pairing = admin.db.collection('officePairings').doc(request.pairingId);
+        const remote = (await pairing.get()).data()!;
+        expect(remote.replacesPrincipalUid).toBe(sourcePrincipal);
+        expect(remote.blockId).toBe(sourceBlock);
+        const newGrant = admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .collection('agentGrants')
+          .doc(remote.principalUid);
+        expect((await newGrant.get()).data()).toMatchObject({
+          ownerUid,
+          installationId: request.installationId,
+          identityId: request.identityId,
+          blockId: sourceBlock,
+          enabled: true,
+        });
+        expect(
+          (
+            await admin.db
+              .collection('worlds')
+              .doc(worldId)
+              .collection('agentGrants')
+              .doc(sourcePrincipal)
+              .get()
+          ).data()
+        ).toMatchObject({ enabled: false, replacedByPairingId: request.pairingId });
+        const inspected = await office('inspect');
+        expect(inspected.status, inspected.stdout).toBe(0);
+        expect(JSON.parse(inspected.stdout)).toMatchObject({
+          blockExists: true,
+          serverAuthorizationChecked: true,
+        });
+        expect((await blockRef.get()).data()).toEqual(blockBefore);
+
+        // Navigate through the router so the owner session and its consent state remain intact.
+        await page.getByRole('link', { name: 'Office', exact: true }).click();
+        await page.getByLabel('World ID', { exact: true }).fill(worldId);
+        await page.getByRole('button', { name: 'Open world', exact: true }).click();
+        await expect(
+          page.getByRole('button', { name: `Open block ${sourceBlock}` }).first()
+        ).toBeVisible();
+        await page
+          .getByRole('button', { name: `Open block ${sourceBlock}` })
+          .first()
+          .click();
+        await expect(page.getByRole('button', { name: 'Desk 1', exact: true })).toBeVisible();
+      } finally {
+        await clearProtectedScopes();
+      }
+    });
+  } finally {
+    await admin.dispose();
+  }
+});
 
 test('native pairing resumes its protected proof and a separate process uses the scoped credential', async ({
   openSession,

--- a/apps/office/e2e/pairing-browser.spec.ts
+++ b/apps/office/e2e/pairing-browser.spec.ts
@@ -4,7 +4,12 @@ import type { Page } from '@playwright/test';
 import { signInWithCustomToken } from 'firebase/auth';
 import { doc, getDocFromServer, setDoc, serverTimestamp } from 'firebase/firestore';
 import { test, signIn } from './browser-session.js';
-import { createFirestoreFixture, setTester } from './firestore-fixture.js';
+import {
+  createFirestoreFixture,
+  setTester,
+  writeAgentGrantFields,
+  writeBlockFields,
+} from './firestore-fixture.js';
 import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
 
 const endpoint = 'http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing';
@@ -137,6 +142,141 @@ test('explicit browser consent issues usable scoped access and revocation preser
     } finally {
       await admin.dispose();
     }
+  }
+});
+
+test('owner pages retained spaces, submits only the source principal and freezes retry intent', async ({
+  openSession,
+}, info) => {
+  const admin = createPairingEmulatorFixture();
+  try {
+    const worldId = admin.db.collection('worlds').doc().id;
+    const { request, url } = requestFor(worldId);
+    const { page } = await openSession(url);
+    const ownerUid = await admitOwner(page, admin.db, worldId);
+    const sourcePrincipal = 'office-agent:ffffffff-ffff-4fff-8fff-ffffffffffff';
+    const sourceBlock = crypto.randomUUID();
+    const sourceIdentity = crypto.randomUUID();
+    const sourceInstallation = crypto.randomUUID();
+    const sourceFields = {
+      version: { integerValue: '1' },
+      ownerUid: { stringValue: ownerUid },
+      installationId: { stringValue: sourceInstallation },
+      identityId: { stringValue: sourceIdentity },
+      blockId: { stringValue: sourceBlock },
+      capabilities: {
+        arrayValue: { values: [{ stringValue: 'layout.read' }, { stringValue: 'layout.write' }] },
+      },
+      enabled: { booleanValue: false },
+      createdAt: { timestampValue: new Date(Date.now() - 120_000).toISOString() },
+      expiresAt: { timestampValue: new Date(Date.now() - 60_000).toISOString() },
+    };
+    for (let index = 0; index < 20; index++) {
+      await writeAgentGrantFields(
+        worldId,
+        `office-agent:00000000-0000-4000-8000-${index.toString().padStart(12, '0')}`,
+        {
+          ...sourceFields,
+          installationId: { stringValue: crypto.randomUUID() },
+          identityId: { stringValue: crypto.randomUUID() },
+          blockId: { stringValue: crypto.randomUUID() },
+        }
+      );
+    }
+    await writeAgentGrantFields(worldId, sourcePrincipal, sourceFields);
+    await writeBlockFields(worldId, sourceBlock, {
+      version: { integerValue: '1' },
+      revision: { integerValue: '1' },
+      objects: { arrayValue: { values: [{ stringValue: 'd000' }] } },
+      updatedAt: { timestampValue: new Date().toISOString() },
+    });
+    const sourceRef = admin.db
+      .collection('worlds')
+      .doc(worldId)
+      .collection('agentGrants')
+      .doc(sourcePrincipal);
+    const blockRef = admin.db
+      .collection('worlds')
+      .doc(worldId)
+      .collection('blocks')
+      .doc(sourceBlock);
+    const sourceBefore = (await sourceRef.get()).data()!;
+    const blockBefore = (await blockRef.get()).data()!;
+
+    await page.getByRole('button', { name: 'Refresh retained spaces', exact: true }).click();
+    await expect(
+      page.getByRole('button', { name: 'Next retained spaces', exact: true })
+    ).toBeEnabled();
+    await page.getByRole('button', { name: 'Next retained spaces', exact: true }).click();
+    const retained = page.getByRole('radio', {
+      name: new RegExp(`Retained block ${sourceBlock} · Previous identity ${sourceIdentity}`),
+    });
+    await expect(retained).toBeVisible();
+    await retained.check();
+    await expect(
+      page.getByRole('radio', { name: 'New empty block', exact: true })
+    ).not.toBeChecked();
+    await page.getByRole('checkbox', { name: 'I recognize this agent and installation.' }).check();
+    await page.screenshot({
+      path: info.outputPath('retained-pairing-desktop.png'),
+      fullPage: true,
+    });
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.screenshot({ path: info.outputPath('retained-pairing-narrow.png'), fullPage: true });
+
+    const firstRequest = page.waitForRequest(
+      (outgoing) => outgoing.url() === `${endpoint}/approve` && outgoing.method() === 'POST'
+    );
+    await page.route(
+      '**/officePairing/approve',
+      async (route) => {
+        const response = await route.fetch();
+        expect(response.status()).toBe(200);
+        await route.abort();
+      },
+      { times: 1 }
+    );
+    await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+    const firstOutgoing = await firstRequest;
+    expect(firstOutgoing.postDataJSON()).toEqual({
+      ...request,
+      replacesPrincipalUid: sourcePrincipal,
+    });
+    await expect(page.getByRole('alert')).toContainText('may already have completed');
+    await expect(
+      page.getByText(`Selected retained block: ${sourceBlock} · Source grant: ${sourcePrincipal}`, {
+        exact: true,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByText('The choice is fixed for this request. Retry keeps the same assignment.', {
+        exact: true,
+      })
+    ).toBeVisible();
+    await expect(page.getByRole('radio', { name: /Retained block/ })).toHaveCount(0);
+    await expect(page.getByRole('radio', { name: 'New empty block', exact: true })).toBeDisabled();
+
+    const retryRequest = page.waitForRequest(
+      (outgoing) => outgoing.url() === `${endpoint}/approve` && outgoing.method() === 'POST'
+    );
+    await page.getByRole('button', { name: 'Retry same approval', exact: true }).click();
+    expect((await retryRequest).postDataJSON()).toEqual({
+      ...request,
+      replacesPrincipalUid: sourcePrincipal,
+    });
+    await expect(page.getByRole('status').filter({ hasText: 'Approved. Return' })).toBeVisible();
+    const pairing = (
+      await admin.db.collection('officePairings').doc(request.pairingId).get()
+    ).data()!;
+    expect(pairing.blockId).toBe(sourceBlock);
+    expect(pairing.replacesPrincipalUid).toBe(sourcePrincipal);
+    expect((await sourceRef.get()).data()).toEqual({
+      ...sourceBefore,
+      replacedByPairingId: request.pairingId,
+    });
+    expect((await blockRef.get()).data()).toEqual(blockBefore);
+  } finally {
+    await admin.dispose();
   }
 });
 

--- a/apps/office/e2e/pairing-reassignment.spec.ts
+++ b/apps/office/e2e/pairing-reassignment.spec.ts
@@ -1,0 +1,391 @@
+import { randomBytes } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+import { signInWithCustomToken } from 'firebase/auth';
+import { doc, getDocFromServer, setDoc, serverTimestamp } from 'firebase/firestore';
+import {
+  APPROVAL_MS,
+  parseClaim,
+} from '../../../services/office/functions/src/pairing-contract.js';
+import { withPairing, post, seedSource } from './pairing-service-fixture.js';
+
+test('retained approval reserves the exact disabled source, retries exactly and rejects changed intent', async () => {
+  await withPairing(async ({ db, owner, request, token }) => {
+    const source = await seedSource(db, owner.uid, request, undefined, undefined, {
+      ...request,
+      installationId: crypto.randomUUID(),
+      identityId: crypto.randomUUID(),
+    });
+    const input = { ...request, replacesPrincipalUid: source.principalUid };
+    const approved = await post('approve', input, token);
+    expect(approved.status).toBe(200);
+    expect(approved.body).toMatchObject({
+      ...request,
+      principalUid: expect.stringMatching(/^office-agent:[0-9a-f-]{36}$/),
+      blockId: source.blockId,
+    });
+    expect(Object.keys(approved.body).sort()).toEqual(
+      [...Object.keys(request), 'principalUid', 'blockId', 'expiresAt'].sort()
+    );
+    const record = db.collection('officePairings').doc(request.pairingId);
+    const stored = (await record.get()).data()!;
+    expect(stored.replacesPrincipalUid).toBe(source.principalUid);
+    expect(stored.blockId).toBe(source.blockId);
+    expect(
+      (
+        await db
+          .collection('worlds')
+          .doc(request.worldId)
+          .collection('agentGrants')
+          .doc(source.principalUid)
+          .get()
+      ).data()
+    ).toEqual({ ...source.grant, replacedByPairingId: request.pairingId });
+    expect(
+      (
+        await db
+          .collection('worlds')
+          .doc(request.worldId)
+          .collection('blocks')
+          .doc(source.blockId)
+          .get()
+      ).data()
+    ).toEqual(source.block);
+    expect(await post('approve', input, token)).toEqual(approved);
+
+    const other = await seedSource(db, owner.uid, request);
+    expect(
+      (await post('approve', { ...input, replacesPrincipalUid: other.principalUid }, token)).status
+    ).toBe(409);
+    expect((await record.get()).data()).toEqual(stored);
+  });
+});
+
+test('retained approval denies missing, malformed, active and foreign source grants', async () => {
+  await withPairing(async ({ db, fixture, owner, request, token }) => {
+    const cases = [
+      { name: 'missing', source: { principalUid: `office-agent:${crypto.randomUUID()}` } },
+      {
+        name: 'malformed',
+        source: await seedSource(db, owner.uid, request),
+      },
+      {
+        name: 'active',
+        source: await seedSource(db, owner.uid, request),
+      },
+      {
+        name: 'foreign',
+        source: await seedSource(db, (await fixture.client(true)).uid, request),
+      },
+    ];
+    await db
+      .collection('worlds')
+      .doc(request.worldId)
+      .collection('agentGrants')
+      .doc(cases[1]!.source.principalUid)
+      .update({ replacedByPairingId: 'not-a-pairing-id' });
+    await db
+      .collection('worlds')
+      .doc(request.worldId)
+      .collection('agentGrants')
+      .doc(cases[2]!.source.principalUid)
+      .update({ enabled: true });
+    for (const current of cases) {
+      const secret = randomBytes(32).toString('base64url');
+      const currentRequest = { ...request, pairingId: parseClaim({ version: 1, secret }) };
+      expect(
+        (
+          await post(
+            'approve',
+            { ...currentRequest, replacesPrincipalUid: current.source.principalUid },
+            token
+          )
+        ).status,
+        current.name
+      ).toBe(409);
+      expect(
+        (await db.collection('officePairings').doc(currentRequest.pairingId).get()).exists,
+        current.name
+      ).toBe(false);
+    }
+  });
+});
+
+test('concurrent retained approvals consume one source; unclaimed expired or disabled reservations reclaim, claimed ones deny', async () => {
+  await withPairing(async ({ db, owner, request, token }) => {
+    const source = await seedSource(db, owner.uid, request, undefined, undefined, {
+      ...request,
+      installationId: crypto.randomUUID(),
+      identityId: crypto.randomUUID(),
+    });
+    const contenders = [
+      {
+        ...request,
+        pairingId: parseClaim({ version: 1, secret: randomBytes(32).toString('base64url') }),
+      },
+      {
+        ...request,
+        pairingId: parseClaim({ version: 1, secret: randomBytes(32).toString('base64url') }),
+      },
+    ];
+    const results = await Promise.all(
+      contenders.map((current) =>
+        post('approve', { ...current, replacesPrincipalUid: source.principalUid }, token)
+      )
+    );
+    expect(results.map((result) => result.status).sort()).toEqual([200, 409]);
+    const winner = results.find((result) => result.status === 200)!.body;
+    expect(winner.blockId).toBe(source.blockId);
+    expect(
+      (
+        await db
+          .collection('worlds')
+          .doc(request.worldId)
+          .collection('agentGrants')
+          .doc(source.principalUid)
+          .get()
+      ).data()
+    ).toMatchObject({ ...source.grant, replacedByPairingId: winner.pairingId });
+    expect(
+      (
+        await db
+          .collection('worlds')
+          .doc(request.worldId)
+          .collection('blocks')
+          .doc(source.blockId)
+          .get()
+      ).data()
+    ).toEqual(source.block);
+
+    for (const state of ['expired', 'disabled'] as const) {
+      const reclaimSource = await seedSource(db, owner.uid, request, undefined, undefined, {
+        ...request,
+        installationId: crypto.randomUUID(),
+        identityId: crypto.randomUUID(),
+      });
+      const firstSecret = randomBytes(32).toString('base64url');
+      const firstRequest = {
+        ...request,
+        pairingId: parseClaim({ version: 1, secret: firstSecret }),
+      };
+      expect(
+        (
+          await post(
+            'approve',
+            { ...firstRequest, replacesPrincipalUid: reclaimSource.principalUid },
+            token
+          )
+        ).status
+      ).toBe(200);
+      const firstRecord = db.collection('officePairings').doc(firstRequest.pairingId);
+      if (state === 'expired') {
+        const expired = Date.now() - 1000;
+        await firstRecord.update({
+          createdAt: new Date(expired - APPROVAL_MS),
+          expiresAt: new Date(expired),
+        });
+      } else await firstRecord.update({ enabled: false });
+      const secondSecret = randomBytes(32).toString('base64url');
+      const secondRequest = {
+        ...request,
+        pairingId: parseClaim({ version: 1, secret: secondSecret }),
+      };
+      const reclaimed = await post(
+        'approve',
+        { ...secondRequest, replacesPrincipalUid: reclaimSource.principalUid },
+        token
+      );
+      expect(reclaimed.status, state).toBe(200);
+      expect(reclaimed.body.blockId, state).toBe(reclaimSource.blockId);
+      expect((await firstRecord.get()).data()?.enabled, state).toBe(false);
+    }
+
+    const claimedSource = await seedSource(db, owner.uid, request, undefined, undefined, {
+      ...request,
+      installationId: crypto.randomUUID(),
+      identityId: crypto.randomUUID(),
+    });
+    const firstSecret = randomBytes(32).toString('base64url');
+    const firstRequest = { ...request, pairingId: parseClaim({ version: 1, secret: firstSecret }) };
+    expect(
+      (
+        await post(
+          'approve',
+          { ...firstRequest, replacesPrincipalUid: claimedSource.principalUid },
+          token
+        )
+      ).status
+    ).toBe(200);
+    expect((await post('claim', { version: 1, secret: firstSecret })).status).toBe(200);
+    const secondSecret = randomBytes(32).toString('base64url');
+    expect(
+      (
+        await post(
+          'approve',
+          {
+            ...request,
+            pairingId: parseClaim({ version: 1, secret: secondSecret }),
+            replacesPrincipalUid: claimedSource.principalUid,
+          },
+          token
+        )
+      ).status
+    ).toBe(409);
+  });
+});
+
+test('reserved-source reuse denies missing, malformed and mismatched predecessor evidence', async () => {
+  await withPairing(async ({ db, owner, request, token }) => {
+    const missing = await seedSource(db, owner.uid, request);
+    await db
+      .collection('worlds')
+      .doc(request.worldId)
+      .collection('agentGrants')
+      .doc(missing.principalUid)
+      .update({ replacedByPairingId: 'a'.repeat(64) });
+    const missingRetry = {
+      ...request,
+      pairingId: parseClaim({ version: 1, secret: randomBytes(32).toString('base64url') }),
+    };
+    expect(
+      (
+        await post(
+          'approve',
+          { ...missingRetry, replacesPrincipalUid: missing.principalUid },
+          token
+        )
+      ).status
+    ).toBe(409);
+
+    const malformed = await seedSource(db, owner.uid, request);
+    const malformedId = 'b'.repeat(64);
+    await db
+      .collection('worlds')
+      .doc(request.worldId)
+      .collection('agentGrants')
+      .doc(malformed.principalUid)
+      .update({ replacedByPairingId: malformedId });
+    await db.collection('officePairings').doc(malformedId).set({ malformed: true });
+    const malformedRetry = {
+      ...request,
+      pairingId: parseClaim({ version: 1, secret: randomBytes(32).toString('base64url') }),
+    };
+    expect(
+      (
+        await post(
+          'approve',
+          { ...malformedRetry, replacesPrincipalUid: malformed.principalUid },
+          token
+        )
+      ).status
+    ).toBe(409);
+
+    const mismatched = await seedSource(db, owner.uid, request);
+    const firstSecret = randomBytes(32).toString('base64url');
+    const firstRequest = {
+      ...request,
+      pairingId: parseClaim({ version: 1, secret: firstSecret }),
+    };
+    expect(
+      (
+        await post(
+          'approve',
+          { ...firstRequest, replacesPrincipalUid: mismatched.principalUid },
+          token
+        )
+      ).status
+    ).toBe(200);
+    await db
+      .collection('officePairings')
+      .doc(firstRequest.pairingId)
+      .update({ enabled: false, blockId: crypto.randomUUID() });
+    const mismatchedRetry = {
+      ...request,
+      pairingId: parseClaim({ version: 1, secret: randomBytes(32).toString('base64url') }),
+    };
+    expect(
+      (
+        await post(
+          'approve',
+          { ...mismatchedRetry, replacesPrincipalUid: mismatched.principalUid },
+          token
+        )
+      ).status
+    ).toBe(409);
+  });
+});
+
+test('retained transfer denies the old cached principal while the newly claimed principal reads the same block', async () => {
+  await withPairing(async ({ fixture, db, auth, owner, request, token, secret }) => {
+    const newRequest = { ...request, capabilities: ['layout.read'] as ['layout.read'] };
+    const sourceRequest = {
+      ...request,
+      installationId: crypto.randomUUID(),
+      identityId: crypto.randomUUID(),
+    };
+    const source = await seedSource(db, owner.uid, request, undefined, undefined, sourceRequest);
+    const sourceRef = db
+      .collection('worlds')
+      .doc(request.worldId)
+      .collection('agentGrants')
+      .doc(source.principalUid);
+    await sourceRef.update({
+      enabled: true,
+      createdAt: new Date(Date.now() - 1_000),
+      expiresAt: new Date(Date.now() + 3_600_000),
+    });
+    const oldAgent = await fixture.client(false, 'device');
+    await signInWithCustomToken(
+      oldAgent.auth,
+      await auth.createCustomToken(source.principalUid, {
+        tmtOfficeAgent: true,
+        tmtInstallationId: sourceRequest.installationId,
+        tmtIdentityId: sourceRequest.identityId,
+      })
+    );
+    expect(
+      (
+        await getDocFromServer(
+          doc(oldAgent.db, 'worlds', request.worldId, 'blocks', source.blockId)
+        )
+      ).data()
+    ).toMatchObject({ version: 1, revision: 1, objects: ['d000'] });
+    await sourceRef.update({ enabled: false });
+    expect(
+      (await post('approve', { ...newRequest, replacesPrincipalUid: source.principalUid }, token))
+        .status
+    ).toBe(200);
+    const claimed = await post('claim', { version: 1, secret });
+    expect(claimed.status).toBe(200);
+    expect(claimed.body.capabilities).toEqual(['layout.read']);
+    const newAgent = await fixture.client(false, 'device');
+    await signInWithCustomToken(newAgent.auth, String(claimed.body.customToken));
+    await expect(
+      getDocFromServer(doc(oldAgent.db, 'worlds', request.worldId, 'blocks', source.blockId))
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+    expect(
+      (
+        await getDocFromServer(
+          doc(newAgent.db, 'worlds', request.worldId, 'blocks', source.blockId)
+        )
+      ).data()
+    ).toMatchObject({ version: 1, revision: 1, objects: ['d000'] });
+    await expect(
+      setDoc(doc(newAgent.db, 'worlds', request.worldId, 'blocks', source.blockId), {
+        version: 1,
+        revision: 2,
+        objects: [],
+        updatedAt: serverTimestamp(),
+      })
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+    expect(
+      (
+        await db
+          .collection('worlds')
+          .doc(request.worldId)
+          .collection('blocks')
+          .doc(source.blockId)
+          .get()
+      ).data()
+    ).toEqual(source.block);
+  });
+});

--- a/apps/office/e2e/pairing-service-fixture.ts
+++ b/apps/office/e2e/pairing-service-fixture.ts
@@ -1,0 +1,110 @@
+import { randomBytes } from 'node:crypto';
+import { expect } from '@playwright/test';
+import { createFirestoreFixture } from './firestore-fixture.js';
+import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
+import { createWorldPort } from '../src/worlds/firebase-worlds.js';
+import { parseClaim } from '../../../services/office/functions/src/pairing-contract.js';
+
+export const endpoint = 'http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing';
+
+export async function post(operation: string, input: unknown, token?: string) {
+  const response = await fetch(`${endpoint}/${operation}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(input),
+    signal: AbortSignal.timeout(10_000),
+  });
+  expect(response.headers.get('cache-control')).toBe('no-store');
+  return { status: response.status, body: (await response.json()) as Record<string, unknown> };
+}
+
+export function field(body: Record<string, unknown>, key: string): string {
+  const value = body[key];
+  if (typeof value !== 'string' || !value) throw new Error(`Missing response field ${key}`);
+  return value;
+}
+
+export async function withPairing(
+  run: (context: Awaited<ReturnType<typeof setup>>) => Promise<void>
+) {
+  const fixture = await createFirestoreFixture();
+  const admin = createPairingEmulatorFixture();
+  try {
+    await run(await setup(fixture, admin.db, admin.auth));
+  } finally {
+    try {
+      await fixture.dispose();
+    } finally {
+      await admin.dispose();
+    }
+  }
+}
+
+async function setup(
+  fixture: Awaited<ReturnType<typeof createFirestoreFixture>>,
+  db: ReturnType<typeof createPairingEmulatorFixture>['db'],
+  auth: ReturnType<typeof createPairingEmulatorFixture>['auth']
+) {
+  const owner = await fixture.client(true);
+  const worlds = createWorldPort(owner.db);
+  const world = worlds.draft('Pairing workshop');
+  await worlds.create(world, owner.uid);
+  const secret = randomBytes(32).toString('base64url');
+  const pairingId = parseClaim({ version: 1, secret });
+  const request = {
+    version: 1 as const,
+    pairingId,
+    worldId: world.id,
+    installationId: crypto.randomUUID(),
+    identityId: crypto.randomUUID(),
+    installationLabel: 'Test installation',
+    identityLabel: 'Alice',
+    capabilities: ['layout.read', 'layout.write'] as ['layout.read', 'layout.write'],
+  };
+  const token = await owner.auth.currentUser!.getIdToken();
+  return { fixture, db, auth, owner, world, secret, request, token };
+}
+
+export async function seedSource(
+  db: ReturnType<typeof createPairingEmulatorFixture>['db'],
+  ownerUid: string,
+  request: {
+    worldId: string;
+    installationId: string;
+    identityId: string;
+    capabilities: ['layout.read'] | ['layout.read', 'layout.write'];
+  },
+  principalUid = `office-agent:${crypto.randomUUID()}`,
+  blockId = crypto.randomUUID(),
+  sourceRequest = request
+) {
+  const createdAt = new Date(Date.now() - 120_000);
+  const fields = {
+    version: 1,
+    ownerUid,
+    installationId: sourceRequest.installationId,
+    identityId: sourceRequest.identityId,
+    blockId,
+    capabilities: sourceRequest.capabilities,
+    enabled: false,
+    createdAt,
+    expiresAt: new Date(createdAt.getTime() + 60_000),
+  };
+  const grantRef = db
+    .collection('worlds')
+    .doc(request.worldId)
+    .collection('agentGrants')
+    .doc(principalUid);
+  await grantRef.set(fields);
+  const blockRef = db.collection('worlds').doc(request.worldId).collection('blocks').doc(blockId);
+  await blockRef.set({ version: 1, revision: 1, objects: ['d000'], updatedAt: new Date() });
+  return {
+    principalUid,
+    blockId,
+    grant: (await grantRef.get()).data()!,
+    block: (await blockRef.get()).data()!,
+  };
+}

--- a/apps/office/e2e/pairing-service.spec.ts
+++ b/apps/office/e2e/pairing-service.spec.ts
@@ -2,8 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { test, expect } from '@playwright/test';
 import { signInWithCustomToken } from 'firebase/auth';
 import { doc, getDocFromServer, setDoc, serverTimestamp } from 'firebase/firestore';
-import { createWorldPort } from '../src/worlds/firebase-worlds.js';
-import { createFirestoreFixture, setTester } from './firestore-fixture.js';
+import { setTester } from './firestore-fixture.js';
 import {
   parseClaim,
   parseApproval,
@@ -12,68 +11,7 @@ import {
 } from '../../../services/office/functions/src/pairing-contract.js';
 import { createPairingStore } from '../../../services/office/functions/src/pairing-store.js';
 import { createPairingService } from '../../../services/office/functions/src/pairing-service.js';
-import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
-
-const endpoint = 'http://127.0.0.1:5001/demo-tmt-office/us-central1/officePairing';
-
-async function post(operation: string, input: unknown, token?: string) {
-  const response = await fetch(`${endpoint}/${operation}`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      ...(token ? { authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify(input),
-    signal: AbortSignal.timeout(10_000),
-  });
-  expect(response.headers.get('cache-control')).toBe('no-store');
-  return { status: response.status, body: (await response.json()) as Record<string, unknown> };
-}
-
-function field(body: Record<string, unknown>, key: string): string {
-  const value = body[key];
-  if (typeof value !== 'string' || !value) throw new Error(`Missing response field ${key}`);
-  return value;
-}
-
-async function withPairing(run: (context: Awaited<ReturnType<typeof setup>>) => Promise<void>) {
-  const fixture = await createFirestoreFixture();
-  const admin = createPairingEmulatorFixture();
-  try {
-    await run(await setup(fixture, admin.db, admin.auth));
-  } finally {
-    try {
-      await fixture.dispose();
-    } finally {
-      await admin.dispose();
-    }
-  }
-}
-
-async function setup(
-  fixture: Awaited<ReturnType<typeof createFirestoreFixture>>,
-  db: ReturnType<typeof createPairingEmulatorFixture>['db'],
-  auth: ReturnType<typeof createPairingEmulatorFixture>['auth']
-) {
-  const owner = await fixture.client(true);
-  const worlds = createWorldPort(owner.db);
-  const world = worlds.draft('Pairing workshop');
-  await worlds.create(world, owner.uid);
-  const secret = randomBytes(32).toString('base64url');
-  const pairingId = parseClaim({ version: 1, secret });
-  const request = {
-    version: 1,
-    pairingId,
-    worldId: world.id,
-    installationId: crypto.randomUUID(),
-    identityId: crypto.randomUUID(),
-    installationLabel: 'Test installation',
-    identityLabel: 'Alice',
-    capabilities: ['layout.read', 'layout.write'],
-  };
-  const token = await owner.auth.currentUser!.getIdToken();
-  return { fixture, db, auth, owner, world, secret, request, token };
-}
+import { endpoint, field, post, withPairing } from './pairing-service-fixture.js';
 
 test('HTTP approval and proof claim produce an actually usable scoped credential', async () => {
   await withPairing(async ({ fixture, db, owner, world, secret, request, token }) => {

--- a/apps/office/src/pairing/pairing-contract.ts
+++ b/apps/office/src/pairing/pairing-contract.ts
@@ -20,8 +20,27 @@ export interface ApprovedPairing extends PairingRequest {
 }
 
 export interface PairingPort {
-  approve(request: PairingRequest, ownerUid: string): Promise<ApprovedPairing>;
+  approve(
+    request: PairingRequest,
+    ownerUid: string,
+    replacement?: PairingReplacement
+  ): Promise<ApprovedPairing>;
   revoke(pairingId: string, ownerUid: string): Promise<void>;
+}
+
+/** Owner-selected intent, never part of the native request fragment. */
+export interface PairingReplacement {
+  principalUid: string;
+  blockId: string;
+}
+
+export function validatePairingReplacement(value: PairingReplacement): void {
+  if (
+    !value.principalUid.startsWith('office-agent:') ||
+    !UUID.test(value.principalUid.slice('office-agent:'.length)) ||
+    !UUID.test(value.blockId)
+  )
+    invalid();
 }
 
 export class PairingActionError extends Error {
@@ -30,7 +49,8 @@ export class PairingActionError extends Error {
       {
         denied: 'Pairing was denied. Check your account and current access.',
         unavailable: 'This request is unavailable or expired. Request a new pairing link.',
-        conflict: 'This challenge already has a different approved binding. Request a new link.',
+        conflict:
+          'The assignment conflicts with an existing approval or transfer. Keep the same choice when retrying; otherwise request a new link.',
         uncertain:
           'The service could not confirm the result. Keep this link and retry the same action; a submitted change may already have completed.',
       }[kind]

--- a/apps/office/src/pairing/pairing-space-choice.tsx
+++ b/apps/office/src/pairing/pairing-space-choice.tsx
@@ -1,0 +1,103 @@
+import { useContext, useEffect, useState, useSyncExternalStore } from 'react';
+import { SpaceContext } from '../spaces/space-view.js';
+import { createSpaceState } from '../spaces/space-state.js';
+import type { SpaceState } from '../spaces/space-state.js';
+import type { PairingState } from './pairing-state.js';
+import type { PairingRequest } from './pairing-contract.js';
+
+/** Selection is approval intent; pages remain owned by the existing space state. */
+export function PairingSpaceChoice({
+  state,
+  request,
+  ownerUid,
+}: {
+  state: PairingState;
+  request: PairingRequest;
+  ownerUid: string;
+}) {
+  const port = useContext(SpaceContext);
+  const [spaces, setSpaces] = useState<SpaceState>();
+  useEffect(() => {
+    if (!port) return;
+    const next = createSpaceState(port, request.worldId, ownerUid);
+    setSpaces(next);
+    void next.refresh();
+    return () => next.dispose();
+  }, [port, request.worldId, ownerUid]);
+  return spaces ? <SpaceChoice state={state} spaces={spaces} /> : null;
+}
+
+function SpaceChoice({ state, spaces }: { state: PairingState; spaces: SpaceState }) {
+  const { attempted, replacement } = useSyncExternalStore(state.subscribe, state.getSnapshot);
+  const { entries, busy, next, error, ready } = useSyncExternalStore(
+    spaces.subscribe,
+    spaces.getSnapshot
+  );
+  return (
+    <fieldset className="pairing-space-choice" disabled={attempted}>
+      <legend>Assigned block</legend>
+      <p>
+        Choose a fresh block or a revoked agent's retained layout. Profiles and notebooks are not
+        transferred.
+      </p>
+      <label>
+        <input
+          type="radio"
+          name="pairing-block"
+          checked={!replacement}
+          onChange={() => state.selectReplacement(null)}
+        />{' '}
+        New empty block
+      </label>
+      {replacement && (
+        <p>
+          Selected retained block: <code>{replacement.blockId}</code> · Source grant:{' '}
+          <code>{replacement.principalUid}</code>
+        </p>
+      )}
+      {attempted ? (
+        <p>The choice is fixed for this request. Retry keeps the same assignment.</p>
+      ) : (
+        <>
+          <button type="button" disabled={busy} onClick={() => void spaces.refresh()}>
+            Refresh retained spaces
+          </button>
+          <button type="button" disabled={busy || !next} onClick={() => void spaces.next()}>
+            Next retained spaces
+          </button>
+          {busy && <p role="status">Loading retained spaces…</p>}
+          {error && <p role="alert">{error}</p>}
+          {ready && !entries.some((entry) => !entry.enabled) && (
+            <p>No revoked grants on this page.</p>
+          )}
+          {entries
+            .filter((entry) => !entry.enabled)
+            .map((entry) => (
+              <label key={entry.principalUid}>
+                <input
+                  type="radio"
+                  name="pairing-block"
+                  checked={replacement?.principalUid === entry.principalUid}
+                  onChange={() =>
+                    state.selectReplacement({
+                      principalUid: entry.principalUid,
+                      blockId: entry.blockId,
+                    })
+                  }
+                />
+                Retained block <code>{entry.blockId}</code> · Previous identity{' '}
+                <code>{entry.identityId}</code>
+                {entry.replacedByPairingId && (
+                  <span>
+                    {' '}
+                    — Reserved or transferred. Approval succeeds only if the earlier reservation is
+                    unclaimed and expired or revoked.
+                  </span>
+                )}
+              </label>
+            ))}
+        </>
+      )}
+    </fieldset>
+  );
+}

--- a/apps/office/src/pairing/pairing-state.test.ts
+++ b/apps/office/src/pairing/pairing-state.test.ts
@@ -24,6 +24,27 @@ function fixture() {
   return { port, state: createPairingState(port, request, 'owner') };
 }
 
+it('freezes a copied assignment choice before uncertain approval and keeps it through retry', async () => {
+  const { port, state } = fixture();
+  const selection = { principalUid: binding.principalUid, blockId: binding.blockId };
+  state.selectReplacement(selection);
+  selection.blockId = request.identityId;
+  vi.mocked(port.approve).mockRejectedValueOnce(new PairingActionError('uncertain'));
+  await state.approve();
+  state.selectReplacement(null);
+  await state.approve();
+  expect(port.approve).toHaveBeenCalledTimes(2);
+  for (const call of vi.mocked(port.approve).mock.calls)
+    expect(call).toEqual([
+      request,
+      'owner',
+      { principalUid: binding.principalUid, blockId: binding.blockId },
+    ]);
+  state.dispose();
+  state.selectReplacement(selection);
+  expect(state.getSnapshot().replacement).toBeNull();
+});
+
 it('viewing is read-only; concurrent actions serialize and uncertain approval retries preserve the request', async () => {
   const { port, state } = fixture();
   expect(port.approve).not.toHaveBeenCalled();

--- a/apps/office/src/pairing/pairing-state.ts
+++ b/apps/office/src/pairing/pairing-state.ts
@@ -1,5 +1,10 @@
 import { PairingActionError } from './pairing-contract.js';
-import type { ApprovedPairing, PairingRequest, PairingPort } from './pairing-contract.js';
+import type {
+  ApprovedPairing,
+  PairingRequest,
+  PairingPort,
+  PairingReplacement,
+} from './pairing-contract.js';
 
 interface PairingSnapshot {
   busy: boolean;
@@ -7,6 +12,7 @@ interface PairingSnapshot {
   approved: ApprovedPairing | null;
   revoked: boolean;
   error: string | null;
+  replacement: PairingReplacement | null;
 }
 
 /** One mounted request owns actions; disposal fences results, not remote writes. */
@@ -17,6 +23,7 @@ export function createPairingState(port: PairingPort, request: PairingRequest, o
     approved: null,
     revoked: false,
     error: null,
+    replacement: null,
   };
   let disposed = false;
   const listeners = new Set<() => void>();
@@ -50,7 +57,16 @@ export function createPairingState(port: PairingPort, request: PairingRequest, o
         listeners.delete(listener);
       };
     },
-    approve: () => act(async () => ({ approved: await port.approve(request, ownerUid) })),
+    selectReplacement(replacement: PairingReplacement | null) {
+      if (disposed || snapshot.attempted) return;
+      publish({ replacement: replacement ? { ...replacement } : null });
+    },
+    approve: () =>
+      act(async () => ({
+        approved: snapshot.replacement
+          ? await port.approve(request, ownerUid, snapshot.replacement)
+          : await port.approve(request, ownerUid),
+      })),
     revoke: () =>
       act(async () => {
         await port.revoke(request.pairingId, ownerUid);
@@ -59,7 +75,14 @@ export function createPairingState(port: PairingPort, request: PairingRequest, o
     dispose() {
       disposed = true;
       listeners.clear();
-      snapshot = { busy: false, attempted: false, approved: null, revoked: false, error: null };
+      snapshot = {
+        busy: false,
+        attempted: false,
+        approved: null,
+        revoked: false,
+        error: null,
+        replacement: null,
+      };
     },
   };
 }

--- a/apps/office/src/pairing/pairing-transport.test.ts
+++ b/apps/office/src/pairing/pairing-transport.test.ts
@@ -1,6 +1,7 @@
 import { expect, it, vi } from 'vitest';
 import { createPairingPort } from './pairing-transport.js';
 import { pairingEndpoint } from '../auth/firebase-config.js';
+import type { PairingRequest } from './pairing-contract.js';
 
 const pairingId = 'a'.repeat(64);
 const endpoint = 'https://pair.example/officePairing';
@@ -8,6 +9,54 @@ const response = () =>
   new Response(JSON.stringify({ version: 1, pairingId, revoked: true }), {
     headers: { 'content-type': 'application/json' },
   });
+
+it('sends the owner selector separately and rejects a different returned retained block', async () => {
+  const id = '00000000-0000-4000-8000-000000000001';
+  const request: PairingRequest = {
+    version: 1,
+    pairingId,
+    worldId: 'a'.repeat(20),
+    installationId: id,
+    identityId: id,
+    installationLabel: 'Device',
+    identityLabel: 'Alice',
+    capabilities: ['layout.read'],
+  };
+  const replacement = { principalUid: `office-agent:${id}`, blockId: id };
+  const auth = { currentUser: { uid: 'owner', getIdToken: async () => 'private-token' } };
+  const binding = {
+    ...request,
+    principalUid: 'office-agent:00000000-0000-4000-8000-000000000002',
+    blockId: id,
+    expiresAt: 2_000_000_000_000,
+  };
+  const send = vi
+    .fn<typeof fetch>()
+    .mockImplementation(
+      async () =>
+        new Response(JSON.stringify(binding), { headers: { 'content-type': 'application/json' } })
+    );
+  const port = createPairingPort(auth, endpoint, send);
+  expect(await port.approve(request, 'owner', replacement)).toEqual(binding);
+  expect(JSON.parse(send.mock.calls[0][1]!.body as string)).toEqual({
+    ...request,
+    replacesPrincipalUid: replacement.principalUid,
+  });
+  expect(request).not.toHaveProperty('replacesPrincipalUid');
+  binding.blockId = '00000000-0000-4000-8000-000000000003';
+  await expect(port.approve(request, 'owner', replacement)).rejects.toMatchObject({
+    kind: 'uncertain',
+  });
+  binding.blockId = id;
+  binding.principalUid = replacement.principalUid;
+  await expect(port.approve(request, 'owner', replacement)).rejects.toMatchObject({
+    kind: 'uncertain',
+  });
+  await expect(
+    port.approve(request, 'owner', { ...replacement, principalUid: '../other' })
+  ).rejects.toThrow();
+  expect(send).toHaveBeenCalledTimes(3);
+});
 
 it('only explicit deployment settings select an endpoint, never request or preview data', () => {
   expect(pairingEndpoint('preview', { VITE_OFFICE_PAIRING_URL: endpoint })).toBeUndefined();

--- a/apps/office/src/pairing/pairing-transport.ts
+++ b/apps/office/src/pairing/pairing-transport.ts
@@ -2,6 +2,7 @@ import {
   parseApprovedPairing,
   parseRevokedPairing,
   PairingActionError,
+  validatePairingReplacement,
 } from './pairing-contract.js';
 import type { PairingPort } from './pairing-contract.js';
 
@@ -74,8 +75,19 @@ export function createPairingPort(
     }
   }
   return {
-    async approve(request, ownerUid) {
-      return parseApprovedPairing(await post('approve', request, ownerUid), request);
+    async approve(request, ownerUid, replacement) {
+      if (replacement) validatePairingReplacement(replacement);
+      const input = replacement
+        ? { ...request, replacesPrincipalUid: replacement.principalUid }
+        : request;
+      const approved = parseApprovedPairing(await post('approve', input, ownerUid), request);
+      if (
+        replacement &&
+        (approved.blockId !== replacement.blockId ||
+          approved.principalUid === replacement.principalUid)
+      )
+        throw new PairingActionError('uncertain');
+      return approved;
     },
     async revoke(pairingId, ownerUid) {
       parseRevokedPairing(await post('revoke', { version: 1, pairingId }, ownerUid), pairingId);

--- a/apps/office/src/pairing/pairing-view.test.tsx
+++ b/apps/office/src/pairing/pairing-view.test.tsx
@@ -9,9 +9,10 @@ import { createWorldState } from '../worlds/world-state.js';
 import { createOfficeRouter } from '../router.js';
 import { OfficeApp } from '../office-app.js';
 import type { ApprovedPairing, PairingRequest, PairingPort } from './pairing-contract.js';
+import type { SpacePort, SpacePage } from '../spaces/space-contract.js';
 import vectors from '../../../../contracts/office/pairing-examples.json' with { type: 'json' };
 
-async function fixture(change: Record<string, unknown> = {}) {
+async function fixture(change: Record<string, unknown> = {}, spaces?: SpacePort) {
   const request = { ...vectors.valid[0], ...change } as PairingRequest;
   const world = { id: request.worldId, name: 'Private studio', ownerUid: 'owner', createdAtMs: 1 };
   let identity: (user: SessionUser | null) => void = () => {};
@@ -55,7 +56,7 @@ async function fixture(change: Record<string, unknown> = {}) {
     createMemoryHistory({ initialEntries: [`/worlds/${world.id}/pair#${fragment}`] })
   );
   const view = render(
-    <OfficeApp router={router} session={session} worlds={worlds} pairing={port} />
+    <OfficeApp router={router} session={session} worlds={worlds} pairing={port} spaces={spaces} />
   );
   return {
     port,
@@ -70,6 +71,54 @@ async function fixture(change: Record<string, unknown> = {}) {
     },
   };
 }
+
+it('pages revoked spaces without approving, then fixes explicit selection across uncertain retry', async () => {
+  const id = '00000000-0000-4000-8000-000000000004';
+  const source = {
+    principalUid: `office-agent:${id}`,
+    identityId: id,
+    installationId: id,
+    blockId: id,
+    capabilities: ['layout.read'] as ['layout.read'],
+    enabled: false,
+    expiresAtMs: 1000,
+  };
+  const spaces: SpacePort = {
+    list: vi
+      .fn()
+      .mockResolvedValueOnce({ entries: [{ ...source, enabled: true }], next: source.principalUid })
+      .mockResolvedValueOnce({ entries: [source], next: null }),
+    block: () => {
+      throw new Error('Approval must not open or mutate a block');
+    },
+  };
+  const f = await fixture({}, spaces);
+  try {
+    const user = userEvent.setup();
+    await screen.findByText('No revoked grants on this page.');
+    expect(f.port.approve).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Next retained spaces' }));
+    await user.click(await screen.findByRole('radio', { name: /Retained block/ }));
+    expect(spaces.list).toHaveBeenLastCalledWith(f.request.worldId, 'owner', source.principalUid);
+    vi.mocked(f.port.approve).mockRejectedValueOnce(new Error('Lost response'));
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Approve pairing' }));
+    await screen.findByText(/The choice is fixed/);
+    const fresh = screen.getByRole('radio', { name: 'New empty block' });
+    await user.click(fresh);
+    await user.click(screen.getByRole('button', { name: 'Retry same approval' }));
+    await screen.findByText(/Approved\. Return/);
+    expect(f.port.approve).toHaveBeenCalledTimes(2);
+    for (const call of vi.mocked(f.port.approve).mock.calls)
+      expect(call).toEqual([
+        f.request,
+        'owner',
+        { principalUid: source.principalUid, blockId: id },
+      ]);
+  } finally {
+    await f.dispose();
+  }
+});
 
 it('requires explicit recognition, renders labels as text and never approves just by viewing', async () => {
   const f = await fixture({ identityLabel: '<img src=x onerror=alert(1)>' });
@@ -125,13 +174,45 @@ it.each(['admission', 'route'] as const)(
   }
 );
 
-it('secret-bearing input fails before any approval operation', async () => {
-  const f = await fixture({ secret: 'must-not-be-accepted' });
+it.each(['secret', 'replacesPrincipalUid'])(
+  'native link field %s fails before any approval operation',
+  async (field) => {
+    const f = await fixture({ [field]: 'must-not-be-accepted' });
+    try {
+      await screen.findByText(/Invalid pairing link/);
+      expect(screen.queryByRole('button', { name: 'Approve pairing' })).toBeNull();
+      expect(f.port.approve).not.toHaveBeenCalled();
+      expect(f.port.revoke).not.toHaveBeenCalled();
+    } finally {
+      await f.dispose();
+    }
+  }
+);
+
+it('late retained-space results cannot restore a departed approval view', async () => {
+  let finish: (page: SpacePage) => void = () => {};
+  const spaces: SpacePort = {
+    list: vi.fn(
+      () =>
+        new Promise<SpacePage>((resolve) => {
+          finish = resolve;
+        })
+    ),
+    block: () => {
+      throw new Error('No block access');
+    },
+  };
+  const f = await fixture({}, spaces);
   try {
-    await screen.findByText(/Invalid pairing link/);
-    expect(screen.queryByRole('button', { name: 'Approve pairing' })).toBeNull();
+    await screen.findByText('Loading retained spaces…');
+    await act(async () => {
+      f.revokeAdmission();
+    });
+    await act(async () => {
+      finish({ entries: [], next: null });
+    });
+    expect(screen.queryByRole('group', { name: 'Assigned block' })).toBeNull();
     expect(f.port.approve).not.toHaveBeenCalled();
-    expect(f.port.revoke).not.toHaveBeenCalled();
   } finally {
     await f.dispose();
   }

--- a/apps/office/src/pairing/pairing-view.tsx
+++ b/apps/office/src/pairing/pairing-view.tsx
@@ -10,6 +10,7 @@ import { parsePairingFragment } from './pairing-contract.js';
 import type { PairingRequest, PairingPort } from './pairing-contract.js';
 import { createPairingState } from './pairing-state.js';
 import type { PairingState } from './pairing-state.js';
+import { PairingSpaceChoice } from './pairing-space-choice.js';
 import './pairing.css';
 
 export const PairingContext = createContext<PairingPort | undefined>(undefined);
@@ -61,10 +62,18 @@ function PairingMount({
     setState(next);
     return () => next.dispose();
   }, [port, request, ownerUid]);
-  return state ? <PairingForm state={state} request={request} /> : null;
+  return state ? <PairingForm state={state} request={request} ownerUid={ownerUid} /> : null;
 }
 
-export function PairingForm({ state, request }: { state: PairingState; request: PairingRequest }) {
+export function PairingForm({
+  state,
+  request,
+  ownerUid,
+}: {
+  state: PairingState;
+  request: PairingRequest;
+  ownerUid: string;
+}) {
   const { busy, attempted, approved, revoked, error } = useSyncExternalStore(
     state.subscribe,
     state.getSnapshot
@@ -107,6 +116,7 @@ export function PairingForm({ state, request }: { state: PairingState; request: 
         This identity may renew its access in leases of up to 24 hours until you revoke it. Renewal
         keeps the same block and permissions; it does not require daily approval.
       </p>
+      <PairingSpaceChoice state={state} request={request} ownerUid={ownerUid} />
       {error && <p role="alert">{error}</p>}
       {approved && (
         <p role="status">

--- a/apps/office/src/pairing/pairing.css
+++ b/apps/office/src/pairing/pairing.css
@@ -30,6 +30,20 @@
 .pairing-panel button {
   margin: 0.5rem 0.5rem 0 0;
 }
+.pairing-space-choice {
+  min-width: 0;
+  margin: 1rem 0;
+  border: 1px solid #d4dccf;
+  border-radius: 0.5rem;
+  overflow-wrap: anywhere;
+}
+.pairing-space-choice label {
+  display: block;
+  margin: 0.75rem 0;
+}
+.pairing-space-choice input {
+  width: auto;
+}
 @media (max-width: 500px) {
   .pairing-panel {
     padding: 1rem;

--- a/apps/office/src/spaces/firebase-spaces.test.ts
+++ b/apps/office/src/spaces/firebase-spaces.test.ts
@@ -27,6 +27,18 @@ it('keeps revoked and expired records visible without inferring presence or auth
   });
   expect(readAgentSpace(principal, { ...value, enabled: true }, 'owner').enabled).toBe(true);
 });
+
+it('projects only a disabled grant with an exact valid transfer receipt', () => {
+  const receipt = { ...value, replacedByPairingId: 'a'.repeat(64) };
+  expect(readAgentSpace(principal, receipt, 'owner').replacedByPairingId).toBe('a'.repeat(64));
+  for (const patch of [
+    { enabled: true },
+    { replacedByPairingId: null },
+    { replacedByPairingId: 'x' },
+    { extra: 1 },
+  ])
+    expect(() => readAgentSpace(principal, { ...receipt, ...patch }, 'owner')).toThrow();
+});
 it('rejects incomplete, expanded, wrong-owner and malformed authority projections', () => {
   for (const key of Object.keys(value)) {
     const incomplete: Record<string, unknown> = { ...value };

--- a/apps/office/src/spaces/firebase-spaces.ts
+++ b/apps/office/src/spaces/firebase-spaces.ts
@@ -26,9 +26,14 @@ export function readAgentSpace(
   ownerUid: string
 ): AgentSpace {
   const capabilities = value.capabilities;
+  const hasReplacement = Object.hasOwn(value, 'replacedByPairingId');
   if (
     !validPrincipal(principalUid) ||
-    Object.keys(value).length !== 9 ||
+    Object.keys(value).length !== (hasReplacement ? 10 : 9) ||
+    (hasReplacement &&
+      (value.enabled !== false ||
+        typeof value.replacedByPairingId !== 'string' ||
+        !/^[0-9a-f]{64}$/.test(value.replacedByPairingId))) ||
     value.version !== 1 ||
     value.ownerUid !== ownerUid ||
     !['installationId', 'identityId', 'blockId'].every(
@@ -56,6 +61,7 @@ export function readAgentSpace(
     capabilities: capabilities.length === 1 ? ['layout.read'] : ['layout.read', 'layout.write'],
     enabled: value.enabled,
     expiresAtMs: value.expiresAt.toMillis(),
+    ...(hasReplacement ? { replacedByPairingId: value.replacedByPairingId as string } : {}),
   };
 }
 

--- a/apps/office/src/spaces/space-contract.ts
+++ b/apps/office/src/spaces/space-contract.ts
@@ -10,6 +10,7 @@ export interface AgentSpace {
   capabilities: PairingCapabilities;
   enabled: boolean;
   expiresAtMs: number;
+  replacedByPairingId?: string;
 }
 export interface SpacePage {
   entries: AgentSpace[];

--- a/apps/office/src/spaces/space-view.tsx
+++ b/apps/office/src/spaces/space-view.tsx
@@ -89,6 +89,13 @@ export function SpaceList({ state, open }: { state: SpaceState; open: (id: strin
               {entry.capabilities.join(', ')}
             </p>
             <button onClick={() => open(entry.blockId)}>Open block {entry.blockId}</button>
+            {entry.replacedByPairingId && (
+              <p>
+                Reserved or transferred through pairing{' '}
+                <code>{entry.replacedByPairingId.slice(0, 12)}</code>. This is not an unassigned
+                block.
+              </p>
+            )}
           </li>
         ))}
       </ul>

--- a/contracts/office/agent-grant-v1.md
+++ b/contracts/office/agent-grant-v1.md
@@ -13,7 +13,7 @@ The issuer must never reuse a retired principal for a different binding. A
 device-wide credential must not implicitly authorize every agent on that device.
 Display names, folders and pane IDs are neither credentials nor lookup keys.
 
-`worlds/{worldId}/agentGrants/{principalUid}` contains exactly:
+An active `worlds/{worldId}/agentGrants/{principalUid}` contains exactly:
 
 | Field            | Value                                                                            |
 | ---------------- | -------------------------------------------------------------------------------- |
@@ -26,6 +26,13 @@ Display names, folders and pane IDs are neither credentials nor lookup keys.
 | `enabled`        | Boolean; only `true` grants access                                               |
 | `createdAt`      | Current lease start as a Firestore timestamp, not later than server request time |
 | `expiresAt`      | Firestore timestamp, after creation and at most 24 hours later                   |
+
+A disabled grant may additionally contain `replacedByPairingId`, a lowercase
+64-hex pairing ID written only by the issuer's
+[reassignment transaction](pairing-v1.md#retained-block-reassignment).
+This receipt marks a reserved or transferred source, not an unassigned block.
+It never grants access, and is invalid on an enabled grant. Client writes cannot
+add or change the receipt; revocation preserves it.
 
 Access requires `createdAt <= request.time < expiresAt`, valid schema, current
 owner tester admission and matching authenticated principal/installation/identity.
@@ -68,8 +75,9 @@ per-entry subscriptions are installed. Invalid records make the page unavailable
 
 Labels reflect the last fetch and the browser clock, not online presence or
 fresh server authorization. Expired enabled leases may renew; revoked records
-remain visible. The inventory does not change grants, recover credentials,
-reassign resources or enumerate blocks without surviving grant references.
+remain visible, including explicit transfer receipts. The inventory itself does
+not change grants, recover credentials or enumerate blocks without surviving
+grant references. Explicit reassignment uses the owner approval flow.
 
 Revocation denies subsequent server operations even with the same cached token.
 It neither erases retained blocks nor recalls already disclosed content. Expiry

--- a/contracts/office/pairing-v1.md
+++ b/contracts/office/pairing-v1.md
@@ -2,7 +2,7 @@
 
 Locally implemented issuer and browser approval protocol. The
 [native pairing contract](native-pairing.md) defines its source-build consumer.
-Assignment management and production activation remain separate gates; no
+Production activation and local credential recovery remain separate gates; no
 public Office distribution is promised by this contract.
 
 ## Proof and consent
@@ -74,7 +74,8 @@ UUIDs use the grant v1 lowercase hyphenated format; world IDs are 20
 alphanumeric characters. Labels are 1..80 Unicode scalar values, nonblank,
 without control characters. Capabilities are exactly the ordered layout lists
 in [agent grant v1](agent-grant-v1.md). No arbitrary paths or additional resource
-permissions are accepted.
+permissions are accepted. `/approve` alone also accepts the optional owner-selected
+`replacesPrincipalUid` described under retained-block reassignment.
 
 Claim responses retain the exact approved binding and approval `expiresAt`, and
 add `customToken` plus `grantExpiresAt` from the validated resource grant. Approval
@@ -99,7 +100,9 @@ is `413 INPUT_TOO_LARGE`.
 `officePairings/{pairingId}` is service-only; Rules deny all client access. Its
 versioned record owns approved immutable input, human owner, generated principal
 UID and independent block UUID, creation/expiry timestamps, `enabled`, `claimed`
-and `nextClaimAt`. Clients cannot select the generated principal/block IDs.
+and `nextClaimAt`. A retained-block approval additionally records immutable
+`replacesPrincipalUid`. Clients cannot select the generated principal; a block
+may only be selected indirectly through the validated source grant below.
 
 Approval retries return the existing record only for the same owner and exact
 input before expiry. They never extend the deadline or re-enable a record.
@@ -127,6 +130,36 @@ uses the same principal and resource rather than manufacturing a second grant.
 The service keeps expired/disabled records as tombstones in this slice: no TTL
 or cleanup silently permits reuse of a pairing ID. Bounded retention and public
 endpoint abuse controls must be reviewed before production activation.
+
+## Retained-block reassignment
+
+The owner may add `replacesPrincipalUid` (`office-agent:` followed by a lowercase
+UUID) to `/approve`. It is not accepted in the native public fragment. Without
+it, approval allocates a fresh block as before. The browser lists bounded grant
+pages and requires explicit recognition and selection; after any attempt the
+choice is fixed for that mounted request. It verifies that the response names
+the selected block, while native claim continues to verify its own identity,
+installation, world and capabilities.
+
+The source must be a complete disabled grant in the same owned world. In the
+approval transaction, reserve it with `replacedByPairingId` and create a new
+pairing/principal that names the same block. No resource document is written,
+copied or deleted; notebooks and profiles do not transfer. Same request and
+source retry returns the same binding; a changed choice conflicts. Two approvals
+cannot consume the same source concurrently.
+
+A marked source can be reclaimed only when its referenced predecessor is
+unclaimed and expired or disabled, with matching owner, world, source and block.
+Disable that predecessor and replace the receipt in the same transaction.
+Missing, malformed, mismatched or claimed predecessor evidence conflicts.
+Once claimed, a later transfer must use the newly issued grant after revocation,
+never an ancestor. The old principal stays disabled and old cached credentials
+remain denied. Expired enabled grants are not eligible: expiry is not revocation.
+
+The original grant records are the sole authority and transfer receipts. Browser
+inventory labels do not promise that a reservation is available; the issuer
+checks current state when approving. Local expired-pending and lost/corrupt
+credential recovery are separate work, not implied by successful reassignment.
 
 ## Lease renewal
 

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -25,7 +25,8 @@ installation/identity claims, live capability/lease and current owner admission.
 Direct client grant writes are owner-only revocation; clients cannot issue or
 enlarge one. The trusted issuer also accepts scoped agent/proof retirement
 cancellation through its [pairing contract](../../contracts/office/pairing-v1.md#retirement-cancellation). This
-does not provide assignment management. Native credential consumption is owned
+supports explicit retained-block reassignment during owner approval. Native
+credential consumption is owned
 by the optional companion described below. Retained UUID blocks
 use the existing layout validator; no parallel layout/ownership document is introduced.
 
@@ -43,8 +44,8 @@ route/admission loss. Late observations and saves cannot restore disposed data.
 selection and controls. No canvas engine, generic scene framework, new global
 store or remote-state copy is introduced. Pointer selection/tile placement and
 equivalent numeric/keyboard controls edit locally; explicit Save uses the
-revision-checked Firestore transaction. Agent reassignment and native block mutation
-commands are not implemented. The contract and shared validation vectors live in `contracts/office`.
+revision-checked Firestore transaction. Native block mutation commands are not
+implemented. The contract and shared validation vectors live in `contracts/office`.
 Save confirmation and conflict inspection use one-shot transaction reads in the
 same adapter, independent of watch-channel recovery. Watch snapshots remain
 the ongoing projection, not an acknowledgment channel for explicit saves.
@@ -130,7 +131,8 @@ signing, Firestore transactions and HTTP platform integration; no custom JWT or
 database client is introduced. Its [pairing contract](../../contracts/office/pairing-v1.md)
 owns the wire format and recovery policy.
 
-`pairing-contract` owns bounded value decoding; `pairing-store` owns transactional
+`pairing-contract` owns bounded wire decoding; `pairing-record` owns strict
+persisted pairing/grant decoding and timestamp shape. `pairing-store` owns transactional
 approval/grant state, compare-expiry lease renewal and live owner admission.
 `pairing-service` verifies human approval/revocation, bound-agent renewal or
 reduction-only agent/proof cancellation
@@ -171,6 +173,16 @@ requires explicit recognition before approval. Existing session/admission and
 selected-world owners gate the route; unmount fences late completions without
 claiming to cancel submitted writes. Skip-to-content focuses the main landmark
 without overwriting the request fragment. The browser cannot claim agent tokens.
+
+The approval form reuses `SpacePort` and its disposable one-page state to select
+a disabled grant's retained block. Selection is separate from the native link
+and freezes after the first attempt; retries cannot silently change assignment.
+The issuer records immutable source intent on the pairing and reserves the
+disabled source grant in the same transaction. Its transfer receipt prevents
+concurrent or ancestral reuse; only a verified abandoned unclaimed reservation
+may be superseded. Grant validation remains shared with claim and renewal.
+No block content, profile or notebook is copied. The exact transition belongs in
+[pairing v1](../../contracts/office/pairing-v1.md#retained-block-reassignment).
 
 ### Public deployment discovery
 

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -42,7 +42,7 @@ Choose **Open block** to inspect or edit the referenced space using the existing
 layout editor. **Open home block** returns to your own layout. Switching spaces
 discards unsaved edits; already submitted writes may still complete on their
 original target. An absent layout is shown as **No saved layout yet**, not as
-deleted content. Reassignment and credential recovery are not available here.
+deleted content. This editor does not change assignment or recover credentials.
 
 ## Native pairing (source builds)
 
@@ -62,6 +62,14 @@ the identity/installation and approve. `pair` waits up to 300 seconds; use
 original pending request. `--read-only` requests only layout read access. Omit
 `--identity` only with verified pane context. Temporary identities are accepted
 without promoting them to saved identities.
+
+The approval form defaults to **New empty block**. To reuse a retired agent's
+layout, select its **Retained block** from the revoked grant pages before
+approving. The first attempt fixes this choice, including uncertain retries.
+The new agent receives a new principal for that block; the previous principal
+stays revoked. Profiles and notebooks do not transfer. A reserved/transferred
+source may reject if already claimed; use the most recent revoked grant, not
+an ancestor. The service can reclaim only an abandoned unclaimed reservation.
 
 World-qualified `status` reports local retained state, not live authority.
 `inspect` checks server access and reports only whether the assigned block exists;

--- a/services/office/functions/src/pairing-contract.ts
+++ b/services/office/functions/src/pairing-contract.ts
@@ -26,6 +26,11 @@ export interface Approval {
   capabilities: ['layout.read'] | ['layout.read', 'layout.write'];
 }
 
+export interface OwnerApproval {
+  request: Approval;
+  replacesPrincipalUid?: string;
+}
+
 export interface Renewal {
   version: 1;
   pairingId: string;
@@ -38,6 +43,8 @@ export const RENEWAL_WINDOW_MS = 5 * 60_000;
 export const CLAIM_INTERVAL_MS = 5000;
 export const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 export const PAIRING_ID = /^[0-9a-f]{64}$/;
+export const PRINCIPAL_UID =
+  /^office-agent:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 export const MAX_TIMESTAMP_MS = 8_640_000_000_000_000;
 
 export function object(value: unknown): Record<string, unknown> {
@@ -112,6 +119,24 @@ export function parseApproval(input: unknown): Approval {
     identityLabel: value.identityLabel,
     capabilities: capabilities.length === 1 ? ['layout.read'] : ['layout.read', 'layout.write'],
   };
+}
+
+/** Owner-only selection kept outside the strict native request contract. */
+export function parseOwnerApproval(input: unknown): OwnerApproval {
+  const value = object(input);
+  const hasReplacement = Object.hasOwn(value, 'replacesPrincipalUid');
+  const replacesPrincipalUid = hasReplacement ? value.replacesPrincipalUid : undefined;
+  const requestValue = { ...value };
+  delete requestValue.replacesPrincipalUid;
+  const request = parseApproval(requestValue);
+  if (
+    hasReplacement &&
+    (typeof replacesPrincipalUid !== 'string' || !PRINCIPAL_UID.test(replacesPrincipalUid))
+  )
+    throw new PairingError('INVALID_ARGUMENT');
+  return replacesPrincipalUid === undefined
+    ? { request }
+    : { request, replacesPrincipalUid: replacesPrincipalUid as string };
 }
 
 export function parseClaim(input: unknown): string {

--- a/services/office/functions/src/pairing-record.ts
+++ b/services/office/functions/src/pairing-record.ts
@@ -1,0 +1,176 @@
+import { Timestamp } from 'firebase-admin/firestore';
+import {
+  APPROVAL_MS,
+  GRANT_MS,
+  PAIRING_ID,
+  PRINCIPAL_UID,
+  UUID,
+  PairingError,
+  exact,
+  isTimestampMillis,
+  object,
+  parseApproval,
+} from './pairing-contract.js';
+import type { Approval } from './pairing-contract.js';
+
+export interface Pairing {
+  request: Approval;
+  ownerUid: string;
+  principalUid: string;
+  blockId: string;
+  createdAt: Timestamp;
+  expiresAt: Timestamp;
+  enabled: boolean;
+  claimed: boolean;
+  nextClaimAt: Timestamp;
+  replacesPrincipalUid?: string;
+}
+
+export interface Grant {
+  version: 1;
+  ownerUid: string;
+  installationId: string;
+  identityId: string;
+  blockId: string;
+  capabilities: Approval['capabilities'];
+  enabled: boolean;
+  createdAt: Timestamp;
+  expiresAt: Timestamp;
+  replacedByPairingId?: string;
+}
+
+function unavailable(): never {
+  throw new PairingError('PAIRING_UNAVAILABLE');
+}
+
+export function timestampMillis(value: Timestamp): number {
+  if (value.nanoseconds % 1_000_000 !== 0) unavailable();
+  const millis = value.toMillis();
+  if (!isTimestampMillis(millis)) unavailable();
+  return millis;
+}
+
+export function decodePairing(input: unknown, id: string): Pairing {
+  try {
+    const value = object(input);
+    exact(value, [
+      'request',
+      'ownerUid',
+      'principalUid',
+      'blockId',
+      'createdAt',
+      'expiresAt',
+      'enabled',
+      'claimed',
+      'nextClaimAt',
+      ...(Object.hasOwn(value, 'replacesPrincipalUid') ? ['replacesPrincipalUid'] : []),
+    ]);
+    const request = parseApproval(value.request);
+    if (
+      request.pairingId !== id ||
+      typeof value.ownerUid !== 'string' ||
+      !value.ownerUid ||
+      typeof value.principalUid !== 'string' ||
+      !PRINCIPAL_UID.test(value.principalUid) ||
+      typeof value.blockId !== 'string' ||
+      !UUID.test(value.blockId) ||
+      !(value.createdAt instanceof Timestamp) ||
+      !(value.expiresAt instanceof Timestamp) ||
+      !(value.nextClaimAt instanceof Timestamp) ||
+      typeof value.enabled !== 'boolean' ||
+      typeof value.claimed !== 'boolean' ||
+      (Object.hasOwn(value, 'replacesPrincipalUid') &&
+        (typeof value.replacesPrincipalUid !== 'string' ||
+          !PRINCIPAL_UID.test(value.replacesPrincipalUid)))
+    )
+      return unavailable();
+    const replacesPrincipalUid = value.replacesPrincipalUid;
+    return {
+      request,
+      ownerUid: value.ownerUid,
+      principalUid: value.principalUid,
+      blockId: value.blockId,
+      createdAt: value.createdAt,
+      expiresAt: value.expiresAt,
+      enabled: value.enabled,
+      claimed: value.claimed,
+      nextClaimAt: value.nextClaimAt,
+      ...(typeof replacesPrincipalUid === 'string' ? { replacesPrincipalUid } : {}),
+    };
+  } catch {
+    return unavailable();
+  }
+}
+
+export function decodeGrant(input: unknown): Grant {
+  try {
+    const value = object(input);
+    exact(value, [
+      'version',
+      'ownerUid',
+      'installationId',
+      'identityId',
+      'blockId',
+      'capabilities',
+      'enabled',
+      'createdAt',
+      'expiresAt',
+      ...(Object.hasOwn(value, 'replacedByPairingId') ? ['replacedByPairingId'] : []),
+    ]);
+    const createdAt = value.createdAt instanceof Timestamp ? value.createdAt : unavailable();
+    const expiresAt = value.expiresAt instanceof Timestamp ? value.expiresAt : unavailable();
+    const capabilities = value.capabilities;
+    if (
+      value.version !== 1 ||
+      typeof value.ownerUid !== 'string' ||
+      !value.ownerUid ||
+      typeof value.installationId !== 'string' ||
+      !UUID.test(value.installationId) ||
+      typeof value.identityId !== 'string' ||
+      !UUID.test(value.identityId) ||
+      typeof value.blockId !== 'string' ||
+      !UUID.test(value.blockId) ||
+      !Array.isArray(capabilities) ||
+      (capabilities.length !== 1 && capabilities.length !== 2) ||
+      capabilities[0] !== 'layout.read' ||
+      (capabilities.length === 2 && capabilities[1] !== 'layout.write') ||
+      typeof value.enabled !== 'boolean' ||
+      (Object.hasOwn(value, 'replacedByPairingId') &&
+        (typeof value.replacedByPairingId !== 'string' ||
+          !PAIRING_ID.test(value.replacedByPairingId)))
+    )
+      return unavailable();
+    const replacedByPairingId = value.replacedByPairingId;
+    const grant: Grant = {
+      version: 1,
+      ownerUid: value.ownerUid,
+      installationId: value.installationId,
+      identityId: value.identityId,
+      blockId: value.blockId,
+      capabilities: capabilities.length === 1 ? ['layout.read'] : ['layout.read', 'layout.write'],
+      enabled: value.enabled,
+      createdAt,
+      expiresAt,
+      ...(typeof replacedByPairingId === 'string' ? { replacedByPairingId } : {}),
+    };
+    if (grant.enabled && grant.replacedByPairingId !== undefined) return unavailable();
+    timestampMillis(grant.createdAt);
+    timestampMillis(grant.expiresAt);
+    return grant;
+  } catch {
+    return unavailable();
+  }
+}
+
+export function validApprovalTimestamps(pairing: Pairing): void {
+  const createdAt = timestampMillis(pairing.createdAt);
+  const expiresAt = timestampMillis(pairing.expiresAt);
+  timestampMillis(pairing.nextClaimAt);
+  if (expiresAt - createdAt !== APPROVAL_MS) unavailable();
+}
+
+export function validGrantDuration(grant: Grant): void {
+  const createdAt = timestampMillis(grant.createdAt);
+  const expiresAt = timestampMillis(grant.expiresAt);
+  if (expiresAt <= createdAt || expiresAt - createdAt > GRANT_MS) unavailable();
+}

--- a/services/office/functions/src/pairing-service.ts
+++ b/services/office/functions/src/pairing-service.ts
@@ -2,7 +2,7 @@ import type { DecodedIdToken } from 'firebase-admin/auth';
 import {
   PairingError,
   UUID,
-  parseApproval,
+  parseOwnerApproval,
   parseClaim,
   parseRenewal,
   parseRevocation,
@@ -49,8 +49,12 @@ export function createPairingService(store: PairingStore, auth: PairingAuthentic
 
   return {
     async approve(input: unknown, authorization?: string) {
-      const request = parseApproval(input);
-      return store.approve(human(await verified(authorization)), request);
+      const approval = parseOwnerApproval(input);
+      return store.approve(
+        human(await verified(authorization)),
+        approval.request,
+        approval.replacesPrincipalUid
+      );
     },
     async claim(input: unknown) {
       const id = parseClaim(input);

--- a/services/office/functions/src/pairing-store.ts
+++ b/services/office/functions/src/pairing-store.ts
@@ -7,26 +7,19 @@ import {
   GRANT_MS,
   isTimestampMillis,
   MAX_TIMESTAMP_MS,
+  PRINCIPAL_UID,
   RENEWAL_WINDOW_MS,
-  UUID,
   PairingError,
-  exact,
-  object,
-  parseApproval,
 } from './pairing-contract.js';
 import type { Approval } from './pairing-contract.js';
-
-interface Pairing {
-  request: Approval;
-  ownerUid: string;
-  principalUid: string;
-  blockId: string;
-  createdAt: Timestamp;
-  expiresAt: Timestamp;
-  enabled: boolean;
-  claimed: boolean;
-  nextClaimAt: Timestamp;
-}
+import {
+  decodeGrant,
+  decodePairing,
+  timestampMillis,
+  validApprovalTimestamps,
+  validGrantDuration,
+} from './pairing-record.js';
+import type { Grant, Pairing } from './pairing-record.js';
 
 export interface ApprovedBinding extends Approval {
   principalUid: string;
@@ -73,70 +66,11 @@ function unavailable(): never {
   throw new PairingError('PAIRING_UNAVAILABLE');
 }
 
-function decode(input: unknown, id: string): Pairing {
-  try {
-    const value = object(input);
-    exact(value, [
-      'request',
-      'ownerUid',
-      'principalUid',
-      'blockId',
-      'createdAt',
-      'expiresAt',
-      'enabled',
-      'claimed',
-      'nextClaimAt',
-    ]);
-    const request = parseApproval(value.request);
-    if (
-      request.pairingId !== id ||
-      typeof value.ownerUid !== 'string' ||
-      !value.ownerUid ||
-      typeof value.principalUid !== 'string' ||
-      !value.principalUid.startsWith('office-agent:') ||
-      !UUID.test(value.principalUid.slice('office-agent:'.length)) ||
-      typeof value.blockId !== 'string' ||
-      !UUID.test(value.blockId) ||
-      !(value.createdAt instanceof Timestamp) ||
-      !(value.expiresAt instanceof Timestamp) ||
-      !(value.nextClaimAt instanceof Timestamp) ||
-      typeof value.enabled !== 'boolean' ||
-      typeof value.claimed !== 'boolean'
-    )
-      return unavailable();
-    return {
-      request,
-      ownerUid: value.ownerUid,
-      principalUid: value.principalUid,
-      blockId: value.blockId,
-      createdAt: value.createdAt,
-      expiresAt: value.expiresAt,
-      enabled: value.enabled,
-      claimed: value.claimed,
-      nextClaimAt: value.nextClaimAt,
-    };
-  } catch {
-    return unavailable();
-  }
-}
-
-function timestampMillis(value: Timestamp): number {
-  if (value.nanoseconds % 1_000_000 !== 0) unavailable();
-  const millis = value.toMillis();
-  if (!isTimestampMillis(millis)) unavailable();
-  return millis;
-}
-
 function validApproval(pairing: Pairing, now: number, temporal: 'active' | 'renewal'): void {
   const createdAt = timestampMillis(pairing.createdAt);
   const expiresAt = timestampMillis(pairing.expiresAt);
-  timestampMillis(pairing.nextClaimAt);
-  if (
-    !pairing.enabled ||
-    createdAt > now ||
-    expiresAt - createdAt !== APPROVAL_MS ||
-    (temporal === 'active' && expiresAt <= now)
-  )
+  validApprovalTimestamps(pairing);
+  if (!pairing.enabled || createdAt > now || (temporal === 'active' && expiresAt <= now))
     unavailable();
 }
 
@@ -159,38 +93,80 @@ function validGrant(
   now: number,
   temporal: 'active' | 'renewal' = 'active'
 ): number {
+  const value = decodeGrant(input);
+  validGrantDuration(value);
+  const createdAt = timestampMillis(value.createdAt);
+  const expiresAt = timestampMillis(value.expiresAt);
+  if (
+    value.ownerUid !== pairing.ownerUid ||
+    value.installationId !== pairing.request.installationId ||
+    value.identityId !== pairing.request.identityId ||
+    value.blockId !== pairing.blockId ||
+    JSON.stringify(value.capabilities) !== JSON.stringify(pairing.request.capabilities) ||
+    value.enabled !== true ||
+    createdAt > now ||
+    (temporal === 'active' && expiresAt <= now)
+  )
+    unavailable();
+  return expiresAt;
+}
+
+function replacementConflict(): never {
+  throw new PairingError('PAIRING_CONFLICT');
+}
+
+function sourceGrant(input: unknown, ownerUid: string, now: number): Grant {
   try {
-    const value = object(input);
-    exact(value, [
-      'version',
-      'ownerUid',
-      'installationId',
-      'identityId',
-      'blockId',
-      'capabilities',
-      'enabled',
-      'createdAt',
-      'expiresAt',
-    ]);
-    const createdAt =
-      value.createdAt instanceof Timestamp ? timestampMillis(value.createdAt) : unavailable();
-    const expiresAt =
-      value.expiresAt instanceof Timestamp ? timestampMillis(value.expiresAt) : unavailable();
+    const grant = decodeGrant(input);
+    validGrantDuration(grant);
+    const createdAt = timestampMillis(grant.createdAt);
+    if (grant.ownerUid !== ownerUid || grant.enabled !== false || createdAt > now)
+      return replacementConflict();
+    return grant;
+  } catch {
+    return replacementConflict();
+  }
+}
+
+function validPredecessor(
+  input: unknown,
+  id: string,
+  source: Grant,
+  sourcePrincipalUid: string,
+  ownerUid: string,
+  request: Approval,
+  now: number
+): Pairing {
+  try {
+    const predecessor = decodePairing(input, id);
+    const createdAt = timestampMillis(predecessor.createdAt);
+    const expiresAt = timestampMillis(predecessor.expiresAt);
+    validApprovalTimestamps(predecessor);
     if (
-      value.version !== 1 ||
-      value.ownerUid !== pairing.ownerUid ||
-      value.installationId !== pairing.request.installationId ||
-      value.identityId !== pairing.request.identityId ||
-      value.blockId !== pairing.blockId ||
-      JSON.stringify(value.capabilities) !== JSON.stringify(pairing.request.capabilities) ||
-      value.enabled !== true ||
+      predecessor.ownerUid !== ownerUid ||
+      predecessor.request.worldId !== request.worldId ||
+      predecessor.blockId !== source.blockId ||
+      predecessor.replacesPrincipalUid !== sourcePrincipalUid ||
+      predecessor.claimed ||
       createdAt > now ||
-      (temporal === 'active' && expiresAt <= now) ||
-      expiresAt <= createdAt ||
-      expiresAt - createdAt > GRANT_MS
+      (predecessor.enabled && expiresAt > now)
+    )
+      return replacementConflict();
+    return predecessor;
+  } catch {
+    return replacementConflict();
+  }
+}
+
+function validSourceReservation(input: unknown, pairing: Pairing, now: number): void {
+  if (pairing.replacesPrincipalUid === undefined) return;
+  try {
+    const source = sourceGrant(input, pairing.ownerUid, now);
+    if (
+      source.blockId !== pairing.blockId ||
+      source.replacedByPairingId !== pairing.request.pairingId
     )
       unavailable();
-    return expiresAt;
   } catch {
     unavailable();
   }
@@ -212,12 +188,9 @@ function renewed(pairing: Pairing, grantExpiresAt: number): RenewedBinding {
 
 export function createPairingStore(db: Firestore, clock: () => number = Date.now) {
   const pairingRef = (id: string) => db.collection('officePairings').doc(id);
-  const grantRef = (pairing: Pairing) =>
-    db
-      .collection('worlds')
-      .doc(pairing.request.worldId)
-      .collection('agentGrants')
-      .doc(pairing.principalUid);
+  const grantRefFor = (worldId: string, principalUid: string) =>
+    db.collection('worlds').doc(worldId).collection('agentGrants').doc(principalUid);
+  const grantRef = (pairing: Pairing) => grantRefFor(pairing.request.worldId, pairing.principalUid);
 
   async function ownsWorld(tx: Transaction, uid: string, worldId: string): Promise<boolean> {
     const [tester, world] = await tx.getAll(
@@ -233,41 +206,107 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
   }
 
   async function current(tx: Transaction, id: string, now: number): Promise<Pairing> {
-    const pairing = decode((await tx.get(pairingRef(id))).data(), id);
+    const pairing = decodePairing((await tx.get(pairingRef(id))).data(), id);
     validApproval(pairing, now, 'active');
     if (!(await ownsWorld(tx, pairing.ownerUid, pairing.request.worldId))) unavailable();
+    if (pairing.replacesPrincipalUid !== undefined) {
+      const source = await tx.get(
+        grantRefFor(pairing.request.worldId, pairing.replacesPrincipalUid)
+      );
+      validSourceReservation(source.data(), pairing, now);
+    }
     return pairing;
   }
 
   return {
-    async approve(uid: string, request: Approval): Promise<ApprovedBinding> {
+    async approve(
+      uid: string,
+      request: Approval,
+      replacesPrincipalUid?: string
+    ): Promise<ApprovedBinding> {
+      if (replacesPrincipalUid !== undefined && !PRINCIPAL_UID.test(replacesPrincipalUid))
+        throw new PairingError('INVALID_ARGUMENT');
       // Random IDs are stable across transaction retries; no minting or delivery in tx.
       const principalUid = `office-agent:${randomUUID()}`;
-      const blockId = randomUUID();
+      const freshBlockId = randomUUID();
       return db.runTransaction(async (tx) => {
         const now = clock();
+        if (!isTimestampMillis(now) || now > MAX_TIMESTAMP_MS - APPROVAL_MS) unavailable();
         if (!(await ownsWorld(tx, uid, request.worldId)))
           throw new PairingError('PERMISSION_DENIED');
         const existing = await tx.get(pairingRef(request.pairingId));
+        const sourceRef =
+          replacesPrincipalUid === undefined
+            ? undefined
+            : grantRefFor(request.worldId, replacesPrincipalUid);
+        const sourceSnapshot = sourceRef === undefined ? undefined : await tx.get(sourceRef);
+        const source =
+          replacesPrincipalUid === undefined
+            ? undefined
+            : sourceGrant(sourceSnapshot?.data(), uid, now);
+        const reservedPairingId = source?.replacedByPairingId;
+        const predecessorSnapshot =
+          reservedPairingId !== undefined && reservedPairingId !== request.pairingId
+            ? await tx.get(pairingRef(reservedPairingId))
+            : undefined;
+        const predecessor =
+          source !== undefined &&
+          reservedPairingId !== undefined &&
+          reservedPairingId !== request.pairingId
+            ? validPredecessor(
+                predecessorSnapshot?.data(),
+                reservedPairingId,
+                source,
+                replacesPrincipalUid!,
+                uid,
+                request,
+                now
+              )
+            : undefined;
+        const predecessorGrantSnapshot =
+          predecessor !== undefined
+            ? await tx.get(grantRefFor(request.worldId, predecessor.principalUid))
+            : undefined;
         if (existing.exists) {
-          const pairing = decode(existing.data(), request.pairingId);
-          if (pairing.ownerUid !== uid || !sameRequest(pairing.request, request))
+          const pairing = decodePairing(existing.data(), request.pairingId);
+          if (
+            pairing.ownerUid !== uid ||
+            !sameRequest(pairing.request, request) ||
+            pairing.replacesPrincipalUid !== replacesPrincipalUid
+          )
             throw new PairingError('PAIRING_CONFLICT');
           validApproval(pairing, now, 'active');
+          if (replacesPrincipalUid !== undefined) {
+            if (
+              source === undefined ||
+              source.blockId !== pairing.blockId ||
+              reservedPairingId !== request.pairingId
+            )
+              return replacementConflict();
+          }
           if (pairing.claimed) validGrant((await tx.get(grantRef(pairing))).data(), pairing, now);
           return view(pairing);
+        }
+        if (source !== undefined && reservedPairingId !== undefined) {
+          if (reservedPairingId === request.pairingId) return replacementConflict();
+          if (predecessor === undefined) return replacementConflict();
+          if (predecessorGrantSnapshot?.exists) return replacementConflict();
+          tx.update(pairingRef(predecessor.request.pairingId), { enabled: false });
         }
         const pairing: Pairing = {
           request,
           ownerUid: uid,
           principalUid,
-          blockId,
+          blockId: source?.blockId ?? freshBlockId,
           createdAt: Timestamp.fromMillis(now),
           expiresAt: Timestamp.fromMillis(now + APPROVAL_MS),
           enabled: true,
           claimed: false,
           nextClaimAt: Timestamp.fromMillis(now),
+          ...(replacesPrincipalUid !== undefined ? { replacesPrincipalUid } : {}),
         };
+        if (sourceRef !== undefined)
+          tx.update(sourceRef, { replacedByPairingId: request.pairingId });
         tx.create(pairingRef(request.pairingId), pairing);
         return view(pairing);
       });
@@ -321,7 +360,7 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
       return db.runTransaction(async (tx) => {
         const now = clock();
         if (!isTimestampMillis(now) || !isTimestampMillis(expectedGrantExpiresAt)) unavailable();
-        const pairing = decode((await tx.get(pairingRef(id))).data(), id);
+        const pairing = decodePairing((await tx.get(pairingRef(id))).data(), id);
         validApproval(pairing, now, 'renewal');
         if (!pairing.claimed || !(await ownsWorld(tx, pairing.ownerUid, pairing.request.worldId)))
           unavailable();
@@ -351,7 +390,7 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
         const snapshot = await tx.get(pairingRef(id));
         let pairing: Pairing;
         try {
-          pairing = decode(snapshot.data(), id);
+          pairing = decodePairing(snapshot.data(), id);
         } catch {
           throw new PairingError(
             actor.kind === 'owner' ? 'PERMISSION_DENIED' : 'PAIRING_UNAVAILABLE'

--- a/services/office/functions/test/pairing-contract.test.ts
+++ b/services/office/functions/test/pairing-contract.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   parseApproval,
   parseClaim,
+  parseOwnerApproval,
   parseRenewal,
   parseRevocation,
 } from '../src/pairing-contract.js';
@@ -37,6 +38,25 @@ describe('pairing input contract', () => {
     expect(() =>
       parseRenewal({ version: 1, pairingId: approval.pairingId, grantExpiresAt: 1, extra: true })
     ).toThrow('INVALID_ARGUMENT');
+  });
+  it('keeps the owner replacement selector outside the native request contract', () => {
+    const principal = 'office-agent:00000000-0000-4000-8000-000000000099';
+    expect(parseOwnerApproval({ ...approval, replacesPrincipalUid: principal })).toEqual({
+      request: approval,
+      replacesPrincipalUid: principal,
+    });
+    expect(() => parseApproval({ ...approval, replacesPrincipalUid: principal })).toThrow(
+      'INVALID_ARGUMENT'
+    );
+    for (const replacesPrincipalUid of [
+      '00000000-0000-4000-8000-000000000099',
+      'office-agent:BAD',
+      null,
+      undefined,
+    ])
+      expect(() => parseOwnerApproval({ ...approval, replacesPrincipalUid })).toThrow(
+        'INVALID_ARGUMENT'
+      );
   });
   it.each([
     { ownerUid: 'self-grant' },

--- a/services/office/functions/test/pairing-reassignment.test.ts
+++ b/services/office/functions/test/pairing-reassignment.test.ts
@@ -1,0 +1,222 @@
+import { Timestamp } from 'firebase-admin/firestore';
+import { describe, expect, it } from 'vitest';
+import { APPROVAL_MS, GRANT_MS } from '../src/pairing-contract.js';
+import { createPairingStore } from '../src/pairing-store.js';
+import {
+  BLOCK,
+  IDENTITY,
+  INSTALLATION,
+  NOW,
+  OWNER,
+  PAIRING,
+  PRINCIPAL,
+  WORLD,
+  seed,
+} from './pairing-store-fixture.js';
+
+const replacement = PRINCIPAL;
+const newPairingId = 'b'.repeat(64);
+const newPrincipal = 'office-agent:00000000-0000-4000-8000-000000000099';
+
+function request(pairingId = newPairingId) {
+  return {
+    version: 1 as const,
+    pairingId,
+    worldId: WORLD,
+    installationId: INSTALLATION,
+    identityId: IDENTITY,
+    installationLabel: 'Installation',
+    identityLabel: 'Alice',
+    capabilities: ['layout.read', 'layout.write'] as ['layout.read', 'layout.write'],
+  };
+}
+
+function sourceFixture() {
+  const fixture = seed(NOW - 1);
+  fixture.values.delete(`officePairings/${PAIRING}`);
+  fixture.values.set(`worlds/${WORLD}/agentGrants/${replacement}`, {
+    version: 1,
+    ownerUid: OWNER,
+    installationId: INSTALLATION,
+    identityId: IDENTITY,
+    blockId: BLOCK,
+    capabilities: ['layout.read', 'layout.write'],
+    enabled: false,
+    createdAt: Timestamp.fromMillis(NOW - GRANT_MS),
+    expiresAt: Timestamp.fromMillis(NOW - 1),
+  });
+  return fixture;
+}
+
+function sourceValue(fixture: ReturnType<typeof sourceFixture>): Record<string, unknown> {
+  return fixture.values.get(`worlds/${WORLD}/agentGrants/${replacement}`) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe('retained block reassignment', () => {
+  it('reserves a disabled source and exact retries preserve its principal choice and block', async () => {
+    const fixture = sourceFixture();
+    const store = createPairingStore(fixture.db, () => NOW);
+    const first = await store.approve(OWNER, request(), replacement);
+    const second = await store.approve(OWNER, request(), replacement);
+
+    expect(second).toEqual(first);
+    expect(first.blockId).toBe(BLOCK);
+    expect(first.principalUid).toBeTruthy();
+    expect(first.principalUid).not.toBe(replacement);
+    expect(fixture.values.get(`worlds/${WORLD}/agentGrants/${replacement}`)).toMatchObject({
+      enabled: false,
+      replacedByPairingId: newPairingId,
+    });
+    expect(fixture.values.get(`officePairings/${newPairingId}`)).toMatchObject({
+      blockId: BLOCK,
+      replacesPrincipalUid: replacement,
+    });
+  });
+
+  it('conflicts when a retry changes the retained-source selection', async () => {
+    const fixture = sourceFixture();
+    const store = createPairingStore(fixture.db, () => NOW);
+    await store.approve(OWNER, request(), replacement);
+    await expect(store.approve(OWNER, request(), undefined)).rejects.toMatchObject({
+      code: 'PAIRING_CONFLICT',
+    });
+  });
+
+  it('rejects an exact retry when the retained source block receipt is corrupted', async () => {
+    const fixture = sourceFixture();
+    const store = createPairingStore(fixture.db, () => NOW);
+    await store.approve(OWNER, request(), replacement);
+    fixture.values.set(`worlds/${WORLD}/agentGrants/${replacement}`, {
+      ...sourceValue(fixture),
+      blockId: '00000000-0000-4000-8000-000000000012',
+    });
+    await expect(store.approve(OWNER, request(), replacement)).rejects.toMatchObject({
+      code: 'PAIRING_CONFLICT',
+    });
+  });
+
+  it('allows the new pairing scope to differ from the retained grant scope', async () => {
+    const fixture = sourceFixture();
+    const store = createPairingStore(fixture.db, () => NOW);
+    const approved = await store.approve(
+      OWNER,
+      {
+        ...request(),
+        installationId: '00000000-0000-4000-8000-000000000010',
+        identityId: '00000000-0000-4000-8000-000000000011',
+        capabilities: ['layout.read'],
+      },
+      replacement
+    );
+    expect(approved.blockId).toBe(BLOCK);
+  });
+
+  it.each([
+    [
+      'missing',
+      (fixture: ReturnType<typeof sourceFixture>) =>
+        fixture.values.delete(`worlds/${WORLD}/agentGrants/${replacement}`),
+    ],
+    [
+      'active',
+      (fixture: ReturnType<typeof sourceFixture>) =>
+        fixture.values.set(`worlds/${WORLD}/agentGrants/${replacement}`, {
+          ...sourceValue(fixture),
+          enabled: true,
+        }),
+    ],
+    [
+      'foreign owner',
+      (fixture: ReturnType<typeof sourceFixture>) =>
+        fixture.values.set(`worlds/${WORLD}/agentGrants/${replacement}`, {
+          ...sourceValue(fixture),
+          ownerUid: 'other-owner',
+        }),
+    ],
+    [
+      'malformed',
+      (fixture: ReturnType<typeof sourceFixture>) =>
+        fixture.values.set(`worlds/${WORLD}/agentGrants/${replacement}`, { invalid: true }),
+    ],
+  ])('denies a %s retained source without creating a pairing', async (_name, mutate) => {
+    const fixture = sourceFixture();
+    mutate(fixture);
+    const store = createPairingStore(fixture.db, () => NOW);
+    await expect(store.approve(OWNER, request(), replacement)).rejects.toMatchObject({
+      code: 'PAIRING_CONFLICT',
+    });
+    expect(fixture.values.has(`officePairings/${newPairingId}`)).toBe(false);
+  });
+
+  it.each([
+    ['expired', { enabled: true, expiresAt: Timestamp.fromMillis(NOW) }],
+    ['disabled', { enabled: false, expiresAt: Timestamp.fromMillis(NOW) }],
+  ])(
+    'reclaims an unclaimed %s predecessor and disables it before publishing the replacement',
+    async (_name, state) => {
+      const fixture = sourceFixture();
+      const predecessorId = PAIRING;
+      const predecessorPrincipal = newPrincipal;
+      fixture.values.set(`officePairings/${predecessorId}`, {
+        request: { ...request(predecessorId) },
+        ownerUid: OWNER,
+        principalUid: predecessorPrincipal,
+        blockId: BLOCK,
+        createdAt: Timestamp.fromMillis(NOW - APPROVAL_MS),
+        expiresAt: state.expiresAt,
+        enabled: state.enabled,
+        claimed: false,
+        nextClaimAt: Timestamp.fromMillis(NOW),
+        replacesPrincipalUid: replacement,
+      });
+      fixture.values.set(`worlds/${WORLD}/agentGrants/${replacement}`, {
+        ...sourceValue(fixture),
+        replacedByPairingId: predecessorId,
+      });
+      const approved = await createPairingStore(fixture.db, () => NOW).approve(
+        OWNER,
+        request(),
+        replacement
+      );
+      expect(approved.blockId).toBe(BLOCK);
+      expect(fixture.values.get(`officePairings/${predecessorId}`)).toMatchObject({
+        enabled: false,
+      });
+      expect(fixture.values.get(`worlds/${WORLD}/agentGrants/${replacement}`)).toMatchObject({
+        replacedByPairingId: newPairingId,
+      });
+    }
+  );
+
+  it('rejects a claimed predecessor and never dislodges its reservation', async () => {
+    const fixture = sourceFixture();
+    fixture.values.set(`officePairings/${PAIRING}`, {
+      request: { ...request(PAIRING) },
+      ownerUid: OWNER,
+      principalUid: newPrincipal,
+      blockId: BLOCK,
+      createdAt: Timestamp.fromMillis(NOW - APPROVAL_MS),
+      expiresAt: Timestamp.fromMillis(NOW),
+      enabled: false,
+      claimed: true,
+      nextClaimAt: Timestamp.fromMillis(NOW),
+      replacesPrincipalUid: replacement,
+    });
+    fixture.values.set(`worlds/${WORLD}/agentGrants/${replacement}`, {
+      ...sourceValue(fixture),
+      replacedByPairingId: PAIRING,
+    });
+    await expect(
+      createPairingStore(fixture.db, () => NOW).approve(OWNER, request(), replacement)
+    ).rejects.toMatchObject({
+      code: 'PAIRING_CONFLICT',
+    });
+    expect(fixture.values.has(`officePairings/${newPairingId}`)).toBe(false);
+    expect(fixture.values.get(`worlds/${WORLD}/agentGrants/${replacement}`)).toMatchObject({
+      replacedByPairingId: PAIRING,
+    });
+  });
+});

--- a/services/office/functions/test/pairing-store-fixture.ts
+++ b/services/office/functions/test/pairing-store-fixture.ts
@@ -42,6 +42,10 @@ function fakeFirestore(initial: Record<string, unknown>) {
       operation({
         get: async (ref: Ref) => snapshot(ref),
         getAll: async (...refs: Ref[]) => refs.map((ref) => snapshot(ref)),
+        create: (ref: Ref, value: Record<string, unknown>) => {
+          if (values.has(ref.path)) throw new Error(`already exists: ${ref.path}`);
+          values.set(ref.path, value);
+        },
         update: (ref: Ref, value: Record<string, unknown>) => {
           const current = values.get(ref.path);
           values.set(ref.path, { ...(current as Record<string, unknown>), ...value });


### PR DESCRIPTION
## Scope

Closes #233. Child of #209 in the personal-office M1 project; this does not close the parent.

Owners can approve a new pairing against a revoked grant's retained block instead of allocating a fresh block. New principals never inherit the former identity's credentials, profile or notebook. Default fresh-block approval is unchanged.

## Architecture and primary review

Reviewed commit: `966793c23fa14bae34274c74b3724e9790628c3d`.

- The existing Firestore approval transaction reserves the source grant and records immutable replacement intent. Its transfer receipt serializes competing approvals; no assignment registry or resource copy is introduced.
- Only an unclaimed, expired or disabled predecessor with matching owner/world/source/block can be superseded. Claimed ancestors cannot be reused. Claim and confirmation share the live source-reservation check; signing remains outside transactions.
- `pairing-record` owns persisted decoding, reused by active-grant and retained-source validation. The public native request/claim contract stays unchanged; only authenticated owner approval accepts the source selector.
- The form reuses `SpacePort` and its bounded page lifecycle, freezes selection before the first attempt, and checks returned block/principal integrity. Existing session/admission/route disposal fences late results.
- Existing service scenarios share their original fixture owner with focused reassignment scenarios. Native tests reuse the process/archive/vault owners; no paid agent, production Firebase or host credential is involved.

Primary review covered every changed source, test and document, the existing approval/claim/renew/revoke callers, Rules, browser runtime composition and native claim validation. Findings corrected before acceptance: an initial old/new identity equality requirement; unvalidated predecessor paths; duplicate validation; retry block correlation; ineffective mismatch controls; Date/Timestamp comparisons; incomplete read-only assertions; and missing test-vault cleanup. Desktop and narrow screenshots were personally inspected. No independent third-party review is claimed.

## Verification

- [x] Primary reviewed every changed file and relevant callers/tests.
- [x] Exact local commands/results are recorded below.
- [x] All 17 CI checks passed on the reviewed head, including the four required gates: Code quality, Docker E2E, Native package matrix and Unit tests. [CI run](https://github.com/wkh237/tmux-team/actions/runs/34728104020).

Local evidence:

- `pnpm check:tooling`: passed, including authoritative documentation formatting.
- `pnpm --filter @tmt/office type:check`, Office source lint, and `pnpm office:test`: passed; 153 tests in 18 files.
- `pnpm exec vitest run test/tooling/office-contracts.test.ts`: 25 passed.
- `pnpm --filter @tmt/office-service check`, `test`, `build`: passed; 109 tests in 5 files.
- Docker browser target checks/builds include full Office/service quality, E2E type checking and preview/emulator/unconfigured-cloud builds on pinned Node 22.
- Two complete isolated browser/Auth/Firestore/Functions/native runs: **53 passed each**, no retries or skips. These prove owner consent, pagination, lost-response retry, contention, abandoned reservation recovery, rejected malformed/claimed predecessors, old cached-token denial, new read-only enforcement, exact retained layout, native protected-proof resume and visible browser layout.
- Offline Linux tooling run: **156 passed in 15 files**, including native executable selection. Host tooling initially failed because its fixture executable is Linux ELF; a test-only image supplied Git/Zsh/readelf rather than weakening assertions or overwriting host binaries.
- `git diff --check`: passed. Test containers and task-owned protected entries were cleaned up.

The standard local browser build could not fetch pinned Rust/Temurin registry metadata. The documented local dependency-cache fallback copied current sources/Rules into the verified #229 image and ran the same checks/builds. Native inputs (`rust`, `skills`, Office JSON contracts) are unchanged since `2881bd9832678e27a883d6f3616a3464856f1692`; no stale native implementation was substituted. The normal Dockerfile is unchanged and remains the CI gate.

Evidence: `/private/tmp/tmt-233-browser-{1,2}.log`, `/private/tmp/tmt-233-browser-{1,2}-test-results`, `/private/tmp/tmt-233-browser-cached-build.log`, `/private/tmp/tmt-233-tooling-docker-final.log`, `/private/tmp/tmt-233-service-{check,test,build}.log`.

## Project lifecycle

Architecture, current command guidance, grant/pairing contracts and the development verification map are updated in this PR. #233 is In Progress pending delivery. #209 retains local expired-pending and lost/corrupt-credential recovery; capability-specific notebook/profile/board work remains separately tracked. No production activation, release or public Office distribution is included.

Branch: `feat/233-retained-block-reassignment`; no extra worktree. Safe branch/image cleanup follows successful merge.
