### PR TITLE
chore: prepare native alpha releases

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -4,17 +4,26 @@ name: Native release artifacts
 # authorized operation; ordinary pull requests do not run this costly matrix.
 on:
   workflow_dispatch:
+    inputs:
+      product:
+        description: Native product to prepare
+        required: true
+        default: cli
+        type: choice
+        options:
+          - cli
+          - office
 
 permissions:
   contents: read
 
 concurrency:
-  group: native-release-${{ github.ref }}
+  group: native-release-${{ inputs.product }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   build:
-    name: Build (${{ matrix.target }})
+    name: Build ${{ inputs.product }} (${{ matrix.target }})
     if: github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
@@ -54,17 +63,18 @@ jobs:
           cargo +1.97.0 install cargo-about --version 0.9.2 --features cli --locked --root "$HOME/.tmt-packaging"
       - name: Build release archive and target manifest
         env:
+          PRODUCT: ${{ inputs.product }}
           TARGET: ${{ matrix.target }}
           MACOSX_DEPLOYMENT_TARGET: '11.0'
         run: |
           export PATH="$HOME/.tmt-packaging/bin:$PATH"
           cargo +1.97.0 fetch --manifest-path rust/Cargo.toml --locked
-          scripts/build-native-artifact.sh "$TARGET" > "$RUNNER_TEMP/$TARGET-dist-manifest.json"
+          scripts/build-native-artifact.sh "$TARGET" "$PRODUCT" > "$RUNNER_TEMP/$TARGET-dist-manifest.json"
           cp "$RUNNER_TEMP/$TARGET-dist-manifest.json" target/distrib/
           cp rust/target/native-notices/THIRD-PARTY-NOTICES.txt "target/distrib/$TARGET-notices.txt"
       - uses: actions/upload-artifact@v4
         with:
-          name: native-${{ matrix.target }}
+          name: native-${{ inputs.product }}-${{ matrix.target }}
           path: |
             target/distrib/*.tar.gz
             target/distrib/*.sha256
@@ -74,7 +84,7 @@ jobs:
           retention-days: 7
 
   assemble:
-    name: Assemble authoritative release manifest
+    name: Assemble authoritative ${{ inputs.product }} release manifest
     needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -99,26 +109,34 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
       - uses: actions/download-artifact@v4
         with:
-          pattern: native-*
+          pattern: native-${{ inputs.product }}-*
           merge-multiple: true
           path: target/distrib
       - name: Merge with cargo-dist and verify bootstrap inputs
+        env:
+          PRODUCT: ${{ inputs.product }}
         run: |
           export PATH="$HOME/.tmt-packaging/bin:$PATH"
           export RUSTUP_TOOLCHAIN=1.97.0
           TMT_NATIVE_REAL_CARGO=$(command -v cargo)
           export TMT_NATIVE_REAL_CARGO
           export CARGO="$GITHUB_WORKSPACE/scripts/native-cargo.sh"
-          version=$(cargo metadata --manifest-path rust/Cargo.toml --locked --no-deps --format-version 1 | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).packages.find(p => p.name === "tmt-cli").version')
-          dist plan --tag "v$version" --output-format=json --no-local-paths > "$RUNNER_TEMP/plan.json"
-          dist build --tag "v$version" --artifacts global --output-format=json --no-local-paths > "$RUNNER_TEMP/dist-manifest.json"
+          package="tmt-$PRODUCT"
+          export PACKAGE="$package"
+          version=$(cargo metadata --manifest-path rust/Cargo.toml --locked --no-deps --format-version 1 | node -pe 'const p=process.env.PACKAGE; JSON.parse(require("fs").readFileSync(0,"utf8")).packages.find(x => x.name === p).version')
+          tag="v$version"
+          if [ "$PRODUCT" = office ]; then tag="tmt-office-v$version"; fi
+          dist plan --tag "$tag" --output-format=json --no-local-paths > "$RUNNER_TEMP/plan.json"
+          dist build --tag "$tag" --artifacts global --output-format=json --no-local-paths > "$RUNNER_TEMP/dist-manifest.json"
           cp "$RUNNER_TEMP/dist-manifest.json" target/distrib/dist-manifest.json
-          node scripts/generate-native-bootstrap.mjs --manifest target/distrib/dist-manifest.json --archive-dir target/distrib --plan "$RUNNER_TEMP/plan.json" > target/distrib/tmt-installer.sh
-          sh -n target/distrib/tmt-installer.sh
-          shellcheck --shell sh target/distrib/tmt-installer.sh
+          if [ "$PRODUCT" = cli ]; then
+            node scripts/generate-native-bootstrap.mjs --manifest target/distrib/dist-manifest.json --archive-dir target/distrib --plan "$RUNNER_TEMP/plan.json" > target/distrib/tmt-installer.sh
+            sh -n target/distrib/tmt-installer.sh
+            shellcheck --shell sh target/distrib/tmt-installer.sh
+          fi
       - uses: actions/upload-artifact@v4
         with:
-          name: native-release-bundle
+          name: native-release-${{ inputs.product }}-bundle
           path: |
             target/distrib/*.tar.gz
             target/distrib/*.sha256
@@ -130,7 +148,7 @@ jobs:
           retention-days: 7
 
   verify:
-    name: Verify final bundle (${{ matrix.target }})
+    name: Verify final ${{ inputs.product }} bundle (${{ matrix.target }})
     needs: assemble
     strategy:
       fail-fast: false
@@ -151,20 +169,30 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
       - uses: actions/download-artifact@v4
         with:
-          name: native-release-bundle
+          name: native-release-${{ inputs.product }}-bundle
           path: target/distrib
       - name: Execute final archive and bootstrap on matching native host
         env:
+          PRODUCT: ${{ inputs.product }}
           TARGET: ${{ matrix.target }}
         run: |
-          node scripts/verify-native-artifact.mjs \
-            --manifest target/distrib/dist-manifest.json \
-            --archive "target/distrib/tmt-cli-$TARGET.tar.gz" --target "$TARGET" \
-            --skill skills/tmux-team/SKILL.md --license LICENSE \
-            --notices "target/distrib/$TARGET-notices.txt"
-          node scripts/verify-native-bootstrap.mjs \
-            --manifest target/distrib/dist-manifest.json \
-            --archive "target/distrib/tmt-cli-$TARGET.tar.gz" --target "$TARGET" \
-            --skill skills/tmux-team/SKILL.md
-          node scripts/generate-native-bootstrap.mjs --manifest target/distrib/dist-manifest.json --archive-dir target/distrib > "$RUNNER_TEMP/installer.sh"
-          cmp "$RUNNER_TEMP/installer.sh" target/distrib/tmt-installer.sh
+          if [ "$PRODUCT" = cli ]; then
+            node scripts/verify-native-artifact.mjs \
+              --manifest target/distrib/dist-manifest.json \
+              --archive "target/distrib/tmt-cli-$TARGET.tar.gz" --target "$TARGET" \
+              --skill skills/tmux-team/SKILL.md --license LICENSE \
+              --notices "target/distrib/$TARGET-notices.txt"
+            node scripts/verify-native-bootstrap.mjs \
+              --manifest target/distrib/dist-manifest.json \
+              --archive "target/distrib/tmt-cli-$TARGET.tar.gz" --target "$TARGET" \
+              --skill skills/tmux-team/SKILL.md
+            node scripts/generate-native-bootstrap.mjs --manifest target/distrib/dist-manifest.json --archive-dir target/distrib > "$RUNNER_TEMP/installer.sh"
+            cmp "$RUNNER_TEMP/installer.sh" target/distrib/tmt-installer.sh
+          else
+            node scripts/verify-native-artifact.mjs \
+              --product office \
+              --manifest target/distrib/dist-manifest.json \
+              --archive "target/distrib/tmt-office-$TARGET.tar.gz" --target "$TARGET" \
+              --license LICENSE \
+              --notices "target/distrib/$TARGET-notices.txt"
+          fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -452,12 +452,17 @@ zero-file success.
 `scripts/native-cargo.sh`, `scripts/native-artifact-policy.mjs` and
 `scripts/verify-native-artifact.mjs` are developer/release tooling. The
 workflow builds the four supported cargo-dist targets, creates target-filtered
-third-party notices, and verifies runtime bytes, linkage, skill contents,
-checksums, archive inventory and executable behavior on matching hosts.
+third-party notices, and verifies runtime bytes, linkage, checksums, archive
+inventory and executable behavior on matching hosts. CLI runs additionally
+verify exact managed-skill contents and the generated bootstrap.
 
-The release workflow remains an explicit preparation and verification workflow;
-publication is separately authorized. Archives, their manifest/checksums,
-notices and generated `tmt-installer.sh` are verified before any public
+The release workflow remains an explicit product-selected preparation and
+verification workflow; publication is separately authorized. CLI and Office
+runs share the four-target cargo-dist build and archive verifier, while keeping
+product-qualified bundles, independent versions and separate immutable tags.
+Only the CLI bundle owns the generated `tmt-installer.sh` and managed-skill
+bootstrap proof. Archives, their product-specific manifest/checksums and notices,
+plus the CLI bootstrap where applicable, are verified before any public
 publication. Raw PR executables do not prove cargo-dist archive correctness.
 The runtime/linkage proof is shared through `scripts/native-runtime-proof.mjs`
 and `scripts/verify-native-runtime.mjs`; do not reintroduce a second archive

--- a/docs/native-release-verification.md
+++ b/docs/native-release-verification.md
@@ -11,10 +11,11 @@ This is verification guidance, not publication authorization.
 ### Explicit multi-platform release preparation
 
 `Native release artifacts` (`.github/workflows/native-release.yml`) is manually
-dispatched, not part of every PR. Dispatch on the authorized release's reviewed,
-required-checks-green main commit and record the run ID and exact SHA in its
-issue. It builds on native macOS arm64/x64 and Linux arm64/x64 hosts using the
-existing pinned tools and `build-native-artifact.sh`. A shared matrix keeps
+dispatched with an explicit `cli` or `office` product, not part of every PR.
+Dispatch each authorized product on the release's reviewed,
+required-checks-green main commit and record the product, run ID and exact SHA in
+its issue. It builds on native macOS arm64/x64 and Linux arm64/x64 hosts using
+the existing pinned tools and `build-native-artifact.sh`. A shared matrix keeps
 build and final verification hosts aligned; dispatches outside main are skipped.
 Cached packaging tools are keyed
 by OS, architecture and exact tool versions; they are developer tools only.
@@ -22,24 +23,29 @@ by OS, architecture and exact tool versions; they are developer tools only.
 cargo-dist itself merges the downloaded `*-dist-manifest.json` inputs through
 `dist build --artifacts global --output-format=json --no-local-paths`. Do not
 hand-merge artifact JSON or enable another installer. Generate a complete
-`dist plan` on the same source and pass it as bootstrap `--plan`: the generator
-requires exact planned archive names/targets, preventing a missing matrix target
-from silently shrinking the release. Bootstrap generation verifies TMT ownership
-and archive inventory/digests before generating code; the final matrix
-then executes both existing verifiers against this final manifest and compares
-the regenerated script bytes. All jobs must pass before publication, even if
-the assembled artifact can already be downloaded. CI artifacts expire in seven
-days. Notices alongside the bundle are verification inputs; each archive also
-contains its own target-filtered notices.
+`dist plan` on the same source. For CLI, pass it as bootstrap `--plan`: the
+generator requires exact planned archive names/targets, preventing a missing
+matrix target from silently shrinking the release. Bootstrap generation verifies
+TMT ownership and archive inventory/digests before generating code; the final
+CLI matrix executes both existing verifiers and compares the regenerated script
+bytes. Office has no bootstrap or managed skill and runs its product-specific
+archive/runtime verifier against the same final-manifest ownership instead. All
+jobs in the selected product run must pass before that product is published,
+even if the assembled artifact can already be downloaded. CI artifacts expire
+in seven days. Product-qualified artifact names prevent concurrent CLI and Office
+runs from being mistaken for one bundle. Notices alongside each bundle are
+verification inputs; every archive also contains its own target-filtered notices.
 
 Publication remains a separately authorized operation, not a workflow side
-effect. Verify the run's exact commit and all required PR checks; enable GitHub
-release immutability before creating a draft prerelease. Attach the four tar.gz
-archives, final `dist-manifest.json` and `tmt-installer.sh`, verify their uploaded
-SHA-256 digests and only then publish the draft. Verify `immutable: true`, tag
-commit and GitHub release attestation (`gh release verify` and
-`gh release verify-asset`). Never replace an immutable release's assets or move
-its tag. A repair needs a new reviewed version.
+effect. Verify the selected product run's exact commit and all required PR checks;
+enable GitHub release immutability before creating a draft prerelease. A CLI
+release attaches its four tar.gz archives, final `dist-manifest.json` and
+`tmt-installer.sh`; an Office release uses the independent `tmt-office-v<version>`
+tag and attaches its four archives and final manifest without a CLI bootstrap.
+Verify uploaded SHA-256 digests before publishing each draft. Verify
+`immutable: true`, tag commit and GitHub release attestation (`gh release verify`
+and `gh release verify-asset`). Never combine product manifests, replace an
+immutable release's assets or move its tag. A repair needs a new reviewed version.
 
 Before promoting README installation instructions, run the actual public script
 with an isolated HOME, application root and prefix, verify version, exact skill,
@@ -209,7 +215,8 @@ not CLI-only skill/SQLite commands. Follow with `office install --yes --archive
 installation and explicit uninstall. Inspect surviving bytes after rejected
 candidates and deactivation. Public availability is a separate authorized gate;
 local cargo-dist's package selection tag does not publish a Git tag. Public Office
-discovery uses `tmt-office-v<version>`; the existing CLI workflow remains CLI-only.
+discovery uses `tmt-office-v<version>`; select `office` explicitly when dispatching
+the shared release workflow and never publish its bundle under a CLI tag.
 
 Native adapter tests cover bounded archive acquisition and publication failures;
 native process contracts use the existing executable selector and sandbox. Test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-team",
-  "version": "5.0.0-alpha.2",
+  "version": "5.0.0-alpha.3",
   "description": "Private developer tooling for tmux-team",
   "private": true,
   "type": "module",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "tmt-adapters"
-version = "5.0.0-alpha.2"
+version = "5.0.0-alpha.3"
 dependencies = [
  "apple-native-keyring-store",
  "base64 0.22.1",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "tmt-cli"
-version = "5.0.0-alpha.2"
+version = "5.0.0-alpha.3"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "tmt-core"
-version = "5.0.0-alpha.2"
+version = "5.0.0-alpha.3"
 dependencies = [
  "icu_casemap",
  "icu_locale_core",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/tmt-core", "crates/tmt-adapters", "crates/tmt-cli", "crates/t
 resolver = "3"
 
 [workspace.package]
-version = "5.0.0-alpha.2"
+version = "5.0.0-alpha.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust:1.97.0-bookworm@sha256:8fa55b2f3ddf97471ab6a767bfa3f37e6bad0986ba823e75fea57e2a2a5c3073 AS native-tests
 WORKDIR /native/rust
 COPY rust/ ./
+COPY contracts/office/ ../contracts/office/
 COPY skills/ ../skills/
 ARG TMT_NATIVE_PROFILE=dev
 RUN cargo build --locked --example tmux-probe \

--- a/test/native/cli.test.ts
+++ b/test/native/cli.test.ts
@@ -52,7 +52,7 @@ describe('native grammar process contract', () => {
       const before = fileSnapshot(sandbox.root);
       const version = await runCli(sandbox, ['--version']);
       expect(version.status).toBe(0);
-      expect(version.stdout).toBe('5.0.0-alpha.2\n');
+      expect(version.stdout).toBe('5.0.0-alpha.3\n');
       expect(version.stderr).toBe('');
       const help = await runCli(sandbox, ['help']);
       expect(help.status).toBe(0);
@@ -165,7 +165,7 @@ describe('native grammar process contract', () => {
       expect(JSON.parse(literal.stdout).identity.name).toBe('--debug');
       const version = await runCli(sandbox, ['--version']);
       expect(version.status).toBe(0);
-      expect(version.stdout).toBe('5.0.0-alpha.2\n');
+      expect(version.stdout).toBe('5.0.0-alpha.3\n');
     });
   });
 
@@ -247,7 +247,7 @@ describe('native grammar process contract', () => {
       copyFileSync(sandbox.cli.executable, executable);
       const result = await runCli({ ...sandbox, cli: { executable, args: [] } }, ['--version']);
       expect(result.status).toBe(0);
-      expect(result.stdout).toBe('5.0.0-alpha.2\n');
+      expect(result.stdout).toBe('5.0.0-alpha.3\n');
       expect(result.stderr).toBe('');
       expect(existsSync(sandbox.database)).toBe(false);
     });


### PR DESCRIPTION
## Summary

- bump the native CLI candidate to `5.0.0-alpha.3`
- extend the existing manual native artifact workflow with an explicit `cli` / `office` product choice while retaining one cargo-dist manifest owner and the same four native targets
- keep CLI bootstrap/managed-skill verification separate from Office's independently versioned `0.1.0-alpha.1` runtime proof
- include Office contract fixtures in the native E2E image after the full gate exposed the missing build context
- document the product-qualified release evidence boundary

## Architecture impact

This changes release/test infrastructure ownership but not runtime modules, public commands, storage, migrations, or Office application behavior. The existing workflow, cargo-dist scripts, artifact policy, and runtime verifier remain the single release pipeline. CLI and Office keep independent tags and bundles; only CLI owns `tmt-installer.sh` and managed-skill bootstrap evidence. `ARCHITECTURE.md` and the native release guide are updated in this PR.

## Review

Primary review inspected the full diff and surrounding version, workflow, artifact, bootstrap, documentation, and Docker fixture owners at exact head `c87d17e6555d5b6a040ada04c9aafd25312af98d`. The Docker fixture correction is intentionally one COPY of the already versioned Office contracts required by the adapter test binary. No findings remain locally.

## Verification

- `actionlint .github/workflows/native-release.yml`
- focused native CLI contract: 9/9 passed
- `pnpm check`
- `pnpm test:run`: 156 passed
- Rust 1.97 fmt, clippy with warnings denied, locked tests/build, storage probe and tmux probe
- Rust 1.88 locked build
- package-scoped CLI and Office debug fixture builds
- native process suite: 162 passed
- Docker E2E twice: 172 passed and 1 existing skip per run; Rust adapter stage 328 passed and 1 ignored per run; cleanup verified
- macOS arm64 CLI cargo-dist archive/verifier: 3,507,072 bytes, SHA-256 `334daf5382e91c39e6059e5c6524f73441211cd5e25187b5b95966dc58aa5faf`
- macOS arm64 Office cargo-dist archive/verifier: 2,618,262 bytes, SHA-256 `7eef84edd00651c63339010273cba01334267c3d3cbefa1e12d51fb01033aaf5`

Local JS checks ran on Node 26 and are not Node 22 CI evidence. The first E2E attempt found the Docker build-context defect before scenarios ran; both complete runs passed after the fix. Full logs and manifests are recorded on #241.

## Publication boundary

This PR does not itself publish, tag, deploy, or change the host installation. After required PR checks pass and this reviewed head is merged, #241 requires separate CLI and Office manual release-workflow runs on the exact `main` SHA, all four final matching-host verifiers per product, immutable release assets/tags, digest and attestation checks, isolated public-install smoke, and only then the authorized local managed update.

Tracks #241
