### PR TITLE
feat(office): add revision-safe native block decoration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,6 +47,12 @@ assignment registry or permission mutation. Rules and the trusted issuer
 enforce authority; views never grant it. Remote snapshots have one owner, separate
 from unsaved drafts and ephemeral
 presentation state. No stored markup executes and no parallel layout is stored.
+Native decoration uses `tmt-core::office_block` for pure layout validation and
+codec conformance, `tmt-adapters::office_block` for readable JSON, and the existing
+paired companion for authenticated conditional Firestore commits. Browser and
+native implementations share the versioned block contract and literal vectors;
+neither creates a second scene store. The CLI owns grammar and presentation, not
+credentials, grant renewal or Firestore transactions.
 Owner approval may select a revoked grant's retained block through the same
 bounded space projection. The pairing transaction reserves that source grant
 with a transfer receipt and records immutable approval intent; no second

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -272,8 +272,13 @@ emulators. Extend the existing fixture owners as each feature ships, not a
 parallel mock implementation of TMT. Independent database observations must
 corroborate UI and command results. Separate green layer suites are not proof of
 this integrated flow. The native pairing browser scenario covers acquisition and
-scoped reads; native resource editing and visible browser results remain separate
-milestone work, not implied by successful credential retention.
+scoped reads. `native-decoration.spec.ts` adds real block show/apply, independent
+stored tokens/revisions, visible scene geometry, exact retry without timestamp
+changes, invalid input, conflicting local callers and read-only/revoked authority.
+Local callers share fail-fast locks: pre-execution contention reports `OFFICE_BUSY`;
+retrying the original intent after the winner must conflict without another write.
+This is not proof of a Firestore precondition race. The existing browser transaction and Rules suites retain that
+independent server-side coverage. Neither replaces the other's acceptance.
 
 Automated acceptance must not call a paid model, use provider/host credentials,
 contact production Firebase or require paid runners. Keep the native-only tmux

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ failure handling, or `tmt help` for command options.
 ## Development
 
 Office is an optional work in progress. Its CLI installation/status commands are
-implemented; source builds also support pairing and scoped access with renewable
-leases. No public Office release is available yet. See
+implemented; source builds also support pairing and agent block decoration with
+scoped, renewable access. No public Office release is available yet. See
 [Office commands](docs/office/commands.md); ordinary TMT use does not require it.
 
 Contributor-only requirements and checks are in [development](DEVELOPMENT.md).

--- a/apps/office/e2e/native-decoration-fixture.ts
+++ b/apps/office/e2e/native-decoration-fixture.ts
@@ -1,0 +1,148 @@
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { expect, type Page } from '@playwright/test';
+import { signIn } from './browser-session.js';
+import { setTester } from './firestore-fixture.js';
+import { createPairingEmulatorFixture } from '../../../services/office/functions/test/emulator-fixture.js';
+import { runCli, withSandbox, type Sandbox } from '../../../test/support/cli-process.js';
+import { clearOfficeScopes, installNativeOffice } from './native-office-fixture.js';
+
+type Admin = ReturnType<typeof createPairingEmulatorFixture>;
+type Document = ReturnType<ReturnType<Admin['db']['collection']>['doc']>;
+type Office = (command: string[], extra?: string[]) => ReturnType<typeof runCli>;
+
+export type OpenSession = (url?: string) => Promise<{ page: Page }>;
+
+export interface NativeDecorationContext {
+  blockId: string;
+  blockRef: Document;
+  grantRef: Document;
+  office: Office;
+  page: Page;
+  sandbox: Sandbox;
+  worldId: string;
+}
+
+async function pairNative(
+  sandbox: Sandbox,
+  admin: Admin,
+  openSession: OpenSession,
+  readOnly = false
+): Promise<NativeDecorationContext> {
+  const prefix = await installNativeOffice(sandbox);
+  const identity = readOnly ? 'ReadOnlyDecorationNative' : 'DecorationNative';
+  expect((await runCli(sandbox, ['identity', 'create', identity, '--json'])).status).toBe(0);
+  const worldId = admin.db.collection('worlds').doc().id;
+  const world = `http://127.0.0.1:4173/worlds/${worldId}`;
+  const office: Office = (command, extra = []) =>
+    runCli(
+      sandbox,
+      [
+        'office',
+        ...command,
+        '--prefix',
+        prefix,
+        '--world',
+        world,
+        '--identity',
+        identity,
+        '--emulator',
+        '--json',
+        ...extra,
+      ],
+      { deadlineMs: 35_000 }
+    );
+  const pairFlags = (timeout: string) => [
+    ...(readOnly ? ['--read-only'] : []),
+    '--timeout',
+    timeout,
+  ];
+  const pending = await office(['pair'], pairFlags('5'));
+  expect(pending.status, pending.stdout).toBe(1);
+  expect(JSON.parse(pending.stdout).error.code).toBe('OFFICE_PAIRING_PENDING');
+  const link = pending.stderr.trim();
+  expect(link.startsWith(`${world}/pair#tmt-pair=`)).toBe(true);
+  const request = JSON.parse(
+    Buffer.from(link.split('#tmt-pair=')[1]!, 'base64url').toString('utf8')
+  ) as { pairingId: string; capabilities: string[] };
+  expect(request.capabilities).toEqual(
+    readOnly ? ['layout.read'] : ['layout.read', 'layout.write']
+  );
+
+  const { page } = await openSession(link);
+  await signIn(page, readOnly ? 'Native read-only owner' : 'Native decoration owner');
+  const ownerUid = (await page.getByText(/^UID: /).innerText()).replace(/^UID: /, '').trim();
+  await admin.db
+    .collection('worlds')
+    .doc(worldId)
+    .set({ version: 1, name: 'Native decoration office', ownerUid, createdAt: new Date() });
+  await setTester(ownerUid, true);
+  await expect(page.getByRole('region', { name: 'Agent pairing request' })).toBeVisible();
+  await page.getByRole('checkbox', { name: 'I recognize this agent and installation.' }).check();
+  await page.getByRole('button', { name: 'Approve pairing', exact: true }).click();
+  await expect(page.getByRole('status').filter({ hasText: 'Approved. Return' })).toBeVisible();
+
+  const paired = await office(['pair'], pairFlags('25'));
+  expect(paired.status, paired.stdout).toBe(0);
+  expect(JSON.parse(paired.stdout).state).toBe('credential');
+  const pairing = admin.db.collection('officePairings').doc(request.pairingId);
+  const remote = (await pairing.get()).data()!;
+  const blockId = String(remote.blockId);
+  const grantRef = admin.db
+    .collection('worlds')
+    .doc(worldId)
+    .collection('agentGrants')
+    .doc(String(remote.principalUid));
+  expect((await grantRef.get()).data()).toMatchObject({
+    enabled: true,
+    blockId,
+    capabilities: request.capabilities,
+  });
+  const blockRef = admin.db.collection('worlds').doc(worldId).collection('blocks').doc(blockId);
+  return { blockId, blockRef, grantRef, office, page, sandbox, worldId };
+}
+
+export async function withNativeDecoration(
+  openSession: OpenSession,
+  readOnly: boolean,
+  run: (context: NativeDecorationContext) => Promise<void>
+): Promise<void> {
+  const admin = createPairingEmulatorFixture();
+  try {
+    await withSandbox(async (sandbox) => {
+      try {
+        await run(await pairNative(sandbox, admin, openSession, readOnly));
+      } finally {
+        await clearOfficeScopes(sandbox);
+      }
+    });
+  } finally {
+    await admin.dispose();
+  }
+}
+
+export function layoutFile(sandbox: Sandbox, name: string, objects: readonly unknown[]): string {
+  const file = path.join(sandbox.root, name);
+  writeFileSync(file, `${JSON.stringify({ objects })}\n`);
+  return file;
+}
+
+export function rawFile(sandbox: Sandbox, name: string, contents: string): string {
+  const file = path.join(sandbox.root, name);
+  writeFileSync(file, contents);
+  return file;
+}
+
+export async function openAssignedBlock(
+  page: Page,
+  worldId: string,
+  blockId: string
+): Promise<void> {
+  await page.getByRole('link', { name: 'Office', exact: true }).click();
+  await page.getByLabel('World ID', { exact: true }).fill(worldId);
+  await page.getByRole('button', { name: 'Open world', exact: true }).click();
+  const open = page.getByRole('button', { name: `Open block ${blockId}`, exact: true });
+  await expect(open).toBeVisible();
+  await open.click();
+  await expect(page.getByRole('region', { name: 'Office block editor' })).toBeVisible();
+}

--- a/apps/office/e2e/native-decoration.spec.ts
+++ b/apps/office/e2e/native-decoration.spec.ts
@@ -1,0 +1,245 @@
+import { readFileSync } from 'node:fs';
+import { expect } from '@playwright/test';
+import { test } from './browser-session.js';
+import {
+  layoutFile,
+  openAssignedBlock,
+  rawFile,
+  withNativeDecoration,
+} from './native-decoration-fixture.js';
+
+test('native block show/apply reaches durable state and visible browser geometry', async ({
+  openSession,
+}) => {
+  test.setTimeout(150_000);
+  await withNativeDecoration(openSession, false, async (context) => {
+    const missing = await context.office(['block', 'show']);
+    expect(missing.status, missing.stdout).toBe(0);
+    expect(JSON.parse(missing.stdout)).toMatchObject({
+      blockId: context.blockId,
+      revision: 0,
+      objects: [],
+    });
+    expect((await context.blockRef.get()).exists).toBe(false);
+
+    const objects = [
+      { asset: 'desk', x: 2, y: 3, rotation: 0 },
+      { asset: 'plant', x: 8, y: 4, rotation: 0 },
+    ] as const;
+    const file = layoutFile(context.sandbox, 'native-layout.json', objects);
+    const applied = await context.office(
+      ['block', 'apply'],
+      ['--file', file, '--if-revision', '0']
+    );
+    expect(applied.status, applied.stdout).toBe(0);
+    const result = JSON.parse(applied.stdout);
+    expect(result).toMatchObject({ blockId: context.blockId, revision: 1, objects });
+    const stored = (await context.blockRef.get()).data()!;
+    expect(stored).toMatchObject({ version: 1, revision: 1, objects: ['d023', 'p084'] });
+    expect(stored.updatedAt).toBeDefined();
+
+    const retry = await context.office(['block', 'apply'], ['--file', file, '--if-revision', '0']);
+    expect(retry.status, retry.stdout).toBe(0);
+    expect(JSON.parse(retry.stdout)).toEqual(result);
+    expect((await context.blockRef.get()).data()).toEqual(stored);
+
+    await openAssignedBlock(context.page, context.worldId, context.blockId);
+    await expect(context.page.getByRole('button', { name: 'Desk 1', exact: true })).toBeVisible();
+    await expect(context.page.getByRole('button', { name: 'Plant 2', exact: true })).toBeVisible();
+    expect(
+      await context.page
+        .locator('svg.block-scene > g > g')
+        .evaluateAll((elements) => elements.map((element) => element.getAttribute('transform')))
+    ).toEqual([
+      'translate(4 4) rotate(0) translate(-2 -1)',
+      'translate(9 5) rotate(0) translate(-1 -1)',
+    ]);
+    for (const viewport of [
+      { name: 'desktop', width: 1280, height: 900 },
+      { name: 'narrow', width: 390, height: 844 },
+    ]) {
+      await context.page.setViewportSize(viewport);
+      await expect(context.page.getByRole('button', { name: 'Desk 1', exact: true })).toBeVisible();
+      expect(
+        await context.page.evaluate(() => document.documentElement.scrollWidth)
+      ).toBeLessThanOrEqual(viewport.width);
+      await context.page.locator('.block-editor').screenshot({
+        path: test.info().outputPath(`native-decoration-${viewport.name}.png`),
+      });
+    }
+  });
+});
+
+test('native block apply preserves conflicts, concurrent winners and invalid-input state', async ({
+  openSession,
+}) => {
+  test.setTimeout(150_000);
+  await withNativeDecoration(openSession, false, async (context) => {
+    const firstObjects = [{ asset: 'desk', x: 2, y: 2, rotation: 0 }] as const;
+    const firstFile = layoutFile(context.sandbox, 'native-first-layout.json', firstObjects);
+    const first = await context.office(
+      ['block', 'apply'],
+      ['--file', firstFile, '--if-revision', '0']
+    );
+    expect(first.status, first.stdout).toBe(0);
+    const beforeConflict = (await context.blockRef.get()).data()!;
+
+    const staleFile = layoutFile(context.sandbox, 'native-stale-layout.json', [
+      { asset: 'plant', x: 8, y: 2, rotation: 0 },
+    ]);
+    const staleFileBytes = readFileSync(staleFile);
+    const stale = await context.office(
+      ['block', 'apply'],
+      ['--file', staleFile, '--if-revision', '0']
+    );
+    expect(stale.status).toBe(1);
+    expect(JSON.parse(stale.stdout).error.code).toBe('OFFICE_REVISION_CONFLICT');
+    expect(stale.stderr).toBe('');
+    expect((await context.blockRef.get()).data()).toEqual(beforeConflict);
+    expect(readFileSync(staleFile)).toEqual(staleFileBytes);
+
+    const leftFile = layoutFile(context.sandbox, 'native-left-layout.json', [
+      { asset: 'desk', x: 4, y: 4, rotation: 0 },
+    ]);
+    const rightFile = layoutFile(context.sandbox, 'native-right-layout.json', [
+      { asset: 'plant', x: 10, y: 4, rotation: 0 },
+    ]);
+    const leftFileBytes = readFileSync(leftFile);
+    const rightFileBytes = readFileSync(rightFile);
+    // The local lock is fail-fast, not a queue. A loser can be rejected before
+    // execution; its later original-intent retry must detect the winner.
+    const concurrent = await Promise.all([
+      context.office(['block', 'apply'], ['--file', leftFile, '--if-revision', '1']),
+      context.office(['block', 'apply'], ['--file', rightFile, '--if-revision', '1']),
+    ]);
+    expect(concurrent.map((result) => result.status).sort()).toEqual([0, 1]);
+    const winnerIndex = concurrent.findIndex((result) => result.status === 0);
+    const winner = concurrent.find((result) => result.status === 0)!;
+    const loser = concurrent.find((result) => result.status === 1)!;
+    expect(['OFFICE_BUSY', 'OFFICE_REVISION_CONFLICT']).toContain(
+      JSON.parse(loser.stdout).error.code
+    );
+    const winnerObjects = JSON.parse(winner.stdout).objects;
+    const expectedWinner =
+      winnerIndex === 0
+        ? { objects: [{ asset: 'desk', x: 4, y: 4, rotation: 0 }], tokens: ['d044'] }
+        : { objects: [{ asset: 'plant', x: 10, y: 4, rotation: 0 }], tokens: ['p0a4'] };
+    expect(winnerObjects).toEqual(expectedWinner.objects);
+    const afterConcurrent = (await context.blockRef.get()).data()!;
+    expect(afterConcurrent.revision).toBe(2);
+    expect(afterConcurrent.objects).toEqual(expectedWinner.tokens);
+    const retryLoser = await context.office(
+      ['block', 'apply'],
+      ['--file', winnerIndex === 0 ? rightFile : leftFile, '--if-revision', '1']
+    );
+    expect(retryLoser.status).toBe(1);
+    expect(JSON.parse(retryLoser.stdout).error.code).toBe('OFFICE_REVISION_CONFLICT');
+    expect((await context.blockRef.get()).data()).toEqual(afterConcurrent);
+    expect(readFileSync(leftFile)).toEqual(leftFileBytes);
+    expect(readFileSync(rightFile)).toEqual(rightFileBytes);
+
+    const unrelated = await context.office(['block', 'show', crypto.randomUUID()]);
+    expect(unrelated.status).toBe(1);
+    expect(JSON.parse(unrelated.stdout).error.code).toBe('OFFICE_REMOTE_DENIED');
+    expect((await context.blockRef.get()).data()).toEqual(afterConcurrent);
+
+    const malformedFile = rawFile(context.sandbox, 'malformed.json', '{"objects":');
+    const malformedBytes = readFileSync(malformedFile);
+    const malformed = await context.office(
+      ['block', 'apply'],
+      ['--file', malformedFile, '--if-revision', '2']
+    );
+    expect(malformed.status).toBe(1);
+    expect(JSON.parse(malformed.stdout).error.code).toBe('OFFICE_LAYOUT_INVALID');
+    expect((await context.blockRef.get()).data()).toEqual(afterConcurrent);
+    expect(readFileSync(malformedFile)).toEqual(malformedBytes);
+
+    const oversizedFile = rawFile(
+      context.sandbox,
+      'oversized.json',
+      `{"objects":[]}${' '.repeat(65_536)}`
+    );
+    const oversizedBytes = readFileSync(oversizedFile);
+    const oversized = await context.office(
+      ['block', 'apply'],
+      ['--file', oversizedFile, '--if-revision', '2']
+    );
+    expect(oversized.status).toBe(1);
+    expect(JSON.parse(oversized.stdout).error.code).toBe('OFFICE_LAYOUT_INVALID');
+    expect((await context.blockRef.get()).data()).toEqual(afterConcurrent);
+    expect(readFileSync(oversizedFile)).toEqual(oversizedBytes);
+
+    const overflowFile = layoutFile(
+      context.sandbox,
+      'native-overflow-layout.json',
+      Array.from({ length: 17 }, (_, index) => ({
+        asset: 'plant',
+        x: (index % 8) * 2,
+        y: Math.floor(index / 8) * 2,
+        rotation: 0,
+      }))
+    );
+    const overflow = await context.office(
+      ['block', 'apply'],
+      ['--file', overflowFile, '--if-revision', '2']
+    );
+    expect(overflow.status).toBe(1);
+    expect(JSON.parse(overflow.stdout).error.code).toBe('OFFICE_LAYOUT_INVALID');
+    expect((await context.blockRef.get()).data()).toEqual(afterConcurrent);
+  });
+});
+
+test('revoked native grant denies show and apply without changing the durable block', async ({
+  openSession,
+}) => {
+  test.setTimeout(120_000);
+  await withNativeDecoration(openSession, false, async (context) => {
+    const file = layoutFile(context.sandbox, 'native-revocation-layout.json', [
+      { asset: 'desk', x: 2, y: 2, rotation: 0 },
+    ]);
+    const fileBytes = readFileSync(file);
+    const applied = await context.office(
+      ['block', 'apply'],
+      ['--file', file, '--if-revision', '0']
+    );
+    expect(applied.status, applied.stdout).toBe(0);
+    const beforeRevocation = (await context.blockRef.get()).data()!;
+    await context.grantRef.update({ enabled: false });
+
+    const deniedShow = await context.office(['block', 'show']);
+    expect(deniedShow.status).toBe(1);
+    expect(JSON.parse(deniedShow.stdout).error.code).toBe('OFFICE_REMOTE_DENIED');
+    const deniedApply = await context.office(
+      ['block', 'apply'],
+      ['--file', file, '--if-revision', '1']
+    );
+    expect(deniedApply.status).toBe(1);
+    expect(JSON.parse(deniedApply.stdout).error.code).toBe('OFFICE_REMOTE_DENIED');
+    expect((await context.blockRef.get()).data()).toEqual(beforeRevocation);
+    expect(readFileSync(file)).toEqual(fileBytes);
+  });
+});
+
+test('read-only native pairing can show its assigned block but cannot apply a layout', async ({
+  openSession,
+}) => {
+  test.setTimeout(120_000);
+  await withNativeDecoration(openSession, true, async (context) => {
+    const shown = await context.office(['block', 'show']);
+    expect(shown.status, shown.stdout).toBe(0);
+    expect(JSON.parse(shown.stdout)).toMatchObject({
+      blockId: context.blockId,
+      revision: 0,
+      objects: [],
+    });
+    const file = layoutFile(context.sandbox, 'native-read-only-layout.json', [
+      { asset: 'plant', x: 8, y: 8, rotation: 0 },
+    ]);
+    const fileBytes = readFileSync(file);
+    const denied = await context.office(['block', 'apply'], ['--file', file, '--if-revision', '0']);
+    expect(denied.status).toBe(1);
+    expect(JSON.parse(denied.stdout).error.code).toBe('OFFICE_REMOTE_DENIED');
+    expect((await context.blockRef.get()).exists).toBe(false);
+    expect(readFileSync(file)).toEqual(fileBytes);
+  });
+});

--- a/apps/office/src/blocks/block-view.tsx
+++ b/apps/office/src/blocks/block-view.tsx
@@ -164,7 +164,8 @@ export function BlockEditor({
               </button>
             </div>
             <p className="block-note">
-              Private to you. Agent assignment and invitations are not connected yet.
+              Private to your office. Only the owner and an explicitly assigned agent can access
+              this block.
             </p>
           </aside>
         </div>

--- a/contracts/office/block-v1.md
+++ b/contracts/office/block-v1.md
@@ -47,8 +47,10 @@ check in Rules. Curated SVG primitives are repository code, not stored markup.
 Firestore's `objects` field stores that same ordered list as four-character
 ASCII tokens, not maps: asset (`d`, `c`, `p`, `r`), rotation (`0`..`3`), X and Y
 as one lowercase base-32 digit each (`0`..`9`, `a`..`v`). For example `d1us`
-is a desk rotated once at (30, 28). `block-contract.ts` owns the only codec;
-the browser and future command inputs retain readable named fields. There is
+is a desk rotated once at (30, 28). `block-contract.ts` implements the browser
+codec; `tmt-core::office_block` implements the pure native codec against the same
+literal conformance vectors and this contract. Native adapters own readable JSON
+and Firestore envelopes; command inputs retain readable named fields. There is
 no second stored layout or cache. Unknown tokens/fields reject, never truncate.
 
 Encoding permits one bounded regex per slot to enforce asset-specific rotated
@@ -69,6 +71,14 @@ as saved. Pointer placement and form/keyboard edits cause no remote writes.
 Save performs a transaction read, at most one document write, then one server
 read; transaction retries and Rules-dependent reads may add reads. Reset takes
 the latest server-confirmed layout and discards the local draft explicitly.
+
+Native show performs one authorized document read. Apply reads, conditionally
+commits at most one write using the observed server update time (or `exists:false`
+for creation), then reads canonical state. An exact retry needs only the read.
+Failed preconditions may require another read to distinguish a conflict from an
+identical concurrent retry. No automatic write retry or revision rebasing occurs.
+Authentication refresh, eligible lease renewal and pending retirement cleanup
+can add separate operations; ordinary layout reads do not enumerate the world.
 
 Leaving the world or losing admission disposes the editor, its listener and
 private draft; late callbacks cannot repopulate it. Reload still signs out under

--- a/contracts/office/native-companion.md
+++ b/contracts/office/native-companion.md
@@ -4,7 +4,7 @@ This internal local protocol is separate from the proposed remote work-handoff
 schema. It grants no Office access and does not replace pairing.
 
 The core-owned `OfficeInvocation` has exact operations `probe`, `pair-begin`,
-`pair-poll`, `pair-status`, `unpair`, `inspect` and `sync`. Its argument vector is
+`pair-poll`, `pair-status`, `unpair`, `inspect`, `sync`, `block-show` and `block-apply`. Its argument vector is
 `__tmt-office`, `1`, `<operation>`. Unknown versions, operations,
 extra arguments and non-UTF-8 arguments fail with exit 1, empty stdout and a brief
 stderr diagnostic. There is no arbitrary argv forwarding or shell evaluation.
@@ -42,6 +42,20 @@ exercise the real compiled companion. The independent native artifact verifier
 separately checks actual Office archives; neither constitutes public publication.
 
 ## Pairing operations
+
+Block operations use the same protected scope selectors and 4096-byte internal
+message/output bounds. `block-show` additionally accepts nullable `blockId`;
+`block-apply` also requires `layout` (exact readable `objects`) and
+`expectedRevision`. Input files are validated before encoding this compact
+message; the 64 KiB file limit is not an expanded companion payload allowance.
+Success returns exactly `blockId`, `revision` and readable `objects`; the host
+validates the response and supplies catalog/limits from the pure domain owner.
+Errors use the same allowlisted envelope, including `OFFICE_LAYOUT_INVALID`
+and `OFFICE_REVISION_CONFLICT`. `OFFICE_BUSY` denotes proven pre-execution local
+lock contention; unclassified process/transport failures after launch never
+become a busy/no-write claim.
+Unsupported operations from older companions
+are failures, never evidence of a saved layout. See [block v1](block-v1.md).
 
 Pairing and inspect operations consume one bounded JSON object on stdin (4096 bytes):
 `world`, `identityId`, `emulator` and `readOnly`, with no unknown or duplicate

--- a/contracts/office/native-pairing.md
+++ b/contracts/office/native-pairing.md
@@ -71,7 +71,8 @@ status is local-only and returns `unpaired`, `pending`, `credential`, `expired` 
 with `serverAuthorizationChecked: false`. Inspect performs a server-authorized
 read of the assigned block, not a world-wide index. Its result is
 `blockExists: true|false` with `serverAuthorizationChecked: true`; it does not
-return or interpret layout contents. Missing pairing fails `OFFICE_NOT_PAIRED`.
+return layout contents. It reuses the validated block reader; malformed stored
+layouts are errors, not usable-space confirmation. Missing pairing fails `OFFICE_NOT_PAIRED`.
 
 A stable installation UUID is independent of release receipts and binary prefixes:
 one logical installation per ConfigPaths root. Only that public UUID and scope

--- a/docs/office/architecture.md
+++ b/docs/office/architecture.md
@@ -95,7 +95,15 @@ Firebase setup is implied.
 There is no work connector, deployed service or shared browser runtime package yet.
 The independently versioned native `tmt-office` companion currently implements
 the [typed local protocol](../../contracts/office/native-companion.md), including
-pairing, local status and an authorized assigned-block existence check.
+pairing, local status, an authorized assigned-block existence check and
+revision-safe block show/apply. Pure native scene validation lives in
+`tmt-core::office_block`; readable JSON belongs to `tmt-adapters::office_block`.
+The companion's scoped remote adapter reads one block and commits with its
+server update-time precondition (or nonexistence for creation), then rereads
+canonical state. It shares pairing refresh/renewal and scope locks, not a generic
+CRUD service. Exact retries preserve the timestamp; conflicting revisions never
+rebase automatically. Browser and native codecs conform to the same literal
+block vectors. There is no local scene cache or second grant registry.
 Its optional adapter feature owns discovery, Auth exchange/refresh, invocation-owned
 resource-lease renewal, identity retirement hook consumption and protected
 scope records. It has no public distribution. The CLI's explicit `office`

--- a/docs/office/commands.md
+++ b/docs/office/commands.md
@@ -79,7 +79,7 @@ replacement has a different UUID and cannot inherit the pairing. `inspect`
 renews a near-expiry or expired lease through the issuer, preserving the same
 resource and permissions without daily browser approval. Local status does not
 renew. Revoked or missing grants cannot be renewed; expired pending approvals
-and lost credentials still need recovery work. Unpair remains planned.
+and lost credentials still need a new owner-approved request.
 Identity retirement queues cleanup locally. Pair/inspect attempt queued Office
 cleanup; to retry explicitly without an active identity or pane, run:
 
@@ -102,6 +102,49 @@ It confirms revocation before retaining a secret-free receipt; an explicit pair
 can then start again under the same identity. Pending cancellation may require
 the owner to cancel using the original link first. Failure never permits deleting
 credentials. This is separate from the proposed connector lifecycle below.
+
+## Agent decoration (source builds)
+
+After pairing, use the same world and identity selectors:
+
+```sh
+tmt office block show --world <url> --identity Alice --json
+tmt office block apply --world <url> --identity Alice --file layout.json --if-revision 0 --json
+```
+
+`show` returns `blockId`, `revision`, readable `objects`, the curated `catalog`
+and room `limits`. An absent layout has revision 0 and no objects. An optional
+block ID after `show` or `apply` must equal the pairing's assignment; omitting it
+selects that assignment, not another identity's room.
+
+The input file contains only `objects`, for example:
+
+```json
+{
+  "objects": [
+    { "asset": "desk", "x": 4, "y": 6, "rotation": 0 },
+    { "asset": "plant", "x": 10, "y": 6, "rotation": 0 }
+  ]
+}
+```
+
+Use the revision returned by `show`, not a guessed number. Apply replaces the
+complete ordered layout; an empty list clears it. The [block contract](../../contracts/office/block-v1.md)
+owns dimensions, layering and bounds. Files larger than 64 KiB or invalid objects
+fail before submission. Plain output is readable JSON; `--json` is compact.
+
+`OFFICE_REVISION_CONFLICT` means another layout won: reread and deliberately
+reconcile before applying a new revision. An exact retry of identical ordered
+objects at expected+1 performs no write. `OFFICE_REMOTE_UNCERTAIN` does not mean
+the save failed: retain the draft, reread, and retry only the same original
+revision/intent until the outcome is known. Apply returns server-confirmed current
+data, which may include a subsequent editor's update; inspect it before summarizing.
+Read-only or revoked grants cannot write. These commands renew eligible leases
+and use the same scoped access and cleanup mechanism as inspect.
+
+`OFFICE_BUSY` is different from an uncertain save: the local lock prevented the
+operation from starting. After the other operation finishes, retry the same
+revision and layout. There is no automatic queue or revision rebasing.
 
 ## Planned connected commands
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "icu_locale_core",
  "icu_normalizer",
  "semver",
+ "serde_json",
  "sha2",
  "uuid",
 ]

--- a/rust/crates/tmt-adapters/Cargo.toml
+++ b/rust/crates/tmt-adapters/Cargo.toml
@@ -7,12 +7,12 @@ license.workspace = true
 publish.workspace = true
 
 [features]
-office = ["dep:serde", "dep:url", "dep:getrandom", "dep:keyring-core", "dep:zbus-secret-service-keyring-store", "dep:apple-native-keyring-store"]
+office = ["dep:url", "dep:getrandom", "dep:keyring-core", "dep:zbus-secret-service-keyring-store", "dep:apple-native-keyring-store"]
 
 [dependencies]
 getrandom = { workspace = true, optional = true }
 keyring-core = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde.workspace = true
 url = { workspace = true, optional = true }
 ureq.workspace = true
 tmt-core.workspace = true

--- a/rust/crates/tmt-adapters/src/lib.rs
+++ b/rust/crates/tmt-adapters/src/lib.rs
@@ -12,6 +12,8 @@ mod json_document;
 #[cfg(unix)]
 pub mod native_install;
 #[cfg(unix)]
+pub mod office_block;
+#[cfg(unix)]
 pub mod office_companion;
 #[cfg(feature = "office")]
 pub mod office_deployment;

--- a/rust/crates/tmt-adapters/src/office_block.rs
+++ b/rust/crates/tmt-adapters/src/office_block.rs
@@ -1,0 +1,196 @@
+//! Readable block input/output. Firestore envelopes belong to the remote adapter.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::path::Path;
+use tmt_core::{
+    office_block::{
+        BLOCK_SIZE, BlockLayout, Furniture, FurnitureAsset, INPUT_LIMIT, MAX_REVISION, OBJECT_LIMIT,
+    },
+    office_protocol::OfficeError,
+};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LayoutInput {
+    objects: Vec<ObjectInput>,
+}
+
+impl LayoutInput {
+    pub(crate) fn validate(self) -> Result<BlockLayout, OfficeError> {
+        validated_objects(self.objects)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ObjectInput {
+    asset: String,
+    x: u8,
+    y: u8,
+    rotation: u8,
+}
+
+fn validated_objects(objects: Vec<ObjectInput>) -> Result<BlockLayout, OfficeError> {
+    let objects = objects
+        .into_iter()
+        .map(|object| {
+            Ok(Furniture {
+                asset: FurnitureAsset::parse(&object.asset).ok_or(OfficeError::LayoutInvalid)?,
+                x: object.x,
+                y: object.y,
+                rotation: object.rotation,
+            })
+        })
+        .collect::<Result<Vec<_>, OfficeError>>()?;
+    BlockLayout::new(objects).map_err(|_| OfficeError::LayoutInvalid)
+}
+
+pub fn read_layout_file(path: &Path) -> Result<BlockLayout, OfficeError> {
+    let bytes =
+        crate::bounded_file::read(path, INPUT_LIMIT).map_err(|_| OfficeError::LayoutInvalid)?;
+    decode_layout(&bytes)
+}
+
+pub(crate) fn decode_layout(bytes: &[u8]) -> Result<BlockLayout, OfficeError> {
+    if bytes.len() > INPUT_LIMIT {
+        return Err(OfficeError::LayoutInvalid);
+    }
+    let input: LayoutInput =
+        serde_json::from_slice(bytes).map_err(|_| OfficeError::LayoutInvalid)?;
+    input.validate()
+}
+
+pub(crate) fn layout_value(layout: &BlockLayout) -> Value {
+    json!({"objects": layout.objects().iter().map(|object| json!({
+        "asset": object.asset.name(), "x":object.x, "y":object.y,"rotation":object.rotation
+    })).collect::<Vec<_>>()})
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockSnapshot {
+    pub block_id: String,
+    pub revision: u64,
+    pub layout: BlockLayout,
+}
+
+impl BlockSnapshot {
+    pub fn public_value(&self) -> Value {
+        let mut value = self.wire_value();
+        value["limits"] = json!({"size":BLOCK_SIZE,"objects":OBJECT_LIMIT});
+        value["catalog"] = json!(
+            FurnitureAsset::ALL
+                .iter()
+                .map(|asset| {
+                    let (width, height) = asset.dimensions();
+                    json!({"asset":asset.name(),"width":width,"height":height})
+                })
+                .collect::<Vec<_>>()
+        );
+        value
+    }
+
+    pub(crate) fn wire_value(&self) -> Value {
+        let mut value = layout_value(&self.layout);
+        value["blockId"] = json!(self.block_id);
+        value["revision"] = json!(self.revision);
+        value
+    }
+
+    pub(crate) fn decode(bytes: &[u8]) -> Result<Self, OfficeError> {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Snapshot {
+            block_id: String,
+            revision: u64,
+            objects: Vec<ObjectInput>,
+        }
+        let wire: Snapshot =
+            serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+        if uuid::Uuid::parse_str(&wire.block_id)
+            .ok()
+            .is_none_or(|id| id.to_string() != wire.block_id)
+            || wire.revision > MAX_REVISION
+        {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let layout =
+            validated_objects(wire.objects).map_err(|_| OfficeError::CredentialsInvalid)?;
+        if wire.revision == 0 && !layout.objects().is_empty() {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        Ok(Self {
+            block_id: wire.block_id,
+            revision: wire.revision,
+            layout,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn readable_wire_round_trips_without_exposing_storage_tokens() {
+        let layout =
+            decode_layout(br#"{"objects":[{"asset":"desk","x":30,"y":28,"rotation":1}]}"#).unwrap();
+        assert_eq!(layout.encode(), ["d1us"]);
+        let snapshot = BlockSnapshot {
+            block_id: "11111111-1111-4111-8111-111111111111".into(),
+            revision: 1,
+            layout,
+        };
+        let bytes = serde_json::to_vec(&snapshot.wire_value()).unwrap();
+        assert_eq!(BlockSnapshot::decode(&bytes).unwrap(), snapshot);
+        assert_eq!(snapshot.public_value()["objects"][0]["asset"], "desk");
+        assert_eq!(
+            snapshot.public_value()["catalog"].as_array().unwrap().len(),
+            4
+        );
+    }
+
+    #[test]
+    fn actual_readable_inputs_conform_to_shared_literal_vectors() {
+        let vectors: Vec<Value> = serde_json::from_str(include_str!(
+            "../../../../contracts/office/block-v1.vectors.json"
+        ))
+        .unwrap();
+        for vector in vectors {
+            let result =
+                decode_layout(&serde_json::to_vec(&json!({"objects":[vector["item"]]})).unwrap());
+            assert_eq!(
+                result.is_ok(),
+                vector["valid"].as_bool().unwrap(),
+                "{}",
+                vector["name"]
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_envelopes_and_oversized_files_are_rejected() {
+        for bytes in [
+            b"{}".as_slice(),
+            br#"{"objects":[],"extra":true}"#,
+            br#"{"objects":["d000"]}"#,
+            br#"{"objects":[],"objects":[]}"#,
+        ] {
+            assert_eq!(decode_layout(bytes), Err(OfficeError::LayoutInvalid));
+        }
+        assert_eq!(
+            decode_layout(&vec![b' '; INPUT_LIMIT + 1]),
+            Err(OfficeError::LayoutInvalid)
+        );
+        let directory = crate::test_support::TestDirectory::new();
+        let file = directory.path.join("layout.json");
+        std::fs::write(&file, br#"{"objects":[]}"#).unwrap();
+        assert!(read_layout_file(&file).unwrap().objects().is_empty());
+        std::fs::write(&file, vec![b' '; INPUT_LIMIT + 1]).unwrap();
+        assert_eq!(read_layout_file(&file), Err(OfficeError::LayoutInvalid));
+        assert_eq!(
+            read_layout_file(&directory.path),
+            Err(OfficeError::LayoutInvalid)
+        );
+    }
+}

--- a/rust/crates/tmt-adapters/src/office_companion.rs
+++ b/rust/crates/tmt-adapters/src/office_companion.rs
@@ -37,7 +37,13 @@ pub fn invoke_office_pairing(
     call: &PairingCall<'_>,
     deadline: Instant,
 ) -> io::Result<PairingReply> {
-    if matches!(operation, OfficeInvocation::Probe | OfficeInvocation::Sync) {
+    if matches!(
+        operation,
+        OfficeInvocation::Probe
+            | OfficeInvocation::Sync
+            | OfficeInvocation::BlockShow
+            | OfficeInvocation::BlockApply
+    ) {
         return Err(invalid_pairing());
     }
     let input = serde_json::to_vec(
@@ -48,6 +54,62 @@ pub fn invoke_office_pairing(
     }
     let bytes = invoke_json(executable, operation, &input, deadline)?;
     decode_pairing_reply(&bytes, call.world)
+}
+
+pub fn invoke_office_block(
+    executable: &Path,
+    call: &PairingCall<'_>,
+    block_id: Option<&str>,
+    edit: Option<(&tmt_core::office_block::BlockLayout, u64)>,
+    deadline: Instant,
+) -> io::Result<Result<crate::office_block::BlockSnapshot, OfficeError>> {
+    let mut input = serde_json::json!({"world":call.world,"identityId":call.identity_id,"emulator":call.emulator,"readOnly":false,"blockId":block_id});
+    let operation = if let Some((layout, revision)) = edit {
+        if revision >= tmt_core::office_block::MAX_REVISION {
+            return Ok(Err(OfficeError::LayoutInvalid));
+        }
+        input["layout"] = crate::office_block::layout_value(layout);
+        input["expectedRevision"] = serde_json::json!(revision);
+        OfficeInvocation::BlockApply
+    } else {
+        OfficeInvocation::BlockShow
+    };
+    let input = serde_json::to_vec(&input)?;
+    if input.len() > 4096 {
+        return Err(invalid_pairing());
+    }
+    let bytes = match invoke_json(executable, operation, &input, deadline) {
+        Ok(bytes) => bytes,
+        // The installer lock failed before the child was launched. Command
+        // failures after launch are wrapped as Other by invoke_json and must
+        // remain uncertain; never advertise a possibly committed write as busy.
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+            return Ok(Err(OfficeError::Busy));
+        }
+        Err(error) => return Err(error),
+    };
+    decode_block_reply(&bytes, block_id)
+}
+
+fn decode_block_reply(
+    bytes: &[u8],
+    block_id: Option<&str>,
+) -> io::Result<Result<crate::office_block::BlockSnapshot, OfficeError>> {
+    if bytes.len() > 4096 {
+        return Err(invalid_pairing());
+    }
+    let value: serde_json::Value = serde_json::from_slice(bytes).map_err(|_| invalid_pairing())?;
+    if value.as_object().is_some_and(|object| object.len() == 1)
+        && let Some(error) = value["error"].as_str().and_then(OfficeError::parse)
+    {
+        return Ok(Err(error));
+    }
+    let snapshot =
+        crate::office_block::BlockSnapshot::decode(bytes).map_err(|_| invalid_pairing())?;
+    if block_id.is_some_and(|id| id != snapshot.block_id) {
+        return Err(invalid_pairing());
+    }
+    Ok(Ok(snapshot))
 }
 
 pub fn invoke_office_sync(
@@ -216,6 +278,35 @@ fn finish_probe(running: RunningCommand, expected_version: &semver::Version) -> 
 #[cfg(test)]
 mod pairing_tests {
     use super::*;
+
+    #[test]
+    fn block_replies_are_bounded_typed_and_match_explicit_targets() {
+        let id = "11111111-1111-4111-8111-111111111111";
+        let value = serde_json::json!({"blockId":id,"revision":0,"objects":[]});
+        let bytes = serde_json::to_vec(&value).unwrap();
+        assert_eq!(
+            decode_block_reply(&bytes, Some(id))
+                .unwrap()
+                .unwrap()
+                .revision,
+            0
+        );
+        assert!(decode_block_reply(&bytes, Some("22222222-2222-4222-8222-222222222222")).is_err());
+        assert_eq!(
+            decode_block_reply(br#"{"error":"OFFICE_REVISION_CONFLICT"}"#, None).unwrap(),
+            Err(OfficeError::RevisionConflict)
+        );
+        for invalid in [
+            serde_json::json!({"blockId":id,"revision":0,"objects":[{"asset":"desk","x":0,"y":0,"rotation":0}]}),
+            serde_json::json!({"blockId":id,"revision":1,"objects":[],"token":"unexpected"}),
+            serde_json::json!({"blockId":id,"revision":1,"objects":["d000"]}),
+            serde_json::json!({"error":"UNKNOWN"}),
+            serde_json::json!({"state":"credential"}),
+        ] {
+            assert!(decode_block_reply(&serde_json::to_vec(&invalid).unwrap(), None).is_err());
+        }
+        assert!(decode_block_reply(&vec![b' '; 4097], None).is_err());
+    }
 
     #[test]
     fn sync_reports_are_bounded_and_expose_only_public_delivery_state() {

--- a/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/invocation.rs
@@ -21,6 +21,12 @@ struct Request {
     identity_id: String,
     emulator: bool,
     read_only: bool,
+    #[serde(default)]
+    block_id: Option<String>,
+    #[serde(default)]
+    layout: Option<crate::office_block::LayoutInput>,
+    #[serde(default)]
+    expected_revision: Option<u64>,
 }
 
 pub fn execute(operation: OfficeInvocation, bytes: &[u8]) -> Vec<u8> {
@@ -45,8 +51,48 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
             json!({"completed":report.completed,"failed":report.failed,"pending":report.pending,"failureCode":report.failure.map(|error| error.code())}),
         );
     }
-    let request: Request =
+    let mut request: Request =
         serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+    let block = matches!(
+        operation,
+        OfficeInvocation::BlockShow | OfficeInvocation::BlockApply
+    );
+    let raw: Value = serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+    let fields = raw.as_object().ok_or(OfficeError::CredentialsInvalid)?;
+    let expected_fields = if operation == OfficeInvocation::BlockApply {
+        7
+    } else if block {
+        5
+    } else {
+        4
+    };
+    if fields.len() != expected_fields
+        || (block && (!fields.contains_key("blockId") || request.read_only))
+        || (!block
+            && ["blockId", "layout", "expectedRevision"]
+                .iter()
+                .any(|key| fields.contains_key(*key)))
+    {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    let edit = match operation {
+        OfficeInvocation::BlockApply => {
+            let revision = request
+                .expected_revision
+                .filter(|value| *value < tmt_core::office_block::MAX_REVISION)
+                .ok_or(OfficeError::LayoutInvalid)?;
+            let layout = request
+                .layout
+                .take()
+                .ok_or(OfficeError::LayoutInvalid)?
+                .validate()?;
+            Some((layout, revision))
+        }
+        _ if request.layout.is_some() || request.expected_revision.is_some() => {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        _ => None,
+    };
     let mode = if request.emulator {
         DeploymentMode::Emulator
     } else {
@@ -95,7 +141,9 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
                 entry.write(&record.encode()?)?;
                 Ok(json!({"state":"revoked"}))
             }
-            OfficeInvocation::Inspect => {
+            OfficeInvocation::Inspect
+            | OfficeInvocation::BlockShow
+            | OfficeInvocation::BlockApply => {
                 let mut record = existing.ok_or(OfficeError::NotPaired)?;
                 if record.refresh_if_needed(&target, now_ms()?, deadline)? {
                     active_identity(&paths, &identity.id)?;
@@ -107,8 +155,19 @@ fn run(operation: OfficeInvocation, bytes: &[u8]) -> Result<Value, OfficeError> 
                     entry.write(&record.encode()?)?;
                 }
                 active_identity(&paths, &identity.id)?;
-                let exists = record.inspect(&target, now_ms()?, deadline)?;
-                Ok(json!({"blockExists":exists}))
+                if block {
+                    let snapshot = record.block(
+                        &target,
+                        now_ms()?,
+                        request.block_id.as_deref(),
+                        edit.as_ref().map(|(layout, revision)| (layout, *revision)),
+                        deadline,
+                    )?;
+                    Ok(snapshot.wire_value())
+                } else {
+                    let exists = record.inspect(&target, now_ms()?, deadline)?;
+                    Ok(json!({"blockExists":exists}))
+                }
             }
             OfficeInvocation::PairStatus => {
                 let now = now_ms()?;
@@ -211,4 +270,78 @@ pub(super) fn now_ms() -> Result<u64, OfficeError> {
         .as_millis()
         .try_into()
         .map_err(|_| OfficeError::CredentialsUnavailable)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scoped() -> Value {
+        // Invalid deployment is an intentional downstream sentinel: valid input
+        // reaches deployment validation without reading any host identity/vault.
+        json!({"world":"invalid", "identityId":"identity", "emulator":false, "readOnly":false})
+    }
+
+    fn error(operation: OfficeInvocation, value: &Value) -> OfficeError {
+        run(operation, &serde_json::to_vec(value).unwrap()).unwrap_err()
+    }
+
+    #[test]
+    fn block_input_is_typed_and_does_not_expand_pairing_inputs() {
+        let mut show = scoped();
+        assert_eq!(
+            error(OfficeInvocation::Inspect, &show),
+            OfficeError::DeploymentInvalid
+        );
+        show["blockId"] = Value::Null;
+        assert_eq!(
+            error(OfficeInvocation::BlockShow, &show),
+            OfficeError::DeploymentInvalid
+        );
+        assert_eq!(
+            error(OfficeInvocation::Inspect, &show),
+            OfficeError::CredentialsInvalid
+        );
+        show["layout"] = json!({"objects":[]});
+        show["expectedRevision"] = json!(0);
+        assert_eq!(
+            error(OfficeInvocation::BlockApply, &show),
+            OfficeError::DeploymentInvalid
+        );
+        assert_eq!(
+            error(OfficeInvocation::BlockShow, &show),
+            OfficeError::CredentialsInvalid
+        );
+        show["expectedRevision"] = json!(tmt_core::office_block::MAX_REVISION);
+        assert_eq!(
+            error(OfficeInvocation::BlockApply, &show),
+            OfficeError::LayoutInvalid
+        );
+        show["expectedRevision"] = json!(0);
+        show["layout"] = json!({"objects":[{"asset":"rug","rotation":0,"x":31,"y":31}]});
+        assert_eq!(
+            error(OfficeInvocation::BlockApply, &show),
+            OfficeError::LayoutInvalid
+        );
+    }
+
+    #[test]
+    fn unknown_duplicate_and_oversized_payloads_fail_before_scope_access() {
+        let mut value = scoped();
+        value["blockId"] = Value::Null;
+        value["unknown"] = json!(true);
+        assert_eq!(
+            error(OfficeInvocation::BlockShow, &value),
+            OfficeError::CredentialsInvalid
+        );
+        let duplicate = br#"{"world":"invalid","identityId":"identity","emulator":false,"readOnly":false,"blockId":null,"layout":{"objects":[],"objects":[]},"expectedRevision":0}"#;
+        assert_eq!(
+            run(OfficeInvocation::BlockApply, duplicate),
+            Err(OfficeError::CredentialsInvalid)
+        );
+        assert_eq!(
+            run(OfficeInvocation::BlockShow, &vec![b' '; 4097]),
+            Err(OfficeError::CredentialsInvalid)
+        );
+    }
 }

--- a/rust/crates/tmt-adapters/src/office_pairing/local.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/local.rs
@@ -142,8 +142,12 @@ fn read_id(directory: &std::path::Path) -> Result<Option<String>, OfficeError> {
     Ok(Some(id))
 }
 
-fn unavailable(_: io::Error) -> OfficeError {
-    OfficeError::CredentialsUnavailable
+fn unavailable(error: io::Error) -> OfficeError {
+    if error.kind() == io::ErrorKind::WouldBlock {
+        OfficeError::Busy
+    } else {
+        OfficeError::CredentialsUnavailable
+    }
 }
 
 #[cfg(test)]
@@ -242,7 +246,7 @@ mod tests {
             .with_scope(&target, identity, |key| {
                 assert_eq!(
                     installation.with_scope(&target, identity, |_| Ok(())),
-                    Err(OfficeError::CredentialsUnavailable)
+                    Err(OfficeError::Busy)
                 );
                 Ok(key.to_string())
             })

--- a/rust/crates/tmt-adapters/src/office_pairing/record.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/record.rs
@@ -184,6 +184,35 @@ impl PairingRecord {
         }
     }
 
+    pub(super) fn block(
+        &self,
+        target: &WorldTarget,
+        now_ms: u64,
+        requested_id: Option<&str>,
+        edit: Option<(&tmt_core::office_block::BlockLayout, u64)>,
+        deadline: std::time::Instant,
+    ) -> Result<crate::office_block::BlockSnapshot, OfficeError> {
+        match &self.phase {
+            Phase::Paired {
+                grant_expires_at,
+                block_id,
+                credential,
+                ..
+            } => {
+                if now_ms >= *grant_expires_at {
+                    return Err(OfficeError::PairingExpired);
+                }
+                if requested_id.is_some_and(|id| id != block_id)
+                    || (edit.is_some() && self.approval.read_only())
+                {
+                    return Err(OfficeError::RemoteDenied);
+                }
+                credential.block(&self.deployment(target)?, block_id, edit, deadline)
+            }
+            Phase::Pending { .. } | Phase::Revoked {} => Err(OfficeError::NotPaired),
+        }
+    }
+
     pub fn pending(
         deployment: &OfficeDeployment,
         approval: Approval,

--- a/rust/crates/tmt-adapters/src/office_pairing/remote.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/remote.rs
@@ -1,5 +1,7 @@
 //! Fixed Firebase REST operations; no caller-provided credential destination.
 
+mod blocks;
+
 use super::{
     Approval, Claim, OfficeError, Proof,
     wire::{RESPONSE_LIMIT, valid_token},
@@ -154,48 +156,8 @@ impl AgentCredential {
         block_id: &str,
         deadline: Instant,
     ) -> Result<bool, OfficeError> {
-        if !super::wire::valid_uuid(block_id) || !valid_token(&self.id_token) {
-            return Err(OfficeError::CredentialsInvalid);
-        }
-        let base = match deployment.target().mode() {
-            DeploymentMode::Cloud => "https://firestore.googleapis.com",
-            DeploymentMode::Emulator => "http://127.0.0.1:8080",
-        };
-        let name = format!(
-            "projects/{}/databases/(default)/documents/worlds/{}/blocks/{block_id}",
-            deployment.project_id(),
-            deployment.target().world_id()
-        );
-        let agent = office_http::agent(deployment.target().mode(), deadline)
-            .map_err(|_| OfficeError::RemoteUncertain)?;
-        let mut response = agent
-            .get(format!("{base}/v1/{name}"))
-            .header("Authorization", &format!("Bearer {}", self.id_token))
-            .header("Accept", "application/json")
-            .header("Cache-Control", "no-store")
-            .call()
-            .map_err(|_| OfficeError::RemoteUncertain)?;
-        match response.status().as_u16() {
-            200 => {
-                let bytes = office_http::json_body(&mut response, RESPONSE_LIMIT)
-                    .map_err(|_| OfficeError::RemoteUncertain)?;
-                #[derive(Deserialize)]
-                struct Document {
-                    name: String,
-                }
-                let document: Document =
-                    serde_json::from_slice(&bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
-                if document.name != name {
-                    return Err(OfficeError::CredentialsInvalid);
-                }
-                // Existence only: no parallel layout codec or unchecked fields.
-                Ok(true)
-            }
-            404 => Ok(false),
-            401 | 403 => Err(OfficeError::RemoteDenied),
-            300..=399 => Err(OfficeError::CredentialsInvalid),
-            _ => Err(OfficeError::RemoteUncertain),
-        }
+        self.block(deployment, block_id, None, deadline)
+            .map(|snapshot| snapshot.revision != 0)
     }
 
     pub fn exchange(

--- a/rust/crates/tmt-adapters/src/office_pairing/remote/blocks.rs
+++ b/rust/crates/tmt-adapters/src/office_pairing/remote/blocks.rs
@@ -1,0 +1,359 @@
+//! Scoped Firestore block reads and conditional single-document commits.
+
+use super::{AgentCredential, DeploymentMode, OfficeDeployment, OfficeError, valid_token};
+use crate::{office_block::BlockSnapshot, office_http};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::time::Instant;
+use tmt_core::office_block::{BlockLayout, MAX_REVISION};
+
+const DOCUMENT_LIMIT: usize = 8192;
+
+struct Document {
+    snapshot: BlockSnapshot,
+    update_time: Option<String>,
+}
+
+struct BlockResource<'a> {
+    deployment: &'a OfficeDeployment,
+    token: &'a str,
+    block_id: &'a str,
+    base: &'static str,
+    name: String,
+    deadline: Instant,
+}
+
+impl AgentCredential {
+    pub(in crate::office_pairing) fn block(
+        &self,
+        deployment: &OfficeDeployment,
+        block_id: &str,
+        edit: Option<(&BlockLayout, u64)>,
+        deadline: Instant,
+    ) -> Result<BlockSnapshot, OfficeError> {
+        if !super::super::wire::valid_uuid(block_id) || !valid_token(&self.id_token) {
+            return Err(OfficeError::CredentialsInvalid);
+        }
+        let resource = BlockResource {
+            deployment,
+            token: &self.id_token,
+            block_id,
+            base: match deployment.target().mode() {
+                DeploymentMode::Cloud => "https://firestore.googleapis.com",
+                DeploymentMode::Emulator => "http://127.0.0.1:8080",
+            },
+            name: format!(
+                "projects/{}/databases/(default)/documents/worlds/{}/blocks/{block_id}",
+                deployment.project_id(),
+                deployment.target().world_id()
+            ),
+            deadline,
+        };
+        let current = resource.read()?;
+        let Some((layout, expected)) = edit else {
+            return Ok(current.snapshot);
+        };
+        if expected >= MAX_REVISION {
+            return Err(OfficeError::LayoutInvalid);
+        }
+        if exact_retry(&current.snapshot, layout, expected) {
+            return Ok(current.snapshot);
+        }
+        if current.snapshot.revision != expected {
+            return Err(OfficeError::RevisionConflict);
+        }
+        match resource.commit(&current, layout, expected + 1) {
+            Ok(()) => {
+                let confirmed = resource.read()?;
+                if confirmed.snapshot.revision < expected + 1
+                    || (confirmed.snapshot.revision == expected + 1
+                        && &confirmed.snapshot.layout != layout)
+                {
+                    return Err(OfficeError::RemoteUncertain);
+                }
+                Ok(confirmed.snapshot)
+            }
+            Err(error @ (OfficeError::RevisionConflict | OfficeError::RemoteDenied)) => {
+                // A concurrent exact retry can win the conditional write. Re-read
+                // under current authority; never retry with a new revision.
+                let observed = resource.read()?;
+                if exact_retry(&observed.snapshot, layout, expected) {
+                    Ok(observed.snapshot)
+                } else if observed.snapshot.revision != expected {
+                    Err(OfficeError::RevisionConflict)
+                } else {
+                    Err(error)
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn exact_retry(snapshot: &BlockSnapshot, layout: &BlockLayout, expected: u64) -> bool {
+    snapshot.revision == expected + 1 && &snapshot.layout == layout
+}
+
+impl BlockResource<'_> {
+    fn read(&self) -> Result<Document, OfficeError> {
+        let agent = office_http::agent(self.deployment.target().mode(), self.deadline)
+            .map_err(|_| OfficeError::RemoteUncertain)?;
+        let mut response = agent
+            .get(format!("{}/v1/{}", self.base, self.name))
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/json")
+            .header("Cache-Control", "no-store")
+            .call()
+            .map_err(|_| OfficeError::RemoteUncertain)?;
+        match response.status().as_u16() {
+            200 => {
+                let bytes = office_http::json_body(&mut response, DOCUMENT_LIMIT)
+                    .map_err(|_| OfficeError::RemoteUncertain)?;
+                decode_document(&bytes, &self.name, self.block_id)
+            }
+            404 => Ok(Document {
+                snapshot: BlockSnapshot {
+                    block_id: self.block_id.into(),
+                    revision: 0,
+                    layout: BlockLayout::new(vec![])
+                        .map_err(|_| OfficeError::CredentialsInvalid)?,
+                },
+                update_time: None,
+            }),
+            401 | 403 => Err(OfficeError::RemoteDenied),
+            300..=399 => Err(OfficeError::CredentialsInvalid),
+            _ => Err(OfficeError::RemoteUncertain),
+        }
+    }
+
+    fn commit(
+        &self,
+        current: &Document,
+        layout: &BlockLayout,
+        revision: u64,
+    ) -> Result<(), OfficeError> {
+        let body = commit_body(&self.name, current.update_time.as_deref(), layout, revision);
+        let url = format!(
+            "{}/v1/projects/{}/databases/(default)/documents:commit",
+            self.base,
+            self.deployment.project_id()
+        );
+        let agent = office_http::agent(self.deployment.target().mode(), self.deadline)
+            .map_err(|_| OfficeError::RemoteUncertain)?;
+        let mut response = agent
+            .post(url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .send(body.to_string())
+            .map_err(|_| OfficeError::RemoteUncertain)?;
+        match response.status().as_u16() {
+            200 => {
+                let bytes = office_http::json_body(&mut response, DOCUMENT_LIMIT)
+                    .map_err(|_| OfficeError::RemoteUncertain)?;
+                let value: Value =
+                    serde_json::from_slice(&bytes).map_err(|_| OfficeError::RemoteUncertain)?;
+                if value["writeResults"]
+                    .as_array()
+                    .is_none_or(|items| items.len() != 1)
+                    || value["commitTime"].as_str().is_none()
+                {
+                    return Err(OfficeError::RemoteUncertain);
+                }
+                Ok(())
+            }
+            401 | 403 => Err(OfficeError::RemoteDenied),
+            409 | 412 => Err(OfficeError::RevisionConflict),
+            400 => {
+                let bytes = office_http::json_body(&mut response, DOCUMENT_LIMIT)
+                    .map_err(|_| OfficeError::RemoteUncertain)?;
+                let value: Value =
+                    serde_json::from_slice(&bytes).map_err(|_| OfficeError::RemoteUncertain)?;
+                if value["error"]["status"] == "FAILED_PRECONDITION" {
+                    Err(OfficeError::RevisionConflict)
+                } else {
+                    Err(OfficeError::RemoteUncertain)
+                }
+            }
+            300..=399 => Err(OfficeError::CredentialsInvalid),
+            _ => Err(OfficeError::RemoteUncertain),
+        }
+    }
+}
+
+fn commit_body(
+    name: &str,
+    update_time: Option<&str>,
+    layout: &BlockLayout,
+    revision: u64,
+) -> Value {
+    let precondition = update_time.map_or_else(
+        || json!({"exists":false}),
+        |time| json!({"updateTime":time}),
+    );
+    json!({"writes":[{
+        "update":{"name":name,"fields":{
+            "version":{"integerValue":"1"},
+            "revision":{"integerValue":revision.to_string()},
+            "objects":{"arrayValue":{"values":layout.encode().iter().map(|token| json!({"stringValue":token})).collect::<Vec<_>>()}}
+        }},
+        "currentDocument":precondition,
+        "updateTransforms":[{"fieldPath":"updatedAt","setToServerValue":"REQUEST_TIME"}]
+    }]})
+}
+
+fn decode_document(bytes: &[u8], name: &str, block_id: &str) -> Result<Document, OfficeError> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct WireDocument {
+        name: String,
+        fields: Value,
+        update_time: String,
+    }
+    let document: WireDocument =
+        serde_json::from_slice(bytes).map_err(|_| OfficeError::CredentialsInvalid)?;
+    let fields = document
+        .fields
+        .as_object()
+        .ok_or(OfficeError::CredentialsInvalid)?;
+    if document.name != name
+        || fields.len() != 4
+        || document.update_time.is_empty()
+        || fields.get("version") != Some(&json!({"integerValue":"1"}))
+    {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    let revision = fields
+        .get("revision")
+        .and_then(|field| field["integerValue"].as_str())
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| (1..=MAX_REVISION).contains(value))
+        .ok_or(OfficeError::CredentialsInvalid)?;
+    if fields["revision"] != json!({"integerValue":revision.to_string()}) {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    let timestamp = fields
+        .get("updatedAt")
+        .and_then(|field| field["timestampValue"].as_str())
+        .ok_or(OfficeError::CredentialsInvalid)?;
+    if timestamp.is_empty() || fields["updatedAt"] != json!({"timestampValue":timestamp}) {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    let array = fields
+        .get("objects")
+        .and_then(|field| field.get("arrayValue"))
+        .ok_or(OfficeError::CredentialsInvalid)?;
+    let values = array.get("values").cloned().unwrap_or_else(|| json!([]));
+    if fields["objects"] != json!({"arrayValue": {"values":values}})
+        && fields["objects"] != json!({"arrayValue":{}})
+    {
+        return Err(OfficeError::CredentialsInvalid);
+    }
+    let tokens = values
+        .as_array()
+        .ok_or(OfficeError::CredentialsInvalid)?
+        .iter()
+        .map(|value| {
+            let token = value["stringValue"]
+                .as_str()
+                .ok_or(OfficeError::CredentialsInvalid)?;
+            if value != &json!({"stringValue":token}) {
+                return Err(OfficeError::CredentialsInvalid);
+            }
+            Ok(token.to_owned())
+        })
+        .collect::<Result<Vec<_>, OfficeError>>()?;
+    let layout = BlockLayout::decode(&tokens).map_err(|_| OfficeError::CredentialsInvalid)?;
+    Ok(Document {
+        snapshot: BlockSnapshot {
+            block_id: block_id.into(),
+            revision,
+            layout,
+        },
+        update_time: Some(document.update_time),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn document() -> Value {
+        json!({"name":"expected", "updateTime":"2026-09-13T00:00:00Z", "fields":{
+            "version":{"integerValue":"1"}, "revision":{"integerValue":"7"},
+            "objects":{"arrayValue":{"values":[{"stringValue":"d1us"}]}},
+            "updatedAt":{"timestampValue":"2026-09-13T00:00:00Z"}
+        }})
+    }
+
+    #[test]
+    fn firestore_decoder_rejects_other_resources_and_invalid_document_fields() {
+        let good = document();
+        let read = |value: &Value| {
+            decode_document(&serde_json::to_vec(value).unwrap(), "expected", "block")
+        };
+        let parsed = read(&good).unwrap();
+        assert_eq!(parsed.snapshot.revision, 7);
+        assert_eq!(parsed.snapshot.layout.encode(), ["d1us"]);
+        for (pointer, replacement) in [
+            ("/name", json!("another")),
+            ("/fields/version/integerValue", json!("2")),
+            ("/fields/revision/integerValue", json!("0")),
+            ("/fields/revision/integerValue", json!("9007199254740992")),
+            (
+                "/fields/objects/arrayValue/values/0/stringValue",
+                json!("d1ut"),
+            ),
+            (
+                "/fields/updatedAt",
+                json!({"stringValue":"not a timestamp"}),
+            ),
+        ] {
+            let mut invalid = good.clone();
+            *invalid.pointer_mut(pointer).unwrap() = replacement;
+            assert!(read(&invalid).is_err(), "{pointer}");
+        }
+        let mut extra = good.clone();
+        extra["fields"]["owner"] = json!({"stringValue":"forged"});
+        assert!(read(&extra).is_err());
+    }
+
+    #[test]
+    fn commit_has_exact_precondition_and_server_timestamp_not_client_time() {
+        let layout = BlockLayout::decode(&["d1us".into()]).unwrap();
+        let create = commit_body("expected", None, &layout, 1);
+        assert_eq!(
+            create["writes"][0]["currentDocument"],
+            json!({"exists":false})
+        );
+        let update = commit_body("expected", Some("server-update-time"), &layout, 8);
+        let write = &update["writes"][0];
+        assert_eq!(
+            write["currentDocument"],
+            json!({"updateTime":"server-update-time"})
+        );
+        assert_eq!(
+            write["updateTransforms"],
+            json!([{"fieldPath":"updatedAt","setToServerValue":"REQUEST_TIME"}])
+        );
+        assert_eq!(
+            write["update"]["fields"]["revision"],
+            json!({"integerValue":"8"})
+        );
+        assert!(write["update"]["fields"].get("updatedAt").is_none());
+    }
+
+    #[test]
+    fn exact_retry_requires_both_revision_and_ordered_content() {
+        let layout = BlockLayout::decode(&["d000".into(), "p022".into()]).unwrap();
+        let snapshot = BlockSnapshot {
+            block_id: "block".into(),
+            revision: 7,
+            layout: layout.clone(),
+        };
+        assert!(exact_retry(&snapshot, &layout, 6));
+        assert!(!exact_retry(&snapshot, &layout, 7));
+        let reordered = BlockLayout::decode(&["p022".into(), "d000".into()]).unwrap();
+        assert!(!exact_retry(&snapshot, &reordered, 6));
+    }
+}

--- a/rust/crates/tmt-cli/src/grammar.rs
+++ b/rust/crates/tmt-cli/src/grammar.rs
@@ -278,6 +278,29 @@ fn office_commands() -> Command {
             "sync",
             "Deliver pending identity retirement hooks to Office",
         ))
+        .subcommand(
+            office("block", "Read or edit an Office block")
+                .subcommand(office_scope(
+                    office("show", "Show the selected Office block")
+                        .arg(operand("block-id", false)),
+                    true,
+                ))
+                .subcommand(office_scope(
+                    office("apply", "Apply a complete layout to an Office block")
+                        .arg(operand("block-id", false))
+                        .arg(Arg::new("file").long("file").required(true))
+                        .arg(
+                            Arg::new("if-revision")
+                                .long("if-revision")
+                                .required(true)
+                                .value_parser(
+                                    clap::value_parser!(u64)
+                                        .range(0..tmt_core::office_block::MAX_REVISION),
+                                ),
+                        ),
+                    true,
+                )),
+        )
         .subcommand(office_scope(
             office(
                 "inspect",

--- a/rust/crates/tmt-cli/src/invocation.rs
+++ b/rust/crates/tmt-cli/src/invocation.rs
@@ -80,6 +80,12 @@ pub enum OfficeOperation {
     Open,
     Status,
     Sync,
+    Block {
+        world: String,
+        identity: Option<String>,
+        emulator: bool,
+        operation: OfficeBlockOperation,
+    },
     Unpair {
         world: String,
         identity: Option<String>,
@@ -113,6 +119,18 @@ pub enum OfficeOperation {
     },
     Uninstall {
         yes: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OfficeBlockOperation {
+    Show {
+        block_id: Option<String>,
+    },
+    Apply {
+        block_id: Option<String>,
+        file: String,
+        if_revision: u64,
     },
 }
 

--- a/rust/crates/tmt-cli/src/main.rs
+++ b/rust/crates/tmt-cli/src/main.rs
@@ -13,6 +13,7 @@ mod install_command;
 mod invocation;
 mod native_install_command;
 mod native_upgrade_command;
+mod office_block_command;
 mod office_command;
 mod office_pairing_command;
 mod output;

--- a/rust/crates/tmt-cli/src/office_block_command.rs
+++ b/rust/crates/tmt-cli/src/office_block_command.rs
@@ -1,0 +1,111 @@
+//! One-shot Office block composition; all authorization remains in the companion.
+
+use crate::{
+    invocation::{OfficeBlockOperation, OfficeOperation, OutputMode},
+    office_pairing_command::{pairing_error, resolve_identity, sync_before_operation},
+    output::Failure,
+};
+use std::{
+    io::{self, Write},
+    path::Path,
+    time::{Duration, Instant},
+};
+use tmt_adapters::{
+    interrupt::Interrupt,
+    office_block::read_layout_file,
+    office_companion::{PairingCall, invoke_office_block},
+};
+
+pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> Result<u8, Failure> {
+    let OfficeOperation::Block {
+        world,
+        identity: selector,
+        emulator,
+        operation,
+    } = operation
+    else {
+        return Err(Failure::new(
+            "USAGE_ERROR",
+            "Expected an Office block operation.",
+            1,
+        ));
+    };
+
+    let (block_id, edit) = match operation {
+        OfficeBlockOperation::Show { block_id } => (block_id, None),
+        OfficeBlockOperation::Apply {
+            block_id,
+            file,
+            if_revision,
+        } => {
+            // Read and validate the complete bounded input before crossing the
+            // companion boundary; this command never overwrites the input file.
+            let layout = read_layout_file(Path::new(&file)).map_err(pairing_error)?;
+            (block_id, Some((layout, if_revision)))
+        }
+    };
+    let identity = resolve_identity(selector.as_deref())?;
+    let interrupt = Interrupt::install().map_err(unavailable)?;
+    sync_before_operation(executable)?;
+    if interrupt.is_interrupted() {
+        return Err(crate::office_pairing_command::interrupted());
+    }
+    let call = PairingCall {
+        world: &world,
+        identity_id: &identity.id,
+        emulator,
+        read_only: false,
+    };
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let snapshot = match edit {
+        Some((layout, revision)) => invoke_office_block(
+            executable,
+            &call,
+            block_id.as_deref(),
+            Some((&layout, revision)),
+            deadline,
+        ),
+        None => invoke_office_block(executable, &call, block_id.as_deref(), None, deadline),
+    }
+    .map_err(remote_unavailable)?
+    .map_err(block_error)?;
+    if interrupt.is_interrupted() {
+        return Err(crate::office_pairing_command::interrupted());
+    }
+    let value = snapshot.public_value();
+    let output = if mode.json {
+        value.to_string()
+    } else {
+        serde_json::to_string_pretty(&value).map_err(unavailable)?
+    };
+    writeln!(io::stdout().lock(), "{output}").map_err(unavailable)?;
+    Ok(0)
+}
+
+fn unavailable(error: impl std::error::Error + 'static) -> Failure {
+    Failure::new(
+        "OFFICE_IO_ERROR",
+        "Could not access local Office state or output.",
+        1,
+    )
+    .caused_by(error)
+}
+
+fn remote_unavailable(error: impl std::error::Error + 'static) -> Failure {
+    unconfirmed().caused_by(error)
+}
+
+fn unconfirmed() -> Failure {
+    Failure::new(
+        "OFFICE_REMOTE_UNCERTAIN",
+        "Office did not confirm the block operation. A save may have reached the server. Keep your draft and read the current block before retrying the original revision and intent.",
+        1,
+    )
+}
+
+fn block_error(error: tmt_core::office_protocol::OfficeError) -> Failure {
+    if error == tmt_core::office_protocol::OfficeError::RemoteUncertain {
+        return unconfirmed();
+    }
+    pairing_error(error)
+}

--- a/rust/crates/tmt-cli/src/office_command.rs
+++ b/rust/crates/tmt-cli/src/office_command.rs
@@ -220,6 +220,12 @@ fn run(
             }
             crate::office_pairing_command::run(&executable, operation, mode)
         }
+        OfficeOperation::Block { .. } => {
+            if !installed(&executable)? {
+                return Err(Failure::new("OFFICE_NOT_INSTALLED", INSTALL_HINT, 1));
+            }
+            crate::office_block_command::run(&executable, operation, mode)
+        }
         OfficeOperation::Status | OfficeOperation::Open => {
             if !installed(&executable)? {
                 if matches!(operation, OfficeOperation::Status)

--- a/rust/crates/tmt-cli/src/office_pairing_command.rs
+++ b/rust/crates/tmt-cli/src/office_pairing_command.rs
@@ -18,6 +18,24 @@ use tmt_adapters::{
 };
 use tmt_core::office_protocol::{OfficeError, OfficeInvocation};
 
+pub(crate) fn resolve_identity(
+    selector: Option<&str>,
+) -> Result<tmt_core::identity::Identity, Failure> {
+    let selector = identity_context::required(selector)?;
+    let paths = ConfigPaths::discover().map_err(unavailable)?;
+    let mut storage = Storage::open(paths.database).map_err(unavailable)?;
+    let identity = identity_context::resolve(&mut storage, selector)?;
+    storage.close().map_err(unavailable)?;
+    Ok(identity)
+}
+
+pub(crate) fn sync_before_operation(executable: &Path) -> Result<(), Failure> {
+    match invoke_office_sync(executable, Instant::now() + Duration::from_secs(30)) {
+        Ok(Ok(report)) if report.pending == 0 => Ok(()),
+        _ => writeln!(io::stderr().lock(), "Office retirement cleanup remains unconfirmed. Run tmt office sync to retry; the requested operation is checked separately.").map_err(unavailable),
+    }
+}
+
 pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> Result<u8, Failure> {
     if matches!(operation, OfficeOperation::Sync) {
         return sync(executable, mode);
@@ -29,10 +47,7 @@ pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> R
         operation,
         OfficeOperation::Pair { .. } | OfficeOperation::Inspect { .. }
     ) {
-        match invoke_office_sync(executable, Instant::now() + Duration::from_secs(30)) {
-            Ok(Ok(report)) if report.pending == 0 => {},
-            _ => writeln!(io::stderr().lock(), "Office retirement cleanup remains unconfirmed. Run tmt office sync to retry; the requested operation is checked separately.").map_err(unavailable)?,
-        }
+        sync_before_operation(executable)?;
         if interrupt.is_interrupted() {
             return Err(interrupted());
         }
@@ -70,11 +85,7 @@ pub fn run(executable: &Path, operation: OfficeOperation, mode: OutputMode) -> R
             ));
         }
     };
-    let selector = identity_context::required(identity.as_deref())?;
-    let paths = ConfigPaths::discover().map_err(unavailable)?;
-    let mut storage = Storage::open(paths.database).map_err(unavailable)?;
-    let identity = identity_context::resolve(&mut storage, selector)?;
-    storage.close().map_err(unavailable)?;
+    let identity = resolve_identity(identity.as_deref())?;
     let call = PairingCall {
         world: &world,
         identity_id: &identity.id,
@@ -215,7 +226,7 @@ fn sync(executable: &Path, mode: OutputMode) -> Result<u8, Failure> {
     Ok(u8::from(report.pending > 0 || report.failed > 0))
 }
 
-fn pairing_error(error: OfficeError) -> Failure {
+pub(crate) fn pairing_error(error: OfficeError) -> Failure {
     let message = match error {
         OfficeError::PairingPending => {
             "Pairing is not yet confirmed. Retry the same command within the original approval window."
@@ -227,6 +238,15 @@ fn pairing_error(error: OfficeError) -> Failure {
             "The retained pairing or grant has expired. No new pairing was created."
         }
         OfficeError::NotPaired => "This active identity has no Office pairing.",
+        OfficeError::Busy => {
+            "Another Office operation holds the local lock. This operation did not start; retry the same command after it finishes."
+        }
+        OfficeError::LayoutInvalid => {
+            "The Office block layout is invalid or exceeds the supported bounds. No change was made."
+        }
+        OfficeError::RevisionConflict => {
+            "The Office block changed after it was read. Read the current layout and reconcile your draft before submitting a new revision. No layout was changed by this attempt."
+        }
         _ => {
             "Office could not validate the operation. Retained pairing state was not intentionally deleted."
         }
@@ -243,7 +263,7 @@ fn unavailable(error: impl std::error::Error + 'static) -> Failure {
     .caused_by(error)
 }
 
-fn interrupted() -> Failure {
+pub(crate) fn interrupted() -> Failure {
     Failure::new(
         "OFFICE_INTERRUPTED",
         "Office pairing interrupted. Retry the same command to inspect or resume retained state.",

--- a/rust/crates/tmt-cli/src/parser.rs
+++ b/rust/crates/tmt-cli/src/parser.rs
@@ -153,12 +153,34 @@ fn translate(path: &[&str], m: &ArgMatches) -> Result<Invocation, String> {
         | ["office", "unpair"]
         | ["office", "inspect"]
         | ["office", "sync"]
+        | ["office", "block", "show"]
+        | ["office", "block", "apply"]
         | ["office", "install"]
         | ["office", "upgrade"]
         | ["office", "uninstall"] => Invocation::Office {
             prefix: text(m, "prefix"),
             operation: match path.last().copied() {
                 Some("sync") => OfficeOperation::Sync,
+                Some("show") if path.get(1) == Some(&"block") => OfficeOperation::Block {
+                    world: required(m, "world"),
+                    identity: text(m, "identity"),
+                    emulator: flag(m, "emulator"),
+                    operation: OfficeBlockOperation::Show {
+                        block_id: text(m, "block-id"),
+                    },
+                },
+                Some("apply") if path.get(1) == Some(&"block") => OfficeOperation::Block {
+                    world: required(m, "world"),
+                    identity: text(m, "identity"),
+                    emulator: flag(m, "emulator"),
+                    operation: OfficeBlockOperation::Apply {
+                        block_id: text(m, "block-id"),
+                        file: required(m, "file"),
+                        if_revision: *m
+                            .get_one::<u64>("if-revision")
+                            .expect("grammar supplies block revision"),
+                    },
+                },
                 Some("unpair") => OfficeOperation::Unpair {
                     world: required(m, "world"),
                     identity: text(m, "identity"),

--- a/rust/crates/tmt-cli/src/parser_tests.rs
+++ b/rust/crates/tmt-cli/src/parser_tests.rs
@@ -165,6 +165,165 @@ fn office_sync_is_install_scoped_not_active_identity_scoped() {
 }
 
 #[test]
+fn office_block_commands_are_typed_and_scoped() {
+    use crate::invocation::{OfficeBlockOperation, OfficeOperation};
+    let world = "https://office.example/worlds/abcdefghijklmnopqrst";
+    assert_eq!(
+        parsed(&["office", "block", "show", "--world", world]).invocation,
+        Invocation::Office {
+            prefix: None,
+            operation: OfficeOperation::Block {
+                world: world.into(),
+                identity: None,
+                emulator: false,
+                operation: OfficeBlockOperation::Show { block_id: None },
+            },
+        }
+    );
+    assert_eq!(
+        parsed(&[
+            "office",
+            "block",
+            "show",
+            "block-123",
+            "--world",
+            world,
+            "--identity",
+            "Alice",
+            "--emulator",
+            "--json",
+        ])
+        .invocation,
+        Invocation::Office {
+            prefix: None,
+            operation: OfficeOperation::Block {
+                world: world.into(),
+                identity: Some("Alice".into()),
+                emulator: true,
+                operation: OfficeBlockOperation::Show {
+                    block_id: Some("block-123".into()),
+                },
+            },
+        }
+    );
+    assert_eq!(
+        parsed(&[
+            "office",
+            "block",
+            "apply",
+            "block-123",
+            "--world",
+            world,
+            "--file",
+            "layout.json",
+            "--if-revision",
+            "7",
+        ])
+        .invocation,
+        Invocation::Office {
+            prefix: None,
+            operation: OfficeOperation::Block {
+                world: world.into(),
+                identity: None,
+                emulator: false,
+                operation: OfficeBlockOperation::Apply {
+                    block_id: Some("block-123".into()),
+                    file: "layout.json".into(),
+                    if_revision: 7,
+                },
+            },
+        }
+    );
+    let max_revision = tmt_core::office_block::MAX_REVISION.to_string();
+    let max_minus_one = (tmt_core::office_block::MAX_REVISION - 1).to_string();
+    assert_eq!(
+        parsed(&[
+            "office",
+            "block",
+            "apply",
+            "--world",
+            world,
+            "--file",
+            "layout.json",
+            "--if-revision",
+            &max_minus_one,
+        ])
+        .invocation,
+        Invocation::Office {
+            prefix: None,
+            operation: OfficeOperation::Block {
+                world: world.into(),
+                identity: None,
+                emulator: false,
+                operation: OfficeBlockOperation::Apply {
+                    block_id: None,
+                    file: "layout.json".into(),
+                    if_revision: tmt_core::office_block::MAX_REVISION - 1,
+                },
+            },
+        }
+    );
+    for input in [
+        vec!["office", "block", "show"],
+        vec![
+            "office",
+            "block",
+            "apply",
+            "--world",
+            world,
+            "--file",
+            "layout.json",
+        ],
+        vec![
+            "office",
+            "block",
+            "apply",
+            "--world",
+            world,
+            "--if-revision",
+            "7",
+        ],
+        vec![
+            "office",
+            "block",
+            "apply",
+            "--world",
+            world,
+            "--file",
+            "layout.json",
+            "--if-revision",
+            "-1",
+        ],
+        vec![
+            "office",
+            "block",
+            "apply",
+            "--world",
+            world,
+            "--file",
+            "layout.json",
+            "--if-revision",
+            &max_revision,
+        ],
+        vec![
+            "office",
+            "block",
+            "show",
+            "--world",
+            world,
+            "--file",
+            "layout.json",
+        ],
+    ] {
+        assert_eq!(
+            parse_error(&input).code,
+            "USAGE_ERROR",
+            "arguments: {input:?}"
+        );
+    }
+}
+
+#[test]
 fn native_upgrade_alias_and_selection_share_one_typed_contract() {
     for command in ["upgrade", "update"] {
         let invocation = parsed(&[

--- a/rust/crates/tmt-core/Cargo.toml
+++ b/rust/crates/tmt-core/Cargo.toml
@@ -16,3 +16,6 @@ icu_normalizer.workspace = true
 icu_casemap.workspace = true
 icu_locale_core.workspace = true
 sha2.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/rust/crates/tmt-core/src/lib.rs
+++ b/rust/crates/tmt-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod identity_hooks;
 pub mod limits;
 pub mod names;
 pub mod native_install;
+pub mod office_block;
 pub mod office_protocol;
 pub mod profile;
 pub mod request;
@@ -17,5 +18,7 @@ pub mod skill_provider;
 
 #[cfg(test)]
 mod identity_tests;
+#[cfg(test)]
+mod office_block_tests;
 #[cfg(test)]
 mod settings_tests;

--- a/rust/crates/tmt-core/src/office_block.rs
+++ b/rust/crates/tmt-core/src/office_block.rs
@@ -1,0 +1,204 @@
+//! Pure domain validation and storage codec for Office block layouts.
+
+/// The block is a square room measured in tiles.
+pub const BLOCK_SIZE: u8 = 32;
+/// The maximum number of ordered furniture objects in a layout.
+pub const OBJECT_LIMIT: usize = 16;
+/// The largest revision exactly representable by a JavaScript number.
+pub const MAX_REVISION: u64 = crate::limits::MAX_JS_SAFE_INTEGER;
+/// The maximum input size reserved for bounded block documents.
+pub const INPUT_LIMIT: usize = 65_536;
+
+/// The fixed furniture catalog shared by the browser and native adapters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FurnitureAsset {
+    Desk,
+    Chair,
+    Plant,
+    Rug,
+}
+
+impl FurnitureAsset {
+    /// The catalog order is part of the domain API for consumers that build a menu.
+    pub const ALL: [Self; 4] = [Self::Desk, Self::Chair, Self::Plant, Self::Rug];
+
+    /// Parse the public, lower-case asset name exactly.
+    pub fn parse(value: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|asset| asset.name() == value)
+    }
+
+    /// The public asset name used by readable views and commands.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Desk => "desk",
+            Self::Chair => "chair",
+            Self::Plant => "plant",
+            Self::Rug => "rug",
+        }
+    }
+
+    /// The single-character storage token for this asset.
+    pub const fn token(self) -> char {
+        match self {
+            Self::Desk => 'd',
+            Self::Chair => 'c',
+            Self::Plant => 'p',
+            Self::Rug => 'r',
+        }
+    }
+
+    /// The unrotated footprint in tiles, as width then height.
+    pub const fn dimensions(self) -> (u8, u8) {
+        match self {
+            Self::Desk => (4, 2),
+            Self::Chair | Self::Plant => (2, 2),
+            Self::Rug => (6, 4),
+        }
+    }
+
+    fn from_token(value: u8) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|asset| asset.token() as u8 == value)
+    }
+}
+
+/// One ordered decoration in a block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Furniture {
+    pub asset: FurnitureAsset,
+    pub x: u8,
+    pub y: u8,
+    pub rotation: u8,
+}
+
+impl Furniture {
+    /// Return the rotated footprint in tiles, as width then height.
+    pub const fn dimensions(self) -> (u8, u8) {
+        let (width, height) = self.asset.dimensions();
+        if self.rotation % 2 == 1 {
+            (height, width)
+        } else {
+            (width, height)
+        }
+    }
+
+    fn validate(self) -> Result<(), LayoutError> {
+        if self.rotation > 3 {
+            return Err(LayoutError::InvalidRotation);
+        }
+        let (width, height) = self.dimensions();
+        if self.x > BLOCK_SIZE.saturating_sub(width) || self.y > BLOCK_SIZE.saturating_sub(height) {
+            return Err(LayoutError::OutOfBounds);
+        }
+        Ok(())
+    }
+}
+
+/// A validated, ordered block layout. Overlap is intentionally preserved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockLayout {
+    objects: Vec<Furniture>,
+}
+
+impl BlockLayout {
+    /// Validate an ordered list without sorting, deduplicating, or rejecting overlap.
+    pub fn new(objects: Vec<Furniture>) -> Result<Self, LayoutError> {
+        if objects.len() > OBJECT_LIMIT {
+            return Err(LayoutError::TooManyObjects);
+        }
+        objects.iter().copied().try_for_each(Furniture::validate)?;
+        Ok(Self { objects })
+    }
+
+    /// Borrow the validated objects in their original paint order.
+    pub fn objects(&self) -> &[Furniture] {
+        &self.objects
+    }
+
+    /// Encode the layout as four-character storage tokens.
+    pub fn encode(&self) -> Vec<String> {
+        self.objects
+            .iter()
+            .map(|object| {
+                format!(
+                    "{}{}{}{}",
+                    object.asset.token(),
+                    object.rotation,
+                    encode_digit(object.x),
+                    encode_digit(object.y)
+                )
+            })
+            .collect()
+    }
+
+    /// Decode and validate the ordered storage tokens.
+    pub fn decode(tokens: &[String]) -> Result<Self, LayoutError> {
+        if tokens.len() > OBJECT_LIMIT {
+            return Err(LayoutError::TooManyObjects);
+        }
+
+        let objects = tokens
+            .iter()
+            .map(|token| {
+                let bytes = token.as_bytes();
+                if bytes.len() != 4 {
+                    return Err(LayoutError::InvalidToken);
+                }
+                let asset =
+                    FurnitureAsset::from_token(bytes[0]).ok_or(LayoutError::InvalidToken)?;
+                let rotation = bytes[1]
+                    .checked_sub(b'0')
+                    .filter(|rotation| *rotation <= 3)
+                    .ok_or(LayoutError::InvalidToken)?;
+                let x = decode_digit(bytes[2]).ok_or(LayoutError::InvalidToken)?;
+                let y = decode_digit(bytes[3]).ok_or(LayoutError::InvalidToken)?;
+                Ok(Furniture {
+                    asset,
+                    x,
+                    y,
+                    rotation,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::new(objects)
+    }
+}
+
+/// Why a proposed or stored layout is invalid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutError {
+    TooManyObjects,
+    InvalidRotation,
+    OutOfBounds,
+    InvalidToken,
+}
+
+impl std::fmt::Display for LayoutError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::TooManyObjects => "Block layout has too many objects.",
+            Self::InvalidRotation => "Furniture rotation must be between zero and three.",
+            Self::OutOfBounds => "Furniture footprint must fit inside the block.",
+            Self::InvalidToken => "Invalid stored furniture token.",
+        })
+    }
+}
+
+impl std::error::Error for LayoutError {}
+
+fn encode_digit(value: u8) -> char {
+    match value {
+        0..=9 => (b'0' + value) as char,
+        10..=31 => (b'a' + value - 10) as char,
+        _ => unreachable!("validated block coordinates are base-32 digits"),
+    }
+}
+
+fn decode_digit(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'v' => Some(value - b'a' + 10),
+        _ => None,
+    }
+}

--- a/rust/crates/tmt-core/src/office_block_tests.rs
+++ b/rust/crates/tmt-core/src/office_block_tests.rs
@@ -1,0 +1,212 @@
+use super::office_block::{
+    BLOCK_SIZE, BlockLayout, Furniture, FurnitureAsset, INPUT_LIMIT, LayoutError, MAX_REVISION,
+    OBJECT_LIMIT,
+};
+use serde_json::Value;
+
+fn strict_item(value: &Value) -> Option<Furniture> {
+    let object = value.as_object()?;
+    if object.len() != 4
+        || !object
+            .keys()
+            .all(|key| matches!(key.as_str(), "asset" | "x" | "y" | "rotation"))
+    {
+        return None;
+    }
+    Some(Furniture {
+        asset: FurnitureAsset::parse(object.get("asset")?.as_str()?)?,
+        x: object.get("x")?.as_i64()?.try_into().ok()?,
+        y: object.get("y")?.as_i64()?.try_into().ok()?,
+        rotation: object.get("rotation")?.as_i64()?.try_into().ok()?,
+    })
+}
+
+#[test]
+fn catalog_is_ordered_and_has_contract_metadata() {
+    assert_eq!(
+        FurnitureAsset::ALL,
+        [
+            FurnitureAsset::Desk,
+            FurnitureAsset::Chair,
+            FurnitureAsset::Plant,
+            FurnitureAsset::Rug,
+        ]
+    );
+    assert_eq!(FurnitureAsset::parse("desk"), Some(FurnitureAsset::Desk));
+    assert_eq!(FurnitureAsset::parse("Desk"), None);
+    assert_eq!(FurnitureAsset::Desk.name(), "desk");
+    assert_eq!(FurnitureAsset::Desk.token(), 'd');
+    assert_eq!(FurnitureAsset::Desk.dimensions(), (4, 2));
+    assert_eq!(FurnitureAsset::Chair.dimensions(), (2, 2));
+    assert_eq!(FurnitureAsset::Plant.dimensions(), (2, 2));
+    assert_eq!(FurnitureAsset::Rug.dimensions(), (6, 4));
+    assert_eq!(BLOCK_SIZE, 32);
+    assert_eq!(OBJECT_LIMIT, 16);
+    assert_eq!(MAX_REVISION, 9_007_199_254_740_991);
+    assert_eq!(INPUT_LIMIT, 65_536);
+}
+
+#[test]
+fn layout_preserves_order_and_allows_intentional_overlap() {
+    let first = Furniture {
+        asset: FurnitureAsset::Desk,
+        x: 0,
+        y: 0,
+        rotation: 0,
+    };
+    let second = Furniture {
+        asset: FurnitureAsset::Rug,
+        x: 0,
+        y: 0,
+        rotation: 0,
+    };
+    let layout = BlockLayout::new(vec![first, second]).unwrap();
+    assert_eq!(layout.objects(), &[first, second]);
+    assert_eq!(layout.encode(), ["d000", "r000"]);
+}
+
+#[test]
+fn layout_accepts_empty_and_maximum_but_rejects_the_seventeenth_object() {
+    let object = Furniture {
+        asset: FurnitureAsset::Chair,
+        x: 0,
+        y: 0,
+        rotation: 0,
+    };
+    assert_eq!(BlockLayout::new(Vec::new()).unwrap().objects(), &[]);
+    assert!(BlockLayout::new(vec![object; OBJECT_LIMIT]).is_ok());
+    assert_eq!(
+        BlockLayout::new(vec![object; OBJECT_LIMIT + 1]),
+        Err(LayoutError::TooManyObjects)
+    );
+}
+
+#[test]
+fn layout_validates_rotated_footprints_at_room_boundaries() {
+    assert!(
+        BlockLayout::new(vec![Furniture {
+            asset: FurnitureAsset::Desk,
+            x: 28,
+            y: 30,
+            rotation: 0,
+        }])
+        .is_ok()
+    );
+    assert!(
+        BlockLayout::new(vec![Furniture {
+            asset: FurnitureAsset::Desk,
+            x: 30,
+            y: 28,
+            rotation: 1,
+        }])
+        .is_ok()
+    );
+    assert_eq!(
+        BlockLayout::new(vec![Furniture {
+            asset: FurnitureAsset::Desk,
+            x: 29,
+            y: 30,
+            rotation: 0,
+        }]),
+        Err(LayoutError::OutOfBounds)
+    );
+    assert_eq!(
+        BlockLayout::new(vec![Furniture {
+            asset: FurnitureAsset::Rug,
+            x: 0,
+            y: 0,
+            rotation: 4,
+        }]),
+        Err(LayoutError::InvalidRotation)
+    );
+}
+
+#[test]
+fn codec_round_trip_is_canonical_and_rejects_malformed_tokens() {
+    let objects = vec![
+        Furniture {
+            asset: FurnitureAsset::Desk,
+            x: 30,
+            y: 28,
+            rotation: 1,
+        },
+        Furniture {
+            asset: FurnitureAsset::Rug,
+            x: 28,
+            y: 26,
+            rotation: 3,
+        },
+    ];
+    let layout = BlockLayout::new(objects.clone()).unwrap();
+    assert_eq!(layout.encode(), ["d1us", "r3sq"]);
+    assert_eq!(
+        BlockLayout::decode(&layout.encode()).unwrap().objects(),
+        objects
+    );
+
+    for token in [
+        "D000",
+        "d400",
+        "d00w",
+        "d00A",
+        "d0000",
+        "d00",
+        "https://example.test",
+    ] {
+        assert_eq!(
+            BlockLayout::decode(&[token.to_owned()]),
+            Err(LayoutError::InvalidToken),
+            "{token}"
+        );
+    }
+    let oversized = vec!["d000".to_owned(); OBJECT_LIMIT + 1];
+    assert_eq!(
+        BlockLayout::decode(&oversized),
+        Err(LayoutError::TooManyObjects)
+    );
+}
+
+#[test]
+fn literal_contract_vectors_match_in_both_directions() {
+    let corpus: Value = serde_json::from_str(include_str!(
+        "../../../../contracts/office/block-v1.vectors.json"
+    ))
+    .unwrap();
+    for vector in corpus.as_array().unwrap() {
+        let valid = vector["valid"].as_bool().unwrap();
+        let stored = vector["stored"].as_str();
+        let item = strict_item(&vector["item"]);
+        if valid {
+            let item = item.unwrap();
+            let layout = BlockLayout::new(vec![item]).unwrap();
+            assert_eq!(layout.encode(), [stored.unwrap()]);
+            assert_eq!(
+                BlockLayout::decode(&[stored.unwrap().to_owned()]).unwrap(),
+                layout
+            );
+        } else {
+            if let Some(stored) = stored {
+                assert!(BlockLayout::decode(&[stored.to_owned()]).is_err());
+            }
+            if let Some(item) = item {
+                assert!(BlockLayout::new(vec![item]).is_err());
+            }
+        }
+    }
+}
+
+#[test]
+fn vector_deserialization_rejects_unknown_item_fields() {
+    let corpus: Value = serde_json::from_str(include_str!(
+        "../../../../contracts/office/block-v1.vectors.json"
+    ))
+    .unwrap();
+    let item = corpus
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|vector| vector["name"] == "extra content")
+        .unwrap()["item"]
+        .clone();
+    assert!(strict_item(&item).is_none());
+}

--- a/rust/crates/tmt-core/src/office_protocol.rs
+++ b/rust/crates/tmt-core/src/office_protocol.rs
@@ -24,6 +24,9 @@ pub enum OfficeError {
     PairingExpired,
     RemoteDenied,
     RemoteUncertain,
+    LayoutInvalid,
+    RevisionConflict,
+    Busy,
 }
 
 impl OfficeError {
@@ -37,6 +40,9 @@ impl OfficeError {
             Self::PairingExpired => "OFFICE_PAIRING_EXPIRED",
             Self::RemoteDenied => "OFFICE_REMOTE_DENIED",
             Self::RemoteUncertain => "OFFICE_REMOTE_UNCERTAIN",
+            Self::LayoutInvalid => "OFFICE_LAYOUT_INVALID",
+            Self::RevisionConflict => "OFFICE_REVISION_CONFLICT",
+            Self::Busy => "OFFICE_BUSY",
         }
     }
 
@@ -50,6 +56,9 @@ impl OfficeError {
             Self::PairingExpired,
             Self::RemoteDenied,
             Self::RemoteUncertain,
+            Self::LayoutInvalid,
+            Self::RevisionConflict,
+            Self::Busy,
         ]
         .into_iter()
         .find(|value| value.code() == code)
@@ -72,6 +81,8 @@ pub enum OfficeInvocation {
     Unpair,
     Inspect,
     Sync,
+    BlockShow,
+    BlockApply,
 }
 
 impl OfficeInvocation {
@@ -84,6 +95,8 @@ impl OfficeInvocation {
             Self::Unpair => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "unpair"],
             Self::Inspect => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "inspect"],
             Self::Sync => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "sync"],
+            Self::BlockShow => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "block-show"],
+            Self::BlockApply => ["__tmt-office", OFFICE_PROTOCOL_VERSION, "block-apply"],
         }
     }
 
@@ -96,6 +109,8 @@ impl OfficeInvocation {
             Self::Unpair,
             Self::Inspect,
             Self::Sync,
+            Self::BlockShow,
+            Self::BlockApply,
         ]
         .into_iter()
         .find(|operation| arguments == operation.arguments())
@@ -156,6 +171,8 @@ mod tests {
             ("unpair", OfficeInvocation::Unpair),
             ("inspect", OfficeInvocation::Inspect),
             ("sync", OfficeInvocation::Sync),
+            ("block-show", OfficeInvocation::BlockShow),
+            ("block-apply", OfficeInvocation::BlockApply),
         ] {
             assert_eq!(operation.arguments(), ["__tmt-office", "1", name]);
             assert_eq!(

--- a/services/office/README.md
+++ b/services/office/README.md
@@ -9,10 +9,12 @@ not implied by this implementation. Unspecified paths remain denied.
 Rules also enforce [scoped agent grants](../../contracts/office/agent-grant-v1.md)
 for UUID blocks with live expiry, capability and owner-admission checks. The
 trusted issuer is implemented under `functions/` for emulator verification;
-the browser can explicitly approve/revoke, but native pairing is not implemented.
+the browser can explicitly approve/revoke, and the native companion pairs and
+reads/edits its assigned block through authenticated client requests.
 Do not manually enable anonymous authentication or create production agent grants
 to simulate pairing.
-The current browser continues to edit only the owner's home block.
+The owner can edit the home block and inspect/edit assigned or retained agent
+blocks through the existing space inventory.
 
 [Pairing v1](../../contracts/office/pairing-v1.md) defines approval, proof claim,
 retry and revocation. Non-emulator activation defaults off. No Functions are
@@ -50,7 +52,7 @@ The default image/Compose service does not install Chromium or start the app.
 It also does not start Functions. The integrated `browser-tests` target builds
 the service and starts its loopback-only Functions emulator on port 5001.
 Its browser scenarios exercise actual owner approval, scoped credential use and
-revocation. No native CLI pairing command is implied by a browser test link.
+revocation, including actual native pairing and revision-safe decoration commands.
 Do not mount credentials, host config or repository roots into this service.
 The first image build downloads tools and emulator binaries; later runs use the
 cached image. Rebuild deliberately to update pinned tools, not on every test.

--- a/skills/tmux-team/SKILL.md
+++ b/skills/tmux-team/SKILL.md
@@ -466,7 +466,7 @@ after an observer timeout; do not replace the identity or delete pairing state.
 `--read-only` requests layout read only; otherwise pair requests read/write.
 
 World-qualified status is local retained state, not live authorization. Inspect
-checks server access and returns `blockExists`; it does not read layouts or list
+checks server access and returns `blockExists`; it does not return layouts or list
 agents. A revoked grant can still have local status `credential`. Same-name
 replacement never inherits the old identity UUID's pairing. `inspect` renews a
 paired lease with five minutes or less remaining, including expiry, after
@@ -478,7 +478,7 @@ the current inspect fails expired; a later invocation can renew it. Do not loop
 on failures. Disabled/missing grants, expired pending approvals and lost
 credentials cannot be repaired by silently creating another grant. Report those
 errors; never delete state to bypass revocation. Uninstall does not revoke
-remote grants. Do not use proposed connector or resource-edit commands.
+remote grants. Do not use proposed connector commands.
 
 Use `unpair` to explicitly revoke a pairing without removing the identity or
 workspace content. A confirmed result retains a secret-free `revoked` receipt;
@@ -496,6 +496,33 @@ revocation. Locked credentials or uncertain results stay pending. Resolve the
 reported obstacle before retrying; do not loop or delete protected state.
 No invocation means no background delivery guarantee. Confirmed revocation
 retains block contents; a saved identity merely going offline is not retirement.
+
+### Decorate your paired space
+
+With a compatible source-built Office companion, read your assigned block first:
+
+```sh
+tmt office block show --world <world-url> --identity <name> --json
+tmt office block apply --world <world-url> --identity <name> --file layout.json --if-revision <revision> --json
+```
+
+Omit `--identity` only in verified pane context. No block ID is needed: the pairing
+selects your assigned space. `show` returns `blockId`, `revision`, `objects`,
+`catalog` and `limits`. Create a JSON file containing only `{"objects":[...]}`;
+each object has `asset`, integer `x`, `y` and `rotation` (0–3 quarter turns).
+Use the catalog footprints; rotated objects must fit inside the room. List order
+controls overlap. Apply replaces the whole list, including an empty list to clear
+it. Files are limited to 64 KiB and layouts to 16 objects. Custom art is not supported.
+
+Use the revision you read (0 for an absent layout). On `OFFICE_REVISION_CONFLICT`,
+reread and reconcile intentionally; never blindly overwrite at the new revision.
+On `OFFICE_BUSY`, another local operation prevented this one from starting;
+retry the same intent/revision after it finishes, not in an unbounded loop.
+On `OFFICE_REMOTE_UNCERTAIN`, retain your input file, reread and compare before
+retrying the same intent/revision. An identical exact retry does not write again.
+Read-only/revoked access is not permission to re-pair automatically. After success,
+inspect the returned canonical layout and give the user a short description of
+the confirmed arrangement; another editor may have changed it after your write.
 
 ## Configuration safety
 


### PR DESCRIPTION
## Summary

- Add scoped `office block show` and revision-required `office block apply` with readable layouts, catalog discovery and bounded file input.
- Reuse the installed companion, protected pairing scope, active identity checks, credential refresh and grant renewal. Conditional Firestore writes share the existing block contract and Rules; there is no new CRUD service, identity registry or scene cache.
- Distinguish proven pre-execution `OFFICE_BUSY` from an uncertain save. Preserve original drafts and revision intent; exact retries do not write again.
- Update installed agent guidance, command/contracts/architecture documentation and stale Office UI/service descriptions.

Closes #191.
Related M1 work remains independently tracked in #213 (optional Office skill lifecycle) and #238 (custom data-only decoration packs).

## Architecture and review

The primary reviewed the pure block domain, native readable JSON boundary, companion protocol, scope/credential lifecycle, conditional Firestore commit and reply decoding, public parser/command composition, installed guidance and browser fixture/scenario assertions. An independent bounded review inspected the authorization, revision, retry and uncertainty paths.

- Browser and native codecs conform to the same literal block contract vectors.
- Existing inspect reuses the block reader instead of retaining a parallel HTTP read implementation.
- Public `BlockLayout` and `FurnitureAsset` names distinguish the scene domain from existing installer types; architecture checks were not weakened.
- Local locks are fail-fast, not queues. Busy is reported only where execution is known not to have begun. Process/transport failures after launch remain uncertain.
- E2E assertions use independent literal stored tokens and full-document preservation, not an encoder copied from production or terminal echoes.

## Verification

- Current Busy-source all-features workspace tests passed: adapters 357 (1 ignored), CLI 46, architecture 21, core 67. All-features/all-targets Clippy passed. Two final rustfmt-only changes were applied after these runs; current-host formatting recheck passed and snapshot comparison confirmed no semantic drift.
- Current-source Docker browser acceptance: focused decoration 4/4; full suite twice, 60/60 each. The image includes rebuilt native binaries; the primary verified host fixture/spec/UI hashes against the inside-image evidence.
- Image build passed service checks/tests/build, app checks/tests/typecheck and preview/emulator/cloud builds.
- Primary visually reviewed desktop (1280x900) and narrow (390x844) screenshots: persisted desk/plant geometry matches the command intent, controls reflow without horizontal overflow. The red emulator-only diagnostic banner is not production UI.
- `pnpm docs:format:check` and `git diff --check` passed.
- Required CI on reviewed commit: pending.

Reviewed head: `18fe606` (primary-owned integration and final review).

The user's Luna session in tmux `2.0` is reserved for a subsequent owner-authorized usability check. It has not been restarted or used as a substitute for deterministic tests. No production deployment or public release is included.

Local evidence: `/private/tmp/tmt-191-browser-final-focused-3.log`, `/private/tmp/tmt-191-browser-{1,2}.log`, `/private/tmp/tmt-191-browser-final-build-4.log`. Screenshots are retained in `/private/tmp/tmt-191-browser-final-focused-3-results/`. These paths are local review artifacts, not public downloads.
