### PR TITLE
feat(office): cancel and restart scoped pairings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -120,6 +120,13 @@ reference, never a duplicate credential or grant. OS random
 bytes create proofs; explicit Keychain/Secret Service backends fail closed.
 Background connection and resource editing remain unimplemented.
 
+Explicit `office unpair` reuses the record's reduction-only revocation path and
+scope lock. Only a confirmed revoked receipt can be replaced by a new explicit
+pair request. Owner cancellation of an unknown public request uses the existing
+issuer transaction to write a disabled pairing, never a second cancellation store.
+Browser request snapshots share the existing contract decoder across state and
+transport; uncertain cancellation prevents switching back to approval.
+
 Identity retirement remains the existing binding transaction's responsibility.
 `tmt-core::identity_hooks` owns typed subscriptions and delivery state;
 `storage::identity_hooks` registers subscriptions and atomically queues retirement

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -210,6 +210,12 @@ the disposable store. No host Keychain, credentials or installed CLI is used.
 This is Linux credential-store evidence, not macOS runtime or real release-archive
 acceptance. Reuse the separate native artifact verifier for published artifacts.
 
+`native-cancellation.spec.ts` verifies expired protected state, unknown-request
+preservation, browser cancellation, secret-free receipts and same-identity fresh
+pairing using the real CLI and isolated vault. `pairing-cancellation.spec.ts`
+checks cancellation/approval races and denied unknown-request writes through the
+real issuer. Neither replaces cached-token denial or retirement coverage.
+
 `native-hooks.spec.ts` adds the causal retirement path using a private real tmux
 server and the container's `sqlite3` tool as an independent state observer.
 Verify local retirement plus pending notification before any remote cleanup,

--- a/apps/office/e2e/native-cancellation.spec.ts
+++ b/apps/office/e2e/native-cancellation.spec.ts
@@ -1,0 +1,186 @@
+import { expect } from '@playwright/test';
+import { test, signIn } from './browser-session.js';
+import { setTester } from './firestore-fixture.js';
+import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
+import { runCli, withSandbox } from '../../../test/support/cli-process.js';
+import {
+  installNativeOffice,
+  protectedOfficeRecord,
+  officeScopeKeys,
+  clearOfficeScopes,
+} from './native-office-fixture.js';
+import { post } from './pairing-service-fixture.js';
+
+test('expired native request cancels without approval and re-pairs under the same identity', async ({
+  openSession,
+}) => {
+  test.setTimeout(120_000);
+  const admin = createPairingEmulatorFixture();
+  try {
+    await withSandbox(async (sandbox) => {
+      try {
+        const prefix = await installNativeOffice(sandbox);
+        expect(
+          (await runCli(sandbox, ['identity', 'create', 'CancelNative', '--json'])).status
+        ).toBe(0);
+        const worldId = admin.db.collection('worlds').doc().id;
+        const world = `http://127.0.0.1:4173/worlds/${worldId}`;
+        const office = (operation: string, extra: string[] = []) =>
+          runCli(
+            sandbox,
+            [
+              'office',
+              operation,
+              '--prefix',
+              prefix,
+              '--world',
+              world,
+              '--identity',
+              'CancelNative',
+              '--emulator',
+              '--json',
+              ...extra,
+            ],
+            { deadlineMs: 35_000 }
+          );
+        const pending = await office('pair', ['--timeout', '5']);
+        expect(JSON.parse(pending.stdout).error.code).toBe('OFFICE_PAIRING_PENDING');
+        const link = pending.stderr.trim();
+        const keys = officeScopeKeys(sandbox);
+        expect(keys).toHaveLength(1);
+        const key = keys[0]!;
+        const stored = await protectedOfficeRecord(sandbox, key, 'lookup');
+        expect(stored.status).toBe(0);
+        const record = JSON.parse(stored.stdout);
+        const request = record.approval;
+        // Move only the bounded local approval clock; no five-minute sleep or
+        // fake remote success. The actual CLI must observe expiration.
+        record.createdAt = Date.now() - 301_000;
+        record.expiresAt = record.createdAt + 300_000;
+        record.phase.nextClaimAt = record.createdAt;
+        expect(
+          (await protectedOfficeRecord(sandbox, key, 'store', JSON.stringify(record))).status
+        ).toBe(0);
+        expect(JSON.parse((await office('status')).stdout).state).toBe('expired');
+        const before = (await protectedOfficeRecord(sandbox, key, 'lookup')).stdout;
+        const unknown = await office('unpair');
+        expect(unknown.status).toBe(1);
+        expect(JSON.parse(unknown.stdout).error.code).toBe('OFFICE_OWNER_CANCELLATION_REQUIRED');
+        expect(unknown.stderr.trim()).toBe(link);
+        expect((await protectedOfficeRecord(sandbox, key, 'lookup')).stdout).toBe(before);
+        expect(
+          (await admin.db.collection('officePairings').doc(request.pairingId).get()).exists
+        ).toBe(false);
+
+        const { page } = await openSession(link);
+        await signIn(page, 'Cancellation owner');
+        const ownerUid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+        await admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .set({ version: 1, name: 'Cancellation office', ownerUid, createdAt: new Date() });
+        await setTester(ownerUid, true);
+        await page.getByRole('button', { name: 'Cancel request', exact: true }).click();
+        await expect(
+          page.getByRole('status').filter({ hasText: 'Request cancelled.' })
+        ).toBeVisible();
+        const tombstone = (
+          await admin.db.collection('officePairings').doc(request.pairingId).get()
+        ).data()!;
+        expect(tombstone).toMatchObject({ enabled: false, claimed: false, request });
+        expect(
+          (await admin.db.collection('worlds').doc(worldId).collection('agentGrants').get()).empty
+        ).toBe(true);
+        expect((await post('claim', { version: 1, secret: record.phase.secret })).status).toBe(404);
+        const cancelled = await office('unpair');
+        expect(cancelled.status, cancelled.stdout).toBe(0);
+        expect(JSON.parse(cancelled.stdout).state).toBe('revoked');
+        const receipt = JSON.parse((await protectedOfficeRecord(sandbox, key, 'lookup')).stdout);
+        expect(receipt.phase).toEqual({ state: 'revoked' });
+        expect((await office('unpair')).status).toBe(0);
+
+        const fresh = await office('pair', ['--read-only', '--timeout', '5']);
+        expect(JSON.parse(fresh.stdout).error.code).toBe('OFFICE_PAIRING_PENDING');
+        const next = JSON.parse((await protectedOfficeRecord(sandbox, key, 'lookup')).stdout);
+        expect(next.approval.identityId).toBe(request.identityId);
+        expect(next.approval.pairingId).not.toBe(request.pairingId);
+        expect(next.phase.secret).not.toBe(record.phase.secret);
+        expect(next.approval.capabilities).toEqual(['layout.read']);
+        await page.goto(fresh.stderr.trim());
+        await page
+          .getByRole('checkbox', { name: 'I recognize this agent and installation.' })
+          .check();
+        await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+        await expect(
+          page.getByRole('status').filter({ hasText: 'Approved. Return' })
+        ).toBeVisible();
+        const paired = await office('pair', ['--read-only', '--timeout', '20']);
+        expect(paired.status, paired.stdout).toBe(0);
+        expect(JSON.parse(paired.stdout).identityId).toBe(request.identityId);
+        expect((await office('inspect')).status).toBe(0);
+        const newRemote = (
+          await admin.db.collection('officePairings').doc(next.approval.pairingId).get()
+        ).data()!;
+        expect(newRemote.enabled).toBe(true);
+        const retainedBlock = admin.db
+          .collection('worlds')
+          .doc(worldId)
+          .collection('blocks')
+          .doc(newRemote.blockId);
+        await retainedBlock.set({
+          version: 1,
+          revision: 1,
+          objects: ['d000'],
+          updatedAt: new Date(),
+        });
+        const retainedBefore = (await retainedBlock.get()).data();
+        expect((await office('unpair')).status).toBe(0);
+        expect(
+          (await admin.db.collection('officePairings').doc(next.approval.pairingId).get()).data()
+            ?.enabled
+        ).toBe(false);
+        expect((await retainedBlock.get()).data()).toEqual(retainedBefore);
+        expect(
+          (
+            await admin.db
+              .collection('worlds')
+              .doc(worldId)
+              .collection('agentGrants')
+              .doc(newRemote.principalUid)
+              .get()
+          ).data()?.enabled
+        ).toBe(false);
+        const replacement = await office('pair', ['--timeout', '5']);
+        expect(JSON.parse(replacement.stdout).error.code).toBe('OFFICE_PAIRING_PENDING');
+        const replacementRecord = JSON.parse(
+          (await protectedOfficeRecord(sandbox, key, 'lookup')).stdout
+        );
+        expect(replacementRecord.approval.identityId).toBe(request.identityId);
+        expect(replacementRecord.approval.capabilities).toEqual(['layout.read', 'layout.write']);
+        expect(replacementRecord.approval.pairingId).not.toBe(next.approval.pairingId);
+        await page.goto(replacement.stderr.trim());
+        await page
+          .getByRole('checkbox', { name: 'I recognize this agent and installation.' })
+          .check();
+        await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+        await expect(
+          page.getByRole('status').filter({ hasText: 'Approved. Return' })
+        ).toBeVisible();
+        expect((await office('pair', ['--timeout', '20'])).status).toBe(0);
+        const replacementRemote = (
+          await admin.db
+            .collection('officePairings')
+            .doc(replacementRecord.approval.pairingId)
+            .get()
+        ).data()!;
+        expect(replacementRemote.blockId).not.toBe(newRemote.blockId);
+        expect((await retainedBlock.get()).data()).toEqual(retainedBefore);
+        expect((await office('unpair')).status).toBe(0);
+      } finally {
+        await clearOfficeScopes(sandbox);
+      }
+    });
+  } finally {
+    await admin.dispose();
+  }
+});

--- a/apps/office/e2e/native-office-fixture.ts
+++ b/apps/office/e2e/native-office-fixture.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { readdirSync } from 'node:fs';
 import { expect } from '@playwright/test';
 import { createArtifact } from '../../../test/support/native-artifact.js';
 import { runCli, type Sandbox } from '../../../test/support/cli-process.js';
@@ -51,4 +52,22 @@ export function protectedOfficeRecord(
     ],
     input === undefined ? {} : { stdin: input }
   );
+}
+
+export function officeScopeKeys(sandbox: Sandbox): string[] {
+  try {
+    return readdirSync(path.join(sandbox.globalDir, 'office'))
+      .filter((name) => /^[0-9a-f]{64}\.lock$/.test(name))
+      .map((name) => name.slice(0, -'.lock'.length));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+export async function clearOfficeScopes(sandbox: Sandbox): Promise<void> {
+  for (const key of officeScopeKeys(sandbox)) {
+    expect((await protectedOfficeRecord(sandbox, key, 'clear')).status).toBe(0);
+    expect((await protectedOfficeRecord(sandbox, key, 'lookup')).status).toBe(1);
+  }
 }

--- a/apps/office/e2e/native-pairing.spec.ts
+++ b/apps/office/e2e/native-pairing.spec.ts
@@ -6,7 +6,11 @@ import { test, signIn } from './browser-session.js';
 import { setTester, writeAgentGrantFields, writeBlockFields } from './firestore-fixture.js';
 import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
 import { runCli, withSandbox } from '../../../test/support/cli-process.js';
-import { installNativeOffice, protectedOfficeRecord } from './native-office-fixture.js';
+import {
+  installNativeOffice,
+  protectedOfficeRecord,
+  clearOfficeScopes,
+} from './native-office-fixture.js';
 
 test('native pairing selects a retained block, resumes it, and exposes the same layout in Office', async ({
   openSession,
@@ -15,21 +19,6 @@ test('native pairing selects a retained block, resumes it, and exposes the same 
   const admin = createPairingEmulatorFixture();
   try {
     await withSandbox(async (sandbox) => {
-      const clearProtectedScopes = async () => {
-        let names: string[];
-        try {
-          names = readdirSync(path.join(sandbox.globalDir, 'office'));
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
-          throw error;
-        }
-        for (const name of names) {
-          if (!/^[0-9a-f]{64}\.lock$/.test(name)) continue;
-          const key = name.slice(0, -'.lock'.length);
-          expect((await protectedOfficeRecord(sandbox, key, 'clear')).status).toBe(0);
-          expect((await protectedOfficeRecord(sandbox, key, 'lookup')).status).toBe(1);
-        }
-      };
       try {
         const prefix = await installNativeOffice(sandbox);
         expect(
@@ -189,7 +178,7 @@ test('native pairing selects a retained block, resumes it, and exposes the same 
           .click();
         await expect(page.getByRole('button', { name: 'Desk 1', exact: true })).toBeVisible();
       } finally {
-        await clearProtectedScopes();
+        await clearOfficeScopes(sandbox);
       }
     });
   } finally {

--- a/apps/office/e2e/pairing-cancellation.spec.ts
+++ b/apps/office/e2e/pairing-cancellation.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+import { post, withPairing } from './pairing-service-fixture.js';
+
+test('owner cancellation serializes with approval and never resurrects an unknown request', async () => {
+  await withPairing(async ({ db, request, token, secret }) => {
+    const results = await Promise.all([
+      post('approve', request, token),
+      post('revoke', { version: 1, publicApproval: request }, token),
+    ]);
+    expect([200, 404]).toContain(results[0]!.status);
+    expect(results[1]!.status).toBe(200);
+    const pairing = db.collection('officePairings').doc(request.pairingId);
+    expect((await pairing.get()).data()).toMatchObject({ request, enabled: false, claimed: false });
+    expect((await post('approve', request, token)).status).toBe(404);
+    expect((await post('claim', { version: 1, secret })).status).toBe(404);
+    expect(
+      (await db.collection('worlds').doc(request.worldId).collection('agentGrants').get()).empty
+    ).toBe(true);
+    expect(
+      (await db.collection('worlds').doc(request.worldId).collection('blocks').get()).empty
+    ).toBe(true);
+  });
+});
+
+test('unknown-request cancellation requires live human ownership and preserves denied state', async () => {
+  await withPairing(async ({ fixture, db, request, token, owner }) => {
+    const stranger = await fixture.client(true);
+    const otherToken = await stranger.auth.currentUser!.getIdToken();
+    const body = { version: 1, publicApproval: request };
+    const pairing = db.collection('officePairings').doc(request.pairingId);
+    expect((await post('revoke', body, otherToken)).status).toBe(403);
+    expect((await pairing.get()).exists).toBe(false);
+    await db.collection('testers').doc(owner.uid).delete();
+    expect((await post('revoke', body, token)).status).toBe(403);
+    expect((await pairing.get()).exists).toBe(false);
+    await db.collection('testers').doc(owner.uid).set({ enabled: true });
+    expect((await post('revoke', body, token)).status).toBe(200);
+    const before = (await pairing.get()).data();
+    expect(
+      (
+        await post(
+          'revoke',
+          { version: 1, publicApproval: { ...request, identityLabel: 'Changed' } },
+          token
+        )
+      ).status
+    ).toBe(409);
+    expect((await pairing.get()).data()).toEqual(before);
+    expect((await post('revoke', body, token)).status).toBe(200);
+    expect((await pairing.get()).data()).toEqual(before);
+  });
+});

--- a/apps/office/src/pairing/pairing-contract.ts
+++ b/apps/office/src/pairing/pairing-contract.ts
@@ -25,7 +25,7 @@ export interface PairingPort {
     ownerUid: string,
     replacement?: PairingReplacement
   ): Promise<ApprovedPairing>;
-  revoke(pairingId: string, ownerUid: string): Promise<void>;
+  revoke(request: PairingRequest, ownerUid: string): Promise<void>;
 }
 
 /** Owner-selected intent, never part of the native request fragment. */
@@ -137,6 +137,15 @@ function parseRequest(value: unknown, worldId: string): PairingRequest {
     identityLabel: input.identityLabel,
     capabilities: parsedCapabilities,
   };
+}
+
+/** Canonical immutable request snapshot for one mounted action or transport call. */
+export function snapshotPairingRequest(request: PairingRequest): PairingRequest {
+  const parsed = parseRequest(request, request.worldId);
+  return Object.freeze({
+    ...parsed,
+    capabilities: Object.freeze([...parsed.capabilities]),
+  }) as PairingRequest;
 }
 
 function requestFields(value: Record<string, unknown>): Record<string, unknown> {

--- a/apps/office/src/pairing/pairing-space-choice.tsx
+++ b/apps/office/src/pairing/pairing-space-choice.tsx
@@ -28,13 +28,17 @@ export function PairingSpaceChoice({
 }
 
 function SpaceChoice({ state, spaces }: { state: PairingState; spaces: SpaceState }) {
-  const { attempted, replacement } = useSyncExternalStore(state.subscribe, state.getSnapshot);
+  const { attempted, revocationAttempted, replacement } = useSyncExternalStore(
+    state.subscribe,
+    state.getSnapshot
+  );
+  const locked = attempted || revocationAttempted;
   const { entries, busy, next, error, ready } = useSyncExternalStore(
     spaces.subscribe,
     spaces.getSnapshot
   );
   return (
-    <fieldset className="pairing-space-choice" disabled={attempted}>
+    <fieldset className="pairing-space-choice" disabled={locked}>
       <legend>Assigned block</legend>
       <p>
         Choose a fresh block or a revoked agent's retained layout. Profiles and notebooks are not
@@ -55,7 +59,7 @@ function SpaceChoice({ state, spaces }: { state: PairingState; spaces: SpaceStat
           <code>{replacement.principalUid}</code>
         </p>
       )}
-      {attempted ? (
+      {locked ? (
         <p>The choice is fixed for this request. Retry keeps the same assignment.</p>
       ) : (
         <>

--- a/apps/office/src/pairing/pairing-state.test.ts
+++ b/apps/office/src/pairing/pairing-state.test.ts
@@ -78,10 +78,46 @@ it('failed revocation preserves confirmed approval; explicit retry revokes once 
   await state.revoke();
   expect(state.getSnapshot()).toMatchObject({ approved: binding, revoked: false });
   await state.revoke();
-  expect(port.revoke).toHaveBeenLastCalledWith(request.pairingId, 'owner');
+  expect(port.revoke).toHaveBeenLastCalledWith(request, 'owner');
   expect(state.getSnapshot()).toMatchObject({ approved: null, revoked: true, error: null });
   await state.approve();
   expect(port.approve).toHaveBeenCalledOnce();
+  state.dispose();
+});
+
+it('cancels before approval and retries the same immutable request after uncertainty', async () => {
+  const { port, state } = fixture();
+  vi.mocked(port.revoke).mockRejectedValueOnce(new PairingActionError('uncertain'));
+  await state.revoke();
+  expect(state.getSnapshot()).toMatchObject({
+    approved: null,
+    revoked: false,
+    revocationAttempted: true,
+  });
+  state.selectReplacement({ principalUid: binding.principalUid, blockId: binding.blockId });
+  expect(state.getSnapshot().replacement).toBeNull();
+  await state.approve();
+  expect(port.approve).not.toHaveBeenCalled();
+  await state.revoke();
+  expect(port.revoke).toHaveBeenNthCalledWith(1, request, 'owner');
+  expect(port.revoke).toHaveBeenNthCalledWith(2, request, 'owner');
+  expect(state.getSnapshot()).toMatchObject({ revoked: true, error: null });
+  state.dispose();
+});
+
+it('freezes the original request for approval and revocation retries', async () => {
+  const { port, state } = fixture();
+  await state.approve();
+  await state.revoke();
+  const approvalRequest = vi.mocked(port.approve).mock.calls[0][0];
+  const revokeRequest = vi.mocked(port.revoke).mock.calls[0][0];
+  expect(approvalRequest).toBe(revokeRequest);
+  expect(() => {
+    approvalRequest.identityLabel = 'changed';
+  }).toThrow();
+  expect(() => {
+    (approvalRequest.capabilities as unknown as string[])[0] = 'layout.write';
+  }).toThrow();
   state.dispose();
 });
 
@@ -105,4 +141,26 @@ it('disposal clears private results, suppresses late completion and prevents sub
   expect(changed).toHaveBeenCalledOnce();
   expect(state.getSnapshot()).toMatchObject({ approved: null, attempted: false, busy: false });
   expect(port.approve).toHaveBeenCalledOnce();
+});
+
+it('disposal fences a pending cancellation and prevents a later retry', async () => {
+  let resolve: () => void = () => {};
+  const { port, state } = fixture();
+  vi.mocked(port.revoke).mockImplementationOnce(
+    () =>
+      new Promise((done) => {
+        resolve = done;
+      })
+  );
+  const changed = vi.fn();
+  state.subscribe(changed);
+  const pending = state.revoke();
+  expect(changed).toHaveBeenCalledOnce();
+  state.dispose();
+  resolve();
+  await pending;
+  await state.revoke();
+  expect(changed).toHaveBeenCalledOnce();
+  expect(port.revoke).toHaveBeenCalledOnce();
+  expect(state.getSnapshot()).toMatchObject({ revoked: false, revocationAttempted: false });
 });

--- a/apps/office/src/pairing/pairing-state.ts
+++ b/apps/office/src/pairing/pairing-state.ts
@@ -1,4 +1,4 @@
-import { PairingActionError } from './pairing-contract.js';
+import { PairingActionError, snapshotPairingRequest } from './pairing-contract.js';
 import type {
   ApprovedPairing,
   PairingRequest,
@@ -9,6 +9,7 @@ import type {
 interface PairingSnapshot {
   busy: boolean;
   attempted: boolean;
+  revocationAttempted: boolean;
   approved: ApprovedPairing | null;
   revoked: boolean;
   error: string | null;
@@ -17,9 +18,11 @@ interface PairingSnapshot {
 
 /** One mounted request owns actions; disposal fences results, not remote writes. */
 export function createPairingState(port: PairingPort, request: PairingRequest, ownerUid: string) {
+  const originalRequest = snapshotPairingRequest(request);
   let snapshot: PairingSnapshot = {
     busy: false,
     attempted: false,
+    revocationAttempted: false,
     approved: null,
     revoked: false,
     error: null,
@@ -32,9 +35,19 @@ export function createPairingState(port: PairingPort, request: PairingRequest, o
     snapshot = { ...snapshot, ...change };
     for (const listener of listeners) listener();
   }
-  async function act(action: () => Promise<Partial<PairingSnapshot>>) {
-    if (disposed || snapshot.busy || snapshot.revoked) return;
-    publish({ busy: true, attempted: true, error: null });
+  async function act(action: () => Promise<Partial<PairingSnapshot>>, kind: 'approve' | 'revoke') {
+    if (
+      disposed ||
+      snapshot.busy ||
+      snapshot.revoked ||
+      (kind === 'approve' && snapshot.revocationAttempted)
+    )
+      return;
+    publish({
+      busy: true,
+      error: null,
+      ...(kind === 'approve' ? { attempted: true } : { revocationAttempted: true }),
+    });
     try {
       publish(await action());
     } catch (error) {
@@ -58,26 +71,30 @@ export function createPairingState(port: PairingPort, request: PairingRequest, o
       };
     },
     selectReplacement(replacement: PairingReplacement | null) {
-      if (disposed || snapshot.attempted) return;
+      if (disposed || snapshot.attempted || snapshot.revocationAttempted) return;
       publish({ replacement: replacement ? { ...replacement } : null });
     },
     approve: () =>
-      act(async () => ({
-        approved: snapshot.replacement
-          ? await port.approve(request, ownerUid, snapshot.replacement)
-          : await port.approve(request, ownerUid),
-      })),
+      act(
+        async () => ({
+          approved: snapshot.replacement
+            ? await port.approve(originalRequest, ownerUid, snapshot.replacement)
+            : await port.approve(originalRequest, ownerUid),
+        }),
+        'approve'
+      ),
     revoke: () =>
       act(async () => {
-        await port.revoke(request.pairingId, ownerUid);
+        await port.revoke(originalRequest, ownerUid);
         return { approved: null, revoked: true };
-      }),
+      }, 'revoke'),
     dispose() {
       disposed = true;
       listeners.clear();
       snapshot = {
         busy: false,
         attempted: false,
+        revocationAttempted: false,
         approved: null,
         revoked: false,
         error: null,

--- a/apps/office/src/pairing/pairing-transport.test.ts
+++ b/apps/office/src/pairing/pairing-transport.test.ts
@@ -5,6 +5,16 @@ import type { PairingRequest } from './pairing-contract.js';
 
 const pairingId = 'a'.repeat(64);
 const endpoint = 'https://pair.example/officePairing';
+const revokeRequest: PairingRequest = {
+  version: 1,
+  pairingId,
+  worldId: 'a'.repeat(20),
+  installationId: '00000000-0000-4000-8000-000000000001',
+  identityId: '00000000-0000-4000-8000-000000000002',
+  installationLabel: 'Device',
+  identityLabel: 'Alice',
+  capabilities: ['layout.read'],
+};
 const response = () =>
   new Response(JSON.stringify({ version: 1, pairingId, revoked: true }), {
     headers: { 'content-type': 'application/json' },
@@ -78,7 +88,7 @@ it('only explicit deployment settings select an endpoint, never request or previ
 it('uses the selected owner token only in a no-redirect/no-cookie bounded POST header', async () => {
   const send = vi.fn<typeof fetch>().mockResolvedValue(response());
   const auth = { currentUser: { uid: 'owner', getIdToken: async () => 'private-token' } };
-  await createPairingPort(auth, endpoint, send).revoke(pairingId, 'owner');
+  await createPairingPort(auth, endpoint, send).revoke(revokeRequest, 'owner');
   expect(send).toHaveBeenCalledOnce();
   const [url, options] = send.mock.calls[0];
   expect(url).toBe(`${endpoint}/revoke`);
@@ -89,7 +99,10 @@ it('uses the selected owner token only in a no-redirect/no-cookie bounded POST h
     cache: 'no-store',
     headers: { authorization: 'Bearer private-token' },
   });
-  expect(options?.body).toBe(JSON.stringify({ version: 1, pairingId }));
+  expect(JSON.parse(options?.body as string)).toEqual({
+    version: 1,
+    publicApproval: revokeRequest,
+  });
   expect(options?.signal).toBeInstanceOf(AbortSignal);
 });
 
@@ -106,12 +119,12 @@ it('session change during token acquisition cannot send an approval as the previ
   };
   const send = vi.fn<typeof fetch>();
   const port = createPairingPort(auth, endpoint, send);
-  const pending = port.revoke(pairingId, 'owner');
+  const pending = port.revoke(revokeRequest, 'owner');
   auth.currentUser = null;
   resolve('private-token');
   await expect(pending).rejects.toMatchObject({ kind: 'denied' });
   expect(send).not.toHaveBeenCalled();
-  await expect(port.revoke(pairingId, 'other')).rejects.toMatchObject({ kind: 'denied' });
+  await expect(port.revoke(revokeRequest, 'other')).rejects.toMatchObject({ kind: 'denied' });
 });
 
 it('oversize or invalid successful responses remain uncertain and error bodies are never displayed', async () => {
@@ -122,14 +135,14 @@ it('oversize or invalid successful responses remain uncertain and error bodies a
     new Response('private server path', { status: 503 }),
   ]) {
     const port = createPairingPort(auth, endpoint, vi.fn<typeof fetch>().mockResolvedValue(reply));
-    await expect(port.revoke(pairingId, 'owner')).rejects.toMatchObject({ kind: 'uncertain' });
+    await expect(port.revoke(revokeRequest, 'owner')).rejects.toMatchObject({ kind: 'uncertain' });
   }
   const denied = createPairingPort(
     auth,
     endpoint,
     vi.fn<typeof fetch>().mockResolvedValue(new Response('private server path', { status: 403 }))
   );
-  await expect(denied.revoke(pairingId, 'owner')).rejects.toMatchObject({ kind: 'denied' });
+  await expect(denied.revoke(revokeRequest, 'owner')).rejects.toMatchObject({ kind: 'denied' });
 });
 
 it.each([
@@ -146,6 +159,6 @@ it.each([
       endpoint,
       vi.fn<typeof fetch>().mockResolvedValue(new Response('sensitive server details', { status }))
     );
-    await expect(port.revoke(pairingId, 'owner')).rejects.toMatchObject({ kind });
+    await expect(port.revoke(revokeRequest, 'owner')).rejects.toMatchObject({ kind });
   }
 );

--- a/apps/office/src/pairing/pairing-transport.ts
+++ b/apps/office/src/pairing/pairing-transport.ts
@@ -2,6 +2,7 @@ import {
   parseApprovedPairing,
   parseRevokedPairing,
   PairingActionError,
+  snapshotPairingRequest,
   validatePairingReplacement,
 } from './pairing-contract.js';
 import type { PairingPort } from './pairing-contract.js';
@@ -76,11 +77,15 @@ export function createPairingPort(
   }
   return {
     async approve(request, ownerUid, replacement) {
+      const originalRequest = snapshotPairingRequest(request);
       if (replacement) validatePairingReplacement(replacement);
       const input = replacement
-        ? { ...request, replacesPrincipalUid: replacement.principalUid }
-        : request;
-      const approved = parseApprovedPairing(await post('approve', input, ownerUid), request);
+        ? { ...originalRequest, replacesPrincipalUid: replacement.principalUid }
+        : originalRequest;
+      const approved = parseApprovedPairing(
+        await post('approve', input, ownerUid),
+        originalRequest
+      );
       if (
         replacement &&
         (approved.blockId !== replacement.blockId ||
@@ -89,8 +94,12 @@ export function createPairingPort(
         throw new PairingActionError('uncertain');
       return approved;
     },
-    async revoke(pairingId, ownerUid) {
-      parseRevokedPairing(await post('revoke', { version: 1, pairingId }, ownerUid), pairingId);
+    async revoke(request, ownerUid) {
+      const originalRequest = snapshotPairingRequest(request);
+      parseRevokedPairing(
+        await post('revoke', { version: 1, publicApproval: originalRequest }, ownerUid),
+        originalRequest.pairingId
+      );
     },
   };
 }

--- a/apps/office/src/pairing/pairing-view.test.tsx
+++ b/apps/office/src/pairing/pairing-view.test.tsx
@@ -139,7 +139,26 @@ it('requires explicit recognition, renders labels as text and never approves jus
     expect(f.port.approve).toHaveBeenCalledExactlyOnceWith(f.request, 'owner');
     await user.click(screen.getByRole('button', { name: 'Revoke request' }));
     await screen.findByText(/Request revoked\. Existing workspace content is retained/);
-    expect(f.port.revoke).toHaveBeenCalledExactlyOnceWith(f.request.pairingId, 'owner');
+    expect(f.port.revoke).toHaveBeenCalledExactlyOnceWith(f.request, 'owner');
+  } finally {
+    await f.dispose();
+  }
+});
+
+it('offers explicit cancellation before approval and does not approve while cancellation is uncertain', async () => {
+  const f = await fixture();
+  try {
+    const user = userEvent.setup();
+    vi.mocked(f.port.revoke).mockRejectedValueOnce(new Error('Lost response'));
+    await user.click(await screen.findByRole('button', { name: 'Cancel request' }));
+    await screen.findByText(/may already have completed/);
+    expect(f.port.revoke).toHaveBeenCalledExactlyOnceWith(f.request, 'owner');
+    expect(screen.queryByRole('button', { name: 'Approve pairing' })).toBeNull();
+    await user.click(screen.getByRole('button', { name: 'Retry cancel request' }));
+    await screen.findByText(/Request cancelled\. Existing workspace content is retained/);
+    expect(f.port.approve).not.toHaveBeenCalled();
+    expect(f.port.revoke).toHaveBeenCalledTimes(2);
+    expect(f.port.revoke).toHaveBeenLastCalledWith(f.request, 'owner');
   } finally {
     await f.dispose();
   }

--- a/apps/office/src/pairing/pairing-view.tsx
+++ b/apps/office/src/pairing/pairing-view.tsx
@@ -74,7 +74,7 @@ export function PairingForm({
   request: PairingRequest;
   ownerUid: string;
 }) {
-  const { busy, attempted, approved, revoked, error } = useSyncExternalStore(
+  const { busy, attempted, revocationAttempted, approved, revoked, error } = useSyncExternalStore(
     state.subscribe,
     state.getSnapshot
   );
@@ -127,8 +127,12 @@ export function PairingForm({
           . This does not mean the agent is connected.
         </p>
       )}
-      {revoked && <p role="status">Request revoked. Existing workspace content is retained.</p>}
-      {!approved && !revoked && (
+      {revoked && (
+        <p role="status">
+          Request {attempted ? 'revoked' : 'cancelled'}. Existing workspace content is retained.
+        </p>
+      )}
+      {!approved && !revoked && !revocationAttempted && (
         <form
           onSubmit={(event) => {
             event.preventDefault();
@@ -149,9 +153,13 @@ export function PairingForm({
           </button>
         </form>
       )}
-      {attempted && !revoked && (
-        <button disabled={busy} onClick={() => void state.revoke()}>
-          Revoke request
+      {!revoked && (
+        <button type="button" disabled={busy} onClick={() => void state.revoke()}>
+          {attempted || approved
+            ? 'Revoke request'
+            : revocationAttempted
+              ? 'Retry cancel request'
+              : 'Cancel request'}
         </button>
       )}
     </section>

--- a/contracts/office/native-companion.md
+++ b/contracts/office/native-companion.md
@@ -4,7 +4,7 @@ This internal local protocol is separate from the proposed remote work-handoff
 schema. It grants no Office access and does not replace pairing.
 
 The core-owned `OfficeInvocation` has exact operations `probe`, `pair-begin`,
-`pair-poll`, `pair-status`, `inspect` and `sync`. Its argument vector is
+`pair-poll`, `pair-status`, `unpair`, `inspect` and `sync`. Its argument vector is
 `__tmt-office`, `1`, `<operation>`. Unknown versions, operations,
 extra arguments and non-UTF-8 arguments fail with exit 1, empty stdout and a brief
 stderr diagnostic. There is no arbitrary argv forwarding or shell evaluation.
@@ -59,6 +59,12 @@ adapters stay in the Office feature, not the CLI or core. See
 [native pairing](native-pairing.md) for scope, deadlines and server authority.
 Future operations require a reviewed typed contract before implementation;
 the probe response is never a generic payload or remote authentication.
+
+`unpair` uses the same scoped input. Success returns `state: revoked`; a denied
+pending cancellation returns `state: pending` plus the original `approvalUrl`
+for owner cancellation, never a cleanup confirmation. Other failures retain the
+normal error result. An older companion rejects `unpair`; the host must not
+interpret unsupported-operation failure as successful revocation.
 
 `sync` consumes exactly `{}`; it requires no active identity or world selector.
 It returns exactly `completed`, `failed`, `pending` (unsigned counts) and

--- a/contracts/office/native-pairing.md
+++ b/contracts/office/native-pairing.md
@@ -55,6 +55,7 @@ and oversized headers/bodies before use.
 tmt office pair --world <url> [--identity <name>] [--read-only] [--timeout <seconds>]
 tmt office status --world <url> [--identity <name>]
 tmt office inspect --world <url> [--identity <name>]
+tmt office unpair --world <url> [--identity <name>]
 ```
 
 These retain existing Office prefix/output conventions. Names resolve through the
@@ -66,7 +67,7 @@ Pair requests layout read/write unless `--read-only`. Timeout is integer seconds
 poll floor. Human mode prints the public approval URL before polling. JSON mode
 puts that URL on stderr and one final object on stdout. No secret enters output
 or argv. Unqualified status retains installation-only behavior; world-qualified
-status is local-only and returns `unpaired`, `pending`, `credential` or `expired`,
+status is local-only and returns `unpaired`, `pending`, `credential`, `expired` or `revoked`,
 with `serverAuthorizationChecked: false`. Inspect performs a server-authorized
 read of the assigned block, not a world-wide index. Its result is
 `blockExists: true|false` with `serverAuthorizationChecked: true`; it does not
@@ -104,10 +105,31 @@ Office failures use the existing envelope and exit 1:
 `OFFICE_INTERRUPTED`, exit 130. Existing identity/grammar errors retain their
 owners. An unavailable claim cannot distinguish absent from denied approval.
 
-Reassignment and lost-credential recovery remain #209 requirements. Retirement
+Retained-block reassignment is supported during owner approval. Lost-credential
+repair remains separate work, not an implicit M1 acceptance gate. Retirement
 delivery is defined below; token refresh never extends a grant lease.
 Actual native/browser/isolated-vault evidence is required by the
 [local-first acceptance contract](../../DEVELOPMENT.md#personal-office-milestone-acceptance).
+
+## Explicit cancellation and reuse
+
+`unpair` uses the existing protected scope lock and revocation writer. Pending
+records use original proof; paired records refresh Auth if necessary and use
+their bound agent token, without renewing the resource lease. Only a confirmed
+response permits writing a secret-free `revoked` receipt. Retrying that receipt
+is local and idempotent. Missing/corrupt records are not reset; network, Auth and
+vault failures retain evidence and do not report cleanup complete.
+
+For denied pending cancellation, output the original public approval link and
+`OFFICE_OWNER_CANCELLATION_REQUIRED` (exit 1). The owner can cancel on that page
+before approval, then the agent retries unpair. Unavailability is not evidence
+that no delayed approval can occur.
+
+Only an explicit `pair` may replace a confirmed revoked receipt with a fresh
+request, proof and capability selection under the same identity UUID. Pending
+intent remains immutable even after expiry. No block, notebook or profile is
+deleted or inherited by re-pairing. Older companions without unpair support
+fail rather than claim successful cleanup.
 
 ## Invocation-owned renewal
 

--- a/contracts/office/pairing-v1.md
+++ b/contracts/office/pairing-v1.md
@@ -18,8 +18,8 @@ approval requests. The current owner's ID token is sent only in the
 HTTP is allowed only for the demo emulator).
 
 There is no unauthenticated durable "begin" write. The admitted human owner must
-approve the exact installation/identity/world and layout capability selection
-before the service creates a pairing record. Display labels are untrusted
+approve or explicitly cancel the exact public request before the service creates
+a pairing record; cancellation creates only a disabled tombstone. Display labels are untrusted
 presentation, not evidence of local identity or authority. The native client must
 also compare the claimed binding with its own expected values before storing
 credentials. A comparison code or copied link alone does not prove possession.
@@ -197,6 +197,15 @@ unavailable-pairing, conflict and unavailable-service errors retain their
 HTTP mappings. No browser receives agent tokens or direct grant-read authority.
 
 ## Retirement cancellation
+
+Owner cancellation also accepts exactly `{version:1,publicApproval:<approval input>}`.
+It requires an admitted human world owner, never an agent bearer. Existing records
+must match that owner and exact request. For an unknown request, the same revoke
+transaction creates a disabled, unclaimed pairing with ordinary generated IDs
+and timestamps, but no grant, token or resource. Those IDs are inert placeholders,
+not issued assignments. Repeated cancellation is idempotent; late approval/claim
+cannot revive the record. Existing source-transfer receipts and resources remain
+unchanged. Viewing the link or logging in never cancels it automatically.
 
 `POST /revoke` accepts exactly `{version:1,pairingId}` with a verified,
 non-revoked bearer token, or `{version:1,secret}` without an Authorization header.

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -97,6 +97,12 @@ not retired and do not enqueue this cleanup.
 The [native pairing contract](../../contracts/office/native-pairing.md) owns exact
 scope, output, errors and emulator restrictions.
 
+Source builds also support `tmt office unpair --world <url> --identity <name>`.
+It confirms revocation before retaining a secret-free receipt; an explicit pair
+can then start again under the same identity. Pending cancellation may require
+the owner to cancel using the original link first. Failure never permits deleting
+credentials. This is separate from the proposed connector lifecycle below.
+
 ## Planned connected commands
 
 The following connected behaviors are proposals, not installed instructions.
@@ -112,7 +118,6 @@ the in-progress pair/status/inspect inputs, outputs and deployment trust boundar
 | `tmt office run`                                           | Run the connector in the foreground; Ctrl-C stops it without cancelling native work                     |
 | `tmt office publish <identity> --capability review`        | Publish an explicitly selected identity UUID and allowed capability; no implicit all-agent publication  |
 | `tmt office unpublish <identity>`                          | Reject new work for that published identity, without deleting local identity or retained exchanges      |
-| `tmt office unpair`                                        | Revoke remotely, then remove local credentials; offline failure reports pending revocation, not success |
 | `tmt office social <identity> --minutes 10 --max-turns 20` | Request a bounded, opt-in social session; participants may decline and workspace tools stay disabled    |
 
 ## Decoration and discovery
@@ -199,9 +204,8 @@ do not probe for updates or incur Office startup/network cost.
   accepting work and reports `OFFICE_REVOKED`; it does not silently re-pair.
 - Duplicate connector startup for one device is rejected through an owned local
   lock. Crash recovery inspects durable dispatch records before claiming work.
-- `unpair` while offline can forget local credentials only through a separately
-  explicit `--local-only` action that warns remote revocation is still required.
-  Never report an unreachable remote device as revoked.
+- Pairing cancellation follows the native contract above; unreachable remote
+  state is never reported as revoked, and there is no local-only forget shortcut.
 - `status --json` distinguishes installed compatibility, locally known pairing,
   process observation and the age of any last remote observation. It cannot claim
   current remote availability from a stale cache.

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -109,16 +109,16 @@ The following connected behaviors are proposals, not installed instructions.
 The [native pairing contract](../../contracts/office/native-pairing.md) refines
 the in-progress pair/status/inspect inputs, outputs and deployment trust boundary.
 
-| Command                                                    | Planned behavior                                                                                        |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `tmt office`                                               | Open the selected world's web UI; never implicitly run a connector or publish agents                    |
-| `tmt office install --yes`                                 | Explicitly acquire and verify the official extension; `--yes` consents to installation only             |
-| `tmt office upgrade`                                       | Explicit verified extension update, with compatibility checks and rollback-safe activation              |
-| `tmt office status --json`                                 | Local extension/pairing/connector status; no network or automatic update check                          |
-| `tmt office run`                                           | Run the connector in the foreground; Ctrl-C stops it without cancelling native work                     |
-| `tmt office publish <identity> --capability review`        | Publish an explicitly selected identity UUID and allowed capability; no implicit all-agent publication  |
-| `tmt office unpublish <identity>`                          | Reject new work for that published identity, without deleting local identity or retained exchanges      |
-| `tmt office social <identity> --minutes 10 --max-turns 20` | Request a bounded, opt-in social session; participants may decline and workspace tools stay disabled    |
+| Command                                                    | Planned behavior                                                                                       |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `tmt office`                                               | Open the selected world's web UI; never implicitly run a connector or publish agents                   |
+| `tmt office install --yes`                                 | Explicitly acquire and verify the official extension; `--yes` consents to installation only            |
+| `tmt office upgrade`                                       | Explicit verified extension update, with compatibility checks and rollback-safe activation             |
+| `tmt office status --json`                                 | Local extension/pairing/connector status; no network or automatic update check                         |
+| `tmt office run`                                           | Run the connector in the foreground; Ctrl-C stops it without cancelling native work                    |
+| `tmt office publish <identity> --capability review`        | Publish an explicitly selected identity UUID and allowed capability; no implicit all-agent publication |
+| `tmt office unpublish <identity>`                          | Reject new work for that published identity, without deleting local identity or retained exchanges     |
+| `tmt office social <identity> --minutes 10 --max-turns 20` | Request a bounded, opt-in social session; participants may decline and workspace tools stay disabled   |
 
 ## Decoration and discovery
 

--- a/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
@@ -76,6 +76,25 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
             active_identity(&paths, &identity.id)?;
         }
         match operation {
+            OfficeInvocation::Unpair => {
+                let mut record = existing.ok_or(OfficeError::NotPaired)?;
+                if record.has_credentials()
+                    && record.refresh_if_needed(&target, now_ms()?, deadline)?
+                {
+                    entry.write(&record.encode()?)?;
+                }
+                match record.revoke(&target, deadline) {
+                    Err(OfficeError::RemoteDenied) if record.is_pending() => {
+                        // Unknown or denied pending approval is not confirmed cleanup.
+                        return Ok(
+                            json!({"state":"pending","approvalUrl":record.approval().approval_url(&target)?}),
+                        );
+                    }
+                    result => result?,
+                }
+                entry.write(&record.encode()?)?;
+                Ok(json!({"state":"revoked"}))
+            }
             OfficeInvocation::Inspect => {
                 let mut record = existing.ok_or(OfficeError::NotPaired)?;
                 if record.refresh_if_needed(&target, now_ms()?, deadline)? {
@@ -99,13 +118,13 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
             }
             OfficeInvocation::PairBegin => {
                 let record = match existing {
-                    Some(record) => {
+                    Some(record) if !record.is_revoked() => {
                         if record.approval().read_only() != request.read_only {
                             return Err(OfficeError::CredentialsInvalid);
                         }
                         record
                     }
-                    None => {
+                    _ => {
                         let deployment = OfficeDeployment::discover(target.clone(), deadline)
                             .map_err(|error| {
                                 if error.kind() == std::io::ErrorKind::InvalidData {

--- a/rust/crates/tmt-adapters/src/office_pairing/record.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/record.rs
@@ -45,6 +45,14 @@ enum Phase {
 }
 
 impl PairingRecord {
+    pub(super) fn is_pending(&self) -> bool {
+        matches!(self.phase, Phase::Pending { .. })
+    }
+
+    pub(super) fn is_revoked(&self) -> bool {
+        matches!(self.phase, Phase::Revoked {})
+    }
+
     pub(super) fn has_credentials(&self) -> bool {
         matches!(self.phase, Phase::Paired { .. })
     }

--- a/rust/crates/tmt-adapters/src/office_pairing/record_tests.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/record_tests.rs
@@ -20,6 +20,8 @@ fn fixture() -> (WorldTarget, PairingRecord) {
 #[test]
 fn revoked_receipt_has_no_secret_and_can_resume_without_remote_authority() {
     let (target, mut record) = fixture();
+    assert!(record.is_pending());
+    assert!(!record.is_revoked());
     let secret = record.reserve_claim(1000).unwrap().secret();
     // Remote confirmation is exercised by the emulator test; this assertion
     // isolates the durable terminal representation and its retry behavior.
@@ -32,6 +34,8 @@ fn revoked_receipt_has_no_secret_and_can_resume_without_remote_authority() {
     );
     let mut resumed = PairingRecord::decode(&bytes, &target, INSTALLATION, IDENTITY).unwrap();
     assert_eq!(resumed.local_state(u64::MAX), "revoked");
+    assert!(resumed.is_revoked());
+    assert!(!resumed.is_pending());
     assert!(!resumed.has_credentials());
     // An elapsed deadline proves a terminal retry needs no network exchange.
     resumed.revoke(&target, std::time::Instant::now()).unwrap();

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -270,6 +270,10 @@ fn office(name: &'static str, about: &'static str) -> Command {
 
 fn office_commands() -> Command {
     office("office", "Manage the optional Office companion")
+        .subcommand(office_scope(
+            office("unpair", "Revoke the selected identity's Office pairing"),
+            true,
+        ))
         .subcommand(office(
             "sync",
             "Deliver pending identity retirement hooks to Office",

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -80,6 +80,11 @@ pub enum OfficeOperation {
     Open,
     Status,
     Sync,
+    Unpair {
+        world: String,
+        identity: Option<String>,
+        emulator: bool,
+    },
     Inspect {
         world: String,
         identity: Option<String>,

--- a/rust/crates/tmt-cli/src/office_command.rs
+++ b/rust/crates/tmt-cli/src/office_command.rs
@@ -212,6 +212,7 @@ fn run(
     match operation {
         OfficeOperation::Pair { .. }
         | OfficeOperation::PairStatus { .. }
+        | OfficeOperation::Unpair { .. }
         | OfficeOperation::Inspect { .. }
         | OfficeOperation::Sync => {
             if !installed(&executable)? {

--- a/rust/crates/tmt-cli/src/office_pairing_command.rs
+++ b/rust/crates/tmt-cli/src/office_pairing_command.rs
@@ -38,6 +38,7 @@ pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> R
         }
     }
     let inspect = matches!(&operation, OfficeOperation::Inspect { .. });
+    let unpair = matches!(&operation, OfficeOperation::Unpair { .. });
     let (world, identity, emulator, read_only, timeout, pair) = match operation {
         OfficeOperation::Pair {
             world,
@@ -52,6 +53,11 @@ pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> R
             emulator,
         } => (world, identity, emulator, false, 30, false),
         OfficeOperation::Inspect {
+            world,
+            identity,
+            emulator,
+        } => (world, identity, emulator, false, 30, false),
+        OfficeOperation::Unpair {
             world,
             identity,
             emulator,
@@ -78,6 +84,8 @@ pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> R
     let deadline = Instant::now() + Duration::from_secs(timeout);
     let mut operation = if pair {
         OfficeInvocation::PairBegin
+    } else if unpair {
+        OfficeInvocation::Unpair
     } else if inspect {
         OfficeInvocation::Inspect
     } else {
@@ -101,6 +109,29 @@ pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> R
         }
         let reply = result.map_err(|_| Failure::new("OFFICE_REMOTE_UNCERTAIN", "Office did not confirm the operation. Retry the same pairing; no new approval was requested.", 1))?;
         match reply {
+            PairingReply::Pending(link) if unpair => {
+                writeln!(io::stderr().lock(), "{link}").map_err(unavailable)?;
+                return Err(Failure::new(
+                    "OFFICE_OWNER_CANCELLATION_REQUIRED",
+                    "Cancellation is unconfirmed. Ask the owner to cancel this request using the link, then retry unpair. Retained credentials were not removed.",
+                    1,
+                ));
+            }
+            PairingReply::State(state) if unpair && state == "revoked" => {
+                let value =
+                    serde_json::json!({"state":"revoked","identityId":identity.id,"world":world});
+                writeln!(
+                    io::stdout().lock(),
+                    "{}",
+                    if mode.json {
+                        value.to_string()
+                    } else {
+                        "Office pairing revoked. Workspace content is retained.".into()
+                    }
+                )
+                .map_err(unavailable)?;
+                return Ok(0);
+            }
             PairingReply::Inspected(exists) if inspect => {
                 let value = serde_json::json!({"blockExists":exists,"identityId":identity.id,"world":world,"serverAuthorizationChecked":true});
                 writeln!(
@@ -132,7 +163,9 @@ pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> R
                     .map_err(unavailable)?;
                 }
             }
-            PairingReply::State(state) if !inspect && (!pair || state == "credential") => {
+            PairingReply::State(state)
+                if !inspect && !unpair && (!pair || state == "credential") =>
+            {
                 let value = serde_json::json!({"state":state,"identityId":identity.id,"world":world,"serverAuthorizationChecked":false});
                 writeln!(io::stdout().lock(), "{}", if mode.json { value.to_string() } else { format!("Office pairing: {state}. Server authorization is checked when accessing a resource.") }).map_err(unavailable)?;
                 return Ok(0);

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -150,6 +150,7 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
         ["office"]
         | ["office", "status"]
         | ["office", "pair"]
+        | ["office", "unpair"]
         | ["office", "inspect"]
         | ["office", "sync"]
         | ["office", "install"]
@@ -158,6 +159,11 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
             prefix: text(m, "prefix"),
             operation: match path.last().copied() {
                 Some("sync") => OfficeOperation::Sync,
+                Some("unpair") => OfficeOperation::Unpair {
+                    world: required(m, "world"),
+                    identity: text(m, "identity"),
+                    emulator: flag(m, "emulator"),
+                },
                 Some("inspect") => OfficeOperation::Inspect {
                     world: required(m, "world"),
                     identity: text(m, "identity"),

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -14,6 +14,17 @@ fn office_pairing_has_bounded_typed_options_and_retains_unqualified_status() {
     use crate::invocation::OfficeOperation;
     let world = "https://office.example/worlds/abcdefghijklmnopqrst";
     assert_eq!(
+        parsed(&["office", "unpair", "--world", world, "--identity", "Alice"]).invocation,
+        Invocation::Office {
+            prefix: None,
+            operation: OfficeOperation::Unpair {
+                world: world.into(),
+                identity: Some("Alice".into()),
+                emulator: false,
+            }
+        }
+    );
+    assert_eq!(
         parsed(&[
             "office",
             "pair",
@@ -69,6 +80,9 @@ fn office_pairing_has_bounded_typed_options_and_retains_unqualified_status() {
         vec!["office", "status", "--identity", "Alice"],
         vec!["office", "status", "--emulator"],
         vec!["office", "inspect"],
+        vec!["office", "unpair"],
+        vec!["office", "unpair", "--world", world, "--read-only"],
+        vec!["office", "unpair", "--world", world, "--timeout", "5"],
         vec!["office", "status", "--world", world, "--read-only"],
     ] {
         assert_eq!(parse_error(&input).code, "USAGE_ERROR");

--- a/rust/crates/tmt-core/src/office_protocol.rs
+++ b/rust/crates/tmt-core/src/office_protocol.rs
@@ -69,6 +69,7 @@ pub enum OfficeInvocation {
     PairBegin,
     PairPoll,
     PairStatus,
+    Unpair,
     Inspect,
     Sync,
 }
@@ -80,6 +81,7 @@ impl OfficeInvocation {
             Self::PairBegin => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "pair-begin"],
             Self::PairPoll => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "pair-poll"],
             Self::PairStatus => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "pair-status"],
+            Self::Unpair => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "unpair"],
             Self::Inspect => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "inspect"],
             Self::Sync => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "sync"],
         }
@@ -91,6 +93,7 @@ impl OfficeInvocation {
             Self::PairBegin,
             Self::PairPoll,
             Self::PairStatus,
+            Self::Unpair,
             Self::Inspect,
             Self::Sync,
         ]
@@ -150,6 +153,7 @@ mod tests {
             ("pair-begin", OfficeInvocation::PairBegin),
             ("pair-poll", OfficeInvocation::PairPoll),
             ("pair-status", OfficeInvocation::PairStatus),
+            ("unpair", OfficeInvocation::Unpair),
             ("inspect", OfficeInvocation::Inspect),
             ("sync", OfficeInvocation::Sync),
         ] {

--- a/services/office/functions/src/pairing-contract.ts
+++ b/services/office/functions/src/pairing-contract.ts
@@ -168,11 +168,17 @@ export function parseRenewal(input: unknown): Renewal {
 
 export type Revocation =
   | { kind: 'pairing'; pairingId: string }
-  | { kind: 'proof'; pairingId: string };
+  | { kind: 'proof'; pairingId: string }
+  | { kind: 'ownerApproval'; request: Approval };
 
 export function parseRevocation(input: unknown): Revocation {
   const value = object(input);
   if (Object.hasOwn(value, 'secret')) return { kind: 'proof', pairingId: parseClaim(value) };
+  if (Object.hasOwn(value, 'publicApproval')) {
+    exact(value, ['version', 'publicApproval']);
+    if (value.version !== 1) throw new PairingError('INVALID_ARGUMENT');
+    return { kind: 'ownerApproval', request: parseApproval(value.publicApproval) };
+  }
   exact(value, ['version', 'pairingId']);
   if (value.version !== 1 || !matches(value.pairingId, PAIRING_ID))
     throw new PairingError('INVALID_ARGUMENT');

--- a/services/office/functions/src/pairing-service.ts
+++ b/services/office/functions/src/pairing-service.ts
@@ -26,7 +26,11 @@ export function createPairingService(store: PairingStore, auth: PairingAuthentic
   }
 
   function human(token: DecodedIdToken): string {
-    if (token.firebase?.sign_in_provider !== 'google.com' || token.email_verified !== true)
+    if (
+      token.tmtOfficeAgent === true ||
+      token.firebase?.sign_in_provider !== 'google.com' ||
+      token.email_verified !== true
+    )
       throw new PairingError('PERMISSION_DENIED');
     return token.uid;
   }
@@ -86,6 +90,15 @@ export function createPairingService(store: PairingStore, auth: PairingAuthentic
       if (request.kind === 'proof') {
         if (authorization !== undefined) throw new PairingError('INVALID_ARGUMENT');
         await store.revoke({ kind: 'proof' }, request.pairingId);
+      } else if (request.kind === 'ownerApproval') {
+        await store.revoke(
+          {
+            kind: 'ownerApproval',
+            uid: human(await verified(authorization)),
+            request: request.request,
+          },
+          request.request.pairingId
+        );
       } else {
         const token = await verified(authorization);
         await store.revoke(
@@ -95,7 +108,11 @@ export function createPairingService(store: PairingStore, auth: PairingAuthentic
           request.pairingId
         );
       }
-      return { version: 1, pairingId: request.pairingId, revoked: true };
+      return {
+        version: 1,
+        pairingId: request.kind === 'ownerApproval' ? request.request.pairingId : request.pairingId,
+        revoked: true,
+      };
     },
   };
 }

--- a/services/office/functions/src/pairing-store.ts
+++ b/services/office/functions/src/pairing-store.ts
@@ -40,7 +40,8 @@ export interface AgentIdentity {
 export type RevocationActor =
   | { kind: 'owner'; uid: string }
   | { kind: 'agent'; agent: AgentIdentity }
-  | { kind: 'proof' };
+  | { kind: 'proof' }
+  | { kind: 'ownerApproval'; uid: string; request: Approval };
 
 function matchesAgent(pairing: Pairing, agent: AgentIdentity): boolean {
   return (
@@ -386,22 +387,52 @@ export function createPairingStore(db: Firestore, clock: () => number = Date.now
     },
 
     async revoke(actor: RevocationActor, id: string): Promise<void> {
+      const tombstonePrincipalUid =
+        actor.kind === 'ownerApproval' ? `office-agent:${randomUUID()}` : undefined;
+      const tombstoneBlockId = actor.kind === 'ownerApproval' ? randomUUID() : undefined;
       await db.runTransaction(async (tx) => {
+        const now = clock();
         const snapshot = await tx.get(pairingRef(id));
+        if (actor.kind === 'ownerApproval' && !snapshot.exists) {
+          if (
+            actor.request.pairingId !== id ||
+            !isTimestampMillis(now) ||
+            now > MAX_TIMESTAMP_MS - APPROVAL_MS
+          )
+            unavailable();
+          if (!(await ownsWorld(tx, actor.uid, actor.request.worldId)))
+            throw new PairingError('PERMISSION_DENIED');
+          tx.create(pairingRef(id), {
+            request: actor.request,
+            ownerUid: actor.uid,
+            principalUid: tombstonePrincipalUid!,
+            blockId: tombstoneBlockId!,
+            createdAt: Timestamp.fromMillis(now),
+            expiresAt: Timestamp.fromMillis(now + APPROVAL_MS),
+            enabled: false,
+            claimed: false,
+            nextClaimAt: Timestamp.fromMillis(now),
+          });
+          return;
+        }
         let pairing: Pairing;
         try {
           pairing = decodePairing(snapshot.data(), id);
         } catch {
           throw new PairingError(
-            actor.kind === 'owner' ? 'PERMISSION_DENIED' : 'PAIRING_UNAVAILABLE'
+            actor.kind === 'owner' || actor.kind === 'ownerApproval'
+              ? 'PERMISSION_DENIED'
+              : 'PAIRING_UNAVAILABLE'
           );
         }
-        if (actor.kind === 'owner') {
+        if (actor.kind === 'owner' || actor.kind === 'ownerApproval') {
           if (
             pairing.ownerUid !== actor.uid ||
             !(await ownsWorld(tx, actor.uid, pairing.request.worldId))
           )
             throw new PairingError('PERMISSION_DENIED');
+          if (actor.kind === 'ownerApproval' && !sameRequest(pairing.request, actor.request))
+            throw new PairingError('PAIRING_CONFLICT');
         } else if (
           actor.kind === 'agent' &&
           (!pairing.claimed || !matchesAgent(pairing, actor.agent))

--- a/services/office/functions/test/pairing-contract.test.ts
+++ b/services/office/functions/test/pairing-contract.test.ts
@@ -30,6 +30,10 @@ describe('pairing input contract', () => {
       kind: 'pairing',
       pairingId: approval.pairingId,
     });
+    expect(parseRevocation({ version: 1, publicApproval: approval })).toEqual({
+      kind: 'ownerApproval',
+      request: approval,
+    });
     expect(parseRenewal({ version: 1, pairingId: approval.pairingId, grantExpiresAt: 1 })).toEqual({
       version: 1,
       pairingId: approval.pairingId,
@@ -75,6 +79,14 @@ describe('pairing input contract', () => {
     { capabilities: ['layout.read', 'layout.read'] },
   ])('rejects altered binding %j', (change) => {
     expect(() => parseApproval({ ...approval, ...change })).toThrow('INVALID_ARGUMENT');
+  });
+  it.each([
+    { version: 2, publicApproval: approval },
+    { version: 1, publicApproval: { ...approval, capabilities: ['layout.write'] } },
+    { version: 1, publicApproval: approval, pairingId: approval.pairingId },
+    { version: 1, publicApproval: approval, secret: 'invalid' },
+  ])('rejects altered public approval revocations %j', (input) => {
+    expect(() => parseRevocation(input)).toThrow('INVALID_ARGUMENT');
   });
   it('rejects every omitted field, null, arrays and inherited fields', () => {
     for (const field of Object.keys(approval)) {

--- a/services/office/functions/test/pairing-revocation.test.ts
+++ b/services/office/functions/test/pairing-revocation.test.ts
@@ -19,6 +19,16 @@ import {
 
 const pairingPath = `officePairings/${PAIRING}`;
 const grantPath = `worlds/${WORLD}/agentGrants/${PRINCIPAL}`;
+const publicApproval = {
+  version: 1 as const,
+  pairingId: PAIRING,
+  worldId: WORLD,
+  installationId: INSTALLATION,
+  identityId: IDENTITY,
+  installationLabel: 'Installation',
+  identityLabel: 'Alice',
+  capabilities: ['layout.read', 'layout.write'] as ['layout.read', 'layout.write'],
+};
 const actors: RevocationActor[] = [
   { kind: 'owner', uid: OWNER },
   { kind: 'agent', agent },
@@ -197,6 +207,104 @@ describe('revocation authentication and proof', () => {
       code: 'PAIRING_UNAVAILABLE',
     });
     expect(fixture.values.has(`officePairings/${digest}`)).toBe(false);
+    expect(fixture.updates).toEqual([]);
+  });
+
+  it('lets an admitted owner cancel an unknown request without grants or resources', async () => {
+    const fixture = setup({
+      uid: OWNER,
+      email_verified: true,
+      firebase: { sign_in_provider: 'google.com' },
+    });
+    fixture.values.delete(pairingPath);
+    await expect(
+      fixture.service.revoke({ version: 1, publicApproval }, 'Bearer owner-token')
+    ).resolves.toEqual({ version: 1, pairingId: PAIRING, revoked: true });
+    expect(fixture.values.get(pairingPath)).toMatchObject({
+      request: publicApproval,
+      ownerUid: OWNER,
+      enabled: false,
+      claimed: false,
+    });
+    expect(fixture.values.has(grantPath)).toBe(true);
+    expect(fixture.values.get(grantPath)).toMatchObject({ enabled: true });
+    expect(fixture.values.size).toBe(4);
+    expect(fixture.createCustomToken).not.toHaveBeenCalled();
+  });
+
+  it('cancels a known request only for the exact admitted owner request and is idempotent', async () => {
+    const fixture = setup({
+      uid: OWNER,
+      email_verified: true,
+      firebase: { sign_in_provider: 'google.com' },
+    });
+    await expect(
+      fixture.service.revoke({ version: 1, publicApproval }, 'Bearer owner-token')
+    ).resolves.toEqual({ version: 1, pairingId: PAIRING, revoked: true });
+    const afterFirst = new Map(fixture.values);
+    await expect(
+      fixture.service.revoke({ version: 1, publicApproval }, 'Bearer owner-token')
+    ).resolves.toEqual({ version: 1, pairingId: PAIRING, revoked: true });
+    expect(fixture.values.get(pairingPath)).toMatchObject({ enabled: false });
+    expect(fixture.values.get(grantPath)).toMatchObject({ enabled: false });
+    expect(fixture.values.get(`worlds/${WORLD}`)).toEqual(afterFirst.get(`worlds/${WORLD}`));
+    expect(fixture.verifyIdToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('denies changed intent, wrong owner/admission and agent public cancellation without writes', async () => {
+    const changed = { ...publicApproval, capabilities: ['layout.read'] as ['layout.read'] };
+    const cases = [
+      {
+        token: { uid: OWNER, email_verified: true, firebase: { sign_in_provider: 'google.com' } },
+        input: { version: 1, publicApproval: changed },
+        code: 'PAIRING_CONFLICT',
+      },
+      {
+        token: {
+          uid: 'other-owner',
+          email_verified: true,
+          firebase: { sign_in_provider: 'google.com' },
+        },
+        input: { version: 1, publicApproval },
+        code: 'PERMISSION_DENIED',
+      },
+      {
+        token: { uid: OWNER, email_verified: true, firebase: { sign_in_provider: 'google.com' } },
+        input: { version: 1, publicApproval },
+        code: 'PERMISSION_DENIED',
+        ownerAdmitted: false,
+      },
+      { token: agentToken, input: { version: 1, publicApproval }, code: 'PERMISSION_DENIED' },
+    ];
+    for (const testCase of cases) {
+      const fixture = setup(testCase.token);
+      if (testCase.ownerAdmitted === false) fixture.values.delete(`testers/${OWNER}`);
+      const before = new Map(fixture.values);
+      await expect(fixture.service.revoke(testCase.input, 'Bearer token')).rejects.toMatchObject({
+        code: testCase.code,
+      });
+      expect(fixture.values).toEqual(before);
+      expect(fixture.updates).toEqual([]);
+    }
+  });
+
+  it('prevents late approval and claim of an owner-cancelled unknown request', async () => {
+    const fixture = setup({
+      uid: OWNER,
+      email_verified: true,
+      firebase: { sign_in_provider: 'google.com' },
+    });
+    fixture.values.delete(pairingPath);
+    const store = createPairingStore(fixture.db, () => NOW);
+    await store.revoke({ kind: 'ownerApproval', uid: OWNER, request: publicApproval }, PAIRING);
+    const before = new Map(fixture.values);
+    await expect(store.approve(OWNER, publicApproval)).rejects.toMatchObject({
+      code: 'PAIRING_UNAVAILABLE',
+    });
+    await expect(store.reserveClaim(PAIRING)).rejects.toMatchObject({
+      code: 'PAIRING_UNAVAILABLE',
+    });
+    expect(fixture.values).toEqual(before);
     expect(fixture.updates).toEqual([]);
   });
 

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -454,6 +454,7 @@ Compatible source builds support explicit pairing:
 tmt office pair --world <world-url> --identity <name> --timeout 30
 tmt office status --world <world-url> --identity <name> --json
 tmt office inspect --world <world-url> --identity <name> --json
+tmt office unpair --world <world-url> --identity <name> --json
 ```
 
 The world URL is canonical HTTPS `/worlds/<world-id>`. Omit `--identity` only
@@ -478,6 +479,13 @@ on failures. Disabled/missing grants, expired pending approvals and lost
 credentials cannot be repaired by silently creating another grant. Report those
 errors; never delete state to bypass revocation. Uninstall does not revoke
 remote grants. Do not use proposed connector or resource-edit commands.
+
+Use `unpair` to explicitly revoke a pairing without removing the identity or
+workspace content. A confirmed result retains a secret-free `revoked` receipt;
+then an explicit `pair` can request new capabilities under the same identity.
+If `OFFICE_OWNER_CANCELLATION_REQUIRED` is returned, give the user the original
+public link to cancel, then retry unpair. Never approve/cancel on their behalf,
+interpret failure as revocation, or delete credentials to force a fresh pairing.
 
 Retiring a paired identity queues Office cleanup by UUID. Pair/inspect attempt
 pending cleanup; ordinary `ls`, `rm` and `unbind` do not contact Office. Use


### PR DESCRIPTION
## Summary

- Add explicit owner cancellation before approval through the existing revocation transaction. Unknown public requests become disabled, unclaimed tombstones; no grants or resources are created.
- Add `tmt office unpair` using the existing protected scope and revocation path. Preserve proof/credentials on failure and retain a secret-free receipt only after confirmation.
- Allow an explicit new pair request from that receipt under the same identity UUID, with a fresh proof and capability choice.
- Keep browser cancellation intent immutable across uncertainty and use one contract-owned request snapshot instead of duplicated field projections.

Closes #235.

Parent #209 retains outstanding scope. Production Office and lost/corrupt credential repair are excluded.

## Architecture review

The primary reviewed CLI grammar/dispatch, typed companion operations, protected record transitions and their callers, service authentication/transaction ownership, browser contract/state/transport/views, and changed test assertions. No new registry, cleanup queue or credential store was introduced. Scope locks serialize local unpair against claim publication; Firestore remains authoritative for remote access.

Reviewed implementation: `850a6dcd561d7c45423893a6a6c8dddca6eb953e`. Current head `8450c272cd6d001100f178a0beaa3225748437e0` adds only reviewed Markdown table spacing; runtime and test sources are unchanged.

Remote revocation may race an already-issued claim response. Local `credential` is intentionally not a claim of current server authorization; live Rules deny revoked access. A further remote check would only move that race. This does not permit a concurrent native claim to overwrite a confirmed local revoked receipt.

Canonical native/pairing contracts, architecture guidance and the installed core skill are updated. Optional Office skill delivery and resource editing remain their own slices.

## Local verification

- Service tests: 117 passed; service check/build passed.
- Pairing browser unit tests: 58 passed; type check passed.
- Rust workspace with Docker `--init`: adapters 348 passed / 1 existing artifact-gated test ignored; CLI 45 passed; architecture 21 passed; core 60 passed. Clippy and formatting passed.
- Initial process-reaping failure was traced to a test container launched without required `--init`; the isolated case and full workspace passed with the documented environment, without source or assertion changes.
- Documentation formatting, skill validation and diff whitespace checks passed.
- Initial CI caught command-reference table spacing because the ad hoc local formatter call did not use the repository ignore settings. The correction passed the complete documented `pnpm docs:format:check`; no behavior or checks were weakened.
- Full browser/emulator/native acceptance: 56/56 passed twice with clean emulator shutdown. Current fixture hashes matched the rebuilt image; service and Office gates plus preview/emulator/cloud builds passed. Primary inspected desktop/narrow pairing screenshots, including the pre-approval cancellation control.
- The initial offline browser attempt could not load the documented public Google popup script. Both canonical runs used the existing restricted browser routing; no production authentication or data calls were permitted.
- All required CI passed on reviewed head `8450c272cd6d001100f178a0beaa3225748437e0`: Code quality, Native package matrix, Unit tests, Docker E2E. Primary independently verified the exact head and results.

No production Firebase, host credential store, host tmux, public release or browser-UI workaround was used. GitHub Projects status remains unsynchronized because the CLI token lacks Projects scope; repo operations remain available.
