### PR TITLE
docs: consolidate development review and scope guidance

### DIFF
--- a/.agents/skills/tmt-dev/SKILL.md
+++ b/.agents/skills/tmt-dev/SKILL.md
@@ -19,40 +19,26 @@ Read the repository guidance before planning work:
 
 ## Required workflow
 
-1. Start from a tracked issue whose outcome, scope, acceptance criteria,
-   dependencies, and project relationship are clear. Create its dedicated branch
-   before implementation; use an additional worktree only when AGENTS calls for
-   isolation or concurrent work. Follow AGENTS for state and commit attribution.
-2. Before editing, inspect relevant existing patterns locally or delegate a
-   read-only audit when it is worth the coordination and review effort. Keep
-   inspection proportional to the change; record material findings and their
-   disposition. Delegation is not mandatory. Prefer Luna for simple, bounded
-   tasks and large-scale detection or scanning.
-3. The primary reviewer owns the architecture design: define the affected
-   boundary, inputs and outputs, risks, and reuse of existing ports/helpers
-   before implementation.
-4. Implement directly or delegate according to total effort and coupling, not
-   a requirement to assign work. When delegating, set explicit file ownership,
-   constraints, and verification requirements. Do not let concurrent agents
-   edit overlapping files. Keep architectural and integration decisions with
-   the primary agent.
-5. The primary reviewer reviews every changed file and the relevant callers,
-   fixtures, and tests. Passing reports or green CI are evidence, not a
-   substitute for that review. Record findings, dispositions, and the reviewed
-   commit in the PR and GitHub issue.
-6. Run the exact checks required by the changed layer and report their commands
-   and results. Add behavioral tests for changed contracts, including relevant
-   failure, cleanup, or lifecycle cases.
-   During runtime retirement, map assertions rather than file names or counts:
-   returned-error rollback is not crash recovery, and policy tests are not
-   terminal-output tests. Preserve a positive control when a fixture could pass
-   without executing its intended mutation. Review resource destruction order
-   when consolidating cleanup helpers; reuse the existing test-only child owner
-   and stop/reap children before their files are removed.
-7. Before an authorized merge, verify all required CI passed on the current
-   reviewed commit. Review later edits and rerun affected checks. Keep
-   GitHub issue status, branch/PR links, verification evidence, and deferred work
-   current; clean up the worktree only after its state is safely handed off.
+1. Follow AGENTS for issue/branch lifecycle, incidental-edit exceptions, pattern
+   inspection, delegation and context budget. Confirm the bounded outcome and
+   acceptance criteria before implementation.
+2. Define the affected inputs/outputs, state transitions, responsibility owners
+   and risks. Reuse existing ports/helpers; avoid parallel sources of truth.
+3. Implement and apply AGENTS' primary-review gate. For a feature spanning PRs,
+   review the integrated flow across those PRs, not only the latest diff:
+   ownership, transitions, retries, partial failure and cleanup must agree.
+   Consolidate confirmed duplicate responsibility; do not create a generic
+   framework merely to centralize code.
+4. Verify the changed layers using DEVELOPMENT and CONVENTIONS. Record the
+   reviewed revision, findings, dispositions and exact verification evidence.
+   When replacing implementations, map behavioral assertions, not test counts:
+   returned-error rollback is not crash recovery. Preserve resource cleanup
+   ordering through the existing child-process owner.
+5. Close the bounded review when relevant evidence supports the agreed behavior,
+   correctness/security blockers and confirmed duplicate responsibilities in
+   scope are resolved, and deferred risks are explicit. A broad audit is not a
+   demand to find nothing else to improve. Follow AGENTS for authorized merge,
+   tracker updates and safe cleanup.
 
 ## Architecture maintenance
 

--- a/.agents/skills/tmt-e2e/SKILL.md
+++ b/.agents/skills/tmt-e2e/SKILL.md
@@ -21,7 +21,8 @@ Use this skill for the repository's Docker E2E test foundation. Keep E2E tests s
 
 ## Test quality gate
 
-Do not optimize for a passing suite or a larger test count. Every scenario must name the concrete regression risk or invariant it covers, and a reviewer should be able to explain what realistic defect would make it fail.
+Apply [CONVENTIONS' test review rules](../../../CONVENTIONS.md#tests-and-review),
+including concrete defect coverage and meaningful positive/negative controls.
 
 - Cover distinct boundaries and failure modes instead of repeating equivalent happy paths.
 - Exercise the subject under test rather than recreating its logic in the harness. Mock agents are allowed because they are deterministic peers; `tmt` and tmux themselves stay real.
@@ -69,7 +70,10 @@ Keep orchestration in the wrapper and scenario assertions in Vitest. Do not dupl
 
 ## Scope guard
 
-This foundation covers CLI/tmux integration scenarios only. Do not expand it into daemon behavior, persistence, team workflows, aliases, or memory unless a separate, explicit requirement adds those areas.
+This skill covers CLI/tmux integration; Office browser/emulator verification is
+defined in DEVELOPMENT. Test existing persistence and identity contracts where
+the CLI flow requires them. Test work does not authorize new product behavior
+or silently expand the tracked feature's acceptance criteria.
 
 ## Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,21 @@ and issue as well. Use the linked E2E or release skill when applicable. If a
 required reference is missing or contradicts the code, report and resolve that
 discrepancy within scope before relying on it; do not invent a convention.
 
+## Context and evidence budget
+
+- Reuse completely read, unchanged guidance within a task unless a higher-priority
+  instruction requires rereading. Record paths, revision and completed reads at
+  handoff; verify provenance and changes before reuse. Reread when uncertain.
+- Locate relevant source and reference sections first. Read required instructions
+  completely, using bounded chunks to avoid truncation and repeated loading.
+- Keep bulk inventories and logs in artifacts. Request concise findings with
+  actionable risks and evidence locations; inspect original excerpts as needed.
+  Verify published text with equality or a focused diff against its source.
+- Keep handoffs to decisions, unresolved risks and evidence. While awaiting a
+  gate, research only the next dependencies and decisions, not a full new feature.
+
+These limits reduce repeated input, not required primary review or verification.
+
 ## Architecture ownership and primary review
 
 The primary agent owns the architectural model, design tradeoffs, decomposition,
@@ -34,13 +49,15 @@ follow-up is not permission to ship inaccurate descriptions of current behavior.
 
 ## Pattern audit before changes
 
-Before editing code, tests, documentation, configuration, or repository skills, inspect the relevant existing patterns. The primary agent decides whether to inspect locally or delegate, based on the total implementation, coordination, and review effort. Delegation is optional, not a prerequisite for making changes.
+Before editing code or guidance, inspect relevant architecture, helpers, fixtures
+and conventions for reusable patterns, duplicate responsibility and conflicts.
+Keep inspection proportional; record material findings and resolve them within scope.
 
-Keep the inspection proportional to the change. Inspect relevant architecture, helpers, fixtures, scripts, naming conventions, tests, documentation, and skills to identify reusable patterns, duplicated behavior, and conflicts. Prefer `gpt-5.6-luna` for simple, bounded tasks and large-scale detection or scanning. A delegated read-only audit must not edit files, mutate external systems, or broaden the requested scope.
-
-The primary agent reviews findings before editing, records material findings and their disposition, and reuses or extends established abstractions where practical. Correct unnecessary duplication or inconsistent implementation within scope before continuing.
-
-Do not split tightly coupled architecture or integration work merely to use another agent. Direct implementation requires no delegation exception. Delegation never expands the user's authorization.
+Delegate only when the saved work or independent coverage exceeds coordination
+and review cost. Prefer `gpt-5.6-luna` for bounded scans and simple, verifiable work;
+keep tightly coupled design and integration with the primary. Assign explicit
+ownership and verification, prevent overlapping edits, and keep read-only audits
+free of mutations. Delegation never expands authorization.
 
 ## Repository content language
 
@@ -61,6 +78,10 @@ fixture provenance. Each definition has one document owner; other guides link
 to it rather than copying it. Removing narrative must not remove a safety gate
 or present planned behavior as shipped.
 
+When revising guidance, replace or consolidate overlapping rules before adding
+new ones. Resolve contradictions against the owning contract and verified behavior;
+ask when resolution would require an undecided product or authorization choice.
+
 ## Delivery lifecycle
 
 - GitHub Issues is the active tracker for TMT. Historical Linear links are
@@ -69,11 +90,6 @@ or present planned behavior as shipped.
   dedicated branch/worktree, and one reviewable PR. Confirm outcome, scope,
   acceptance criteria, dependencies and project relationship before editing;
   mark the issue started when implementation begins. Split oversized work first.
-- Delegate only when it reduces total effort or provides useful independent coverage.
-  Prefer `gpt-5.6-luna` for simple, bounded work and large-scale detection or scanning.
-  When delegating, give explicit file ownership, constraints and verification
-  requirements; prevent overlapping edits. The primary retains design,
-  integration, and acceptance authority.
 - Keep decisions, progress, blockers, deferred work, branch/PR links and evidence
   synchronized in GitHub. Do not mark work done before its delivery state supports it.
 - Every Codex-created commit includes `Co-authored-by: Codex <codex@openai.com>`.
@@ -94,7 +110,10 @@ or present planned behavior as shipped.
 - Prefer small, purpose-specific interfaces and existing dependency-injection boundaries over new global state or parallel abstractions.
 - Put shared behavior in one named helper only after more than one caller needs it; keep scenario-specific behavior close to the scenario.
 - Use names that describe observable behavior and stable domain concepts rather than implementation accidents.
-- Keep changes bounded to the tracked issue. Record adjacent improvements as follow-up work instead of silently expanding scope.
+- Keep completion criteria bounded to the agreed outcome. Classify adjacent findings
+  as blocking correctness/security defects or deferred improvements; explain the
+  dependency before expanding scope. Do not silently turn optional hardening into
+  a milestone gate or declare unresolved blockers complete.
 
 ## Verification quality
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -112,6 +112,10 @@ observable failure/cleanup postconditions. Verify causal agent output rather
 than terminal echo. Cover compatibility, negative paths and partial failure,
 not only the new happy path. Demonstrate regression tests fail against the
 original defect when practical; explain when that evidence cannot be obtained.
+For high-risk guards, use a valid positive control and change the relevant
+condition in isolation: an unrelated failure must not satisfy the negative
+assertion. Where practical, disable or perturb the intended guard to confirm
+the test detects its absence; report unverified sensitivity honestly.
 
 Primary review examines test setup and assertions as code. Do not weaken an
 assertion, bypass a gate or count more tests as proof of correctness. Use fixture


### PR DESCRIPTION
## Summary

- Consolidate repository guidance instead of repeating delegation and review policy across skills.
- Require bounded cross-PR lifecycle review, explicit blockers versus deferred improvements, and meaningful test controls.
- Correct the development skill's incidental-edit exception and the E2E skill's outdated persistence scope wording.

Related to #198. This incidental guidance change does not close the architecture audit or certify Office M1 complete.

## Review and verification

Primary reviewed the four changed files and their owning guidance. Existing primary review, authorization, cleanup and CI gates remain intact. No runtime, module, persistence or trust boundary changes; ARCHITECTURE.md therefore needs no update.

- `pnpm exec prettier --check AGENTS.md CONVENTIONS.md .agents/skills/tmt-dev/SKILL.md .agents/skills/tmt-e2e/SKILL.md` passed.
- `git diff --check` passed.
- Skill validation passed for both repository skills.
- Runtime tests are not claimed for documentation-only edits; required CI must pass on the reviewed head before merge.

The personal `tmt-ticket-update` skill was updated separately outside this repository and is not included in this PR.
